### PR TITLE
sketch: let input-wise actor and send input-wise ctrl msg

### DIFF
--- a/oneflow/core/actor/actor.cpp
+++ b/oneflow/core/actor/actor.cpp
@@ -277,7 +277,8 @@ void Actor::ActUntilFail() {
     act_id_ += 1;
     std::function<bool(Regst*)> IsNaiveAllowedReturnToProducer = [](Regst*) { return true; };
     TryLogActEvent([&] { Act(&IsNaiveAllowedReturnToProducer); });
-    AsyncSendCtrlRegstMsg();
+    AsyncSendCtrlRegstMsgToProducer();
+    AsyncSendCtrlRegstMsgToConsumer();
 
     std::vector<int64_t> regst_desc_ids;
     naive_consumed_data_rs_.ForEachRegstDeq([&](const std::deque<Regst*>& reg_deq) {
@@ -434,9 +435,12 @@ int Actor::ProcessReadableCtrlRegstMsg(const ActorMsg& msg) {
   return consumed_ctrl_rs_.TryPushBackRegst(msg.regst());
 }
 
-void Actor::AsyncSendCtrlRegstMsg() {
+void Actor::AsyncSendCtrlRegstMsgToProducer() {
+  auto IsChosenRegstDescId = [&](int64_t regst_desc_id) {
+    return ConsumedCtrlRegstValid(regst_desc_id);
+  };
   std::vector<int64_t> regst_desc_ids;
-  consumed_ctrl_rs_.ForEachRegstDeq([&](const std::deque<Regst*>& reg_deq) {
+  consumed_ctrl_rs_.ForChosenRegstDeq(IsChosenRegstDescId, [&](const std::deque<Regst*>& reg_deq) {
     CHECK(reg_deq.empty() == false);
     int32_t returned_regst_num =
         reg_deq.front()->regst_desc()->regst_desc_type().ctrl_regst_desc().returned_regst_num();
@@ -452,21 +456,27 @@ void Actor::AsyncSendCtrlRegstMsg() {
   for (int64_t regst_desc_id : regst_desc_ids) {
     CHECK_EQ(0, consumed_ctrl_rs_.TryPopFrontRegst(regst_desc_id));
   }
+}
 
-  regst_desc_ids.clear();
-  writeable_produced_ctrl_rs_.ForEachRegstDeq([&](const std::deque<Regst*>& reg_deq) {
-    CHECK(reg_deq.empty() == false);
-    Regst* regst = reg_deq.front();
-    regst->set_act_id(act_id_);
-    auto regst_reading_cnt_it = produced_ctrl_regst2reading_cnt_.find(regst);
-    CHECK_EQ(regst_reading_cnt_it->second, 0);
-    for (int64_t consumer : regst->consumers_actor_id()) {
-      AsyncSendMsg(ActorMsg::BuildRegstMsgToConsumer(actor_id_, consumer, regst));
-      ++total_reading_ctrl_cnt_;
-      regst_reading_cnt_it->second += 1;
-    }
-    regst_desc_ids.push_back(regst->regst_desc_id());
-  });
+void Actor::AsyncSendCtrlRegstMsgToConsumer() {
+  auto IsChosenRegstDescId = [&](int64_t regst_desc_id) {
+    return ProducedCtrlRegstValid(regst_desc_id);
+  };
+  std::vector<int64_t> regst_desc_ids;
+  writeable_produced_ctrl_rs_.ForChosenRegstDeq(
+      IsChosenRegstDescId, [&](const std::deque<Regst*>& reg_deq) {
+        CHECK(reg_deq.empty() == false);
+        Regst* regst = reg_deq.front();
+        regst->set_act_id(act_id_);
+        auto regst_reading_cnt_it = produced_ctrl_regst2reading_cnt_.find(regst);
+        CHECK_EQ(regst_reading_cnt_it->second, 0);
+        for (int64_t consumer : regst->consumers_actor_id()) {
+          AsyncSendMsg(ActorMsg::BuildRegstMsgToConsumer(actor_id_, consumer, regst));
+          ++total_reading_ctrl_cnt_;
+          regst_reading_cnt_it->second += 1;
+        }
+        regst_desc_ids.push_back(regst->regst_desc_id());
+      });
   for (int64_t regst_desc_id : regst_desc_ids) {
     CHECK_EQ(0, writeable_produced_ctrl_rs_.TryPopFrontRegst(regst_desc_id));
   }

--- a/oneflow/core/actor/actor.h
+++ b/oneflow/core/actor/actor.h
@@ -92,6 +92,9 @@ class Actor {
                   // area
   }
 
+  virtual bool ConsumedCtrlRegstValid(int64_t regst_desc_id) const { return true; }
+  virtual bool ProducedCtrlRegstValid(int64_t regst_desc_id) const { return true; }
+
   // Async Do on device_ctx_
   void AsyncLaunchKernel(const KernelCtx&, std::function<Regst*(int64_t)> Regst4RegstDescId);
   void AsyncLaunchKernel(const KernelCtx&);
@@ -131,7 +134,8 @@ class Actor {
   int ProcessWriteableCtrlRegstMsg(const ActorMsg& msg);
   int ProcessReadableCtrlRegstMsg(const ActorMsg& msg);
   void AsyncSendEORDMsgForAllProducedCtrlRegstDesc();
-  void AsyncSendCtrlRegstMsg();
+  void AsyncSendCtrlRegstMsgToProducer();
+  void AsyncSendCtrlRegstMsgToConsumer();
   int TryUpdtStateAsProducedRegst(Regst* regst);
   void TakeOverNaiveConsumed(const PbMap<std::string, RegstDescIdSet>& consumed_ids);
   void AddNaiveConsumed(const RegstDescIdSet&);

--- a/oneflow/core/actor/input_wise_compute_actor.cpp
+++ b/oneflow/core/actor/input_wise_compute_actor.cpp
@@ -110,4 +110,6 @@ void InputWiseCompActor::AsyncReturnAllCustomizedReadableRegst() {
   CHECK_EQ(0, readable_regst_desc_cnt_);
 }
 
+bool InputWiseCompActor::ProducedCtrlRegstValid(int64_t regst_desc_id) const { return true; }
+
 }  // namespace oneflow

--- a/oneflow/core/actor/input_wise_compute_actor.h
+++ b/oneflow/core/actor/input_wise_compute_actor.h
@@ -22,6 +22,8 @@ class InputWiseCompActor : public CompActor {
     return GetDeviceType() == DeviceType::kGPU && Global<JobDesc>::Get()->enable_mem_sharing();
   }
 
+  bool ProducedCtrlRegstValid(int64_t regst_desc_id) const override;
+
  private:
   void Act() override;
   void NormalProcessCustomizedReadableRegstMsg(const ActorMsg&) override;


### PR DESCRIPTION
为InputWiseCompActor 发送input-wise ctrl msg 提供支撑。第一个应用场景是allreduce里add 向gather发送的控制边，可以从add 直接向gather前面的copyh2d发送控制消息，而不是让add后面的copyd2h去发送控制消息。这个PR与旧代码逻辑上等价，完整的功能在dev_use_nccl分支去完成。