### PR TITLE
fix: can not access the regst_desc_id of network regst

### DIFF
--- a/oneflow/core/actor/actor.cpp
+++ b/oneflow/core/actor/actor.cpp
@@ -431,7 +431,12 @@ int Actor::ProcessWriteableCtrlRegstMsg(const ActorMsg& msg) {
 }
 
 int Actor::ProcessReadableCtrlRegstMsg(const ActorMsg& msg) {
-  return consumed_ctrl_rs_.TryPushBackRegst(msg.regst());
+  if (consumed_ctrl_rs_.HasRegstDescId(msg.regst_desc_id())) {
+    CHECK_EQ(0, consumed_ctrl_rs_.TryPushBackRegst(msg.regst()));
+    return 0;
+  } else {
+    return -1;
+  }
 }
 
 void Actor::AsyncSendCtrlRegstMsg() {


### PR DESCRIPTION
如果一个regst msg是来自其它机器的，不能直接通过regst.regst_desc_id() 访问拿到它的regst_desc_id，而只能从msg.regst_desc_id() 。