### PR TITLE
fix issue: not unbind bn with empty regst

### DIFF
--- a/oneflow/core/graph/exec_graph.cpp
+++ b/oneflow/core/graph/exec_graph.cpp
@@ -30,6 +30,13 @@ void ExecNode::BindBnWithOneOfTheRegsts(const std::string& bn,
   CHECK(has_binded);
 }
 
+void ExecNode::UnbindBnWithEmptyRegst() {
+  EraseIf<std::string, std::shared_ptr<RegstDesc>>(
+      &bn_in_op2regst_, [](HashMap<std::string, std::shared_ptr<RegstDesc>>::iterator it) {
+        return it->second->regst_desc_type().has_data_regst_desc() && it->second->NumOfLbi() == 0;
+      });
+}
+
 void ExecNode::ToProto(bool is_forward, const ParallelContext* parallel_ctx,
                        ExecNodeProto* ret) const {
   op_->GenKernelConf(GetBlobDesc4BnInOpFunc(), is_forward, parallel_ctx, ret->mutable_kernel_conf(),

--- a/oneflow/core/graph/exec_graph.h
+++ b/oneflow/core/graph/exec_graph.h
@@ -50,6 +50,7 @@ class ExecNode final : public Node<ExecNode, ExecEdge> {
   void AddBnToRegstAndBindIt(const PbRpf<std::string>& (Operator::*bns_getter)() const,
                              std::shared_ptr<RegstDesc>);
   void BindBnWithOneOfTheRegsts(const std::string&, const std::list<std::shared_ptr<RegstDesc>>&);
+  void UnbindBnWithEmptyRegst();
 
   void set_fw_node(ExecNode* val) { fw_node_ = val; }
   ExecNode* fw_node() { return fw_node_; }

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -97,6 +97,7 @@ void TaskGraph::RemoveEmptyRegsts() {
   ForEachNode([&](TaskNode* node) { node->EraseZeroSizeProducedBlob(); });
   ForEachNode([&](TaskNode* node) { node->EraseZeroSizeConsumedRegst(); });
   ForEachNode([&](TaskNode* node) { node->EraseZeroSizeProducedRegst(); });
+  ForEachNode([&](TaskNode* node) { node->UnbindBnWithEmptyRegst(); });
 }
 
 void TaskGraph::AddOrderingCtrlEdgeInSameChain() {

--- a/oneflow/core/graph/task_node.cpp
+++ b/oneflow/core/graph/task_node.cpp
@@ -118,6 +118,10 @@ void TaskNode::EraseZeroSizeProducedRegst() {
       });
 }
 
+void TaskNode::UnbindBnWithEmptyRegst() {
+  exec_gph_.ForEachNode([&](ExecNode* exec_node) { exec_node->UnbindBnWithEmptyRegst(); });
+}
+
 std::string TaskNode::VisualStr() const {
   std::stringstream ss;
   ss << TaskType_Name(GetTaskType()) << "\\n"

--- a/oneflow/core/graph/task_node.h
+++ b/oneflow/core/graph/task_node.h
@@ -65,6 +65,7 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
   void EraseZeroSizeProducedBlob();
   void EraseZeroSizeConsumedRegst();
   void EraseZeroSizeProducedRegst();
+  void UnbindBnWithEmptyRegst();
 
   // Others
   virtual TaskType GetTaskType() const { return TaskType::kInvalid; }


### PR DESCRIPTION
把weak_ptr 改成shared_ptr之后，在exec_node的bn_in_op2regst那里没有删除bn_in_op 和 空regst之间的关系，导致plan里仍会输出一个bn_in_op 到空regst的映射，但那个regst已经在producer那里删除了。