### PR TITLE
refine operator repeated bn methods 

### DIFF
--- a/oneflow/core/operator/anchor_target_op.cpp
+++ b/oneflow/core/operator/anchor_target_op.cpp
@@ -31,10 +31,10 @@ void AnchorTargetOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)>
                                     const ParallelContext* parallel_ctx) const {
   const AnchorTargetOpConf& conf = op_conf().anchor_target_conf();
   const size_t num_layers = conf.anchor_generator_conf_size();
-  CHECK_EQ(RepeatedObnSize("rpn_labels"), num_layers);
-  CHECK_EQ(RepeatedObnSize("rpn_bbox_targets"), num_layers);
-  CHECK_EQ(RepeatedObnSize("rpn_bbox_inside_weights"), num_layers);
-  CHECK_EQ(RepeatedObnSize("rpn_bbox_outside_weights"), num_layers);
+  CHECK_EQ(conf.rpn_labels_size(), num_layers);
+  CHECK_EQ(conf.rpn_bbox_targets_size(), num_layers);
+  CHECK_EQ(conf.rpn_bbox_inside_weights_size(), num_layers);
+  CHECK_EQ(conf.rpn_bbox_outside_weights_size(), num_layers);
   // input: gt_boxes (N, G, 4)
   const BlobDesc* gt_boxes_bd = GetBlobDesc4BnInOp("gt_boxes");
   CHECK(gt_boxes_bd->has_dim1_valid_num_field());
@@ -52,17 +52,17 @@ void AnchorTargetOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)>
     CHECK_GT(width, 0);
     num_anchors += height * width * num_anchors_per_cell;
     // repeat output: rpn_labels (N, H, W, A) int32_t
-    BlobDesc* rpn_labels_bd = GetBlobDesc4BnInOp(RepeatedObn("rpn_labels", layer));
+    BlobDesc* rpn_labels_bd = GetBlobDesc4BnInOp(GenRepeatedBn("rpn_labels", layer));
     rpn_labels_bd->set_data_type(DataType::kInt32);
     rpn_labels_bd->mut_shape() = Shape({num_ims, height, width, num_anchors_per_cell});
     // repeat output: rpn_bbox_targets (N, H, W, 4 * A) T
-    BlobDesc* rpn_bbox_targets_bd = GetBlobDesc4BnInOp(RepeatedObn("rpn_bbox_targets", layer));
+    BlobDesc* rpn_bbox_targets_bd = GetBlobDesc4BnInOp(GenRepeatedBn("rpn_bbox_targets", layer));
     rpn_bbox_targets_bd->set_data_type(gt_boxes_bd->data_type());
     rpn_bbox_targets_bd->mut_shape() = Shape({num_ims, height, width, num_anchors_per_cell * 4});
     // repeat output: rpn_bbox_inside_weights same as rpn_bbox_targets
-    *GetBlobDesc4BnInOp(RepeatedObn("rpn_bbox_inside_weights", layer)) = *rpn_bbox_targets_bd;
+    *GetBlobDesc4BnInOp(GenRepeatedBn("rpn_bbox_inside_weights", layer)) = *rpn_bbox_targets_bd;
     // repeat output: rpn_bbox_outside_weights same as rpn_bbox_targets
-    *GetBlobDesc4BnInOp(RepeatedObn("rpn_bbox_outside_weights", layer)) = *rpn_bbox_targets_bd;
+    *GetBlobDesc4BnInOp(GenRepeatedBn("rpn_bbox_outside_weights", layer)) = *rpn_bbox_targets_bd;
   }
   // const_buf: anchors ((H1 * W1 + H2 * W2 + ...) * A, 4) T
   BlobDesc* anchors_blob_desc = GetBlobDesc4BnInOp("anchors");

--- a/oneflow/core/operator/fpn_collect_op.cpp
+++ b/oneflow/core/operator/fpn_collect_op.cpp
@@ -18,8 +18,8 @@ void FpnCollectOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> G
   const FpnCollectOpConf& conf = op_conf().fpn_collect_conf();
   const int64_t num_layers = conf.num_layers();
   const int64_t total_top_n = conf.top_n_per_piece() * parallel_ctx->parallel_num();
-  CHECK_EQ(RepeatedIbnSize("rpn_rois_fpn"), num_layers);
-  CHECK_EQ(RepeatedIbnSize("rpn_roi_probs_fpn"), num_layers);
+  CHECK_EQ(conf.rpn_rois_fpn_size(), num_layers);
+  CHECK_EQ(conf.rpn_roi_probs_fpn_size(), num_layers);
   int64_t max_num_rois_per_layer = 0;
   int64_t total_num_rois = 0;
   DataType data_type = DataType::kInvalidDataType;
@@ -27,9 +27,9 @@ void FpnCollectOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> G
   bool set_has_record_id_in_device_piece_field = false;
   FOR_RANGE(size_t, i, 0, num_layers) {
     // input: rpn_rois_fpn_i (R, 5) T
-    BlobDesc* rois_blob_desc_i = GetBlobDesc4BnInOp(RepeatedIbn("rpn_rois_fpn", i));
+    BlobDesc* rois_blob_desc_i = GetBlobDesc4BnInOp(GenRepeatedBn("rpn_rois_fpn", i));
     // input: rpn_rois_fpn_i (R) T
-    BlobDesc* roi_probs_blob_desc_i = GetBlobDesc4BnInOp(RepeatedIbn("rpn_roi_probs_fpn", i));
+    BlobDesc* roi_probs_blob_desc_i = GetBlobDesc4BnInOp(GenRepeatedBn("rpn_roi_probs_fpn", i));
     CHECK_EQ(rois_blob_desc_i->shape().At(0), roi_probs_blob_desc_i->shape().At(0));
     CHECK_EQ(rois_blob_desc_i->data_type(), roi_probs_blob_desc_i->data_type());
     CHECK_EQ(rois_blob_desc_i->has_dim0_valid_num_field(),

--- a/oneflow/core/operator/fpn_distribute_op.cpp
+++ b/oneflow/core/operator/fpn_distribute_op.cpp
@@ -18,6 +18,7 @@ const PbMessage& FpnDistributeOp::GetCustomizedConf() const {
 void FpnDistributeOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx) const {
+  const FpnDistributeOpConf& fpn_distribute_conf = op_conf().fpn_distribute_conf();
   // in: (post_nms_topn, 5)
   const BlobDesc* collected_rois_blob_desc = GetBlobDesc4BnInOp("collected_rois");
   CHECK_EQ(collected_rois_blob_desc->shape().At(1), 5);
@@ -29,15 +30,13 @@ void FpnDistributeOp::InferBlobDescs(
   }
   CHECK(collected_rois_blob_desc->has_record_id_in_device_piece_field());
   // out: rois (post_nms_topn, 5)
-  FOR_RANGE(int32_t, idx, 0, RepeatedObnSize("rois")) {
-    *GetBlobDesc4BnInOp(RepeatedObn("rois", idx)) = *collected_rois_blob_desc;
+  FOR_RANGE(int32_t, idx, 0, fpn_distribute_conf.rois_size()) {
+    *GetBlobDesc4BnInOp(GenRepeatedBn("rois", idx)) = *collected_rois_blob_desc;
   }
-  CHECK_EQ(RepeatedObnSize("rois"), op_conf().fpn_distribute_conf().roi_max_level()
-                                        - op_conf().fpn_distribute_conf().roi_min_level() + 1);
-  CHECK_GE(op_conf().fpn_distribute_conf().roi_max_level(),
-           op_conf().fpn_distribute_conf().roi_canonical_level());
-  CHECK_LE(op_conf().fpn_distribute_conf().roi_min_level(),
-           op_conf().fpn_distribute_conf().roi_canonical_level());
+  CHECK_EQ(fpn_distribute_conf.rois_size(),
+           fpn_distribute_conf.roi_max_level() - fpn_distribute_conf.roi_min_level() + 1);
+  CHECK_GE(fpn_distribute_conf.roi_max_level(), fpn_distribute_conf.roi_canonical_level());
+  CHECK_LE(fpn_distribute_conf.roi_min_level(), fpn_distribute_conf.roi_canonical_level());
   // out: roi_indices (post_nms_topn)
   BlobDesc* roi_indices_blob_desc = GetBlobDesc4BnInOp("roi_indices");
   *roi_indices_blob_desc = *collected_rois_blob_desc;

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -85,36 +85,6 @@ const std::string& Operator::SoleBbbn() const {
   CHECK_EQ(bw_buf_bns().size(), 1);
   return bw_buf_bns().Get(0);
 }
-std::string Operator::RepeatedIbn(const std::string& prefix, int32_t idx) const {
-  CHECK_LT(idx, RepeatedIbnSize(prefix));
-  return prefix + "_" + std::to_string(idx);
-}
-int32_t Operator::RepeatedIbnSize(const std::string& prefix) const {
-  int32_t ret = 0;
-  for (const auto& ibn : input_bns()) {
-    std::string idx_str = std::to_string(ret);
-    size_t idx_size = idx_str.size();
-    size_t ibn_size = ibn.size();
-    std::string prefix_substr = ibn.substr(0, ibn_size - idx_size - 1);
-    if (prefix_substr == prefix) { ret++; }
-  }
-  return ret;
-}
-std::string Operator::RepeatedObn(const std::string& prefix, int32_t idx) const {
-  CHECK_LT(idx, RepeatedObnSize(prefix));
-  return prefix + "_" + std::to_string(idx);
-}
-int32_t Operator::RepeatedObnSize(const std::string& prefix) const {
-  int32_t ret = 0;
-  for (const auto& obn : output_bns()) {
-    std::string idx_str = std::to_string(ret);
-    size_t idx_size = idx_str.size();
-    size_t obn_size = obn.size();
-    std::string prefix_substr = obn.substr(0, obn_size - idx_size - 1);
-    if (prefix_substr == prefix) { ret++; }
-  }
-  return ret;
-}
 
 void Operator::InferBlobDescsIf(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                                 const ParallelContext* parallel_ctx,

--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -91,10 +91,6 @@ class Operator {
   const std::string& SoleDtbn() const;
   const std::string& SoleFbbn() const;
   const std::string& SoleBbbn() const;
-  std::string RepeatedIbn(const std::string&, int32_t) const;
-  int32_t RepeatedIbnSize(const std::string&) const;
-  std::string RepeatedObn(const std::string&, int32_t) const;
-  int32_t RepeatedObnSize(const std::string&) const;
 
 #define DEFINE_BLOB_NAMES_GETTER(getter_name)                                           \
   const PbRpf<std::string>& getter_name() const { return op_attribute_.getter_name(); } \


### PR DESCRIPTION
- 删除RepeatedObn和RepeatedIbn方法，使用GenRepeatedBn代替
- 删除RepeatedObnSize和RepeatedIbnSize方法，改为直接读取op_conf中的配置