### PR TITLE
Refine forward header field in accuracy

### DIFF
--- a/oneflow/core/kernel/accuracy_kernel.cpp
+++ b/oneflow/core/kernel/accuracy_kernel.cpp
@@ -40,12 +40,6 @@ void AccuracyKernel<device_type, PredType, LabelType>::ForwardDim0ValidNum(
 }
 
 template<DeviceType device_type, typename PredType, typename LabelType>
-void AccuracyKernel<device_type, PredType, LabelType>::ForwardDim1ValidNum(
-    const KernelCtx& ctx, std::function<Blob*(const std::string&)> BnInOp2Blob) const {
-  UNIMPLEMENTED();
-}
-
-template<DeviceType device_type, typename PredType, typename LabelType>
 void AccuracyKernel<device_type, PredType, LabelType>::ForwardRecordIdInDevicePiece(
     const KernelCtx& ctx, std::function<Blob*(const std::string&)> BnInOp2Blob) const {
   // do nothing

--- a/oneflow/core/kernel/accuracy_kernel.h
+++ b/oneflow/core/kernel/accuracy_kernel.h
@@ -18,8 +18,6 @@ class AccuracyKernel final : public KernelIf<device_type> {
                           std::function<Blob*(const std::string&)>) const override;
   void ForwardDim0ValidNum(const KernelCtx& ctx,
                            std::function<Blob*(const std::string&)> BnInOp2Blob) const override;
-  void ForwardDim1ValidNum(const KernelCtx& ctx,
-                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override;
   void ForwardRecordIdInDevicePiece(
       const KernelCtx& ctx, std::function<Blob*(const std::string&)> BnInOp2Blob) const override;
   void SetAccuracyInstanceNumBlob(

--- a/oneflow/core/kernel/loss_kernel.h
+++ b/oneflow/core/kernel/loss_kernel.h
@@ -26,10 +26,6 @@ class LossKernel : public KernelIf<device_type> {
                      std::function<Blob*(const std::string&)> BnInOp2Blob) const override;
   void ForwardDim0ValidNum(const KernelCtx& ctx,
                            std::function<Blob*(const std::string&)> BnInOp2Blob) const override;
-  void ForwardDim1ValidNum(const KernelCtx& ctx,
-                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {
-    UNIMPLEMENTED();
-  }
   void ForwardRecordIdInDevicePiece(
       const KernelCtx& ctx, std::function<Blob*(const std::string&)> BnInOp2Blob) const override;
   void SetLossInstanceNumBlob(const KernelCtx& ctx,


### PR DESCRIPTION
Accuracy及其后续计算节点暂时不需要使用header中描述变长的field