### PR TITLE
fix: fix the enable_mem_sharing field of reduce regsts

### DIFF
--- a/oneflow/core/graph/copy_task_node.cpp
+++ b/oneflow/core/graph/copy_task_node.cpp
@@ -14,7 +14,7 @@ void CopyTaskNode::ProduceAllRegstsAndBindEdges() {
         && (dst_node_type == TaskType::kReduceLocalAdd
             || dst_node_type == TaskType::kReduceGlobalAdd
             || dst_node_type == TaskType::kReduceGather)) {
-      out_regst = ProduceRegst(name, true, 1, 1);
+      out_regst = ProduceRegst(name, false, 1, 1);
     }
     TaskType src_node_type = SoleInEdge()->src_node()->GetTaskType();
     if (copy_hd->copy_type() == CopyHdOpConf::D2H

--- a/oneflow/core/graph/reduce_gather_compute_task_node.cpp
+++ b/oneflow/core/graph/reduce_gather_compute_task_node.cpp
@@ -4,7 +4,7 @@
 namespace oneflow {
 
 void ReduceGatherCompTaskNode::ProduceAllRegstsAndBindEdges() {
-  this->SoleOutEdge()->AddRegst("out", ProduceRegst("out", true, 1, 1));
+  this->SoleOutEdge()->AddRegst("out", ProduceRegst("out", false, 1, 1));
 }
 
 void ReduceGatherCompTaskNode::ConsumeAllRegsts() {

--- a/oneflow/core/graph/reduce_global_add_compute_task_node.cpp
+++ b/oneflow/core/graph/reduce_global_add_compute_task_node.cpp
@@ -4,7 +4,7 @@
 namespace oneflow {
 
 void ReduceGlobalAddCompTaskNode::ProduceAllRegstsAndBindEdges() {
-  ProduceRegst("out", true, 1, 1);
+  ProduceRegst("out", false, 1, 1);
   for (TaskEdge* edge : out_edges()) { BindEdgeWithProducedRegst(edge, "out"); }
 }
 

--- a/oneflow/core/graph/reduce_local_add_compute_task_node.cpp
+++ b/oneflow/core/graph/reduce_local_add_compute_task_node.cpp
@@ -8,7 +8,7 @@ void ReduceLocalAddCompTaskNode::ProduceAllRegstsAndBindEdges() {
     std::vector<CompTaskNode*> succ_comp_task_nodes = GetSuccCompTaskNodesOnEdge(edge);
     CHECK_EQ(succ_comp_task_nodes.size(), 1);
     std::string regst_name = "out_" + std::to_string(succ_comp_task_nodes.front()->machine_id());
-    std::shared_ptr<RegstDesc> out_regst = ProduceRegst(regst_name, true, 1, 1);
+    std::shared_ptr<RegstDesc> out_regst = ProduceRegst(regst_name, false, 1, 1);
     edge->AddRegst(regst_name, out_regst);
   }
 }

--- a/oneflow/core/graph/reduce_scatter_compute_task_node.cpp
+++ b/oneflow/core/graph/reduce_scatter_compute_task_node.cpp
@@ -27,7 +27,7 @@ void ReduceScatterCompTaskNode::ProduceAllRegstsAndBindEdges() {
           edge_index_of_this_dst_dev * dev_num_of_each_machine + dst_dev_index_of_this_machine;
     }
     std::string out_regst_name = "out_" + std::to_string(out_edge_index);
-    std::shared_ptr<RegstDesc> out_regst = ProduceRegst(out_regst_name, true, 1, 1);
+    std::shared_ptr<RegstDesc> out_regst = ProduceRegst(out_regst_name, false, 1, 1);
     edge->AddRegst(out_regst_name, out_regst);
   }
 }

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -183,6 +183,7 @@ void TaskGraph::EnableMemSharingInOneReduce(const ReduceTaskNodes& reduce_task_n
   std::vector<int64_t> blob_index2offset(parallel_num, 0);
 
   auto SetMemSharedField4Regst = [&](RegstDesc* regst, int64_t blob_id) {
+    regst->set_enable_mem_sharing(true);
     regst->set_mem_shared_id(mem_shared_id);
     regst->set_mem_shared_offset(blob_index2offset.at(blob_id));
   };
@@ -191,6 +192,7 @@ void TaskGraph::EnableMemSharingInOneReduce(const ReduceTaskNodes& reduce_task_n
   {
     std::shared_ptr<RegstDesc> consumed_regst =
         reduce_task_nodes.scatter->GetSoleConsumedRegst("in");
+    consumed_regst->set_enable_mem_sharing(true);
     consumed_regst->set_mem_shared_id(mem_shared_id);
     consumed_regst->set_mem_shared_offset(0);
     int64_t total_model_byte_size =

--- a/oneflow/core/job/compiler.cpp
+++ b/oneflow/core/job/compiler.cpp
@@ -60,7 +60,9 @@ Plan Compiler::DoCompile() {
   task_gph->ForEachNode(std::bind(&TaskNode::EraseEmptyProducedRegst, _1));
   task_gph->ForEachNode(std::bind(&TaskNode::ClearOutOfDateConsumedRegst, _1));
   task_gph->AddOrderingCtrlEdgeInSameChain();
-  task_gph->EnableMemSharingInReduceStruct();
+  if (job_desc->IsTrain() && job_desc->enable_mem_sharing()) {
+    task_gph->EnableMemSharingInReduceStruct();
+  }
   if (job_desc->IsTrain() && job_desc->other_conf().use_ordered_allreduce_in_mdupdt()) {
     task_gph->AddCtrlEdgeInReduceStruct();
   }


### PR DESCRIPTION
在reduce_task_node.cpp里，ProduceRegst时，enable_mem_sharing默认都是false。（为了保和以前保持一致）
然后在task_graph.cpp的EnableMemSharingInOneReduce()里设置相关regst的enable_mem_sharing为True