### PR TITLE
send act_event once it completes

### DIFF
--- a/oneflow/core/actor/actor.h
+++ b/oneflow/core/actor/actor.h
@@ -132,6 +132,7 @@ class Actor {
   int64_t GetGlobalWorkStreamId() const;
   int64_t GetLocalWorkStreamId() const;
 
+  TaskType task_type_;
   int64_t actor_id_;
   int64_t act_id_;
   std::unique_ptr<ParallelContext> parallel_ctx_;
@@ -163,10 +164,6 @@ class Actor {
   int64_t readable_ctrl_regst_desc_cnt_;
   int64_t writeable_ctrl_regst_desc_cnt_;
   bool is_consumed_ctrl_eord_;
-
-  // Profile
-  std::vector<ActEvent*> act_events_;
-  TaskType task_type_;
 };
 
 class ScopedActEventRecorder {
@@ -177,6 +174,7 @@ class ScopedActEventRecorder {
 
  private:
   Actor* actor_;
+  ActEvent* act_event_;
 };
 
 std::unique_ptr<Actor> NewActor(const TaskProto&, const ThreadCtx&);


### PR DESCRIPTION
前两天把一个actor记录的act event统一放在一个actor析构的时候才向master发送，发现这会带来不稳定:一个actor在析构时需要发送一大批act event，还有很多actor 差不多同时析构，这相当于很多worker瞬间向master 发送大量rpc请求，grpc server会报错（具体原因不明）。现在改回act event一旦记录完成就向master发送，避免了那种瞬间大量rpc请求的情况，这样做并不会太影响速度，因为rpc请求在callback里执行，一般是在另一个线程上，不会影响actor thread，还有一个好处是在真实运行阶段act event不会占用太多内存，一个act event一旦用完就删除了。