### PR TITLE
mem shared for mdupdt first in regst and md diff add regst

### DIFF
--- a/oneflow/core/graph/graph.h
+++ b/oneflow/core/graph/graph.h
@@ -45,8 +45,8 @@ class Graph {
       const std::function<void(NodeType*)>& Handler) const;
 
   // Getters
-  const std::unordered_set<NodeType*>& source_nodes() const;
-  const std::unordered_set<NodeType*>& sink_nodes() const;
+  std::list<NodeType*> source_nodes() const;
+  std::list<NodeType*> sink_nodes() const;
   NodeType* SoleSourceNode() const;
   NodeType* SoleSinkNode() const;
   NodeType* SoleNode() const;
@@ -79,23 +79,47 @@ void Graph<NodeType, EdgeType>::ForEachNode(std::function<void(NodeType*)> NodeH
 }
 
 template<typename NodeType, typename EdgeType>
-void Graph<NodeType, EdgeType>::TopoForEachNode(std::function<void(NodeType*)> NodeHandler) const {
-  std::list<NodeType*> starts;
+std::list<NodeType*> Graph<NodeType, EdgeType>::source_nodes() const {
+  std::list<NodeType*> ret;
   ForEachNode([&](NodeType* node) {
-    if (node->in_edges().empty()) { starts.push_back(node); }
+    if (node->in_edges().empty()) { ret.push_back(node); }
   });
-  TopoForEachNode(starts, &NodeType::ForEachNodeOnInEdge, &NodeType::ForEachNodeOnOutEdge,
+  return ret;
+}
+
+template<typename NodeType, typename EdgeType>
+std::list<NodeType*> Graph<NodeType, EdgeType>::sink_nodes() const {
+  std::list<NodeType*> ret;
+  ForEachNode([&](NodeType* node) {
+    if (node->out_edges().empty()) { ret.push_back(node); }
+  });
+  return ret;
+}
+
+template<typename NodeType, typename EdgeType>
+NodeType* Graph<NodeType, EdgeType>::SoleSourceNode() const {
+  std::list<NodeType*> source_nodes_list = source_nodes();
+  CHECK_EQ(source_nodes_list.size(), 1);
+  return source_nodes_list.front();
+}
+
+template<typename NodeType, typename EdgeType>
+NodeType* Graph<NodeType, EdgeType>::SoleSinkNode() const {
+  std::list<NodeType*> sink_nodes_list = sink_nodes();
+  CHECK_EQ(sink_nodes_list.size(), 1);
+  return sink_nodes_list.front();
+}
+
+template<typename NodeType, typename EdgeType>
+void Graph<NodeType, EdgeType>::TopoForEachNode(std::function<void(NodeType*)> NodeHandler) const {
+  TopoForEachNode(source_nodes(), &NodeType::ForEachNodeOnInEdge, &NodeType::ForEachNodeOnOutEdge,
                   NodeHandler);
 }
 
 template<typename NodeType, typename EdgeType>
 void Graph<NodeType, EdgeType>::ReverseTopoForEachNode(
     std::function<void(NodeType*)> NodeHandler) const {
-  std::list<NodeType*> starts;
-  ForEachNode([&](NodeType* node) {
-    if (node->out_edges().empty()) { starts.push_back(node); }
-  });
-  TopoForEachNode(starts, &NodeType::ForEachNodeOnOutEdge, &NodeType::ForEachNodeOnInEdge,
+  TopoForEachNode(sink_nodes(), &NodeType::ForEachNodeOnOutEdge, &NodeType::ForEachNodeOnInEdge,
                   NodeHandler);
 }
 

--- a/oneflow/core/graph/normal_model_update_compute_task_node.cpp
+++ b/oneflow/core/graph/normal_model_update_compute_task_node.cpp
@@ -157,4 +157,20 @@ void NormalMdUpdtCompTaskNode::InferProducedDataRegstTimeShape() {
   });
 }
 
+void NormalMdUpdtCompTaskNode::EnableMemSharingBetweenFirstInAndProcessedMdDiffRegst() {
+  ExecNode* diff_add_node = exec_gph().SoleSourceNode();
+  RegstDesc* first_in_regst =
+      diff_add_node->RegstDesc4BnInOp(diff_add_node->op()->input_bns().Get(0));
+  RegstDesc* diff_add_out_regst = diff_add_node->RegstDesc4BnInOp(diff_add_node->op()->SoleObn());
+  CHECK_EQ(diff_add_out_regst, GetProducedRegst("processed_model_diff").get());
+  CHECK(first_in_regst->HasSameMemSize(diff_add_out_regst));
+  if (!first_in_regst->HasSetMemSharedId()) {
+    int64_t mem_shared_id = Global<IDMgr>::Get()->NewMemSharedId();
+    first_in_regst->set_enable_mem_sharing(true);
+    first_in_regst->set_mem_shared_id(mem_shared_id);
+    first_in_regst->set_mem_shared_offset(0);
+  }
+  diff_add_out_regst->CopyMemSharedInfoFrom(first_in_regst);
+}
+
 }  // namespace oneflow

--- a/oneflow/core/graph/normal_model_update_compute_task_node.h
+++ b/oneflow/core/graph/normal_model_update_compute_task_node.h
@@ -17,6 +17,7 @@ class NormalMdUpdtCompTaskNode final : public CompTaskNode {
   bool IsReadyForBuild() override;
   void BuildExecGphAndRegst() override;
   void LockRegsts() override;
+  void EnableMemSharingBetweenFirstInAndProcessedMdDiffRegst();
 
   void set_random_seed(uint32_t val) { random_seed_ = val; }
   TaskType GetTaskType() const override { return TaskType::kNormalMdUpdt; }

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -223,6 +223,14 @@ void TaskGraph::EnableMemSharingInReduceStruct() {
   });
 }
 
+void TaskGraph::EnableMemSharingAfterAllManualSetForMdUpdt() {
+  ForEachNode([&](TaskNode* node) {
+    auto* updt = dynamic_cast<NormalMdUpdtCompTaskNode*>(node);
+    if (!updt) { return; }
+    updt->EnableMemSharingBetweenFirstInAndProcessedMdDiffRegst();
+  });
+}
+
 void TaskGraph::RmUselessConsumeRelationshipBetweenFwBw() {
   for (TaskNode* task_node : ordered_task_nodes_) {
     auto bw_node = dynamic_cast<NormalBackwardCompTaskNode*>(task_node);

--- a/oneflow/core/graph/task_graph.h
+++ b/oneflow/core/graph/task_graph.h
@@ -22,6 +22,7 @@ class TaskGraph final : public Graph<TaskNode, TaskEdge> {
   void AddOrderingCtrlEdgeInSameChain();
 
   void EnableMemSharingInReduceStruct();
+  void EnableMemSharingAfterAllManualSetForMdUpdt();
 
   void AddOrderCtrlEdgeBetweenCopyAndMdUpdt();
   void RmUselessConsumeRelationshipBetweenFwBw();

--- a/oneflow/core/job/compiler.cpp
+++ b/oneflow/core/job/compiler.cpp
@@ -108,6 +108,7 @@ Plan Compiler::DoCompile() {
   task_gph->AddOrderingCtrlEdgeInSameChain();
   if (job_desc->IsTrain() && job_desc->enable_mem_sharing()) {
     task_gph->EnableMemSharingInReduceStruct();
+    task_gph->EnableMemSharingAfterAllManualSetForMdUpdt();  // must last mem shared manual set
   }
   if (job_desc->IsTrain()) { task_gph->AddOrderCtrlEdgeBetweenCopyAndMdUpdt(); }
   if (job_desc->IsTrain()) { task_gph->RmUselessConsumeRelationshipBetweenFwBw(); }

--- a/oneflow/core/kernel/normal_model_update_kernel.cpp
+++ b/oneflow/core/kernel/normal_model_update_kernel.cpp
@@ -141,7 +141,7 @@ double ConstantWarmupLearningRate(const ConstantWarmupConf& conf, double lr,
 
 double LinearWarmupLearningRate(const LinearWarmupConf& conf, double lr, int64_t cur_batch_num) {
   CHECK_GT(conf.warmup_batches(), 0);
-  CHECK_GT(conf.start_multiplier(), 0);
+  CHECK_GE(conf.start_multiplier(), 0);
   CHECK_LT(conf.start_multiplier(), 1);
   double start_multiplier = conf.start_multiplier();
   double multiplier = 1.0;

--- a/oneflow/core/register/register_desc.cpp
+++ b/oneflow/core/register/register_desc.cpp
@@ -60,6 +60,12 @@ void RegstDesc::CopyBlobDescFrom(const RegstDesc* rhs) {
   CopyBlobDescWithoutAddLbi(rhs);
 }
 
+void RegstDesc::CopyMemSharedInfoFrom(const RegstDesc* rhs) {
+  enable_mem_sharing_ = rhs->enable_mem_sharing_;
+  mem_shared_id_ = rhs->mem_shared_id_;
+  mem_shared_offset_ = rhs->mem_shared_offset_;
+}
+
 void RegstDesc::CopyBlobDescWithoutAddLbi(const RegstDesc* rhs) {
   CHECK_EQ(is_locked_, false);
   for (const auto& pair : lbi2blob_desc_) {
@@ -141,6 +147,11 @@ void RegstDesc::ToProto(RegstDescProto* ret) const {
   ret->set_enable_mem_sharing(enable_mem_sharing_);
   ret->set_mem_shared_id(mem_shared_id_);
   ret->set_mem_shared_offset(mem_shared_offset_);
+}
+
+bool RegstDesc::HasSameMemSize(const RegstDesc* rhs) {
+  return RtBlobDesc(*(packed_blob_desc_.get())).TotalByteSize()
+         == RtBlobDesc(*(rhs->packed_blob_desc_.get())).TotalByteSize();
 }
 
 bool RegstDesc::HasSameBlobDescs(const RegstDesc* rhs) {

--- a/oneflow/core/register/register_desc.h
+++ b/oneflow/core/register/register_desc.h
@@ -55,6 +55,8 @@ class RegstDesc final {
   void set_mem_shared_offset(int64_t val) { mem_shared_offset_ = val; }
   int32_t mem_shared_id() const { return mem_shared_id_; }
   void set_mem_shared_id(int32_t val) { mem_shared_id_ = val; }
+  bool HasSetMemSharedId() { return mem_shared_id_ != -1; }
+  void CopyMemSharedInfoFrom(const RegstDesc*);
 
   const std::shared_ptr<Shape>& data_regst_time_shape() const {
     CHECK(regst_desc_type_.has_data_regst_desc());
@@ -66,6 +68,7 @@ class RegstDesc final {
   }
   RegstDescTypeProto* mut_regst_desc_type() { return &regst_desc_type_; }
   const RegstDescTypeProto& regst_desc_type() const { return regst_desc_type_; }
+  bool HasSameMemSize(const RegstDesc*);
 
   // util
   int32_t MaxColNum() const { return packed_blob_desc_->max_col_num(); }


### PR DESCRIPTION
内存优化：
对于mdpudt actor，将processed_model_diff regst与第一个in regst 做内存共享，可以节省一整份内存

测试：  bert base

before:  3273M
after:    2663M