### PR TITLE
refine collect active event pre-condition

### DIFF
--- a/oneflow/core/actor/naive_actor.h
+++ b/oneflow/core/actor/naive_actor.h
@@ -20,7 +20,6 @@ class NaiveActor final : public Actor {
   std::pair<bool, std::vector<std::string>> GetNaiveConsumedRegstDescName() override {
     return {true, {}};
   }
-  bool NeedCollectActEvent() const override { return false; }
 };
 
 }  // namespace oneflow

--- a/oneflow/core/job/runtime_context.h
+++ b/oneflow/core/job/runtime_context.h
@@ -16,9 +16,7 @@ class RuntimeCtx final {
 
   int64_t total_piece_num() const { return total_piece_num_; }
   bool is_experiment_phase() const { return is_experiment_phase_; }
-  bool NeedCollectActEvent() const {
-    return is_experiment_phase_ || Global<JobDesc>::Get()->collect_act_event();
-  }
+  bool NeedCollectActEvent() const { return Global<JobDesc>::Get()->collect_act_event(); }
 
   void NewCounter(const std::string& name, int64_t val);
   void DecreaseCounter(const std::string& name);


### PR DESCRIPTION
actor 判断是否collect act event已经使用了is_experiment_phase这个条件，所以runtime_context那里可以不用；naïve actor 默认也collect act event，以前的reduce actor是naïve actor的子类，发现记录reduce related actors 的act event对效率影响很大，现在又测了发现没有什么影响，所以默认所有actor 默认都根据runtime context的设定collect act event