### PR TITLE
Develop variance scaling

### DIFF
--- a/oneflow/core/job/init_op_conf.cpp
+++ b/oneflow/core/job/init_op_conf.cpp
@@ -251,6 +251,13 @@ void InitInitializerConf(InitializerConf* initializer, const InitializerConf::Ty
       initializer->set_allocated_int_range_conf(int_range_conf);
       break;
     }
+    case InitializerConf::kVarianceScalingConf: {
+      VarianceScalingInitializerConf* variance_scaling_conf = new VarianceScalingInitializerConf();
+      variance_scaling_conf->set_scale(param1);
+      variance_scaling_conf->set_variance_norm(static_cast<VarianceNorm>(static_cast<int>(param2)));
+      initializer->set_allocated_variance_scaling_conf(variance_scaling_conf);
+      break;
+    }
     case InitializerConf::TYPE_NOT_SET: {
       LOG(INFO) << "InitializerConf::TYPE_NOT_SET";
       break;

--- a/oneflow/core/kernel/kernel_util.cpp
+++ b/oneflow/core/kernel/kernel_util.cpp
@@ -147,10 +147,12 @@ void VarianceScalingInitializer(const VarianceScalingInitializerConf& initialize
                                 uint32_t random_seed, Blob* blob, const std::string& data_format) {
   CHECK(blob->shape().elem_cnt());
   VarianceNorm variance_norm = static_cast<VarianceNorm>(initializer_conf.variance_norm());
-  T scale = std::sqrt(static_cast<T>(initializer_conf.scale()) / GenInitialFan<T>(variance_norm, blob, data_format));
+  T scale = std::sqrt(static_cast<T>(initializer_conf.scale())
+                      / GenInitialFan<T>(variance_norm, blob, data_format));
+  // constant taken from scipy.stats.truncnorm.std(a=-2, b=2, loc=0., scale=1.)
   T stddev = scale / static_cast<T>(0.87962566103423978);
-  RngTruncatedNormal<T>(blob->shape().elem_cnt(), static_cast<T>(stddev),
-                        random_seed, blob->mut_dptr<T>());
+  RngTruncatedNormal<T>(blob->shape().elem_cnt(), static_cast<T>(stddev), random_seed,
+                        blob->mut_dptr<T>());
 }
 
 template<typename T>
@@ -533,8 +535,9 @@ KU_FLOATING_METHOD InitializeWithConf(DeviceCtx* ctx, const InitializerConf& ini
   } else if (initializer_conf.has_range_conf()) {
     RangeInitializer<T>(initializer_conf.range_conf(), random_seed, blob);
   } else if (initializer_conf.has_variance_scaling_conf()) {
-    VarianceScalingInitializer<T>(initializer_conf.variance_scaling_conf(), random_seed, blob, data_format);
-  }else {
+    VarianceScalingInitializer<T>(initializer_conf.variance_scaling_conf(), random_seed, blob,
+                                  data_format);
+  } else {
     UNIMPLEMENTED();
   }
 }

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -70,6 +70,10 @@ message IntRangeInitializerConf {
   optional int64 axis = 3 [default = -1];
 }
 
+message VarianceScalingInitializerConf {
+  optional int64 scale = 1 [default = 1];
+  optional VarianceNorm variance_norm = 2 [default = kFanIn];
+}
 
 message InitializerConf {
   oneof type {
@@ -83,6 +87,7 @@ message InitializerConf {
     MsraInitializerConf msra_conf = 8;
     RangeInitializerConf range_conf = 9;
     IntRangeInitializerConf int_range_conf = 10;
+    VarianceScalingInitializerConf variance_scaling_conf = 11;
   }
 }
 


### PR DESCRIPTION
实现是参考tensorflow的variance_scaling_initializer。其中：
`T stddev = scale / static_cast<T>(0.87962566103423978);`
参考如下：
https://github.com/tensorflow/tensorflow/blob/8f75c5aa219c4e8d8ce02d74ca8bbd59edfa2137/tensorflow/python/ops/init_ops.py#L536