### PR TITLE
fix bug of Graph::ForEachConnectedComponent

### DIFF
--- a/oneflow/core/graph/graph.h
+++ b/oneflow/core/graph/graph.h
@@ -529,7 +529,7 @@ void Graph<NodeType, EdgeType>::ForEachConnectedComponent(
     const std::function<void(NodeType*, const std::function<void(NodeType*)>&)>& ForEachConnected,
     const std::function<void(const HashSet<NodeType*>&)>& Handler) const {
   auto ForEachPotentialStart = [&](const std::function<void(NodeType*)>& Handler) {
-    BfsForEachNode(starts, ForEachConnected, Handler);
+    BfsForEachNode(starts, &NodeType::ForEachNodeOnInOutEdge, Handler);
   };
   ForEachConnectedComponent(ForEachPotentialStart, ForEachConnected, Handler);
 }


### PR DESCRIPTION
之前的ForEachConnectedComponent没有遍历完所有可能的结点，导致job_completer中TieUpChainHeadersUnReachableFromAnyVariableOps等优化没有作用。