### PR TITLE
fix bug: reduce split kernel inplace

### DIFF
--- a/oneflow/core/kernel/reduce_split_kernel.cpp
+++ b/oneflow/core/kernel/reduce_split_kernel.cpp
@@ -9,7 +9,7 @@ void ReduceSplitKernel<device_type>::ForwardDataContent(
   const char* src_cur_dptr = in_blob->dptr<char>();
   for (const std::string& obn : this->op_attribute().output_bns()) {
     Blob* out_blob = BnInOp2Blob(obn);
-    size_t out_byte_size = out_blob->ByteSizeOfDataContentField();
+    size_t out_byte_size = out_blob->blob_desc().ByteSizeOfBlobBody();
     Memcpy<device_type>(ctx.device_ctx, out_blob->mut_dptr<char>(), src_cur_dptr, out_byte_size);
     src_cur_dptr += out_byte_size;
   }


### PR DESCRIPTION
dev_python分支多卡与单卡loss不一致的问题就是这个

已在InceptionV3网络的单机单卡、单机多卡、多机多卡上测试通过验证。
![image](https://user-images.githubusercontent.com/12186261/65850210-92d0fe80-e380-11e9-81d2-18e438ad238c.png)
![image](https://user-images.githubusercontent.com/12186261/65850226-9f555700-e380-11e9-8e23-87167a9d927a.png)
