### PR TITLE
refactor: rename NormalProcessNaiveReadableRegstMsg() to NormalProces…

### DIFF
--- a/oneflow/core/actor/actor.cpp
+++ b/oneflow/core/actor/actor.cpp
@@ -193,8 +193,11 @@ int Actor::HandlerNormal(const ActorMsg& msg) {
       Regst* regst = msg.regst();
       if (naive_consumed_rs_.HasRegstDescId(regst->regst_desc_id())) {
         CHECK_EQ(0, naive_consumed_rs_.TryPushBackRegst(regst));
-        NormalProcessNaiveReadableRegstMsg(
-            naive_consumed_rs_.RegstDeq4RegstDescId(regst->regst_desc_id()));
+        const auto& rdeq = naive_consumed_rs_.RegstDeq4RegstDescId(regst->regst_desc_id());
+        CHECK(rdeq.empty() == false);
+        if (rdeq.front()->regst_desc()->regst_desc_type().has_data_regst_desc()) {
+          NormalProcessNaiveReadableDataRegstMsg(rdeq);
+        }
       } else if (TryUpdtStateAsProducedRegst(regst) == 0) {
         // do nothing
       } else {

--- a/oneflow/core/actor/actor.h
+++ b/oneflow/core/actor/actor.h
@@ -128,7 +128,7 @@ class Actor {
 
   // Process Msg
   virtual void NormalProcessCustomizedEordMsg(const ActorMsg&) {}
-  virtual void NormalProcessNaiveReadableRegstMsg(const std::deque<Regst*>&) {}
+  virtual void NormalProcessNaiveReadableDataRegstMsg(const std::deque<Regst*>&) {}
   virtual void NormalProcessCustomizedReadableRegstMsg(const ActorMsg&) { UNIMPLEMENTED(); }
   virtual bool NormalTryProcessReadableMsgFromOtherMachine(const ActorMsg&) { return false; }
   int TryUpdtStateAsProducedRegst(Regst* regst);

--- a/oneflow/core/actor/boxing_actor.cpp
+++ b/oneflow/core/actor/boxing_actor.cpp
@@ -9,8 +9,7 @@ void BoxingActor::VirtualActorInit(const TaskProto& task_proto) {
   OF_SET_MSG_HANDLER(&BoxingActor::HandlerNormal);
 }
 
-void BoxingActor::NormalProcessNaiveReadableRegstMsg(const std::deque<Regst*>& rq) {
-  if (rq.back()->regst_desc()->regst_desc_type().has_data_regst_desc() == false) { return; }
+void BoxingActor::NormalProcessNaiveReadableDataRegstMsg(const std::deque<Regst*>& rq) {
   if (rq.back()->packed_blob()->max_col_num() > 1 && col_id_order_ == ColIdOrder::kUnCertain) {
     TrySetColIdOrder(rq.back());
   }

--- a/oneflow/core/actor/boxing_actor.h
+++ b/oneflow/core/actor/boxing_actor.h
@@ -14,7 +14,7 @@ class BoxingActor final : public Actor {
   void VirtualActorInit(const TaskProto&) override;
 
  private:
-  void NormalProcessNaiveReadableRegstMsg(const std::deque<Regst*>&) override;
+  void NormalProcessNaiveReadableDataRegstMsg(const std::deque<Regst*>&) override;
   void Act() override;
   void VirtualAsyncSendNaiveProducedRegstMsgToConsumer();
   void VirtualAsyncSendNaiveConsumedRegstMsgToProducer();

--- a/oneflow/core/actor/normal_backward_compute_actor.cpp
+++ b/oneflow/core/actor/normal_backward_compute_actor.cpp
@@ -33,7 +33,7 @@ void NormalBackwardCompActor::ForEachCurCustomizedReadableRegst(
   }
 }
 
-void NormalBackwardCompActor::NormalProcessNaiveReadableRegstMsg(const std::deque<Regst*>& rq) {
+void NormalBackwardCompActor::NormalProcessNaiveReadableDataRegstMsg(const std::deque<Regst*>& rq) {
   if (rq.size() == 1 && rq.front()->regst_desc_id() == any_out_diff_regst_desc_id_) {
     AsyncReturnModelRegstUntilModelVersionIdEqual(
         GetModelVersionIdFromPieceId(rq.front()->piece_id(), actual_num_of_piece_in_batch_));

--- a/oneflow/core/actor/normal_backward_compute_actor.h
+++ b/oneflow/core/actor/normal_backward_compute_actor.h
@@ -15,7 +15,7 @@ class NormalBackwardCompActor final : public CompActor {
 
  private:
   void ForEachCurCustomizedReadableRegst(std::function<void(const Regst*)>) const override;
-  void NormalProcessNaiveReadableRegstMsg(const std::deque<Regst*>&) override;
+  void NormalProcessNaiveReadableDataRegstMsg(const std::deque<Regst*>&) override;
   void NormalProcessCustomizedReadableRegstMsg(const ActorMsg&) override;
   void Act() override;
   bool IsCustomizedReadReady() override;


### PR DESCRIPTION
…sNaiveReadableDataRegstMsg()

考虑到Derived Actor仅需要考虑data regst，所以`NormalProcessNaiveReadableRegstMsg()`改名为`NormalProcessNaiveReadableDataRegstMsg()`，以供Derived Actor override