### PR TITLE
fix fw_buf of reduce_sum op

### DIFF
--- a/oneflow/core/operator/reduce_sum_op.cpp
+++ b/oneflow/core/operator/reduce_sum_op.cpp
@@ -6,7 +6,7 @@ namespace oneflow {
 void ReduceSumOp::InitFromOpConf() {
   EnrollInputBn("in");
   EnrollOutputBn("out");
-  EnrollFwBufBn("fw_tmp");
+  EnrollDataTmpBn("fw_tmp");
 }
 
 const PbMessage& ReduceSumOp::GetCustomizedConf() const { return op_conf().reduce_sum_conf(); }


### PR DESCRIPTION
把我自作聪明的一小处修改取消。reduce sum op 不会出现在FwTaskNode里，就没办法用fw_buf，只能用data tmp。