### PR TITLE
REGISTER_OP_CREATOR add OnlyCpuSupportPredicator

### DIFF
--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -258,7 +258,9 @@ struct OnlyCpuSupportPredicator {
   extern "C" void Oneflow_OnlyCpuSupported_##OpType() {}                       \
   REGISTER_CLASS_WITH_ARGS(op_type_case, Operator, OpType, const OperatorConf&)
 
-#define REGISTER_OP_CREATOR(op_type_case, creator) \
+#define REGISTER_OP_CREATOR(op_type_case, creator)                              \
+  REGISTER_CLASS_CREATOR(op_type_case, OnlyCpuSupportPredicator,                \
+                         ([] { return new OnlyCpuSupportPredicator(false); })); \
   REGISTER_CLASS_CREATOR(op_type_case, Operator, creator, const OperatorConf&)
 
 std::shared_ptr<Operator> ConstructOp(const OperatorConf& op_conf);


### PR DESCRIPTION
normal_model_update_op 是用 REGISTER_OP_CREATOR 来注册op的creator的，所以REGISTER_OP_CREATOR 宏也需要添加 OnlyCpuSupportPredicator 支持