### PR TITLE
chore(of_submit): update of_submit to support recent proto updates

### DIFF
--- a/oneflow/of_submit
+++ b/oneflow/of_submit
@@ -46,9 +46,9 @@ def SubmitJobToOneMachine(machine, job_conf, oneflow_path, workdir):
   job_conf_file.close()
   SystemCall("scp " + job_conf_file.name + remote_file_prefix + workdir + "/oneflow.job")
   os.remove(job_conf_file.name)
-  oneflow_cmd = "\"cd " + workdir + "; nohup ./oneflow -logtostderr=0 -log_dir=./log -v=0 -logbuflevel=-1 " \
-                + "-job_conf=./oneflow.job -this_machine_name=" + machine.name  \
-                + " 1>/dev/null 2>&1 </dev/null & \""
+  oneflow_cmd = "bash -c \'\"cd " + workdir + "; nohup ./oneflow -logtostderr=0 -log_dir=./log -v=0 -logbuflevel=-1 " \
+                + "-job_conf=./oneflow.job -this_machine_id=" + str(machine.id) \
+                + " 1>/dev/null 2>&1 </dev/null & \"\'"
   SystemCall(ssh_prefix + oneflow_cmd);
 
 def SubmitJob(job_conf, oneflow_path, workdir):


### PR DESCRIPTION
Updates about of_submit:
1. keep up with the recent job_conf.proto udpates
2. add `bash -c` for those who don't use bash as the default shell (e.g. zsh).