### PR TITLE
unify the placement of transpose op

### DIFF
--- a/benchmark/alexnet/1_machine_1_gpu.placement
+++ b/benchmark/alexnet/1_machine_1_gpu.placement
@@ -1,7 +1,6 @@
 placement_group {
   op_set {
     op_name: "decode"
-    op_name: "transpose"
   }
   parallel_conf {
     policy: kDataParallel
@@ -11,6 +10,7 @@ placement_group {
 
 placement_group {
   op_set {
+    op_name: "transpose"
     op_name: "conv1"
     op_name: "pool1"
     op_name: "conv2"


### PR DESCRIPTION
统一配置，1_machine_1_gpu.placement  把 transpose op 搬到gpu上；下一步，当我们完成io 模块的重构后，transpose op还是放在cpu上更快。