### PR TITLE
bugfix: boxing task generate boxing conf; remove wrong check in op_graph

### DIFF
--- a/oneflow/core/graph/boxing_task_node.cpp
+++ b/oneflow/core/graph/boxing_task_node.cpp
@@ -157,10 +157,14 @@ void SetBoxingOpConfBySbpParallel(
     split_conf->set_axis(out_sbp.split_parallel().axis());
     CHECK(is_out_boxing_task_node ^ is_in_boxing_task_node);
     if (is_out_boxing_task_node) {
-      BalancedSplitter in_bs = Global<OpGraph>::Get()->GetBalancedSplitter(in_op.op_name(), lbi);
+      int64_t total_split_num_of_out_op =
+          Global<OpGraph>::Get()->GetSplitNum(out_op.op_name(), lbi);
+      int64_t in_parallel_num = Global<OpGraph>::Get()->GetParallelNum(in_op.op_name());
+      BalancedSplitter in_bs(total_split_num_of_out_op, in_parallel_num);
       Range in_range =
           in_bs.At(sorted_in_edges.front().parallel_id_min, sorted_in_edges.back().parallel_id_max);
-      BalancedSplitter out_bs = Global<OpGraph>::Get()->GetBalancedSplitter(out_op.op_name(), lbi);
+      int64_t out_parallel_num = Global<OpGraph>::Get()->GetParallelNum(out_op.op_name());
+      BalancedSplitter out_bs(total_split_num_of_out_op, out_parallel_num);
       for (const BoxingTaskNode::EdgeInfo& out_edge : sorted_out_edges) {
         Range out_range = out_bs.At(out_edge.parallel_id_min, out_edge.parallel_id_max);
         Range intersectant_range = FindIntersectant(in_range, out_range);

--- a/oneflow/core/graph/op_graph.h
+++ b/oneflow/core/graph/op_graph.h
@@ -121,6 +121,8 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
 
   int32_t GetModelSplitAxis(const std::string& op_name, const LogicalBlobId& lbi) const;
   BalancedSplitter GetBalancedSplitter(const std::string& op_name, const LogicalBlobId& lbi) const;
+  int64_t GetParallelNum(const std::string& op_name) const;
+  int64_t GetSplitNum(const std::string& op_name, const LogicalBlobId& lbi) const;
   const SbpParallel& GetSbpParallel(const std::string& op_name, const LogicalBlobId& lbi) const;
   DataType GetBlobDataType(const LogicalBlobId& lbi) const;
   const BlobDesc& GetLogicalBlobDesc(const LogicalBlobId& lbi) const;
@@ -160,7 +162,6 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
   std::function<bool(const OpNode*, const OpNode*)> MakePredicatorIsDataOrCtrlReachable() const;
   std::list<OpNode*> DataOrCtrlSourceNodes() const;
 
-  int64_t GetSplitNum(const std::string& op_name, const LogicalBlobId& lbi) const;
   HashMap<std::string, OpNode*> op_name2op_node_;
   HashMap<std::string, HashSet<std::string>> producer_op_name2ctrl_consumer_op_names_;
 };


### PR DESCRIPTION
修复 boxing conf生成时，out boxing conf中split part num计算错误的问题
移除op graph中错误的check