### PR TITLE
feat: init_worker can without scp binary and no use uuid

### DIFF
--- a/oneflow/python/deprecated/init_cluster_env.py
+++ b/oneflow/python/deprecated/init_cluster_env.py
@@ -17,24 +17,27 @@ def init_worker_and_master(config_proto):
     oneflow.deprecated.init_worker(config_proto)
     oneflow.init(config_proto)
 
-@oneflow_export('deprecated.init_worker_without_scp_binary')
-def init_worker_without_scp_binary(config_proto):
-
 
 @oneflow_export('deprecated.init_worker')
-def init_worker(config_proto):
-    if (isinstance(config_proto, config_util.ConfigProtoBuilder)):
+def init_worker(config_proto, scp_binary = True, use_uuid = True):
+    if isinstance(config_proto, config_util.ConfigProtoBuilder):
         config_proto = config_proto.config_proto
     assert isinstance(config_proto, ConfigProto)
     config_util.TryCompleteDefaultConfigProto(config_proto)
-    assert(type(config_proto) is job_set_util.ConfigProto)
+    assert type(config_proto) is job_set_util.ConfigProto
     resource = config_proto.resource
-    assert(len(resource.machine) > 0)
+    assert len(resource.machine) > 0
+    assert type(scp_binary) is bool
+    assert type(use_uuid) is bool
     oneflow_worker_path = os.getenv("ONEFLOW_WORKER_BIN")
-    global _temp_run_dir
-    _temp_run_dir = os.getenv("HOME") + "/oneflow_temp/" + str(uuid.uuid1())
-    run_dir = _temp_run_dir
     assert os.path.isfile(oneflow_worker_path)
+    global _temp_run_dir
+    if use_uuid:
+        assert scp_binary is True
+        _temp_run_dir = os.getenv("HOME") + "/oneflow_temp/" + str(uuid.uuid1())
+    else:
+        _temp_run_dir = os.getenv("HOME") + "/oneflow_temp/no_uuid"
+    run_dir = _temp_run_dir
     run_dir = os.path.abspath(os.path.expanduser(run_dir))
     config_file = NamedTemporaryFile(delete=False)
     config_file.write(pbtxt.MessageToString(config_proto))
@@ -43,32 +46,31 @@ def init_worker(config_proto):
     for machine in resource.machine:
         if machine.id == 0:
             continue
-        _SendBinaryAndConfig2Worker(machine, oneflow_worker_path, config_file.name)
+        _SendBinaryAndConfig2Worker(machine, oneflow_worker_path, config_file.name, run_dir, scp_binary)
 
     os.remove(config_file.name)
 
 
 @oneflow_export('deprecated.delete_worker')
 def delete_worker(config_proto):
-    if (isinstance(config_proto, config_util.ConfigProtoBuilder)):
+    if isinstance(config_proto, config_util.ConfigProtoBuilder):
         config_proto = config_proto.config_proto
     assert isinstance(config_proto, ConfigProto)
-    assert(type(config_proto) is job_set_util.ConfigProto)
+    assert type(config_proto) is job_set_util.ConfigProto
     global _temp_run_dir
-    assert(_temp_run_dir != "")
+    assert _temp_run_dir != ""
     for machine in config_proto.resource.machine:
         if machine.id == 0:
             continue
         _SystemCall(ssh_prefix + "\"rm -r " + _temp_run_dir + "\"")
 
-def _SendBinaryAndConfig2Worker(machine, oneflow_worker_path, config_proto_path, run_dir, need_scp):
-    global _temp_run_dir
-    run_dir = _temp_run_dir
+def _SendBinaryAndConfig2Worker(machine, oneflow_worker_path, config_proto_path, run_dir, scp_binary):
     ssh_prefix = "ssh " + getpass.getuser() + "@" + machine.addr + " "
     remote_file_prefix = " " + getpass.getuser() + "@" + machine.addr + ":"
-    assert(run_dir != "")
+    assert run_dir != ""
     _SystemCall(ssh_prefix + "\"mkdir -p " + run_dir + "\"")
-    _SystemCall("scp " + oneflow_worker_path + remote_file_prefix + run_dir + "/oneflow_worker")
+    if scp_binary:
+        _SystemCall("scp " + oneflow_worker_path + remote_file_prefix + run_dir + "/oneflow_worker")
     _SystemCall("scp " + config_proto_path + remote_file_prefix + run_dir + "/config.proto")
     oneflow_cmd = "\"cd " + run_dir + "; " \
                 + "nohup ./oneflow_worker -logtostderr=0 -log_dir=./log -v=0 -logbuflevel=-1 " \


### PR DESCRIPTION
flow.deprecated.init_worker()添加了两个参数，表示是否这次要传输oneflow_worker的binary，以及是否需要用uuid的临时目录名称，默认都是True。

为了方便多次调试，可以在第一次设置 scp_binary = True,  use_uuid = False
之后再调试时，设置scp_binary = False,  use_uuid = False
那么可以在上一次执行的目录下重新启动oneflow_worker来执行。