### PR TITLE
CudaCurrentDeviceGuard

### DIFF
--- a/oneflow/core/device/cuda_util.cpp
+++ b/oneflow/core/device/cuda_util.cpp
@@ -164,6 +164,13 @@ cudaDataType_t GetCudaDataType(DataType val) {
   UNIMPLEMENTED();
 }
 
+CudaCurrentDeviceGuard::CudaCurrentDeviceGuard(int32_t dev_id) {
+  CudaCheck(cudaGetDevice(&saved_dev_id_));
+  CudaCheck(cudaSetDevice(dev_id));
+}
+
+CudaCurrentDeviceGuard::~CudaCurrentDeviceGuard() { CudaCheck(cudaSetDevice(saved_dev_id_)); }
+
 #endif  // WITH_CUDA
 
 }  // namespace oneflow

--- a/oneflow/core/device/cuda_util.h
+++ b/oneflow/core/device/cuda_util.h
@@ -85,6 +85,16 @@ struct CudaDataType;
 OF_PP_FOR_EACH_TUPLE(SPECIALIZE_CUDA_DATA_TYPE, CUDA_DATA_TYPE_SEQ);
 #undef SPECIALIZE_CUDA_DATA_TYPE
 
+class CudaCurrentDeviceGuard final {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaCurrentDeviceGuard)
+  explicit CudaCurrentDeviceGuard(int32_t dev_id);
+  ~CudaCurrentDeviceGuard();
+
+ private:
+  int32_t saved_dev_id_ = -1;
+};
+
 }  // namespace oneflow
 
 #endif  // WITH_CUDA

--- a/oneflow/core/job/nccl_comm_manager.cpp
+++ b/oneflow/core/job/nccl_comm_manager.cpp
@@ -75,8 +75,7 @@ void NcclCommMgr::NcclCommInitRank4Tasks(const std::vector<TaskProto>& tasks,
                                          ncclUniqueId nccl_unique_id) {
   NcclCheck(ncclGroupStart());
   FOR_RANGE(size_t, i, 0, tasks.size()) {
-    int32_t device_id = GetDeviceId4Task(tasks.at(i));
-    cudaSetDevice(device_id);
+    CudaCurrentDeviceGuard guard(GetDeviceId4Task(tasks.at(i)));
     NcclCheck(
         ncclCommInitRank(&((*comms)[i]), (int32_t)tasks.at(i).parallel_ctx().rank_ctx().rank_num(),
                          nccl_unique_id, (int32_t)tasks.at(i).parallel_ctx().rank_ctx().rank_id()));

--- a/oneflow/core/memory/memory_allocator.cpp
+++ b/oneflow/core/memory/memory_allocator.cpp
@@ -24,7 +24,7 @@ char* MemoryAllocator::Allocate(MemoryCase mem_case, std::size_t size) {
     }
     memset(dptr, memset_val, size);
   } else if (mem_case.has_device_cuda_mem()) {
-    CudaCheck(cudaSetDevice(mem_case.device_cuda_mem().device_id()));
+    CudaCurrentDeviceGuard guard(mem_case.device_cuda_mem().device_id());
     CudaCheck(cudaMalloc(&dptr, size));
     CudaCheck(cudaMemset(dptr, memset_val, size));
   } else {
@@ -42,7 +42,7 @@ void MemoryAllocator::Deallocate(char* dptr, MemoryCase mem_case) {
       free(dptr);
     }
   } else if (mem_case.has_device_cuda_mem()) {
-    CudaCheck(cudaSetDevice(mem_case.device_cuda_mem().device_id()));
+    CudaCurrentDeviceGuard guard(mem_case.device_cuda_mem().device_id());
     CudaCheck(cudaFree(dptr));
   } else {
     UNIMPLEMENTED();


### PR DESCRIPTION
CudaCurrentDeviceGuard: 替换直接调用cudaSetDevice,简化代码并保护调用线程cuda device不被污染