### PR TITLE
fix warning: return string reference to temporary

### DIFF
--- a/oneflow/core/common/protobuf.cpp
+++ b/oneflow/core/common/protobuf.cpp
@@ -116,8 +116,7 @@ std::pair<std::string, int32_t> GetFieldNameAndIndex4StrVal(const std::string& f
   return std::make_pair(field_name, idx);
 }
 
-const std::string& GetStrValInPbFdOrPbRpf(const PbMessage& msg,
-                                          const std::string& fd_name_may_have_idx) {
+std::string GetStrValInPbFdOrPbRpf(const PbMessage& msg, const std::string& fd_name_may_have_idx) {
   const PbFd* fd = msg.GetDescriptor()->FindFieldByName(fd_name_may_have_idx);
   if (fd) {
     return GetValFromPbMessage<std::string>(msg, fd_name_may_have_idx);

--- a/oneflow/core/common/protobuf.h
+++ b/oneflow/core/common/protobuf.h
@@ -100,8 +100,7 @@ PbMessage* MutableRepeatedMessageInPbMessage(PbMessage* msg, const std::string& 
 
 // Get/Replace str val maybe repeated;  field_name with index is like "name_0"
 std::pair<std::string, int32_t> GetFieldNameAndIndex4StrVal(const std::string& fd_name_with_idx);
-const std::string& GetStrValInPbFdOrPbRpf(const PbMessage& msg,
-                                          const std::string& fd_name_may_have_idx);
+std::string GetStrValInPbFdOrPbRpf(const PbMessage& msg, const std::string& fd_name_may_have_idx);
 void ReplaceStrValInPbFdOrPbRpf(PbMessage* msg, const std::string& fd_name_may_have_idx,
                                 const std::string& old_val, const std::string& new_val);
 


### PR DESCRIPTION
GetStrValInPbFdOrPbRpf 接口返回值而不是const引用 