### PR TITLE
gdb breakpoints function

### DIFF
--- a/oneflow/core/common/gdb.cpp
+++ b/oneflow/core/common/gdb.cpp
@@ -1,26 +1,94 @@
 #include "oneflow/core/register/blob.h"
 #include "oneflow/core/kernel/kernel_util.h"
+#include "oneflow/core/common/util.h"
+#include "oneflow/core/common/protobuf.h"
 
 namespace oneflow {
 
 // used by gdb only
 namespace gdb {
 
+namespace {
+
+static char* MallocThenCpyD2H(const char* gpu_src, size_t size) {
+  char* cpu_dst = reinterpret_cast<char*>(malloc(size));
+  cudaMemcpy(cpu_dst, gpu_src, size, cudaMemcpyDeviceToHost);
+  return cpu_dst;
+}
+
+static void CpyH2DThenFree(char* gpu_dst, char* cpu_src, size_t size) {
+  cudaMemcpy(gpu_dst, cpu_src, size, cudaMemcpyHostToDevice);
+  free(cpu_src);
+}
+
+template<typename T>
+void LoadFromStrFile(T* buf, const std::string& file_name) {
+  std::ifstream file(file_name);
+  CHECK(file.is_open());
+  std::string line;
+  for (int64_t i = 0; std::getline(file, line); ++i) { buf[i] = oneflow_cast<T>(line); }
+  file.close();
+}
+
+}  // namespace
+
 // used by passing std::string param
 static std::string param0;
 
-static const Blob* CpuBlobCopiedFromGpuBlobPtr(uint64_t gpu_blob_ptr) {
-  Blob* gpu_blob = reinterpret_cast<Blob*>(gpu_blob_ptr);
-  char* cpu_body_ptr = reinterpret_cast<char*>(malloc(gpu_blob->ByteSizeOfDataContentField()));
-  cudaMemcpy(cpu_body_ptr, gpu_blob->dptr(), gpu_blob->ByteSizeOfDataContentField(),
-             cudaMemcpyDeviceToHost);
-  return new Blob(const_cast<Regst*>(gpu_blob->regst()), gpu_blob->blob_desc_ptr(),
-                  reinterpret_cast<char*>(gpu_blob->mut_header_ptr()), cpu_body_ptr);
+static void CudaMemCpyH2DThenFreeCpuPtr(uint64_t gpu_dst, uint64_t cpu_src, size_t size) {
+  CpyH2DThenFree(reinterpret_cast<char*>(gpu_dst), reinterpret_cast<char*>(cpu_src), size);
+}
+
+static void* MallocCpuBufThenCudaMemCpyD2H(uint64_t gpu_src, size_t size) {
+  return MallocThenCpyD2H(reinterpret_cast<char*>(gpu_src), size);
+}
+
+static void FloatBufLoadFromStrFile(uint64_t ptr, const char* file_name) {
+  LoadFromStrFile(reinterpret_cast<float*>(ptr), std::string(file_name));
+}
+
+static void Int32BufLoadFromStrFile(uint64_t ptr, const char* file_name) {
+  LoadFromStrFile(reinterpret_cast<int32_t*>(ptr), std::string(file_name));
 }
 
 static Blob* Blob4BnInOp(const std::function<Blob*(const std::string&)>* BnInOp2Blob,
                          const char* bn_in_op) {
   return (*BnInOp2Blob)(std::string(bn_in_op));
+}
+
+static HashMap<std::string, std::vector<std::string>> GetAllBlobNames(
+    const OpAttribute& op_attribute) {
+  std::list<std::string> attrs{
+      "input_bns",         "input_diff_bns", "output_bns",   "output_diff_bns", "data_tmp_bns",
+      "fw_buf_bns",        "bw_buf_bns",     "model_bns",    "model_diff_bns",  "const_model_bns",
+      "forward_model_bns", "const_buf_bns",  "pb_input_bns", "pb_output_bns",
+  };
+  HashMap<std::string, std::vector<std::string>> ret;
+  for (const auto& attr : attrs) {
+    const auto& repeated_field = GetPbRpfFromPbMessage<std::string>(op_attribute, attr);
+    if (repeated_field.empty() == false) { ret.insert({attr, PbRpf2StdVec(repeated_field)}); }
+  }
+  return ret;
+}
+
+void ForwardEnterBreakPoint(const OpAttribute& op_attribute,
+                            const std::function<Blob*(const std::string&)>& BnInOp2Blob) {
+  // do nothing
+}
+
+void ForwardLeaveBreakPoint(const OpAttribute& op_attribute,
+                            const std::function<Blob*(const std::string&)>& BnInOp2Blob) {
+  // do nothing
+}
+
+void BackwardEnterBreakPoint(const OpAttribute& op_attribute,
+                             const std::function<Blob*(const std::string&)>& BnInOp2Blob) {
+  // do nothing
+}
+
+void BackwardLeaveBreakPoint(const OpAttribute& op_attribute,
+                             const std::function<Blob*(const std::string&)>& BnInOp2Blob) {
+  // do nothing
 }
 
 }  // namespace gdb

--- a/oneflow/core/common/gdb.h
+++ b/oneflow/core/common/gdb.h
@@ -1,0 +1,24 @@
+#ifndef ONEFLOW_CORE_COMMON_GDB_H_
+#define ONEFLOW_CORE_COMMON_GDB_H_
+
+namespace oneflow {
+
+namespace gdb {
+
+void ForwardEnterBreakPoint(const OpAttribute& op_attribute,
+                            const std::function<Blob*(const std::string&)>& BnInOp2Blob);
+
+void ForwardLeaveBreakPoint(const OpAttribute& op_attribute,
+                            const std::function<Blob*(const std::string&)>& BnInOp2Blob);
+
+void BackwardEnterBreakPoint(const OpAttribute& op_attribute,
+                             const std::function<Blob*(const std::string&)>& BnInOp2Blob);
+
+void BackwardLeaveBreakPoint(const OpAttribute& op_attribute,
+                             const std::function<Blob*(const std::string&)>& BnInOp2Blob);
+
+}  // namespace gdb
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_COMMON_GDB_H_

--- a/oneflow/core/kernel/kernel.cpp
+++ b/oneflow/core/kernel/kernel.cpp
@@ -1,4 +1,5 @@
 #include "oneflow/core/kernel/kernel.h"
+#include "oneflow/core/common/gdb.h"
 
 namespace oneflow {
 
@@ -30,9 +31,13 @@ void Kernel::InitModelAndConstBuf(const KernelCtx& ctx, const ParallelContext* p
 void Kernel::Launch(const KernelCtx& ctx,
                     std::function<Blob*(const std::string&)> BnInOp2Blob) const {
   if (kernel_conf_.is_forward()) {
+    gdb::ForwardEnterBreakPoint(op_attribute(), BnInOp2Blob);
     Forward(ctx, BnInOp2Blob);
+    gdb::ForwardLeaveBreakPoint(op_attribute(), BnInOp2Blob);
   } else {
+    gdb::BackwardEnterBreakPoint(op_attribute(), BnInOp2Blob);
     Backward(ctx, BnInOp2Blob);
+    gdb::BackwardLeaveBreakPoint(op_attribute(), BnInOp2Blob);
   }
 }
 


### PR DESCRIPTION
在调试中，我们有时候希望直接在具体某个kernel forward/backward前后设置断点，从某个角度来讲，这是在调试dl_net中的op。
具体实现的办法是：我们先实现四个锚点函数：
```
void ForwardEnterBreakPoint(...);
 void ForwardLeaveBreakPoint(...);
 void BackwardEnterBreakPoint(...);
 void BackwardLeaveBreakPoint(...);
```
然后在kernel 基类函数相应的位置去调用他们。这样的话，不论基类文件怎么变动，不论新增多少子类，我们在gdb中总能很方便的定位到这些断点。
有了这些基本功能，很容易用脚本实现我们所需的op调试功能。
最后使用这些功能也极其简单：
```
(gdb) vsh gdb/of-break-at-kernel-forward-enter-for-op-name "conv"
```