### PR TITLE
 fix overflow bug of mem_zone_unique_id

### DIFF
--- a/oneflow/core/job/inter_job_mem_sharing_util.cpp
+++ b/oneflow/core/job/inter_job_mem_sharing_util.cpp
@@ -40,11 +40,11 @@ HashSet<std::string> GetArgOpNames(const std::vector<Job>& jobs) {
   return arg_op_names;
 }
 
-HashMap<std::string, HashSet<int32_t>> GetInterfaceOpName2JobIds(const std::vector<Job>& jobs) {
+HashMap<std::string, HashSet<int64_t>> GetInterfaceOpName2JobIds(const std::vector<Job>& jobs) {
   HashSet<std::string> arg_op_names = GetArgOpNames(jobs);
-  HashMap<std::string, HashSet<int32_t>> interface_op_name2job_ids;
+  HashMap<std::string, HashSet<int64_t>> interface_op_name2job_ids;
   HashSet<std::string> unique_op_name_check;
-  FOR_RANGE(int32_t, i, 0, jobs.size()) {
+  FOR_RANGE(int64_t, i, 0, jobs.size()) {
     const auto& job = jobs.at(i);
     for (const auto& op : job.net().op()) {
       if (IsInterfaceOpConf(op)) {
@@ -60,12 +60,12 @@ HashMap<std::string, HashSet<int32_t>> GetInterfaceOpName2JobIds(const std::vect
   return interface_op_name2job_ids;
 }
 
-std::vector<HashSet<int32_t>> InitJobId2MutualExclusionJobIds(const std::vector<Job>& jobs) {
-  int32_t job_size = jobs.size();
-  std::vector<HashSet<int32_t>> job_id2mutual_exclusion_ids(job_size);
+std::vector<HashSet<int64_t>> InitJobId2MutualExclusionJobIds(const std::vector<Job>& jobs) {
+  int64_t job_size = jobs.size();
+  std::vector<HashSet<int64_t>> job_id2mutual_exclusion_ids(job_size);
   for (const auto& pair : GetInterfaceOpName2JobIds(jobs)) {
-    for (int32_t first_id : pair.second) {
-      for (int32_t second_id : pair.second) {
+    for (int64_t first_id : pair.second) {
+      for (int64_t second_id : pair.second) {
         if (first_id != second_id) { job_id2mutual_exclusion_ids[first_id].emplace(second_id); }
       }
     }
@@ -79,8 +79,8 @@ std::vector<HashSet<int32_t>> InitJobId2MutualExclusionJobIds(const std::vector<
           if (first_name != second_name) {
             CHECK(job_name2job_id->find(first_name) != job_name2job_id->end());
             CHECK(job_name2job_id->find(second_name) != job_name2job_id->end());
-            int32_t first_id = (*job_name2job_id)[first_name];
-            int32_t second_id = (*job_name2job_id)[second_name];
+            int64_t first_id = (*job_name2job_id)[first_name];
+            int64_t second_id = (*job_name2job_id)[second_name];
             job_id2mutual_exclusion_ids[first_id].emplace(second_id);
           }
         }
@@ -90,34 +90,34 @@ std::vector<HashSet<int32_t>> InitJobId2MutualExclusionJobIds(const std::vector<
   return job_id2mutual_exclusion_ids;
 }
 
-std::vector<HashSet<int32_t>> GetMutualExclusionJobGroups(const std::vector<Job>& jobs) {
-  int32_t job_size = jobs.size();
-  std::vector<HashSet<int32_t>> job_groups;
+std::vector<HashSet<int64_t>> GetMutualExclusionJobGroups(const std::vector<Job>& jobs) {
+  int64_t job_size = jobs.size();
+  std::vector<HashSet<int64_t>> job_groups;
   if (Global<const JobMemSharingStrategy>::Get()->has_mem_sharing_priority()) {
-    job_groups.push_back(HashSet<int32_t>());
-    FOR_RANGE(int32_t, i, 0, job_size) { job_groups.front().emplace(i); }
+    job_groups.push_back(HashSet<int64_t>());
+    FOR_RANGE(int64_t, i, 0, job_size) { job_groups.front().emplace(i); }
     return job_groups;
   }
 
   // default using parallelism_priority strategy
-  std::vector<HashSet<int32_t>> job_id2mutual_exclusion_ids = InitJobId2MutualExclusionJobIds(jobs);
-  std::vector<HashSet<int32_t>> job_id2enable_parallel_ids(job_size);
-  FOR_RANGE(int32_t, i, 0, job_size) {
-    FOR_RANGE(int32_t, j, 0, job_size) {
+  std::vector<HashSet<int64_t>> job_id2mutual_exclusion_ids = InitJobId2MutualExclusionJobIds(jobs);
+  std::vector<HashSet<int64_t>> job_id2enable_parallel_ids(job_size);
+  FOR_RANGE(int64_t, i, 0, job_size) {
+    FOR_RANGE(int64_t, j, 0, job_size) {
       if (job_id2mutual_exclusion_ids[i].find(j) == job_id2mutual_exclusion_ids[i].end()) {
         job_id2enable_parallel_ids[i].emplace(j);
       }
     }
   }
-  int32_t mem_share_group_num = 0;
-  std::vector<int32_t> job_id2mem_share_group_id(job_size, -1);
-  FOR_RANGE(int32_t, this_job_id, 0, job_size) {
-    HashSet<int32_t> mem_share_group_id_used;
-    for (int32_t enable_parallel_job_id : job_id2enable_parallel_ids[this_job_id]) {
-      int32_t group_id = job_id2mem_share_group_id[enable_parallel_job_id];
+  int64_t mem_share_group_num = 0;
+  std::vector<int64_t> job_id2mem_share_group_id(job_size, -1);
+  FOR_RANGE(int64_t, this_job_id, 0, job_size) {
+    HashSet<int64_t> mem_share_group_id_used;
+    for (int64_t enable_parallel_job_id : job_id2enable_parallel_ids[this_job_id]) {
+      int64_t group_id = job_id2mem_share_group_id[enable_parallel_job_id];
       if (group_id != -1) { mem_share_group_id_used.emplace(group_id); }
     }
-    FOR_RANGE(int32_t, this_group_id, 0, mem_share_group_num) {
+    FOR_RANGE(int64_t, this_group_id, 0, mem_share_group_num) {
       if (mem_share_group_id_used.find(this_group_id) == mem_share_group_id_used.end()) {
         job_id2mem_share_group_id[this_job_id] = this_group_id;
         break;
@@ -131,13 +131,13 @@ std::vector<HashSet<int32_t>> GetMutualExclusionJobGroups(const std::vector<Job>
   }
 
   job_groups.resize(mem_share_group_num);
-  FOR_RANGE(int32_t, this_job_id, 0, job_size) {
+  FOR_RANGE(int64_t, this_job_id, 0, job_size) {
     job_groups[job_id2mem_share_group_id[this_job_id]].emplace(this_job_id);
   }
   {
-    HashSet<int32_t> job_id_unique_check;
+    HashSet<int64_t> job_id_unique_check;
     for (auto& job_group : job_groups) {
-      for (int32_t job_id : job_group) { CHECK(job_id_unique_check.emplace(job_id).second); }
+      for (int64_t job_id : job_group) { CHECK(job_id_unique_check.emplace(job_id).second); }
     }
   }
   return job_groups;
@@ -158,7 +158,7 @@ int64_t GenMemZoneUniqueId(int64_t machine_id, const MemoryCase& mem_case) {
 // mem block id infomation
 struct MbiInfo {
   MbiInfo() = default;
-  MbiInfo(int64_t mem_size, int64_t mzuid, int32_t job_id) {
+  MbiInfo(int64_t mem_size, int64_t mzuid, int64_t job_id) {
     this->mem_size = mem_size;
     this->mzuid = mzuid;
     this->job_id = job_id;
@@ -168,16 +168,16 @@ struct MbiInfo {
   int64_t mem_size;
   // mzuid = memory zone unique id
   int64_t mzuid;
-  int32_t job_id;
+  int64_t job_id;
   std::vector<RegstDescProto*> regst_descs;
 };
 
 std::vector<std::unique_ptr<MbiInfo>> InitMemBlockId2MbiInfo(std::vector<Plan>* sub_plans) {
   int64_t mem_block_id_max = Global<IDMgr>::Get()->NewMemSharedId();
   std::vector<std::unique_ptr<MbiInfo>> mem_block_id2mbi_info(mem_block_id_max);
-  for (int32_t job_id = 0; job_id < sub_plans->size(); ++job_id) {
+  for (int64_t job_id = 0; job_id < sub_plans->size(); ++job_id) {
     Plan* sub_plan = &(sub_plans->at(job_id));
-    for (int32_t i = 0; i < sub_plan->task_size(); ++i) {
+    for (int64_t i = 0; i < sub_plan->task_size(); ++i) {
       TaskProto* task = sub_plan->mutable_task(i);
       for (auto& pair : *(task->mutable_produced_regst_desc())) {
         RegstDescProto* regst_desc = &pair.second;
@@ -212,14 +212,14 @@ void InterJobMemSharingUtil::BindInterfaceMemBlockId(const std::vector<Job>& job
                                                      std::vector<Plan>* sub_plans) {
   for (const auto& pair : GetInterfaceOpName2JobIds(jobs)) {
     std::vector<std::vector<TaskProto*>> same_op_name_sorted_task_protos;
-    for (int32_t job_id : pair.second) {
+    for (int64_t job_id : pair.second) {
       same_op_name_sorted_task_protos.push_back(
           SortSameOpNameTaskProtos(pair.first, &sub_plans->at(job_id)));
     }
     const auto& first_vec = same_op_name_sorted_task_protos.at(0);
     for (const auto& task_protos : same_op_name_sorted_task_protos) {
       CHECK_EQ(task_protos.size(), first_vec.size());
-      FOR_RANGE(int32_t, i, 0, first_vec.size()) {
+      FOR_RANGE(int64_t, i, 0, first_vec.size()) {
         CHECK_EQ(task_protos.at(i)->machine_id(), first_vec.at(i)->machine_id());
         CHECK_EQ(task_protos.at(i)->thrd_id(), first_vec.at(i)->thrd_id());
         RegstDescProto* first_regst_desc = PlanUtil::GetSoleProducedDataRegst(first_vec.at(i));
@@ -254,11 +254,11 @@ void InterJobMemSharingUtil::MergeMemBlockBetweenSubPlans(const std::vector<Job>
   std::vector<HashMap<int64_t, HashSet<int32_t>>> job_id2mzuid2mem_block_ids(jobs.size());
   for (int32_t mem_block_id = 0; mem_block_id < mem_block_id2mbi_info.size(); ++mem_block_id) {
     if (mem_block_id2mbi_info[mem_block_id] == nullptr) { continue; }
-    int32_t job_id = mem_block_id2mbi_info[mem_block_id]->job_id;
-    int32_t mzuid = mem_block_id2mbi_info[mem_block_id]->mzuid;
+    int64_t job_id = mem_block_id2mbi_info[mem_block_id]->job_id;
+    int64_t mzuid = mem_block_id2mbi_info[mem_block_id]->mzuid;
     job_id2mzuid2mem_block_ids[job_id][mzuid].emplace(mem_block_id);
   }
-  std::vector<HashSet<int32_t>> job_groups = GetMutualExclusionJobGroups(jobs);
+  std::vector<HashSet<int64_t>> job_groups = GetMutualExclusionJobGroups(jobs);
 
   auto MergeMemBlockIdR2L = [&](int32_t lhs, int32_t rhs) {
     CHECK_NE(lhs, rhs);
@@ -273,7 +273,7 @@ void InterJobMemSharingUtil::MergeMemBlockBetweenSubPlans(const std::vector<Job>
     mem_block_id2mbi_info[rhs].reset(nullptr);
   };
 
-  auto GetMemBlockId7MemSizeList = [&](int32_t job_id, int64_t mzuid) {
+  auto GetMemBlockId7MemSizeList = [&](int64_t job_id, int64_t mzuid) {
     std::vector<std::pair<int64_t, int64_t>> ret;
     for (int64_t mem_block_id : job_id2mzuid2mem_block_ids[job_id][mzuid]) {
       ret.push_back({mem_block_id, mem_block_id2mbi_info[mem_block_id]->mem_size});
@@ -285,9 +285,9 @@ void InterJobMemSharingUtil::MergeMemBlockBetweenSubPlans(const std::vector<Job>
     return ret;
   };
 
-  auto InitMzuid2JobIdsInJobGroup = [&](const HashSet<int32_t>& job_group) {
-    HashMap<int32_t, HashSet<int32_t>> mzuid2job_ids;
-    for (int32_t job_id : job_group) {
+  auto InitMzuid2JobIdsInJobGroup = [&](const HashSet<int64_t>& job_group) {
+    HashMap<int64_t, HashSet<int64_t>> mzuid2job_ids;
+    for (int64_t job_id : job_group) {
       for (const auto& pair : job_id2mzuid2mem_block_ids[job_id]) {
         CHECK(mzuid2job_ids[pair.first].emplace(job_id).second);
       }
@@ -295,10 +295,10 @@ void InterJobMemSharingUtil::MergeMemBlockBetweenSubPlans(const std::vector<Job>
     return mzuid2job_ids;
   };
 
-  auto FindMaxMemBlockNumJobId = [&](const HashSet<int32_t>& job_group, int32_t mzuid) {
-    int32_t max_mem_block_num_job_id = -1;
+  auto FindMaxMemBlockNumJobId = [&](const HashSet<int64_t>& job_group, int64_t mzuid) {
+    int64_t max_mem_block_num_job_id = -1;
     int32_t max_mem_block_num = 0;
-    for (int32_t job_id : job_group) {
+    for (int64_t job_id : job_group) {
       if (job_id2mzuid2mem_block_ids[job_id][mzuid].size() > max_mem_block_num) {
         max_mem_block_num_job_id = job_id;
         max_mem_block_num = job_id2mzuid2mem_block_ids[job_id][mzuid].size();
@@ -310,13 +310,13 @@ void InterJobMemSharingUtil::MergeMemBlockBetweenSubPlans(const std::vector<Job>
 
   for (const auto& job_group : job_groups) {
     if (job_group.size() <= 1) { continue; }
-    HashMap<int32_t, HashSet<int32_t>> mzuid2job_ids = InitMzuid2JobIdsInJobGroup(job_group);
+    HashMap<int64_t, HashSet<int64_t>> mzuid2job_ids = InitMzuid2JobIdsInJobGroup(job_group);
     for (const auto& pair : mzuid2job_ids) {
-      const HashSet<int32_t>& job_ids = pair.second;
+      const HashSet<int64_t>& job_ids = pair.second;
       if (job_ids.size() <= 1) { continue; }
-      int32_t mzuid = pair.first;
-      int32_t merge_job_id = FindMaxMemBlockNumJobId(job_ids, mzuid);
-      for (int32_t job_id : job_ids) {
+      int64_t mzuid = pair.first;
+      int64_t merge_job_id = FindMaxMemBlockNumJobId(job_ids, mzuid);
+      for (int64_t job_id : job_ids) {
         if (job_id == merge_job_id) { continue; }
         auto lhs_info = GetMemBlockId7MemSizeList(merge_job_id, mzuid);
         auto rhs_info = GetMemBlockId7MemSizeList(job_id, mzuid);

--- a/oneflow/core/job/oneflow.cpp
+++ b/oneflow/core/job/oneflow.cpp
@@ -553,7 +553,7 @@ void CompileMainJob(Job* main_job, const LogicalBlobId& critical_section_sink_lb
   ConnectCriticalSectionEndToReentrantLockEnd(main_plan, critical_section_sink_lbi);
 }
 
-void AddJobName2JobId(const std::string& job_name, int32_t job_id) {
+void AddJobName2JobId(const std::string& job_name, int64_t job_id) {
   CHECK(Global<JobName2JobId>::Get()->emplace(job_name, job_id).second);
 }
 


### PR DESCRIPTION
多任务合并mem_shared_id的时候，mzuid有些地方设置成了int32_t，导致了溢出bug