### PR TITLE
Adjust protos

### DIFF
--- a/benchmark/alexnet/single_machine/train/job.prototxt
+++ b/benchmark/alexnet/single_machine/train/job.prototxt
@@ -19,7 +19,7 @@ train_conf {
   default_initializer_conf {
     random_normal_conf {
       mean: 0.0
-      std: 0.1
+      std: 0.01
     }
   }
   piece_num_of_print_loss: 1

--- a/benchmark/alexnet/single_machine/train/net.prototxt
+++ b/benchmark/alexnet/single_machine/train/net.prototxt
@@ -1,7 +1,7 @@
 op {
   name: "decode"
   decode_ofrecord_conf {
-    data_dir: "/datasets/imagenet_OfRecord/train"
+    data_dir: "/dataset/imagenet/train"
     blob {
       name: "encoded"
       data_type: kFloat

--- a/benchmark/alexnet/single_machine/train/placement.prototxt
+++ b/benchmark/alexnet/single_machine/train/placement.prototxt
@@ -25,15 +25,6 @@ placement_group {
     op_name: "conv5"
     op_name: "relu5"
     op_name: "pool5"
-  }
-  parallel_conf {
-    policy: kDataParallel
-    device_name: "192.168.1.11:gpu:0-1"
-  }
-}
-
-placement_group {
-  op_set {
     op_name: "fc1"
     op_name: "relu_fc1"
     op_name: "fc2"
@@ -43,6 +34,6 @@ placement_group {
   }
   parallel_conf {
     policy: kDataParallel
-    device_name: "192.168.1.11:cpu:2"
+    device_name: "192.168.1.11:gpu:0-1"
   }
 }


### PR DESCRIPTION
由于全连接层参数过多，初始化时一旦有某个参数过大，很有可能导致某个输出值变大，进而导致模型更新量大，这样的正反馈过程最终会产生inf和nan值，程序崩溃。

请同事们在以后训练时注意参数的初始化过程！