### PR TITLE
carefully handle depth of act_node

### DIFF
--- a/oneflow/core/graph/act_graph.cpp
+++ b/oneflow/core/graph/act_graph.cpp
@@ -403,9 +403,9 @@ void ActGraph::TopoForEachActNode(const std::list<ActNode*>& starts,
                                   const std::function<void(ActNode*)>& Handler) const {
   std::list<ActNode*> sorted_starts(starts);
   sorted_starts.sort(
-      [](const ActNode* lhs, const ActNode* rhs) { return lhs->act_id() > rhs->act_id(); });
-  DfsTopoForEachNodeSortByDistanceToSink(sorted_starts, &ActNode::ForEachNodeOnInEdge,
-                                         &ActNode::ForEachNodeOnOutEdge, Handler);
+      [](const ActNode* lhs, const ActNode* rhs) { return lhs->act_id() < rhs->act_id(); });
+  TopoForEachNode(sorted_starts, &ActNode::ForEachNodeOnInEdge, &ActNode::ForEachNodeOnOutEdge,
+                  Handler);
 }
 
 void ActGraph::InitDepth() {


### PR DESCRIPTION
regst num很大这一BUG确实是我的锅，ActGraph里每个节点的depth必须用BfsTopoForEach得到才准确。另外还要让act_id > 0的act node的depth尽可能大，也即假定运行时尽可能推迟。