### PR TITLE
Fix clone op need do dim0 valid num

### DIFF
--- a/oneflow/core/operator/clone_op.cpp
+++ b/oneflow/core/operator/clone_op.cpp
@@ -47,6 +47,8 @@ void CloneOp::VirtualGenKernelConf(
       kernel_conf->set_need_do_record_id_in_device_piece(true);
       kernel_conf->set_can_naive_do_record_id_in_device_piece(true);
     }
+  } else {
+    // do nothing
   }
 }
 


### PR DESCRIPTION
后向中插入的clone节点因为没有对应的前向节点，所以Operator基类无法正确生产KernelConf中的need_do_ 和 can_naive_do_字段