### PR TITLE
delete truncated normal initializer

### DIFF
--- a/oneflow/python/model/bert/bert.py
+++ b/oneflow/python/model/bert/bert.py
@@ -67,7 +67,9 @@ class BertBackbone(object):
   def embedding_table(self): return self.embedding_table_
 
 def CreateInitializer(std):
-  return flow.truncated_normal_initializer(std)
+  initializer = op_conf_util.InitializerConf()
+  setattr(initializer.truncated_normal_conf, "std", float(std))
+  return initializer
 
 def _Gelu(in_blob):
   return flow.keras.activations.gelu(in_blob)

--- a/oneflow/python/ops/initializer_util.py
+++ b/oneflow/python/ops/initializer_util.py
@@ -48,11 +48,3 @@ def random_normal_initializer(mean=0.0, stddev=1.0):
     setattr(initializer.random_normal_conf, "std", float(stddev))
 
     return initializer
-
-
-@oneflow_export("truncated_normal_initializer")
-def truncated_normal_initializer(stddev=1.0):
-    initializer = op_conf_util.InitializerConf()
-    setattr(initializer.truncated_normal_conf, "std", float(stddev))
-
-    return initializer


### PR DESCRIPTION
truncated normal initializer在oneflow不支持mean参数，与tf不对齐，暂时不暴露这个api，用到的地方手写