### PR TITLE
perform rpc call in background thread pool

### DIFF
--- a/oneflow/core/actor/actor.cpp
+++ b/oneflow/core/actor/actor.cpp
@@ -257,6 +257,8 @@ void Actor::TryLogActEvent(const std::function<void()>& DoAct) const {
 
     device_ctx_->AddCallBack([act_event]() {
       act_event->set_stop_time(GetCurTime());
+      // The stream poller thread is not allowed to perform blocking RPC call. Hence, the
+      // RPC call is forwarded to the thread pool and will be executed there.
       Global<ThreadMgr>::Get()->compute_thread_pool()->AddWork(
           [act_event]() { Global<CtrlClient>::Get()->PushActEvent(*act_event); });
     });


### PR DESCRIPTION
actor 向master发送act event时的rpc调用是同步调用，这个调用放在cuda stream callback里执行会影响stream 里和gpu有关的调用不能立即执行。通过把rpc 调用再转发到threadpool里去执行来解决这个问题。