### PR TITLE
add prototype

### DIFF
--- a/oneflow/core/graph/exec_graph.cpp
+++ b/oneflow/core/graph/exec_graph.cpp
@@ -53,7 +53,13 @@ void ExecNode::ToProto(bool is_forward, const ParallelContext* parallel_ctx,
 
 void ExecNode::InferBlobDescs(const ParallelContext* parallel_ctx) {
   auto GetBlobDesc4BnInOp = GetBlobDesc4BnInOpFunc();
-  op_->InferBlobDescsIf(GetBlobDesc4BnInOp, parallel_ctx, GlobalJobDesc().RecordPieceSize(),
+  const SbpSignature* sbp_signature = nullptr;
+  {
+    const OpNode* op_node = Global<OpGraph>::Get()->OpNode4OpName(op()->op_name());
+    if (op_node != nullptr) { sbp_signature = &op_node->sbp_signature(); }
+  }
+  op_->InferBlobDescsIf(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature,
+                        GlobalJobDesc().RecordPieceSize(),
                         [this](OpContext* op_ctx) { op_ctx_.reset(op_ctx); });
   Global<OpGraph>::Get()->CheckBlobDescs(op_->op_name(), GetBlobDesc4BnInOp, parallel_ctx);
 }

--- a/oneflow/core/graph/op_graph.h
+++ b/oneflow/core/graph/op_graph.h
@@ -115,7 +115,7 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
   explicit OpGraph(const Job& job) { Init(job); }
   ~OpGraph() = default;
 
-  const OpNode* OpNode4OpName(const std::string& name) const { return op_name2op_node_.at(name); }
+  const OpNode* OpNode4OpName(const std::string& name) const;
 
   std::function<const BlobDesc&(const LogicalBlobId&)> MakeGetterBlobDesc4ModelLbi() const;
 

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -270,8 +270,8 @@ Maybe<void> JobBuildAndInferCtx::AddAndInferOp(const OperatorConf& op_conf,
   parallel_ctx.set_parallel_id(0);
   parallel_ctx.set_parallel_num(1);
   parallel_ctx.set_policy(ParallelPolicy::kDataParallel);
-  JUST(op->InferOutBlobDescsIf(GetBlobDesc4BnInOp, &parallel_ctx, job_->job_conf().piece_size(),
-                               [](OpContext*) {}));
+  JUST(op->InferOutBlobDescsIf(GetBlobDesc4BnInOp, &parallel_ctx, &sbp_sig_to_infer,
+                               job_->job_conf().piece_size(), [](OpContext*) {}));
 
   // check splitability
   JUST(CheckOpBlobSplitability(op, sbp_sig_to_infer, parallel_desc.parallel_num()));

--- a/oneflow/core/operator/constant_op.cpp
+++ b/oneflow/core/operator/constant_op.cpp
@@ -13,7 +13,8 @@ const PbMessage& ConstantOp::GetCustomizedConf() const { return op_conf().consta
 
 Maybe<void> ConstantOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size) const {
   CHECK_EQ_OR_RETURN(parallel_ctx->policy(), ParallelPolicy::kDataParallel);
   const ConstantOpConf& conf = op_conf().constant_conf();
   const DataType& data_type =

--- a/oneflow/core/operator/constant_op.h
+++ b/oneflow/core/operator/constant_op.h
@@ -14,7 +14,7 @@ class ConstantOp final : public Operator {
   void InitFromOpConf() override;
   const PbMessage& GetCustomizedConf() const override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
                              int64_t record_piece_size) const override;
   bool IsAllOutputConst() const override { return true; }
 

--- a/oneflow/core/operator/conv_data_grad_op.cpp
+++ b/oneflow/core/operator/conv_data_grad_op.cpp
@@ -24,8 +24,8 @@ void ConvDataGradOp::InitFromOpConf() {
 
 Maybe<void> ConvDataGradOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   const ConvDataGradOpConf& conf = this->op_conf().conv_data_grad_conf();
   const ConvConf& conv_conf = conf.conv_conf();
   const BlobDesc* dy = GetBlobDesc4BnInOp("dy");

--- a/oneflow/core/operator/conv_data_grad_op.h
+++ b/oneflow/core/operator/conv_data_grad_op.h
@@ -13,7 +13,8 @@ class ConvDataGradOp : public Operator {
 
   void InitFromOpConf() override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+                             int64_t record_piece_size,
                              std::function<void(OpContext*)> EnrollOpCtx) const override;
 
  private:

--- a/oneflow/core/operator/conv_filter_grad_op.cpp
+++ b/oneflow/core/operator/conv_filter_grad_op.cpp
@@ -23,8 +23,8 @@ void ConvFilterGradOp::InitFromOpConf() {
 
 Maybe<void> ConvFilterGradOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   const ConvFilterGradOpConf& conf = this->op_conf().conv_filter_grad_conf();
   const ConvConf& conv_conf = conf.conv_conf();
   const BlobDesc* dy = GetBlobDesc4BnInOp("dy");

--- a/oneflow/core/operator/conv_filter_grad_op.h
+++ b/oneflow/core/operator/conv_filter_grad_op.h
@@ -13,7 +13,8 @@ class ConvFilterGradOp : public Operator {
 
   void InitFromOpConf() override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+                             int64_t record_piece_size,
                              std::function<void(OpContext*)> EnrollOpCtx) const override;
 
  private:

--- a/oneflow/core/operator/conv_op.cpp
+++ b/oneflow/core/operator/conv_op.cpp
@@ -78,8 +78,8 @@ void ConvOp<NDims>::InitFromOpConf() {
 template<int32_t NDims>
 Maybe<void> ConvOp<NDims>::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   const std::string& data_format = GetValFromCustomizedConf<std::string>("data_format");
 
   // in
@@ -110,8 +110,8 @@ Maybe<void> ConvOp<NDims>::InferOutBlobDescs(
 template<int32_t NDims>
 Maybe<void> ConvOp<NDims>::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   const std::string& data_format = GetValFromCustomizedConf<std::string>("data_format");
 
   // in

--- a/oneflow/core/operator/conv_op.h
+++ b/oneflow/core/operator/conv_op.h
@@ -40,10 +40,12 @@ class ConvOp : public Operator {
 
   void InitFromOpConf() override;
   Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                                const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature, int64_t record_piece_size,
                                 std::function<void(OpContext*)> EnrollOpCtx) const override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+                             int64_t record_piece_size,
                              std::function<void(OpContext*)> EnrollOpCtx) const override;
 
  private:

--- a/oneflow/core/operator/decode_ofrecord_op.cpp
+++ b/oneflow/core/operator/decode_ofrecord_op.cpp
@@ -38,7 +38,8 @@ const PbMessage& DecodeOFRecordOp::GetCustomizedConf() const {
 
 Maybe<void> DecodeOFRecordOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size) const {
   int64_t dim0 = GetDim0(record_piece_size, *parallel_ctx);
   if (op_conf().decode_ofrecord_conf().has_in()) {
     BlobDesc* in_blob_desc = GetBlobDesc4BnInOp(SoleIbn());

--- a/oneflow/core/operator/decode_ofrecord_op.h
+++ b/oneflow/core/operator/decode_ofrecord_op.h
@@ -18,7 +18,7 @@ class DecodeOFRecordOp final : public Operator {
   LogicalNode* NewProperLogicalNode() const override { return new DecodeLogicalNode; }
 
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
                              int64_t record_piece_size) const override;
   void VirtualGenKernelConf(std::function<const BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                             const ParallelContext* parallel_ctx,

--- a/oneflow/core/operator/decode_random_op.cpp
+++ b/oneflow/core/operator/decode_random_op.cpp
@@ -20,7 +20,8 @@ void DecodeRandomOp::VirtualGenKernelConf(
 
 Maybe<void> DecodeRandomOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size) const {
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   const DecodeRandomOpConf& conf = op_conf().decode_random_conf();
   std::vector<int64_t> dim_vec(1 + conf.shape().dim_size());

--- a/oneflow/core/operator/decode_random_op.h
+++ b/oneflow/core/operator/decode_random_op.h
@@ -17,7 +17,7 @@ class DecodeRandomOp final : public Operator {
   LogicalNode* NewProperLogicalNode() const override { return new DecodeRandomLogicalNode; }
 
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
                              int64_t record_piece_size) const override;
 
  private:

--- a/oneflow/core/operator/input_op.cpp
+++ b/oneflow/core/operator/input_op.cpp
@@ -26,6 +26,7 @@ const PbMessage& InputOp::GetCustomizedConf() const { return op_conf().input_con
 
 Maybe<void> InputOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                                     const ParallelContext* parallel_ctx,
+                                    const SbpSignature* sbp_signature,
                                     int64_t record_piece_size) const {
   CheckOpConf(op_conf());
   return InterfaceOpUtil::InferOutBlobDesc(op_conf().input_conf().blob_conf(),

--- a/oneflow/core/operator/input_op.h
+++ b/oneflow/core/operator/input_op.h
@@ -14,7 +14,7 @@ class InputOp final : public Operator {
   void InitFromOpConf() override;
   const PbMessage& GetCustomizedConf() const override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
                              int64_t record_piece_size) const override;
 
  private:

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -59,21 +59,29 @@ const std::string& Operator::SoleTbn() const {
 
 Maybe<void> Operator::InferBlobDescsIf(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
-  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, record_piece_size, EnrollOpCtx);
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
+  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature, record_piece_size,
+                        EnrollOpCtx);
 }
 
 Maybe<void> Operator::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
-  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, record_piece_size);
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
+  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature, record_piece_size);
 }
 
 Maybe<void> Operator::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size) const {
+  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature);
+}
+
+Maybe<void> Operator::InferBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx);
 }
 
@@ -86,18 +94,20 @@ Maybe<void> Operator::InferBlobDescs(
 
 Maybe<void> Operator::InferOutBlobDescsIf(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
-  return InferOutBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, record_piece_size, EnrollOpCtx);
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
+  return InferOutBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature, record_piece_size,
+                           EnrollOpCtx);
 }
 
 Maybe<void> Operator::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   // TODO() separate InferOut and InferTmp
   // At present, only conv_op infer out blob separately
-  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, record_piece_size, EnrollOpCtx);
+  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature, record_piece_size,
+                        EnrollOpCtx);
 }
 
 Maybe<void> Operator::InferOutputBlobTimeShapeIf(

--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -98,26 +98,32 @@ class Operator {
   // Read: shape of input_blobs
   // Write: shape of output_blobs
   Maybe<void> InferBlobDescsIf(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                               const ParallelContext*, int64_t record_piece_size,
-			       const SbpSignature* sbp_signature,
+                               const ParallelContext*, const SbpSignature* sbp_signature,
+                               int64_t record_piece_size,
                                std::function<void(OpContext*)> EnrollOpCtx) const;
   virtual Maybe<void> InferBlobDescs(
       std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp, const ParallelContext*,
-      int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const;
+      const SbpSignature* sbp_signature, int64_t record_piece_size,
+      std::function<void(OpContext*)> EnrollOpCtx) const;
   virtual Maybe<void> InferBlobDescs(
       std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp, const ParallelContext*,
-      int64_t record_piece_size) const;
+      const SbpSignature* sbp_signature, int64_t record_piece_size) const;
+  virtual Maybe<void> InferBlobDescs(
+      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp, const ParallelContext*,
+      const SbpSignature* sbp_signature) const;
   virtual Maybe<void> InferBlobDescs(
       std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
       const ParallelContext*) const;
 
   Maybe<void> InferOutBlobDescsIf(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                                  const ParallelContext*, int64_t record_piece_size,
+                                  const ParallelContext*, const SbpSignature* sbp_signature,
+                                  int64_t record_piece_size,
                                   std::function<void(OpContext*)> EnrollOpCtx) const;
 
   virtual Maybe<void> InferOutBlobDescs(
       std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp, const ParallelContext*,
-      int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const;
+      const SbpSignature* sbp_signature, int64_t record_piece_size,
+      std::function<void(OpContext*)> EnrollOpCtx) const;
 
   Maybe<void> InferBatchAxisIf(
       const std::function<const BlobDesc&(const std::string&)>& LogicalBlobDesc4Ibn,

--- a/oneflow/core/operator/record_load_op.cpp
+++ b/oneflow/core/operator/record_load_op.cpp
@@ -13,7 +13,8 @@ const PbMessage& RecordLoadOp::GetCustomizedConf() const { return op_conf().reco
 
 Maybe<void> RecordLoadOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size) const {
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   CHECK_EQ_OR_RETURN(record_piece_size % parallel_ctx->parallel_num(), 0);
   out_blob_desc->mut_shape() = Shape({record_piece_size / parallel_ctx->parallel_num()});

--- a/oneflow/core/operator/record_load_op.h
+++ b/oneflow/core/operator/record_load_op.h
@@ -15,7 +15,7 @@ class RecordLoadOp final : public Operator {
   void InitFromOpConf() override;
   const PbMessage& GetCustomizedConf() const override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
                              int64_t record_piece_size) const override;
   void VirtualGenKernelConf(std::function<const BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                             const ParallelContext*, KernelConf*) const override;

--- a/oneflow/core/operator/reduce_concat_op.cpp
+++ b/oneflow/core/operator/reduce_concat_op.cpp
@@ -29,8 +29,8 @@ LogicalNode* ReduceConcatOp::NewProperLogicalNode() const {
 
 Maybe<void> ReduceConcatOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   const BlobDesc* first_in_blob = GetBlobDesc4BnInOp(input_bns().Get(0));
   const DataType data_type = first_in_blob->data_type();
   for (int32_t i = 1; i < op_conf().reduce_concat_conf().in_num(); ++i) {

--- a/oneflow/core/operator/reduce_concat_op.h
+++ b/oneflow/core/operator/reduce_concat_op.h
@@ -17,7 +17,8 @@ class ReduceConcatOp final : public Operator {
 
   LogicalNode* NewProperLogicalNode() const override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+                             int64_t record_piece_size,
                              std::function<void(OpContext*)> EnrollOpCtx) const override;
 
  private:

--- a/oneflow/core/operator/reshape_op.cpp
+++ b/oneflow/core/operator/reshape_op.cpp
@@ -14,8 +14,7 @@ const PbMessage& ReshapeOp::GetCustomizedConf() const { return op_conf().reshape
 
 Maybe<void> ReshapeOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    const SbpSignature* sbp_signature) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   *out_blob_desc = *in_blob_desc;

--- a/oneflow/core/operator/reshape_op.h
+++ b/oneflow/core/operator/reshape_op.h
@@ -15,7 +15,8 @@ class ReshapeOp final : public Operator {
   const PbMessage& GetCustomizedConf() const override;
 
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+                             const ParallelContext* parallel_ctx,
+                             const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/softmax_grad_op.cpp
+++ b/oneflow/core/operator/softmax_grad_op.cpp
@@ -27,8 +27,8 @@ const PbMessage& SoftmaxGradOp::GetCustomizedConf() const { return op_conf().sof
 
 Maybe<void> SoftmaxGradOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   // dy
   const BlobDesc* dy_blob_desc = GetBlobDesc4BnInOp("dy");
   // dx

--- a/oneflow/core/operator/softmax_grad_op.h
+++ b/oneflow/core/operator/softmax_grad_op.h
@@ -23,7 +23,8 @@ class SoftmaxGradOp final : public Operator {
   const PbMessage& GetCustomizedConf() const override;
 
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+                             int64_t record_piece_size,
                              std::function<void(OpContext*)> EnrollOpCtx) const override;
 
  private:

--- a/oneflow/core/operator/softmax_op.cpp
+++ b/oneflow/core/operator/softmax_op.cpp
@@ -23,8 +23,8 @@ const PbMessage& SoftmaxOp::GetCustomizedConf() const { return op_conf().softmax
 
 Maybe<void> SoftmaxOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   // in
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   // out

--- a/oneflow/core/operator/softmax_op.h
+++ b/oneflow/core/operator/softmax_op.h
@@ -23,7 +23,8 @@ class SoftmaxOp final : public Operator {
   const PbMessage& GetCustomizedConf() const override;
 
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+                             int64_t record_piece_size,
                              std::function<void(OpContext*)> EnrollOpCtx) const override;
 
  private:

--- a/oneflow/core/operator/sparse_cross_entropy_grad_op.cpp
+++ b/oneflow/core/operator/sparse_cross_entropy_grad_op.cpp
@@ -17,8 +17,8 @@ const PbMessage& SparseCrossEntropyGradOp::GetCustomizedConf() const {
 
 Maybe<void> SparseCrossEntropyGradOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   *GetBlobDesc4BnInOp("prediction_diff") = *GetBlobDesc4BnInOp("prediction");
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/sparse_cross_entropy_grad_op.h
+++ b/oneflow/core/operator/sparse_cross_entropy_grad_op.h
@@ -14,7 +14,8 @@ class SparseCrossEntropyGradOp final : public Operator {
   void InitFromOpConf() override;
   const PbMessage& GetCustomizedConf() const override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+                             int64_t record_piece_size,
                              std::function<void(OpContext*)> EnrollOpCtx) const override;
 
  private:

--- a/oneflow/core/operator/sparse_cross_entropy_op.cpp
+++ b/oneflow/core/operator/sparse_cross_entropy_op.cpp
@@ -16,8 +16,8 @@ const PbMessage& SparseCrossEntropyOp::GetCustomizedConf() const {
 
 Maybe<void> SparseCrossEntropyOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, int64_t record_piece_size,
-    std::function<void(OpContext*)> EnrollOpCtx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+    int64_t record_piece_size, std::function<void(OpContext*)> EnrollOpCtx) const {
   const BlobDesc* pred_blob_desc = GetBlobDesc4BnInOp("prediction");
   const BlobDesc* label_blob_desc = GetBlobDesc4BnInOp("label");
   CHECK_OR_RETURN(IsIntegralDataType(label_blob_desc->data_type()));

--- a/oneflow/core/operator/sparse_cross_entropy_op.h
+++ b/oneflow/core/operator/sparse_cross_entropy_op.h
@@ -14,7 +14,8 @@ class SparseCrossEntropyOp final : public Operator {
   void InitFromOpConf() override;
   const PbMessage& GetCustomizedConf() const override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx, int64_t record_piece_size,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature,
+                             int64_t record_piece_size,
                              std::function<void(OpContext*)> EnrollOpCtx) const override;
 
  private:

--- a/oneflow/python/framework/config_util.py
+++ b/oneflow/python/framework/config_util.py
@@ -215,10 +215,10 @@ def set_max_data_id_length(value):
     _SetJobConfAttr(lambda x:x, 'max_data_id_length', value)
     return oneflow.config
 
-@oneflow_export('config.default_initialize_conf')
-def set_default_initialize_conf(value):
+@oneflow_export('config.default_initializer_conf')
+def set_default_initializer_conf(value):
     assert type(value) is dict
-    pb_msg = _GetJobConfAttr(lambda x:x, 'default_initialize_conf')
+    pb_msg = _GetJobConfAttr(lambda x:x, 'default_initializer_conf')
     pb_util.PythonDict2PbMessage(value, pb_msg)
     return oneflow.config
 


### PR DESCRIPTION
很多op需要在infer_blob_desc时使用sbp_signature的信息，比如reshape。
这个信息我们总能提供
1）在job_build_and_infer_ctx和op_graph里，都是先有sbp_signature，再有blob_desc
2）在task_graph里的时候，全局的op_graph上有sbp_signature
3）boxing/copy_hd不需要sbp概念，给他们的指针为空