### PR TITLE
worker node only pull sub_plan

### DIFF
--- a/oneflow/core/comm_network/comm_network.cpp
+++ b/oneflow/core/comm_network/comm_network.cpp
@@ -69,34 +69,13 @@ void CommNet::AddWorkToStream(void* actor_read_id, const std::function<void()>& 
 }
 
 CommNet::CommNet(const Plan& plan) {
-  HashMap<int64_t, int64_t> rid2mid;
-  HashMap<int64_t, int64_t> tid2mid;
   int64_t this_machine_id = Global<MachineCtx>::Get()->this_machine_id();
-
-  for (const TaskProto& task_proto : plan.task()) {
-    for (const auto& regst_desc_it : task_proto.produced_regst_desc()) {
-      rid2mid.emplace(regst_desc_it.second.regst_desc_id(), task_proto.machine_id());
-    }
-    CHECK(tid2mid.emplace(task_proto.task_id(), task_proto.machine_id()).second);
-  }
-  for (const TaskProto& task_proto : plan.task()) {
-    if (task_proto.machine_id() != this_machine_id) { continue; }
-    for (const auto& regst_desc_set_it : task_proto.consumed_regst_desc_id()) {
-      for (int64_t regst_desc_id : regst_desc_set_it.second.regst_desc_id()) {
-        auto rid2mid_it = rid2mid.find(regst_desc_id);
-        CHECK(rid2mid_it != rid2mid.end());
-        peer_machine_id_.insert(rid2mid_it->second);
-      }
-    }
-    for (const auto& regst_desc_it : task_proto.produced_regst_desc()) {
-      for (int64_t consumer_task_id : regst_desc_it.second.consumer_task_id()) {
-        auto tid2mid_it = tid2mid.find(consumer_task_id);
-        CHECK(tid2mid_it != tid2mid.end());
-        peer_machine_id_.insert(tid2mid_it->second);
-      }
-    }
-  }
-  peer_machine_id_.erase(this_machine_id);
+  HashMap<int64_t, MachineIds> net_topo;
+  net_topo = PbMap2HashMap(plan.net_topo().peer_machine_ids());
+  auto machine_ids_it = net_topo.find(this_machine_id);
+  CHECK(machine_ids_it != net_topo.end());
+  std::vector<int64_t> peer_machine_ids = PbRf2StdVec(machine_ids_it->second.machine_id());
+  peer_machine_id_.insert(peer_machine_ids.begin(), peer_machine_ids.end());
 
   ready_cb_poller_ = std::thread([this]() {
     std::function<void()> cb;

--- a/oneflow/core/job/compiler.cpp
+++ b/oneflow/core/job/compiler.cpp
@@ -48,6 +48,47 @@ Plan Compiler::Compile() {
   return plan;
 }
 
+void Compiler::GenNetTopo(Plan* plan) {
+  HashMap<int64_t, int64_t> rid2mid;
+  HashMap<int64_t, int64_t> tid2mid;
+  std::map<int64_t, std::set<int64_t>> net_topo;
+
+  for (const TaskProto& task_proto : plan->task()) {
+    for (const auto& regst_desc_it : task_proto.produced_regst_desc()) {
+      rid2mid.emplace(regst_desc_it.second.regst_desc_id(), task_proto.machine_id());
+    }
+    CHECK(tid2mid.emplace(task_proto.task_id(), task_proto.machine_id()).second);
+  }
+
+  for (const TaskProto& task_proto : plan->task()) {
+    for (const auto& regst_desc_it : task_proto.produced_regst_desc()) {
+      int64_t rid = regst_desc_it.second.regst_desc_id();
+      auto rid2mid_it = rid2mid.find(rid);
+      CHECK(rid2mid_it != rid2mid.end());
+      int64_t producer_mid = rid2mid_it->second;
+      for (int64_t consumer_task_id : regst_desc_it.second.consumer_task_id()) {
+        auto tid2mid_it = tid2mid.find(consumer_task_id);
+        CHECK(tid2mid_it != tid2mid.end());
+        int64_t consumer_mid = tid2mid_it->second;
+        net_topo[producer_mid].insert(consumer_mid);
+        net_topo[consumer_mid].insert(producer_mid);
+      }
+    }
+  }
+
+  HashMap<int64_t, MachineIds> std_net_topo;
+  NetTopo& pb_net_topo = *(plan->mutable_net_topo());
+  for (auto& pair : net_topo) {
+    int64_t src_mid = pair.first;
+    if (pair.second.count(src_mid)) { pair.second.erase(src_mid); }
+    std::vector<int64_t> peer_mids(pair.second.begin(), pair.second.end());
+    MachineIds pb_mids;
+    *(pb_mids.mutable_machine_id()) = StdVec2PbRf<int64_t>(peer_mids);
+    CHECK(std_net_topo.emplace(src_mid, pb_mids).second);
+  }
+  *(pb_net_topo.mutable_peer_machine_ids()) = HashMap2PbMap(std_net_topo);
+}
+
 Plan Compiler::DoCompile() {
 #ifdef WITH_CUDA
   Global<CudnnConvCtxCache>::New();
@@ -78,6 +119,7 @@ Plan Compiler::DoCompile() {
     task_node->ToProto(plan.mutable_task()->Add());
   });
   plan.set_total_mbn_num(total_mbn_num);
+  GenNetTopo(&plan);
   ToDotFile(plan, JoinPath(LogDir(), "/dot/plan.dot"));
 #ifdef WITH_CUDA
   Global<CudnnConvCtxCache>::Delete();

--- a/oneflow/core/job/compiler.h
+++ b/oneflow/core/job/compiler.h
@@ -18,6 +18,7 @@ class Compiler final {
 
  private:
   Plan DoCompile();
+  void GenNetTopo(Plan* plan);
 };
 
 }  // namespace oneflow

--- a/oneflow/core/job/oneflow.cpp
+++ b/oneflow/core/job/oneflow.cpp
@@ -81,6 +81,8 @@ std::string cluster_thrd_ids_key(const std::string& plan_name) {
   return plan_name + "_cluster_thrd_ids";
 }
 
+std::string net_topo_key(const std::string& plan_name) { return plan_name + "_net_topo"; }
+
 std::string sub_plan_key(const std::string& plan_name, int64_t machine_id, int64_t thrd_id) {
   return plan_name + "_" + std::to_string(machine_id) + "_" + std::to_string(thrd_id);
 }
@@ -114,6 +116,8 @@ void PushPlan(const std::string& plan_name, const Plan& plan) {
   }
   Global<CtrlClient>::Get()->PushKV(total_mbn_num_key(plan_name),
                                     std::to_string(plan.total_mbn_num()));
+
+  Global<CtrlClient>::Get()->PushKV(net_topo_key(plan_name), plan.net_topo());
 }
 
 void PullPlan(const std::string& plan_name, Plan* plan) {
@@ -122,18 +126,21 @@ void PullPlan(const std::string& plan_name, Plan* plan) {
   PrintProtoToTextFile(cluster_thrd_ids, JoinPath(LogDir(), cluster_thrd_ids_key(plan_name)));
   HashMap<int64_t, ThrdIds> machine_id2thrd_ids;
   machine_id2thrd_ids = PbMap2HashMap(cluster_thrd_ids.machine_id2thrd_ids());
-  for (const auto& pair : machine_id2thrd_ids) {
-    int64_t machine_id = pair.first;
-    std::vector<int64_t> thrd_id_vec = PbRf2StdVec(pair.second.thrd_id());
-    for (auto thrd_id : thrd_id_vec) {
-      SubPlan sub_plan;
-      Global<CtrlClient>::Get()->PullKV(sub_plan_key(plan_name, machine_id, thrd_id), &sub_plan);
-      plan->mutable_task()->MergeFrom(sub_plan.task());
-    }
+  int64_t machine_id = Global<MachineCtx>::Get()->this_machine_id();
+  auto thrd_ids_it = machine_id2thrd_ids.find(machine_id);
+  CHECK(thrd_ids_it != machine_id2thrd_ids.end());
+  std::vector<int64_t> thrd_id_vec = PbRf2StdVec(thrd_ids_it->second.thrd_id());
+  for (auto thrd_id : thrd_id_vec) {
+    SubPlan sub_plan;
+    Global<CtrlClient>::Get()->PullKV(sub_plan_key(plan_name, machine_id, thrd_id), &sub_plan);
+    plan->mutable_task()->MergeFrom(sub_plan.task());
   }
+  NetTopo net_topo;
   std::string total_mbn_num;
   Global<CtrlClient>::Get()->PullKV(total_mbn_num_key(plan_name), &total_mbn_num);
   plan->set_total_mbn_num(oneflow_cast<int64_t>(total_mbn_num));
+  Global<CtrlClient>::Get()->PullKV(net_topo_key(plan_name), &net_topo);
+  *(plan->mutable_net_topo()) = net_topo;
 }
 
 bool HasRelayPlacement() {
@@ -194,6 +201,7 @@ Oneflow::Oneflow(const std::string& job_conf_filepath, const std::string& this_m
   Plan improved_plan;
   PushAvailableMemDescOfThisMachine();
   AvailableMemDesc amd;
+  double start = GetCurTime();
 
   if (machine_ctx->IsThisMachineMaster()) {
     naive_plan = Compiler().Compile();
@@ -208,6 +216,7 @@ Oneflow::Oneflow(const std::string& job_conf_filepath, const std::string& this_m
   OF_BARRIER();
   PrintProtoToTextFile(naive_plan, JoinPath(LogDir(), "naive_plan"));
   PrintProtoToTextFile(mem_shared_plan, JoinPath(LogDir(), "mem_shared_plan"));
+  LOG(INFO) << "push_pull_plan:" << GetCurTime() - start;
   if (HasRelayPlacement()) {
     // Experiment Runtime
     { Runtime experiment_run(mem_shared_plan, true); }

--- a/oneflow/core/job/plan.proto
+++ b/oneflow/core/job/plan.proto
@@ -3,7 +3,16 @@ package oneflow;
 
 import "oneflow/core/job/task.proto";
 
+message MachineIds {
+  repeated int64 machine_id = 1;
+}
+
+message NetTopo {
+  map<int64, MachineIds> peer_machine_ids = 1;
+}
+
 message Plan {
   repeated TaskProto task = 1;
   required int64 total_mbn_num = 2;
+  required NetTopo net_topo = 3;
 }


### PR DESCRIPTION
worker node 只从master node 拉自己节点上需要的sub_plan，而不是完整的plan。在plan里增加一个字段NetTopo，表示哪些机器之间需要建立网络连接，这样各个worker node即使拉到的是不完整的plan，也知道整个job需要建立什么样的网络拓扑。