### PR TITLE
bw must be able to reach the loss

### DIFF
--- a/oneflow/core/graph/logical_graph.cpp
+++ b/oneflow/core/graph/logical_graph.cpp
@@ -26,14 +26,12 @@ std::function<bool(const LogicalNode*)> MakePredicatorHasActualOutDiff(const Log
   };
   auto ForEachOutNode = [&](LogicalNode* node, const std::function<void(LogicalNode*)>& Handler) {
     node->ForEachNodeOnInEdge([&](LogicalNode* in_node) {
-      if (!HasBwConnection(in_node, node)) return;
-      Handler(in_node);
+      if (HasBwConnection(in_node, node)) { Handler(in_node); }
     });
   };
   auto ForEachInNode = [&](LogicalNode* node, const std::function<void(LogicalNode*)>& Handler) {
     node->ForEachNodeOnOutEdge([&](LogicalNode* out_node) {
-      if (!HasBwConnection(node, out_node)) return;
-      Handler(out_node);
+      if (HasBwConnection(node, out_node)) { Handler(out_node); }
     });
   };
   graph->TopoForEachNode(loss_nodes, ForEachInNode, ForEachOutNode,


### PR DESCRIPTION
 SigmoidLoss <--  conv --> SigmoidOp --> Print 
在如上这种网络结构的情况下，按照现有的build bw的逻辑，对于 SigmoidOp 只要它的前继节点中有含有model的节点就会去建立它的bw，但实际上不应该建立SigmoidOp的bw因为没有节点会给它传diff。
修复办法是在建立bw的逻辑中多增加一个逻辑判断，即在满足现有条件下，一个fw还必须要可达loss节点才会去建立它的bw。
