### PR TITLE
TODO: remove rank_id and rank_num from parallel_ctx

### DIFF
--- a/oneflow/core/job/placement.proto
+++ b/oneflow/core/job/placement.proto
@@ -12,10 +12,10 @@ enum ParallelPolicy {
 message ParallelContext {
   required int64 parallel_id = 1;
   required int64 parallel_num = 2;
-  optional int64 parallel_set_id = 3;
-  optional int64 rank_id = 4;
-  optional int64 rank_num = 5;
-  required ParallelPolicy policy = 6;
+  required ParallelPolicy policy = 3;
+  optional int64 parallel_set_id = 4;
+  optional int64 rank_id = 5;
+  optional int64 rank_num = 6;
 }
 
 message ParallelConf {


### PR DESCRIPTION
今天和俊丞讨论一下，我们需要对parallel_ctx里的rank_num, rank_id,  以及enable memsharing 时的reduce ctx 等重构一下，现在的体系比较混乱。Reduce 相关的actor只有add actor在运行时需要rank_id这个信息。在构图阶段，reduce相关的task node需要知道自己的rank_id, rank_num，或者用于推理形状，或者用于支持内存共享。需要把rank_id, rank_num这类信息统一配置。