### PR TITLE
let mdupdt use compute stream instead of mix stream

### DIFF
--- a/oneflow/core/graph/normal_model_update_compute_task_node.h
+++ b/oneflow/core/graph/normal_model_update_compute_task_node.h
@@ -19,7 +19,6 @@ class NormalMdUpdtCompTaskNode final : public CompTaskNode {
 
   void set_random_seed(uint32_t val) { random_seed_ = val; }
   TaskType GetTaskType() const override { return TaskType::kNormalMdUpdt; }
-  CudaWorkType GetCudaWorkType() const override { return CudaWorkType::kMix; }
   void ToProto(TaskProto*) override;
 
  private:


### PR DESCRIPTION
前几天把mdupdt task 放到reduce scatter/add/gather 那个stream，在inception网络上有稍微的提高，最近在alexnet 上测试发现有较大负作用，所以还是把mdupdt task放到和forward/backward 在一个stream上。