### PR TITLE
ensure poller thread see all the msg in queue

### DIFF
--- a/oneflow/core/common/channel.h
+++ b/oneflow/core/common/channel.h
@@ -51,7 +51,7 @@ template<typename T>
 int Channel<T>::Receive(T* item) {
   std::unique_lock<std::mutex> lock(mutex_);
   cond_.wait(lock, [this]() { return !val_.empty() || is_receive_closed_ || is_send_closed_; });
-  if (val_.empty() || is_receive_closed_) { return -1; }
+  if (val_.empty() && (is_send_closed_ || is_receive_closed_)) { return -1; }
   *item = val_.front();
   val_.pop();
   return 0;


### PR DESCRIPTION
改动了channel的一行代码：确保poller thread在退出循环前把channel里还有未处理的item (或者是消息，或者是callback) 都处理了。旧代码可能会出现：channel里还有item，但一旦channel关闭，剩下的item就不被处理了。