### PR TITLE
bugfix: set ctrl_regst's return_regst_num

### DIFF
--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -349,6 +349,8 @@ void TaskGraph::AddReduceNoBwForwardNodeOverlapingCtrlEdges() {
       RegstDesc* ctrl_regst_desc = node->BuildCtrlRegstDesc(first_identity_node);
       ctrl_regst_desc->UpdtMinRegstNumIfNeed(regst_desc_num);
       ctrl_regst_desc->UpdtMaxRegstNumIfNeed(regst_desc_num);
+      ctrl_regst_desc->mut_regst_desc_type()->mutable_ctrl_regst_desc()->set_returned_regst_num(
+          regst_desc_num);
     });
   }
 }


### PR DESCRIPTION
两个不同时间形状的actor之间的ctrl regst，一定要设置returned_regst_num