### PR TITLE
RegstDesc4RegstDescId

### DIFF
--- a/oneflow/core/register/register_manager.cpp
+++ b/oneflow/core/register/register_manager.cpp
@@ -155,4 +155,10 @@ void RegstMgr::InitOFRecordBlobIfNeed(Blob* blob_ptr) {
   }
 }
 
+const RtRegstDesc& RegstMgr::RegstDesc4RegstDescId(int64_t regst_desc_id) const {
+  const auto& it = regst_desc_id2rt_regst_desc_.find(regst_desc_id);
+  CHECK(it != regst_desc_id2rt_regst_desc_.end());
+  return *it->second;
+}
+
 }  // namespace oneflow

--- a/oneflow/core/register/register_manager.h
+++ b/oneflow/core/register/register_manager.h
@@ -18,6 +18,7 @@ class RegstMgr final {
   ~RegstMgr() = default;
 
   void NewRegsts(const RegstDescProto& regst_desc_proto, std::function<void(Regst*)> OneRegstDone);
+  const RtRegstDesc& RegstDesc4RegstDescId(int64_t regst_desc_id) const;
 
  private:
   friend class Global<RegstMgr>;


### PR DESCRIPTION
通过regst_desc_id获得RtRegstDesc，用来解决Actor在Init阶段需要取得ConsumedRegstDesc中的time shape