### PR TITLE
fix(boxing_actor): not handle ctrl regst in NormalProcessNaiveReadabl…

### DIFF
--- a/oneflow/core/actor/boxing_actor.cpp
+++ b/oneflow/core/actor/boxing_actor.cpp
@@ -10,6 +10,7 @@ void BoxingActor::VirtualActorInit(const TaskProto& task_proto) {
 }
 
 void BoxingActor::NormalProcessNaiveReadableRegstMsg(const std::deque<Regst*>& rq) {
+  if (rq.back()->regst_desc()->regst_desc_type().has_data_regst_desc() == false) { return; }
   if (rq.back()->packed_blob()->max_col_num() > 1 && col_id_order_ == ColIdOrder::kUnCertain) {
     TrySetColIdOrder(rq.back());
   }


### PR DESCRIPTION
…eRegstMsg()

bug：如果BoxingActor所consumed的中有ctrl_regst，而ctrl_regst没有pack_blob(nullptr)，调用pack_blob()->max_col_num()就会出错