### PR TITLE
safe check for inplace data movement

### DIFF
--- a/oneflow/core/actor/reduce_gather_compute_actor.cpp
+++ b/oneflow/core/actor/reduce_gather_compute_actor.cpp
@@ -3,7 +3,8 @@
 namespace oneflow {
 
 void ReduceGatherCompActor::SetKernelCtxOther(void** other) {
-  other_val_ = InBnId4RegstDescId(cur_processed_regst_desc_id());
+  int64_t in_bn_id = InBnId4RegstDescId(cur_processed_regst_desc_id());
+  other_val_ = std::make_pair(in_bn_id, EnableInplace());
   *other = static_cast<void*>(&other_val_);
 }
 

--- a/oneflow/core/actor/reduce_gather_compute_actor.h
+++ b/oneflow/core/actor/reduce_gather_compute_actor.h
@@ -15,7 +15,7 @@ class ReduceGatherCompActor final : public InputWiseCompActor {
   void VirtualCompActorInit(const TaskProto& proto) override { InputWiseCompActor::Init(proto); }
   void SetKernelCtxOther(void** other) override;
 
-  int64_t other_val_;
+  std::pair<int64_t, bool> other_val_;
 };
 
 }  // namespace oneflow

--- a/oneflow/core/kernel/kernel_util.cpp
+++ b/oneflow/core/kernel/kernel_util.cpp
@@ -157,6 +157,7 @@ void Memcpy<DeviceType::kCPU>(DeviceCtx* ctx, void* dst, const void* src, size_t
 #endif
 
 ) {
+  if (dst == src) { return; }
   memcpy(dst, src, sz);
 }
 

--- a/oneflow/core/kernel/kernel_util.cu
+++ b/oneflow/core/kernel/kernel_util.cu
@@ -274,6 +274,7 @@ void MatrixRowReduce(DeviceCtx* ctx, const size_t row_num, const size_t col_num,
 template<>
 void Memcpy<DeviceType::kGPU>(DeviceCtx* ctx, void* dst, const void* src, size_t sz,
                               cudaMemcpyKind kind) {
+  if (kind == cudaMemcpyKind::cudaMemcpyDeviceToDevice && dst == src) { return; }
   CudaCheck(cudaMemcpyAsync(dst, src, sz, kind, ctx->cuda_stream()));
 }
 

--- a/oneflow/core/kernel/reduce_concat_kernel.cpp
+++ b/oneflow/core/kernel/reduce_concat_kernel.cpp
@@ -8,12 +8,12 @@ void ReduceConcatKernel<device_type>::ForwardDataContent(
   const auto* other_val = static_cast<std::pair<int64_t, bool>*>(ctx.other);
   int64_t in_bn_id = other_val->first;
   bool is_inplace = other_val->second;
-  if (is_inplace) { return; }
   Blob* out_blob = BnInOp2Blob("out");
   char* dst_cur_dptr = out_blob->mut_dptr<char>();
   dst_cur_dptr += this->kernel_conf().reduce_concat_conf().data_offset().Get(in_bn_id);
   Blob* in_blob = BnInOp2Blob(this->op_attribute().input_bns().Get(in_bn_id));
   size_t in_byte_size = in_blob->ByteSizeOfDataContentField();
+  if (is_inplace) { CHECK_EQ(dst_cur_dptr, in_blob->dptr<char>()); }
   Memcpy<device_type>(ctx.device_ctx, dst_cur_dptr, in_blob->dptr<char>(), in_byte_size);
 }
 

--- a/oneflow/core/kernel/reduce_global_add_kernel.cpp
+++ b/oneflow/core/kernel/reduce_global_add_kernel.cpp
@@ -10,8 +10,6 @@ void ReduceGlobalAddKernel<device_type, T>::ForwardDataContent(
   bool is_out_blob_inited = std::get<1>(*other_val);
   bool is_inplace_in_blob = std::get<2>(*other_val);
 
-  if (is_inplace_in_blob) { return; }
-
   Blob* out_blob = BnInOp2Blob("out");
   Blob* in_blob = BnInOp2Blob(ibn);
   if (is_out_blob_inited) {
@@ -19,6 +17,7 @@ void ReduceGlobalAddKernel<device_type, T>::ForwardDataContent(
     KernelUtil<device_type, T>::Axpy(ctx.device_ctx, elem_cnt, 1.0, in_blob->dptr<T>(), 1,
                                      out_blob->mut_dptr<T>(), 1);
   } else {
+    if (is_inplace_in_blob) { CHECK_EQ(out_blob->mut_dptr<char>(), in_blob->dptr<char>()); }
     Memcpy<device_type>(ctx.device_ctx, out_blob->mut_dptr<char>(), in_blob->dptr<char>(),
                         out_blob->ByteSizeOfDataContentField());
   }

--- a/oneflow/core/kernel/reduce_local_add_kernel.cpp
+++ b/oneflow/core/kernel/reduce_local_add_kernel.cpp
@@ -11,14 +11,13 @@ void ReduceLocalAddKernel<device_type, T>::ForwardDataContent(
   bool is_out_blob_inited = std::get<2>(*other_val);
   bool is_inplace_in_bn_id = std::get<3>(*other_val);
 
-  if (is_inplace_in_bn_id) { return; }
-
   Blob* in_blob = BnInOp2Blob(this->op_attribute().input_bns().Get(in_bn_id));
   Blob* out_blob = BnInOp2Blob(this->op_attribute().output_bns().Get(out_bn_id));
   if (is_out_blob_inited) {
     KernelUtil<device_type, T>::Axpy(ctx.device_ctx, out_blob->shape().elem_cnt(), 1.0,
                                      in_blob->dptr<T>(), 1, out_blob->mut_dptr<T>(), 1);
   } else {
+    if (is_inplace_in_bn_id) { CHECK_EQ(out_blob->mut_dptr<char>(), in_blob->dptr<char>()); }
     Memcpy<DeviceType::kCPU>(ctx.device_ctx, out_blob->mut_dptr<char>(), in_blob->dptr<char>(),
                              out_blob->ByteSizeOfDataContentField());
   }

--- a/oneflow/core/kernel/reduce_scatter_kernel.cpp
+++ b/oneflow/core/kernel/reduce_scatter_kernel.cpp
@@ -6,12 +6,12 @@ template<DeviceType device_type>
 void ReduceScatterKernel<device_type>::ForwardDataContent(
     const KernelCtx& ctx, std::function<Blob*(const std::string&)> BnInOp2Blob) const {
   bool is_inplace = *static_cast<bool*>(ctx.other);
-  if (is_inplace) { return; }
   const Blob* in_blob = BnInOp2Blob("in");
   const char* src_cur_dptr = in_blob->dptr<char>();
   for (const std::string& obn : this->op_attribute().output_bns()) {
     Blob* out_blob = BnInOp2Blob(obn);
     size_t out_byte_size = out_blob->ByteSizeOfDataContentField();
+    if (is_inplace) { CHECK_EQ(out_blob->mut_dptr<char>(), src_cur_dptr); }
     Memcpy<device_type>(ctx.device_ctx, out_blob->mut_dptr<char>(), src_cur_dptr, out_byte_size);
     src_cur_dptr += out_byte_size;
   }

--- a/oneflow/core/kernel/reduce_split_kernel.cpp
+++ b/oneflow/core/kernel/reduce_split_kernel.cpp
@@ -6,12 +6,12 @@ template<DeviceType device_type>
 void ReduceSplitKernel<device_type>::ForwardDataContent(
     const KernelCtx& ctx, std::function<Blob*(const std::string&)> BnInOp2Blob) const {
   bool is_inplace = *static_cast<bool*>(ctx.other);
-  if (is_inplace) { return; }
   const Blob* in_blob = BnInOp2Blob("in");
   const char* src_cur_dptr = in_blob->dptr<char>();
   for (const std::string& obn : this->op_attribute().output_bns()) {
     Blob* out_blob = BnInOp2Blob(obn);
     size_t out_byte_size = out_blob->ByteSizeOfDataContentField();
+    if (is_inplace) { CHECK_EQ(out_blob->mut_dptr<char>(), src_cur_dptr); }
     Memcpy<device_type>(ctx.device_ctx, out_blob->mut_dptr<char>(), src_cur_dptr, out_byte_size);
     src_cur_dptr += out_byte_size;
   }


### PR DESCRIPTION
让Memcpy 检查src和dst是否相等，如果相等则不执行实际的拷贝动作；在有inplace计算的地方显式检查src和dst相同；在有inplace计算的地方也执行Memcpy，只是在Memcpy内部如果发现src和dst相同，则直接跳过；修复reduce_gather_kernel里gpu上做inplace计算的判断条件