### PR TITLE
color plan dot VERSION-2

### DIFF
--- a/oneflow/core/job/plan_util.cpp
+++ b/oneflow/core/job/plan_util.cpp
@@ -5,6 +5,40 @@
 
 namespace oneflow {
 
+namespace {
+
+std::vector<std::vector<std::string>> GenNodeRank(const Plan& plan) {
+  std::vector<std::vector<std::string>> ret(7);
+  for (const TaskProto& task_proto : plan.task()) {
+    if (task_proto.machine_id() != 0) { continue; }
+    if (Global<IDMgr>::Get()->GetDeviceTypeFromThrdId(task_proto.thrd_id()) == DeviceType::kGPU) {
+      continue;
+    }
+    if (task_proto.exec_sequence().exec_node_size() != 1) { continue; }
+    std::string op_name =
+        task_proto.exec_sequence().exec_node(0).kernel_conf().op_attribute().op_conf().name();
+    std::string node_name = "task" + std::to_string(task_proto.task_id());
+    if (op_name.find("WaitAndSendIds") != std::string::npos) {
+      ret[0].push_back(node_name);
+    } else if (op_name.find("ReentrantLock") != std::string::npos) {
+      ret[1].push_back(node_name);
+    } else if (op_name.find("Case") != std::string::npos) {
+      ret[2].push_back(node_name);
+    } else if (op_name.find("CriticalSection") != std::string::npos) {
+      ret[3].push_back(node_name);
+    } else if (op_name.find("SinkTick") != std::string::npos) {
+      ret[4].push_back(node_name);
+    } else if (op_name.find("Esac") != std::string::npos) {
+      ret[5].push_back(node_name);
+    } else if (op_name.find("CallbackNotify") != std::string::npos) {
+      ret[6].push_back(node_name);
+    }
+  }
+  return ret;
+}
+
+}  // namespace
+
 RegstDescProto* PlanUtil::GetSoleProducedDataRegst(TaskProto* task_proto) {
   RegstDescProto* ret = nullptr;
   for (auto& pair : *task_proto->mutable_produced_regst_desc()) {
@@ -36,6 +70,8 @@ void PlanUtil::ToDotFile(const Plan& plan, const std::string& filepath) {
   }
   std::vector<std::vector<std::string>> machine_id2host_node_list(machine_num);
   HashSet<int64_t> ctrl_regst_desc_ids;
+  HashMap<int64_t, HashMap<int64_t, std::string>> task_id2consumer_regst_id2name;
+  HashMap<int64_t, std::string> task_id2op_name;
 
   auto InsertNodeDefByTaskProto = [&](const TaskProto& task_proto, const std::string& node_def) {
     if (Global<IDMgr>::Get()->GetDeviceTypeFromThrdId(task_proto.thrd_id()) == DeviceType::kGPU) {
@@ -46,54 +82,71 @@ void PlanUtil::ToDotFile(const Plan& plan, const std::string& filepath) {
     }
   };
 
-  auto GenNodeColorStr = [](const RegstDescTypeProto& type) {
-    if (type.has_data_regst_desc()) {
-      return ",color=\"black\",fillcolor=\"lightgray\"";
-    } else if (type.has_ctrl_regst_desc()) {
-      return ",color=\"gray70\",fillcolor=\"lightgray\"";
-    } else {
-      UNIMPLEMENTED();
-    }
+  auto GenEdgeColorStr = [](const RegstDescTypeProto& type) {
+    if (type.has_ctrl_regst_desc()) { return "fontcolor=\"gray65\",color=\"gray65\""; }
+    return "fontcolor=\"gray15\",color=\"gray15\"";
   };
 
-  auto GenEdgeColorStr = [&](int64_t regst_desc_id) {
-    if (ctrl_regst_desc_ids.find(regst_desc_id) != ctrl_regst_desc_ids.end()) {
-      return ",fontcolor=\"gray70\",color=\"gray70\"";
+  auto IsEsac2ReentrantLockEdge = [](const std::string& src_name, const std::string& dst_name) {
+    if (src_name.find("Esac") != std::string::npos
+        && dst_name.find("ReentrantLock") != std::string::npos) {
+      return true;
     }
-    return "";
+    return false;
+  };
+
+  auto IsEsacNode = [](const std::string& name) {
+    if (name.find("Esac") != std::string::npos) { return true; }
+    return false;
   };
 
   auto log_stream = TeePersistentLogStream::Create(filepath);
   // task node
   for (const TaskProto& task_proto : plan.task()) {
-    std::string node_def = "task" + std::to_string(task_proto.task_id()) + "[label=\"";
+    std::string node_def = "task" + std::to_string(task_proto.task_id()) + "[label=\"{{";
+    // node_def += "<task_node_" + std::to_string(task_proto.task_id()) + ">";
+    std::string op_name = "";
     for (const ExecNodeProto& exec_node : task_proto.exec_sequence().exec_node()) {
-      node_def += (exec_node.kernel_conf().op_attribute().op_conf().name() + " ");
+      op_name += (exec_node.kernel_conf().op_attribute().op_conf().name());
     }
+    task_id2op_name[task_proto.task_id()] = op_name;
+    node_def += op_name;
+    size_t index = 0;
+    for (const auto& pair : task_proto.produced_regst_desc()) {
+      std::string regst_id = std::to_string(pair.second.regst_desc_id());
+      if (index % 2 == 0) {
+        node_def += "}|{";
+      } else {
+        node_def += "|";
+      }
+      // node_def += "<regst_desc_" + regst_id + ">";
+      node_def += (pair.first + ":" + regst_id + ":" + std::to_string(pair.second.register_num()));
+      ++index;
+    }
+    node_def += "}}";
     node_def +=
         ("\",tooltip=\"" + task_type2type_str.at(task_proto.task_type()) + "  "
          + std::to_string(task_proto.task_id()) + "-" + std::to_string(task_proto.machine_id())
          + ":" + std::to_string(task_proto.thrd_id()) + ":"
          + std::to_string(task_proto.parallel_ctx().parallel_id())
-         + "\", shape=ellipse, style=\"rounded,filled\", "
-         + "colorscheme=set312, color=" + std::to_string((task_proto.job_id() % 12) + 1) + "];\n");
+         + "\", shape=record, style=\"rounded,filled\""
+         + ",colorscheme=set312, fillcolor=" + std::to_string((task_proto.job_id() % 12) + 1));
+    if (IsEsacNode(op_name)) { node_def += ",width=5,height=1.5"; }
+    node_def += "];\n";
     InsertNodeDefByTaskProto(task_proto, node_def);
-  }
-  // regst node
-  for (const TaskProto& task_proto : plan.task()) {
-    for (const auto& pair : task_proto.produced_regst_desc()) {
-      std::string node_def = "regst_desc" + std::to_string(pair.second.regst_desc_id())
-                             + "[label=\"" + std::to_string(pair.second.regst_desc_id()) + "\""
-                             + GenNodeColorStr(pair.second.regst_desc_type()) + ",tooltip=\""
-                             + "regst_num = " + std::to_string(pair.second.register_num())
-                             + "\",style=\"rounded,filled\",shape=\"box\"];\n";
-      InsertNodeDefByTaskProto(task_proto, node_def);
-      if (pair.second.regst_desc_type().has_ctrl_regst_desc()) {
-        ctrl_regst_desc_ids.insert(pair.second.regst_desc_id());
+    for (const auto& pair : task_proto.consumed_regst_desc_id()) {
+      for (int64_t regst_desc_id : pair.second.regst_desc_id()) {
+        task_id2consumer_regst_id2name[task_proto.task_id()][regst_desc_id] = pair.first;
       }
     }
   }
-  log_stream << "digraph merged_plan_graph {\n splines=\"ortho\";\n";
+
+  log_stream << "digraph merged_plan_graph {\n";
+  log_stream << "splines=\"ortho\";\n";
+  log_stream << "rankdir=TB;\n";
+  log_stream << "nodesep=1.3;\n";
+  log_stream << "ranksep=1.3;\n";
+  log_stream << "node[color=\"gray\"];\n";
   // sub graph
   for (size_t machine_id = 0; machine_id < machine_num; ++machine_id) {
     std::string machine_name = "machine_" + std::to_string(machine_id);
@@ -119,19 +172,40 @@ void PlanUtil::ToDotFile(const Plan& plan, const std::string& filepath) {
   // produce/consume edge
   for (const TaskProto& task_proto : plan.task()) {
     for (const auto& pair : task_proto.produced_regst_desc()) {
-      log_stream << "task" << std::to_string(task_proto.task_id()) << "->regst_desc"
-                 << std::to_string(pair.second.regst_desc_id()) << "[xlabel=\"" << pair.first
-                 << "\"" << GenEdgeColorStr(pair.second.regst_desc_id()) << "];\n";
-    }
-    for (const auto& pair : task_proto.consumed_regst_desc_id()) {
-      for (int64_t regst_desc_id : pair.second.regst_desc_id()) {
-        log_stream << "regst_desc" << std::to_string(regst_desc_id) << "->task"
-                   << std::to_string(task_proto.task_id()) << "[xlabel=\"" << pair.first << "\""
-                   << GenEdgeColorStr(regst_desc_id) << "];\n";
+      const RegstDescProto& regst = pair.second;
+      std::string src_node = "task" + std::to_string(task_proto.task_id());
+      // src_node += ":regst_desc_" + std::to_string(regst.regst_desc_id());
+      for (int64_t consumer_task_id : regst.consumer_task_id()) {
+        std::string dst_node = "task" + std::to_string(consumer_task_id);
+        // dst_node +=  ":task_node_" + std::to_string(consumer_task_id);
+        std::string consumer_regst_name =
+            task_id2consumer_regst_id2name[consumer_task_id][regst.regst_desc_id()];
+        std::string consumer_op_name = task_id2op_name[consumer_task_id];
+        std::string producer_regst_name = pair.first;
+        std::string producer_op_name = task_id2op_name[task_proto.task_id()];
+        std::string tooltip = producer_op_name + " : " + producer_regst_name + " -> "
+                              + consumer_op_name + " : " + consumer_regst_name;
+        if (IsEsac2ReentrantLockEdge(producer_op_name, consumer_op_name)) {
+          log_stream << dst_node << "->" << src_node
+                     << "[arrowhead=\"invempty\",fontcolor=\"red\",color=\"red\",taillabel=\""
+                     << consumer_regst_name << "\",tailtooltip=\"" << tooltip;
+        } else {
+          log_stream << src_node << "->" << dst_node << "["
+                     << GenEdgeColorStr(regst.regst_desc_type()) << ",headlabel=\""
+                     << consumer_regst_name << "\",headtooltip=\"" << tooltip;
+        }
+        log_stream << "\",tooltip=\"" << tooltip << "\",arrowsize=0.5,labeldistance=1.5,penwidth=2"
+                   << "];\n";
       }
     }
   }
-
+  // rank
+  const auto& rank_list = GenNodeRank(plan);
+  for (const auto& current_list : rank_list) {
+    log_stream << "{ rank = same;";
+    for (const auto& node_name : current_list) { log_stream << node_name << "; "; }
+    log_stream << "}\n";
+  }
   log_stream << "}\n";
 }
 


### PR DESCRIPTION
为了在Debug时可以直接从plan的dot图中清晰快速的找到各种信息，而不是需要在plan文件中不断的查找上下游关系并手绘图才能分析构图问题，本pr提供了全新的plan展示方式：
通过dot转化成svg文件，在浏览器中打开

- dot图布局更合理，可以清晰的将WaitAndSendIds、ReentrantLock、Case、SinkTick、Esac、CallBackNotify等task node按照逻辑上的上下关系排列开来。
- 图上根据task所在的位置不同从而聚合在一起，首先按照machine_id聚类，其次按照CPU、GPU device id聚类，其中在GPU上的task node的类背景为淡蓝色
- 将原图中的regst node与produce task node 合并，减少图中一半以上的结点和连边关系，加速svg生成过程，构图更加清晰
- task node显示op name、产出的regst的regst name（in produce task）、regst desc id:regstnum，同时当鼠标移动至task node上，将显示该node的task type、task id：machine id：third_id：parallel_id
- edge上在靠近消费者task node时显示regst name （in consume task），为了在复杂的图上方便查找连边，鼠标移动到regst name或者edge的细线上时，将显示 src_op_name : regst_name -> dst_op_name: regst_name
- ctrl regst消费关系使用灰色边，data regst消费关系使用黑色边
- task node的背景颜色用于区分不同的job
- 扩大node之间的间隙，使得连边排版更容易区分