### PR TITLE
fix a mem sharing bug

### DIFF
--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -408,7 +408,7 @@ void TaskGraph::EnableMemSharingInReduceStruct() {
 void TaskGraph::EnableMemSharingAfterAllManualSetForMdUpdt() {
   ForEachNode([&](TaskNode* node) {
     auto* updt = dynamic_cast<NormalMdUpdtCompTaskNode*>(node);
-    if (!updt) { return; }
+    if (!updt || updt->exec_gph().node_num() == 0) { return; }
     updt->EnableMemSharingBetweenFirstInAndProcessedMdDiffRegst();
   });
 }


### PR DESCRIPTION
• EnableMemSharingAfterManualSetForMdUpdt()功能需要在MdUpdt节点的exec_gph中寻找source结点并CHECK source结点的个数为1。
• 带有模型且trainable == false结点对应的MdUpdt节点中的exec_gph为空，没有source结点。
这两个地方有冲突。
------------------------------------------------------
已经在trainable == false情况下测试通过。