### PR TITLE
disable ctrl edge for MdUpdt task in prediction

### DIFF
--- a/oneflow/core/graph/task_node.cpp
+++ b/oneflow/core/graph/task_node.cpp
@@ -141,7 +141,11 @@ int64_t TaskNode::MemZoneId121() const {
 }
 
 void TaskNode::BuildCtrlRegstDescIfNeed(TaskNode* dst_node) {
-  if (IsMeaningLess() || dst_node->IsMeaningLess()) return;
+  if (IsMeaningLess() || dst_node->IsMeaningLess()) { return; }
+  if (!Global<JobDesc>::Get()->IsTrain() && GetTaskType() == kNormalMdUpdt
+      && dst_node->GetTaskType() == kNormalMdUpdt) {
+    return;
+  }
   const auto& dst_ancestors = dst_node->ancestors();
   if (dst_ancestors.find(this) != dst_ancestors.end()) return;
   RegstDescTypeProto regst_desc_type;


### PR DESCRIPTION
在prediction 场景，kNormalMdUpdt task node 会被合并成一个chain而加上控制边，这会导致现有的actor 退出机制失效。所以在prediction场景，禁止在kNormalMdUpdt task node之间加控制边。