### PR TITLE
reduce struct regst num min = 1

### DIFF
--- a/oneflow/core/graph/task_node.cpp
+++ b/oneflow/core/graph/task_node.cpp
@@ -262,7 +262,8 @@ void TaskNode::FixRegisterNumRange() {
         break;
       }
     }
-    if (in_same_stream == false) {  // TODO: delete this hack
+    if (in_same_stream == false
+        && area_id_ != static_cast<int64_t>(kMdUpdtArea)) {  // TODO: delete this hack
       if (produced_regst->max_register_num() >= 2) { produced_regst->UpdtMinRegstNumIfNeed(2); }
     }
   }


### PR DESCRIPTION
可以节省resnet50 单机多卡 reduce struct 400M 内存。
master resnet50 单机双卡 piece size 只能跑116（消耗内存8G）
这个跑 piece size 116 只需7.6G，最多跑124（8G），再优化一点儿（共享内存，即可以装下128张图）