### PR TITLE
将record_load和loss_print从之前的persistence线程中分离出来

### DIFF
--- a/oneflow/core/job/id_manager.cpp
+++ b/oneflow/core/job/id_manager.cpp
@@ -10,14 +10,12 @@ int64_t IDMgr::GetGpuMixThrdId(int64_t dev_phy_id) const {
   return gpu_device_num_ * 3 + dev_phy_id;
 }
 int64_t IDMgr::GetCpuDeviceThrdId(int64_t dev_phy_id) const {
-  return gpu_device_num_ * 4 + dev_phy_id;
+  return Global<JobDesc>::Get()->base_id_of_cpu_compute() + dev_phy_id;
 }
-int64_t IDMgr::GetPersistenceThrdId(int64_t offset) const {
-  return gpu_device_num_ * 4 + cpu_device_num_ + offset;
+int64_t IDMgr::GetMdSaveThrdId(int64_t offset) const {
+  return Global<JobDesc>::Get()->base_id_of_mdsave() + offset;
 }
-int64_t IDMgr::CommNetThrdId() const {
-  return gpu_device_num_ * 4 + cpu_device_num_ + Global<JobDesc>::Get()->PersistenceWorkerNum();
-}
+int64_t IDMgr::CommNetThrdId() const { return Global<JobDesc>::Get()->base_id_of_comm_net(); }
 
 int64_t IDMgr::NewTaskId(int64_t machine_id, int64_t thrd_id, int64_t local_work_stream_id) {
   int64_t machine_thrd_id = GetMachineThrdId(machine_id, thrd_id);

--- a/oneflow/core/job/id_manager.h
+++ b/oneflow/core/job/id_manager.h
@@ -18,7 +18,7 @@ class IDMgr final {
   int64_t GetGpuD2HThrdId(int64_t dev_phy_id) const;
   int64_t GetGpuMixThrdId(int64_t dev_phy_id) const;
   int64_t GetCpuDeviceThrdId(int64_t dev_phy_id) const;
-  int64_t GetPersistenceThrdId(int64_t offset) const;
+  int64_t GetMdSaveThrdId(int64_t offset) const;
   int64_t CommNetThrdId() const;
 
   int64_t NewTaskId(int64_t machine_id, int64_t thrd_id, int64_t local_work_stream_id);

--- a/oneflow/core/job/job_desc.h
+++ b/oneflow/core/job/job_desc.h
@@ -64,6 +64,18 @@ class JobDesc final {
   float L2() const;
   int32_t DataPartNum() const;
 
+  int32_t base_id_of_gpu() const { return 0; }
+
+  int32_t base_id_of_cpu_compute() const { return 128; }
+
+  int32_t base_id_of_record_load() const { return 256; }
+
+  int32_t base_id_of_loss_print() const { return 384; }
+
+  int32_t base_id_of_mdsave() const { return 512; }
+
+  int32_t base_id_of_comm_net() const { return 640; }
+
  private:
   friend class Global<JobDesc>;
   JobDesc(const std::string& job_conf_filepath);

--- a/oneflow/core/thread/thread.h
+++ b/oneflow/core/thread/thread.h
@@ -20,6 +20,8 @@ class Thread {
 
   void JoinAllActor() { actor_thread_.join(); }
 
+  int64_t ThreadId() const { return thrd_id_; }
+
  protected:
   Thread() = default;
   std::thread& mut_actor_thread() { return actor_thread_; }

--- a/oneflow/core/thread/thread_manager.cpp
+++ b/oneflow/core/thread/thread_manager.cpp
@@ -14,30 +14,57 @@ ThreadMgr::~ThreadMgr() {
   }
 }
 
-Thread* ThreadMgr::GetThrd(int64_t thrd_id) { return threads_.at(thrd_id); }
+Thread* ThreadMgr::GetThrd(int64_t thrd_id) {
+  auto it = std::find_if(threads_.begin(), threads_.end(),
+                         [thrd_id](const Thread* thrd) { return thrd->ThreadId() == thrd_id; });
+  assert(it != threads_.end());
+
+  return *it;
+}
 
 ThreadMgr::ThreadMgr(const Plan& plan) {
   const JobDesc* job_desc = Global<JobDesc>::Get();
-  int64_t thrd_id = 0;
+  int64_t gpu_thrd_id = job_desc->base_id_of_gpu();
 
   const OneMachineBufInfo& info = plan.buf_info().Get(Global<MachineCtx>::Get()->this_machine_id());
 
 #ifdef WITH_CUDA
   FOR_RANGE(int64_t, i, 0, 4) {
     FOR_RANGE(int64_t, dev_phy_id, 0, job_desc->GpuDeviceNum()) {
-      threads_.push_back(new GpuThread(thrd_id, dev_phy_id, info.buf_size(thrd_id)));
-      thrd_id += 1;
+      threads_.push_back(new GpuThread(gpu_thrd_id, dev_phy_id, info.buf_size(gpu_thrd_id)));
+      gpu_thrd_id += 1;
     }
   }
 #endif
+  // cpu compute thread
+  int64_t compute_thrd_id = job_desc->base_id_of_cpu_compute();
   FOR_RANGE(int64_t, i, 0, job_desc->CpuDeviceNum()) {
-    threads_.push_back(new CpuThread(thrd_id, info.buf_size(thrd_id)));
-    thrd_id += 1;
+    threads_.push_back(new CpuThread(compute_thrd_id, info.buf_size(gpu_thrd_id + i)));
+    compute_thrd_id += 1;
   }
+
+  // record load thread and lossprint thread
+  int64_t record_load_thrd_id = job_desc->base_id_of_record_load();
+  int64_t lossprint_thrd_id = job_desc->base_id_of_loss_print();
+  for (const TaskProto& task : plan.task()) {
+    if (task.task_type() == TaskType::kRecordLoad) {
+      threads_.push_back(new CpuThread(record_load_thrd_id++, 0));
+    } else if (task.task_type() == TaskType::kLossPrint) {
+      threads_.push_back(new CpuThread(lossprint_thrd_id++, 0));
+    }
+  }
+
+  // mdsave thread
+  int64_t mdsave_thrd_id = job_desc->base_id_of_mdsave();
   FOR_RANGE(int64_t, i, 0, job_desc->PersistenceWorkerNum()) {
-    threads_.push_back(new CpuThread(thrd_id++, 0));
+    threads_.push_back(new CpuThread(mdsave_thrd_id++, 0));
   }
-  threads_.push_back(new CpuThread(thrd_id++, 0));  // comm_net
+
+  // comm_net
+  int64_t comm_net_thrd_id = job_desc->base_id_of_comm_net();
+  threads_.push_back(new CpuThread(comm_net_thrd_id++, 0));
+
+  // thread pool
   compute_thread_pool_.reset(new ThreadPool(job_desc->CpuDeviceNum()));
 }
 


### PR DESCRIPTION
1.将record_load和loss_print从之前的persistence线程中分离出来；
2.消除IDMgr对ThreadMgr创建线程顺序的依赖，消除不同种类线程id的相互影响使其相互独立。