### PR TITLE
delete GlobalJobDesc() in operator/

### DIFF
--- a/oneflow/core/graph/boxing_task_node.cpp
+++ b/oneflow/core/graph/boxing_task_node.cpp
@@ -278,7 +278,7 @@ std::shared_ptr<Operator> BoxingTaskNode::NewBoxingOp(
   boxing_conf->set_in_num(sorted_in_edges.size());
   boxing_conf->set_out_num(sorted_out_edges.size());
   (this->*method)(lbi, sorted_in_edges, in_logical, sorted_out_edges, out_logical, boxing_conf);
-  return ConstructOp(op_conf);
+  return ConstructOp(op_conf, &GlobalJobDesc());
 }
 
 void BoxingTaskNode::InferProducedDataRegstTimeShape() { NaiveInferProducedDataRegstTimeShape(); }

--- a/oneflow/core/graph/copy_task_node.cpp
+++ b/oneflow/core/graph/copy_task_node.cpp
@@ -35,7 +35,7 @@ void CopyTaskNode::BuildExecGphAndRegst() {
   auto in_regst = GetSoleConsumedRegst("copy_in");
   out_regst->CopyBlobDescFrom(in_regst.get());
   ExecNode* node = mut_exec_gph().NewNode();
-  node->mut_op() = ConstructOp(NewCopyOpConf());
+  node->mut_op() = ConstructOp(NewCopyOpConf(), &GlobalJobDesc());
   node->BindBnWithRegst(node->op()->SoleIbn(), in_regst);
   node->BindBnWithRegst(node->op()->SoleObn(), out_regst);
 }

--- a/oneflow/core/graph/op_graph.h
+++ b/oneflow/core/graph/op_graph.h
@@ -17,7 +17,7 @@ class OpNode final : public Node<OpNode, OpEdge> {
   OF_DISALLOW_COPY_AND_MOVE(OpNode);
   explicit OpNode(const ParallelDesc& parallel_desc, const OperatorConf& op_conf)
       : parallel_desc_(parallel_desc),
-        op_(ConstructOp(op_conf, parallel_desc.device_type())),
+        op_(ConstructOp(op_conf, parallel_desc.device_type(), &GlobalJobDesc())),
         ibns_(op_->input_bns().begin(), op_->input_bns().end()) {}
   ~OpNode() = default;
 

--- a/oneflow/core/graph/reduce_add_compute_task_node.cpp
+++ b/oneflow/core/graph/reduce_add_compute_task_node.cpp
@@ -29,7 +29,7 @@ void ReduceAddCompTaskNode::BuildExecGphAndRegst() {
   reduce_add_op_conf.set_name(this->logical_node()->SoleOp()->op_name());
   reduce_add_op_conf.set_device_type(this->device_type());
   reduce_add_op_conf.mutable_reduce_add_conf()->set_in_num(in_data_edges_size());
-  std::shared_ptr<Operator> reduce_add_op = ConstructOp(reduce_add_op_conf);
+  std::shared_ptr<Operator> reduce_add_op = ConstructOp(reduce_add_op_conf, &GlobalJobDesc());
   node->mut_op() = reduce_add_op;
   for (const std::string& input_bn : reduce_add_op->input_bns()) {
     std::shared_ptr<RegstDesc> in_regst = GetSoleConsumedRegst(input_bn);

--- a/oneflow/core/graph/reduce_gather_compute_task_node.cpp
+++ b/oneflow/core/graph/reduce_gather_compute_task_node.cpp
@@ -29,7 +29,7 @@ void ReduceGatherCompTaskNode::BuildExecGphAndRegst() {
   reduce_gather_op_conf.set_name(this->logical_node()->SoleOp()->op_name());
   reduce_gather_op_conf.set_device_type(this->device_type());
   reduce_gather_op_conf.mutable_reduce_gather_conf()->set_in_num(in_data_edges_size());
-  std::shared_ptr<Operator> reduce_gather_op = ConstructOp(reduce_gather_op_conf);
+  std::shared_ptr<Operator> reduce_gather_op = ConstructOp(reduce_gather_op_conf, &GlobalJobDesc());
   node->mut_op() = reduce_gather_op;
 
   FOR_RANGE(size_t, i, 0, reduce_gather_op->input_bns().size()) {

--- a/oneflow/core/graph/reduce_scatter_compute_task_node.cpp
+++ b/oneflow/core/graph/reduce_scatter_compute_task_node.cpp
@@ -30,7 +30,8 @@ void ReduceScatterCompTaskNode::BuildExecGphAndRegst() {
   reduce_scatter_op_conf.set_device_type(this->device_type());
   reduce_scatter_op_conf.mutable_reduce_scatter_conf()->set_out_num(out_data_edges_size());
 
-  std::shared_ptr<Operator> reduce_scatter_op = ConstructOp(reduce_scatter_op_conf);
+  std::shared_ptr<Operator> reduce_scatter_op =
+      ConstructOp(reduce_scatter_op_conf, &GlobalJobDesc());
   node->mut_op() = reduce_scatter_op;
   node->BindBnWithRegst(reduce_scatter_op->SoleIbn(), GetSoleConsumedRegst("in"));
 

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -162,7 +162,7 @@ Maybe<void> JobBuildAndInferCtx::AddAndInferOp(const OperatorConf& op_conf,
 
   JUST(AddOpNameParallelConf2Placement(op_name, parallel_conf));
 
-  op_name2op_.emplace(op_name, ConstructOp(op_conf));
+  op_name2op_.emplace(op_name, ConstructOp(op_conf, &GlobalJobDesc()));
   Operator* op = op_name2op_.at(op_name).get();
 
   SbpSignature sbp_sig_conf;

--- a/oneflow/core/job/job_builder.cpp
+++ b/oneflow/core/job/job_builder.cpp
@@ -104,7 +104,7 @@ void JobBuilder::AddOrMutOpsOnlyOnce(const ParallelConf& parallel_conf,
 void JobBuilder::ForEachOperator(const std::function<void(const Operator&)>& Handler) const {
   for (const auto& pair : op_name2op_conf_) {
     DeviceType device_type = ParallelDesc(*op_name2parallel_conf_.at(pair.first)).device_type();
-    std::shared_ptr<Operator> op = ConstructOp(*pair.second, device_type);
+    std::shared_ptr<Operator> op = ConstructOp(*pair.second, device_type, &GlobalJobDesc());
     Handler(*op);
   }
 }

--- a/oneflow/core/operator/adam_model_update_op.cpp
+++ b/oneflow/core/operator/adam_model_update_op.cpp
@@ -22,7 +22,7 @@ Maybe<void> AdamModelUpdateOp::MdUpdtVirtualInferBlobDescs(
     const ParallelContext* parallel_ctx) const {
   const auto& adam_conf = op_conf().adam_model_update_conf().user_conf().adam_conf();
   const BlobDesc* model_blob_desc = GetBlobDesc4BnInOp("model");
-  CHECK_EQ_OR_RETURN(model_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  CHECK_EQ_OR_RETURN(model_blob_desc->data_type(), job_desc().DefaultDataType());
   CHECK_EQ_OR_RETURN(model_blob_desc->has_data_id_field(), false);
   CHECK_OR_RETURN(*GetBlobDesc4BnInOp("m") == *model_blob_desc);
   CHECK_OR_RETURN(*GetBlobDesc4BnInOp("v") == *model_blob_desc);

--- a/oneflow/core/operator/basic_rnn_op.cpp
+++ b/oneflow/core/operator/basic_rnn_op.cpp
@@ -22,7 +22,7 @@ Maybe<void> BasicRnnOp::VirtualInferBlobDescs(
   // int64_t embedding_size = in_blob_desc->shape().Count(1);
   int64_t data_num = in_blob_desc->shape().At(0);
   *GetBlobDesc4BnInOp("plus_op_out") =
-      BlobDesc(Shape({data_num, hidden_size}), GlobalJobDesc().DefaultDataType(), false, true,
+      BlobDesc(Shape({data_num, hidden_size}), job_desc().DefaultDataType(), false, true,
                in_blob_desc->max_col_num());
   // *GetBlobDesc4BnInOp("i2h_weight") = BlobDesc(Shape({hidden_size, embedding_size}));
   // *GetBlobDesc4BnInOp("h2h_weight") = BlobDesc(Shape({hidden_size, hidden_size}));

--- a/oneflow/core/operator/constant_op.cpp
+++ b/oneflow/core/operator/constant_op.cpp
@@ -18,7 +18,7 @@ Maybe<void> ConstantOp::InferBlobDescs(
   CHECK_EQ_OR_RETURN(parallel_ctx->policy(), ParallelPolicy::kDataParallel);
   const ConstantOpConf& conf = op_conf().constant_conf();
   const DataType& data_type =
-      conf.has_data_type() ? conf.data_type() : GlobalJobDesc().DefaultDataType();
+      conf.has_data_type() ? conf.data_type() : job_desc().DefaultDataType();
   std::vector<int64_t> dim_vec;
   if (conf.use_device_piece_size_as_dim0()) {
     CHECK_EQ_OR_RETURN(record_piece_size % parallel_ctx->parallel_num(), 0);

--- a/oneflow/core/operator/conv_op.cpp
+++ b/oneflow/core/operator/conv_op.cpp
@@ -85,7 +85,7 @@ Maybe<void> ConvOp<NDims>::InferOutBlobDescs(
   // in
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   CHECK_EQ_OR_RETURN(in_blob_desc->shape().NumAxes(), NDims + 2);
-  // CHECK_EQ(in_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  // CHECK_EQ(in_blob_desc->data_type(), job_desc().DefaultDataType());
 
   // out
   int64_t data_num = in_blob_desc->shape().At(0);
@@ -117,7 +117,7 @@ Maybe<void> ConvOp<NDims>::InferBlobDescs(
   // in
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   CHECK_EQ_OR_RETURN(in_blob_desc->shape().NumAxes(), NDims + 2);
-  // CHECK_EQ(in_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  // CHECK_EQ(in_blob_desc->data_type(), job_desc().DefaultDataType());
 
   // out
   int64_t data_num = in_blob_desc->shape().At(0);

--- a/oneflow/core/operator/decode_ofrecord_op.cpp
+++ b/oneflow/core/operator/decode_ofrecord_op.cpp
@@ -54,7 +54,7 @@ Maybe<void> DecodeOFRecordOp::InferBlobDescs(
     FOR_RANGE(size_t, j, 1, dim_vec.size()) { dim_vec[j] = blob_conf.shape().dim(j - 1); }
     out_blob_desc->mut_shape() = Shape(dim_vec);
     out_blob_desc->set_data_type(blob_conf.data_type());
-    out_blob_desc->set_has_data_id_field(GlobalJobDesc().SizeOfOneDataId() > 0);
+    out_blob_desc->set_has_data_id_field(job_desc().SizeOfOneDataId() > 0);
     out_blob_desc->set_has_col_num_field(blob_conf.max_sequence_size() > 1);
     out_blob_desc->set_max_col_num(blob_conf.max_sequence_size());
     const auto& encode = blob_conf.encode_case();

--- a/oneflow/core/operator/decode_random_op.cpp
+++ b/oneflow/core/operator/decode_random_op.cpp
@@ -30,7 +30,7 @@ Maybe<void> DecodeRandomOp::InferBlobDescs(
   FOR_RANGE(size_t, j, 1, dim_vec.size()) { dim_vec[j] = conf.shape().dim(j - 1); }
   out_blob_desc->mut_shape() = Shape(dim_vec);
   out_blob_desc->set_data_type(conf.data_type());
-  out_blob_desc->set_has_data_id_field(GlobalJobDesc().SizeOfOneDataId() > 0);
+  out_blob_desc->set_has_data_id_field(job_desc().SizeOfOneDataId() > 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/operator/dot_op.cpp
+++ b/oneflow/core/operator/dot_op.cpp
@@ -19,7 +19,7 @@ Maybe<void> DotOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> G
                                   const ParallelContext* parallel_ctx) const {
   BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   BlobDesc* weight_blob_desc = GetBlobDesc4BnInOp("weight");
-  CHECK_EQ_OR_RETURN(in_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  CHECK_EQ_OR_RETURN(in_blob_desc->data_type(), job_desc().DefaultDataType());
   CHECK_EQ_OR_RETURN(in_blob_desc->shape().At(0), weight_blob_desc->shape().At(0));
   CHECK_EQ_OR_RETURN(in_blob_desc->shape().Count(1), weight_blob_desc->shape().Count(1));
   // tmp & tmp storage

--- a/oneflow/core/operator/dropout_op.cpp
+++ b/oneflow/core/operator/dropout_op.cpp
@@ -10,7 +10,7 @@ void DropoutOp::InitFromOpConf() {
   CHECK_LT(dropout_rate, 1);
   EnrollInputBn("in");
   EnrollOutputBn("out");
-  if (GlobalJobDesc().IsTrain()) { EnrollOutputBn("random_mask"); }
+  if (job_desc().IsTrain()) { EnrollOutputBn("random_mask"); }
 }
 
 const PbMessage& DropoutOp::GetCustomizedConf() const { return op_conf().dropout_conf(); }
@@ -21,7 +21,7 @@ Maybe<void> DropoutOp::InferBlobDescs(
   // CHECK_EQ(op_conf().dropout_conf().noise_shape().dim_size(),
   //          GetBlobDesc4BnInOp("in")->shape().NumAxes());
   *GetBlobDesc4BnInOp("out") = *GetBlobDesc4BnInOp("in");
-  if (GlobalJobDesc().IsTrain()) {
+  if (job_desc().IsTrain()) {
     *GetBlobDesc4BnInOp("random_mask") = *GetBlobDesc4BnInOp("in");
     GetBlobDesc4BnInOp("random_mask")->set_data_type(DataType::kFloat);
   }

--- a/oneflow/core/operator/embedding_lookup_accumulate_op.cpp
+++ b/oneflow/core/operator/embedding_lookup_accumulate_op.cpp
@@ -15,7 +15,7 @@ Maybe<void> EmbeddingLookupAccumulateOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx) const {
   // use vars
-  const int64_t num_of_piece_in_batch = GlobalJobDesc().NumOfPiecesInBatch();
+  const int64_t num_of_piece_in_batch = job_desc().NumOfPiecesInBatch();
   const BlobDesc* ids_blob_desc = GetBlobDesc4BnInOp("one_ids");
   const BlobDesc* val_blob_desc = GetBlobDesc4BnInOp("one_val");
 

--- a/oneflow/core/operator/embedding_lookup_op.cpp
+++ b/oneflow/core/operator/embedding_lookup_op.cpp
@@ -30,7 +30,7 @@ Maybe<void> EmbeddingLookupOp::InferBlobDescs(
   // out
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   *out_blob_desc = *in_blob_desc;
-  out_blob_desc->set_data_type(GlobalJobDesc().DefaultDataType());
+  out_blob_desc->set_data_type(job_desc().DefaultDataType());
   out_blob_desc->mut_shape() = Shape({in_blob_desc->shape().At(0), units});
 
   // weight

--- a/oneflow/core/operator/foreign_input_op.cpp
+++ b/oneflow/core/operator/foreign_input_op.cpp
@@ -34,7 +34,7 @@ Maybe<void> ForeignInputOp::InferBlobDescs(
   if (conf.has_data_type()) {
     out_blob_desc->set_data_type(conf.data_type());
   } else {
-    out_blob_desc->set_data_type(GlobalJobDesc().DefaultDataType());
+    out_blob_desc->set_data_type(job_desc().DefaultDataType());
   }
   out_blob_desc->set_has_dim0_valid_num_field(conf.has_dim0_valid_num());
   if (conf.has_dim0_inner_shape()) {

--- a/oneflow/core/operator/fully_connected_op.cpp
+++ b/oneflow/core/operator/fully_connected_op.cpp
@@ -27,7 +27,7 @@ Maybe<void> FullyConnectedOp::InferBlobDescs(
   // useful vars
   const FullyConnectedOpConf& conf = op_conf().fully_connected_conf();
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
-  CHECK_EQ_OR_RETURN(in_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  CHECK_EQ_OR_RETURN(in_blob_desc->data_type(), job_desc().DefaultDataType());
   int32_t units = conf.units();
   if (parallel_ctx->policy() == kModelParallel) {
     BalancedSplitter splitter(units, parallel_ctx->parallel_num());

--- a/oneflow/core/operator/interface_op_util.cpp
+++ b/oneflow/core/operator/interface_op_util.cpp
@@ -55,11 +55,7 @@ Maybe<void> InterfaceOpUtil::InferOutBlobDesc(const InterfaceBlobConf& blob_conf
   out_blob_desc->mut_shape() = Shape(blob_conf.shape());
   CheckShape(out_blob_desc->shape());
   CHECK_GT(out_blob_desc->mut_shape().At(0), 0);
-  if (blob_conf.has_data_type()) {
-    out_blob_desc->set_data_type(blob_conf.data_type());
-  } else {
-    out_blob_desc->set_data_type(GlobalJobDesc().DefaultDataType());
-  }
+  out_blob_desc->set_data_type(blob_conf.data_type());
   out_blob_desc->set_has_dim0_valid_num_field(blob_conf.has_dim0_valid_num());
   if (blob_conf.has_dim0_inner_shape()) {
     CHECK(blob_conf.has_dim0_valid_num());

--- a/oneflow/core/operator/local_reponse_normalization_op.cpp
+++ b/oneflow/core/operator/local_reponse_normalization_op.cpp
@@ -20,7 +20,7 @@ Maybe<void> LocalResponseNormalizationOp::InferBlobDescs(
   const LocalResponseNormalizationOpConf conf = op_conf().local_response_normalization_conf();
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   CHECK_EQ_OR_RETURN(in_blob_desc->shape().NumAxes(), 4);
-  CHECK_EQ_OR_RETURN(in_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  CHECK_EQ_OR_RETURN(in_blob_desc->data_type(), job_desc().DefaultDataType());
   *GetBlobDesc4BnInOp("out") = *in_blob_desc;
 
   if (device_type() == DeviceType::kCPU) {

--- a/oneflow/core/operator/momentum_model_update_op.cpp
+++ b/oneflow/core/operator/momentum_model_update_op.cpp
@@ -10,7 +10,7 @@ Maybe<void> MomentumModelUpdateOp::MdUpdtVirtualInferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx) const {
   const BlobDesc* model_blob_desc = GetBlobDesc4BnInOp("model");
-  CHECK_EQ_OR_RETURN(model_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  CHECK_EQ_OR_RETURN(model_blob_desc->data_type(), job_desc().DefaultDataType());
   CHECK_EQ_OR_RETURN(model_blob_desc->has_data_id_field(), false);
   CHECK_OR_RETURN(*GetBlobDesc4BnInOp("momentum") == *model_blob_desc);
   return Maybe<void>::Ok();

--- a/oneflow/core/operator/multiply_op.cpp
+++ b/oneflow/core/operator/multiply_op.cpp
@@ -18,7 +18,7 @@ Maybe<void> MultiplyOp::InferBlobDescs(
     const ParallelContext* parallel_ctx) const {
   BlobDesc* in_0_blob_desc = GetBlobDesc4BnInOp("in_0");
   BlobDesc* in_1_blob_desc = GetBlobDesc4BnInOp("in_1");
-  CHECK_EQ_OR_RETURN(in_0_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  CHECK_EQ_OR_RETURN(in_0_blob_desc->data_type(), job_desc().DefaultDataType());
   CHECK_EQ_OR_RETURN(in_0_blob_desc->shape(), in_1_blob_desc->shape());
   // out
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");

--- a/oneflow/core/operator/one_hot_op.cpp
+++ b/oneflow/core/operator/one_hot_op.cpp
@@ -15,8 +15,7 @@ Maybe<void> OneHotOp::InferBlobDescs(
     const ParallelContext* parallel_ctx) const {
   const OneHotOpConf& conf = op_conf().one_hot_conf();
   const int64_t depth = conf.depth();
-  const DataType data_type =
-      conf.has_data_type() ? conf.data_type() : GlobalJobDesc().DefaultDataType();
+  const DataType data_type = conf.has_data_type() ? conf.data_type() : job_desc().DefaultDataType();
   CHECK_GT_OR_RETURN(depth, 0);
   const BlobDesc* indices = GetBlobDesc4BnInOp("indices");
   CHECK_OR_RETURN(IsIntegralDataType(indices->data_type()));

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -757,7 +757,7 @@ message CastOpConf {
 
 message InterfaceBlobConf {
   required ShapeProto shape = 1;
-  optional DataType data_type = 2;
+  required DataType data_type = 2;
   optional ShapeProto dim0_inner_shape = 3;
   optional bool has_dim0_valid_num = 4;
   optional bool has_dim1_valid_num = 5;

--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -156,6 +156,8 @@ class Operator {
       const std::function<Maybe<const BlobDesc*>(const std::string&)>& LogicalBlobDesc4Ibn,
       SbpSignatureList* sbp_sig_list) const;
 
+  const JobDesc& job_desc() const { return *job_desc_; }
+
  protected:
   virtual Maybe<void> GetSbpSignatures(
       const std::function<Maybe<const BlobDesc*>(const std::string&)>& LogicalBlobDesc4Ibn,
@@ -255,7 +257,11 @@ class Operator {
     return op_attribute_.mutable_bn_in_op2lbi();
   }
 
+  friend std::shared_ptr<Operator> ConstructOp(const OperatorConf& op_conf, const JobDesc*);
+  void set_job_desc(const JobDesc* job_desc) { job_desc_ = job_desc; }
+
   OpAttribute op_attribute_;
+  const JobDesc* job_desc_;
 };
 
 std::string GenRepeatedBn(const std::string& bn_prefix, int32_t idx);
@@ -308,13 +314,9 @@ struct IsTickTockOpTypeCase final {};
   REGISTER_CLASS_CREATOR(op_type_case, IsTickTockOpTypeCase, \
                          ([] { return new IsTickTockOpTypeCase; }))
 
-std::shared_ptr<Operator> ConstructOp(const OperatorConf& op_conf);
-
-inline std::shared_ptr<Operator> ConstructOp(const OperatorConf& op_conf, DeviceType device_type) {
-  OperatorConf dev_op_conf = op_conf;
-  dev_op_conf.set_device_type(device_type);
-  return ConstructOp(dev_op_conf);
-}
+std::shared_ptr<Operator> ConstructOp(const OperatorConf& op_conf, const JobDesc*);
+std::shared_ptr<Operator> ConstructOp(const OperatorConf& op_conf, DeviceType device_type,
+                                      const JobDesc*);
 
 void EraseEmptyBnInVec(std::function<const BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                        PbRpf<std::string>* bns);

--- a/oneflow/core/operator/recurrent_op.cpp
+++ b/oneflow/core/operator/recurrent_op.cpp
@@ -23,7 +23,7 @@ Maybe<void> RecurrentOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx) const {
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
-  DataType data_type = GlobalJobDesc().DefaultDataType();
+  DataType data_type = job_desc().DefaultDataType();
   CHECK_EQ_OR_RETURN(in_blob_desc->data_type(), data_type);
   CHECK_EQ_OR_RETURN(in_blob_desc->shape().NumAxes(), 2);
   CHECK_EQ_OR_RETURN(in_blob_desc->has_col_num_field(), true);

--- a/oneflow/core/operator/rmsprop_model_update_op.cpp
+++ b/oneflow/core/operator/rmsprop_model_update_op.cpp
@@ -8,7 +8,7 @@ Maybe<void> RMSPropModelUpdateOp::MdUpdtVirtualInferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx) const {
   const BlobDesc* model_blob_desc = GetBlobDesc4BnInOp("model");
-  CHECK_EQ_OR_RETURN(model_blob_desc->data_type(), GlobalJobDesc().DefaultDataType());
+  CHECK_EQ_OR_RETURN(model_blob_desc->data_type(), job_desc().DefaultDataType());
   CHECK_EQ_OR_RETURN(model_blob_desc->has_data_id_field(), false);
   *GetBlobDesc4BnInOp("mean_square") = *model_blob_desc;
   return Maybe<void>::Ok();

--- a/oneflow/core/operator/softmax_op.cpp
+++ b/oneflow/core/operator/softmax_op.cpp
@@ -8,7 +8,7 @@ void SoftmaxOp::InitFromOpConf() {
   CHECK(op_conf().has_softmax_conf());
   EnrollInputBn("in");
   EnrollOutputBn("out");
-  if (GlobalJobDesc().IsTrain() && op_conf().softmax_conf().axis() != -1) {
+  if (job_desc().IsTrain() && op_conf().softmax_conf().axis() != -1) {
     EnrollOutputBn("transpose_in");
     EnrollOutputBn("transpose_out", false);
   } else {

--- a/oneflow/core/operator/variable_op.cpp
+++ b/oneflow/core/operator/variable_op.cpp
@@ -24,7 +24,7 @@ Maybe<OptInt64> GetSplitAxis(const VariableOpConf& variable_conf) {
 void VariableOp::InitFromOpConf() {
   CHECK(op_conf().has_variable_conf());
   if (op_conf().variable_conf().has_tick()) { EnrollInputBn("tick", false); }
-  EnrollOutputBn("out", GlobalJobDesc().IsTrain())->set_is_mutable(true);
+  EnrollOutputBn("out", job_desc().IsTrain())->set_is_mutable(true);
 }
 
 const PbMessage& VariableOp::GetCustomizedConf() const { return op_conf().variable_conf(); }
@@ -33,12 +33,11 @@ Maybe<void> VariableOp::InferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx) const {
   const VariableOpConf& variable_conf = op_conf().variable_conf();
-  OF_CHECK(GlobalJobDesc().job_conf().has_default_initializer_conf()
-           || variable_conf.has_initializer());
+  OF_CHECK(job_desc().job_conf().has_default_initializer_conf() || variable_conf.has_initializer());
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   out_blob_desc->mut_shape() = Shape(variable_conf.shape());
   out_blob_desc->set_data_type(variable_conf.has_data_type() ? variable_conf.data_type()
-                                                             : GlobalJobDesc().DefaultDataType());
+                                                             : job_desc().DefaultDataType());
   const auto& opt_split_axis = JUST(GetSplitAxis(variable_conf));
   if (opt_split_axis->has_value()) {
     int32_t model_split_axis = opt_split_axis->value();


### PR DESCRIPTION
移除operator/目录下的GlobalJobDesc()，换成Operator::job_desc()
xla方面在运行时有可能需要推导blob_desc。于是要用到operator，但是operator相关文件里用到了GlobalJobDesc()，这个只在编译时有效，运行时为空。
