### PR TITLE
Build task node in topological order

### DIFF
--- a/oneflow/core/graph/graph.h
+++ b/oneflow/core/graph/graph.h
@@ -17,8 +17,6 @@ class Graph {
 
   // For Each
   void ForEachNode(std::function<void(NodeType*)> NodeHandler) const;
-  void ForEachNode(std::function<void(NodeType*)> NodeHandler,
-                   std::function<bool(NodeType*)> IsNodeReady) const;
   void TopoForEachNode(std::function<void(NodeType*)> NodeHandler) const;
   void ReverseTopoForEachNode(std::function<void(NodeType*)> NodeHandler) const;
   void ForEachEdge(std::function<void(EdgeType*)> EdgeHandler) const;
@@ -78,30 +76,6 @@ class Graph {
 template<typename NodeType, typename EdgeType>
 void Graph<NodeType, EdgeType>::ForEachNode(std::function<void(NodeType*)> NodeHandler) const {
   for (auto& x : nodes_) { NodeHandler(x.get()); }
-}
-
-template<typename NodeType, typename EdgeType>
-void Graph<NodeType, EdgeType>::ForEachNode(std::function<void(NodeType*)> NodeHandler,
-                                            std::function<bool(NodeType*)> IsNodeReady) const {
-  std::queue<NodeType*> node_queue;
-  HashSet<NodeType*> nodes_pushed;
-  for (auto& x : nodes_) {
-    if (IsNodeReady(x.get())) {
-      node_queue.push(x.get());
-      CHECK(nodes_pushed.insert(x.get()).second);
-    }
-  }
-  while (node_queue.empty() == false) {
-    NodeType* cur_node = node_queue.front();
-    node_queue.pop();
-    NodeHandler(cur_node);
-    cur_node->ForEachNodeOnInOutEdge([&](NodeType* candidate) {
-      if (nodes_pushed.find(candidate) == nodes_pushed.end() && IsNodeReady(candidate)) {
-        node_queue.push(candidate);
-        CHECK(nodes_pushed.insert(candidate).second);
-      }
-    });
-  }
 }
 
 template<typename NodeType, typename EdgeType>

--- a/oneflow/core/graph/task_node.cpp
+++ b/oneflow/core/graph/task_node.cpp
@@ -81,6 +81,7 @@ void TaskNode::PinConsumedRegst() {
 }
 
 void TaskNode::Build() {
+  CHECK(IsReadyForBuild());
   BuildExecGphAndRegst();
   LockRegsts();
   FixRegisterNumRange();

--- a/oneflow/core/job/compiler.cpp
+++ b/oneflow/core/job/compiler.cpp
@@ -60,7 +60,8 @@ Plan Compiler::DoCompile() {
   task_gph->ForEachNode(std::bind(&TaskNode::ProduceAllRegstsAndBindEdges, _1));
   task_gph->ForEachNode(std::bind(&TaskNode::ConsumeAllRegsts, _1));
   task_gph->ForEachNode(std::bind(&TaskNode::PinConsumedRegst, _1));
-  task_gph->ForEachNode(std::bind(&TaskNode::Build, _1), std::bind(&TaskNode::IsReadyForBuild, _1));
+  task_gph->AcyclicTopoForEachNode(
+      [](TaskNode* node) { node->Build(); });  // kMdUpdt task will not be built in Prediction mode
   task_gph->RemoveEmptyRegsts();
   task_gph->AddOrderingCtrlEdgeInSameChain();
   if (job_desc->IsTrain() && job_desc->enable_mem_sharing()) {


### PR DESCRIPTION
原来Build task node以及InferBlobDesc 不是按照TaskGraph的拓扑序，只支持那种有相邻关系的TaskNode之间校验BlobDesc，这就不利于支持那种不相邻的task node之间互相校验/拷贝BlobDesc(例如bw -> allreduce -> mdupdt 网络中，mdupdt 就不能从查看bw 的BlobDesc，因为build mdupdt时，bw 可能还没有build)。现在改成按拓扑序InferBlobDesc，在训练模式，mdupdt会沿着bw -> allreduce -> mdupdt 这样的路线来推理，在预测模式，不存在从fw 到mdupdt的路径，mdupdt tasknode也不会被调用Build函数，这没有关系，因为预测模式mdupdt tasknode也不需要调用Build。