### PR TITLE
Modify codes to support XLA

### DIFF
--- a/oneflow/core/common/protobuf.cpp
+++ b/oneflow/core/common/protobuf.cpp
@@ -69,6 +69,11 @@ int32_t GetEnumFromPbMessage(const PbMessage& msg, const std::string& field_name
 
 OF_PP_FOR_EACH_TUPLE(DEFINE_SET_VAL_IN_PBMESSAGE, PROTOBUF_BASIC_DATA_TYPE_SEQ)
 
+const PbMessage& GetMessageInPbMessage(const PbMessage& msg, const std::string& field_name) {
+  PROTOBUF_REFLECTION(msg, field_name);
+  return r->GetMessage(msg, fd);
+}
+
 PbMessage* MutableMessageInPbMessage(PbMessage* msg, const std::string& field_name) {
   PROTOBUF_REFLECTION((*msg), field_name);
   return r->MutableMessage(msg, fd);
@@ -95,6 +100,67 @@ PbMessage* MutableMessageInPbMessage(PbMessage* msg, int field_index) {
   const auto* r = const_cast<google::protobuf::Reflection*>(msg->GetReflection());
   return r->MutableMessage(msg, fd);
 }
+
+#define DECLARE_GETTER_FUNC_HEADER(type) \
+  template<>                             \
+  type GetValFromPbMessage<type>(const PbMessage& msg, const std::string& field_name)
+
+#define DECLARE_SETTER_FUNC_HEADER(type) \
+  template<>                             \
+  void SetValInPbMessage<type>(PbMessage * msg, const std::string& field_name, const type& val)
+
+#define DEFINE_MESSAGE_VAL_GETTER_AND_SETTER(message_type)              \
+  DECLARE_GETTER_FUNC_HEADER(message_type) {                            \
+    PROTOBUF_REFLECTION(msg, field_name);                               \
+    return *dynamic_cast<const message_type*>(&r->GetMessage(msg, fd)); \
+  }                                                                     \
+  DECLARE_SETTER_FUNC_HEADER(message_type) {                            \
+    PROTOBUF_REFLECTION((*msg), field_name);                            \
+    r->MutableMessage(msg, fd)->CopyFrom(val);                          \
+  }
+
+DEFINE_MESSAGE_VAL_GETTER_AND_SETTER(ShapeProto);
+
+#define DEFINE_ENUM_VAL_GETTER_AND_SETTER(enum_type)         \
+  DECLARE_GETTER_FUNC_HEADER(enum_type) {                    \
+    PROTOBUF_REFLECTION(msg, field_name);                    \
+    return static_cast<enum_type>(r->GetEnumValue(msg, fd)); \
+  }                                                          \
+  DECLARE_SETTER_FUNC_HEADER(enum_type) {                    \
+    PROTOBUF_REFLECTION((*msg), field_name);                 \
+    r->SetEnumValue(msg, fd, val);                           \
+  }
+
+DEFINE_ENUM_VAL_GETTER_AND_SETTER(DataType);
+
+#define DEFINE_VECTOR_VAL_GETTER_AND_SETTER(vec_type, vec_type_name)                        \
+  DECLARE_GETTER_FUNC_HEADER(vec_type) {                                                    \
+    PROTOBUF_REFLECTION(msg, field_name);                                                   \
+    int32_t field_size = r->FieldSize(msg, fd);                                             \
+    vec_type retval(field_size);                                                            \
+    for (int i = 0; i < field_size; ++i) { retval[i] = r->Get##vec_type_name(msg, fd, i); } \
+    return std::move(retval);                                                               \
+  }                                                                                         \
+  DECLARE_SETTER_FUNC_HEADER(vec_type) {                                                    \
+    PROTOBUF_REFLECTION((*msg), field_name);                                                \
+    for (int i = 0; i < val.size(); ++i) { r->Set##vec_type_name(msg, fd, i, val[i]); }     \
+  }
+
+#define MAKE_REPEATED_TUPLE_SEQ(type, type_name) \
+  OF_PP_MAKE_TUPLE_SEQ(std::vector<type>, Repeated##type_name)
+
+#define PROTOBUF_BASIC_REPEATED_DATA_TYPE_SEQ  \
+  MAKE_REPEATED_TUPLE_SEQ(std::string, String) \
+  MAKE_REPEATED_TUPLE_SEQ(int32_t, Int32)      \
+  MAKE_REPEATED_TUPLE_SEQ(uint32_t, UInt32)    \
+  MAKE_REPEATED_TUPLE_SEQ(int64_t, Int64)      \
+  MAKE_REPEATED_TUPLE_SEQ(uint64_t, UInt64)    \
+  MAKE_REPEATED_TUPLE_SEQ(float, Float)        \
+  MAKE_REPEATED_TUPLE_SEQ(double, Double)      \
+  MAKE_REPEATED_TUPLE_SEQ(int16_t, EnumValue)  \
+  MAKE_REPEATED_TUPLE_SEQ(bool, Bool)
+
+OF_PP_FOR_EACH_TUPLE(DEFINE_VECTOR_VAL_GETTER_AND_SETTER, PROTOBUF_BASIC_REPEATED_DATA_TYPE_SEQ);
 
 #define DEFINE_ADD_VAL_IN_PBRF(cpp_type, pb_type_name)                                    \
   template<>                                                                              \

--- a/oneflow/core/common/protobuf.h
+++ b/oneflow/core/common/protobuf.h
@@ -36,6 +36,7 @@ using PbMd = google::protobuf::util::MessageDifferencer;
   OF_PP_MAKE_TUPLE_SEQ(int64_t, Int64)      \
   OF_PP_MAKE_TUPLE_SEQ(uint64_t, UInt64)    \
   OF_PP_MAKE_TUPLE_SEQ(float, Float)        \
+  OF_PP_MAKE_TUPLE_SEQ(double, Double)      \
   OF_PP_MAKE_TUPLE_SEQ(int16_t, EnumValue)  \
   OF_PP_MAKE_TUPLE_SEQ(bool, Bool)
 
@@ -92,6 +93,7 @@ template<typename T>
 void SetValInPbMessage(PbMessage* msg, const std::string& field_name, const T& val);
 
 const PbMessage& GetMessageInPbMessage(const PbMessage& msg, int field_index);
+const PbMessage& GetMessageInPbMessage(const PbMessage& msg, const std::string& field_name);
 
 PbMessage* MutableMessageInPbMessage(PbMessage*, const std::string& field_name);
 PbMessage* MutableMessageInPbMessage(PbMessage*, int field_index);

--- a/oneflow/core/graph/normal_forward_compute_task_node.cpp
+++ b/oneflow/core/graph/normal_forward_compute_task_node.cpp
@@ -35,7 +35,9 @@ void NormalForwardCompTaskNode::ProduceAllRegstsAndBindEdges() {
 }
 
 void NormalForwardCompTaskNode::ConsumeAllRegsts() {
-  ForEachInDataEdge([&](TaskEdge* edge) { ConsumeRegst("in", edge->GetSoleRegst()); });
+  ForEachInDataEdge([&](TaskEdge* edge) {
+    for (const auto& regst : edge->GetRegsts()) { ConsumeRegst("in", regst); }
+  });
 }
 
 bool NormalForwardCompTaskNode::IsReadyForBuild() {

--- a/oneflow/core/graph/optimizer_compute_task_node.cpp
+++ b/oneflow/core/graph/optimizer_compute_task_node.cpp
@@ -4,7 +4,9 @@
 namespace oneflow {
 
 void OptimizerCompTaskNode::ConsumeAllRegsts() {
-  ForEachInDataEdge([&](TaskEdge* edge) { ConsumeRegst("in", edge->GetSoleRegst()); });
+  ForEachInDataEdge([&](TaskEdge* edge) {
+    for (const auto& regst : edge->GetRegsts()) { ConsumeRegst("in", regst); }
+  });
 }
 
 void OptimizerCompTaskNode::ProduceAllRegstsAndBindEdges() { ProduceRegst("tmp", false, 1, 1); }

--- a/oneflow/core/graph/reduce_split_compute_task_node.cpp
+++ b/oneflow/core/graph/reduce_split_compute_task_node.cpp
@@ -5,48 +5,28 @@
 
 namespace oneflow {
 
-namespace {
-
-int32_t GetDataRegstDescCnt(
-    const HashMap<std::string, std::shared_ptr<RegstDesc>> name2regst_desc) {
-  size_t cnt = 0;
-  for (const auto& pair : name2regst_desc) {
-    cnt += pair.second->regst_desc_type().has_data_regst_desc();
-  }
-  return cnt;
-}
-
-}  // namespace
-
 void ReduceSplitCompTaskNode::ProduceAllRegstsAndBindEdges() {
-  std::vector<EdgeInfo> edge_infos;
-  std::shared_ptr<Operator> reduce_split_op = this->logical_node()->SoleOp();
   HashMap<LogicalBlobId, int32_t> lbi2order;
+  std::shared_ptr<Operator> reduce_split_op = this->logical_node()->SoleOp();
   FOR_RANGE(int32_t, idx, 0, reduce_split_op->output_bns().size()) {
+    ProduceRegst("out_" + std::to_string(idx), false, 1, 1);
     const auto& lbi = reduce_split_op->BnInOp2Lbi(reduce_split_op->output_bns().Get(idx));
     CHECK(lbi2order.emplace(lbi, idx).second);
   }
+
   ForEachOutDataEdge([&](TaskEdge* edge) {
     TaskNode* dst_node = edge->dst_node();
     CHECK(edge->dst_node()->GetTaskType() == TaskType::kOptimizer
           || edge->dst_node()->GetTaskType() == TaskType::kNormalForward);
     CompTaskNode* mdupdt_node = dynamic_cast<CompTaskNode*>(dst_node);
     std::shared_ptr<Operator> mdupdt_op = mdupdt_node->logical_node()->SoleOp();
-    int32_t order = -1;
     for (const std::string& ibn : mdupdt_op->input_bns()) {
       const auto& order_it = lbi2order.find(mdupdt_op->BnInOp2Lbi(ibn));
-      if (order_it != lbi2order.end()) { order = order_it->second; }
+      if (order_it != lbi2order.end()) {
+        BindEdgeWithProducedRegst(edge, "out_" + std::to_string(order_it->second));
+      }
     }
-    CHECK_NE(order, -1);
-    EdgeInfo edge_info{edge, order};
-    edge_infos.emplace_back(edge_info);
   });
-  SortEdges(&edge_infos);
-  FOR_RANGE(size_t, idx, 0, edge_infos.size()) {
-    std::string out_regst_name = "out_" + std::to_string(idx);
-    std::shared_ptr<RegstDesc> out_regst = ProduceRegst(out_regst_name, false, 1, 1);
-    edge_infos[idx].edge->AddRegst(out_regst_name, out_regst);
-  }
 }
 
 void ReduceSplitCompTaskNode::ConsumeAllRegsts() {
@@ -68,22 +48,23 @@ void ReduceSplitCompTaskNode::BuildExecGphAndRegst() {
   node->BindBnWithRegst(reduce_split_op->SoleIbn(), GetSoleConsumedRegst("in"));
 
   FOR_RANGE(size_t, i, 0, reduce_split_op->output_bns().size()) {
-    std::shared_ptr<RegstDesc> out_regst = GetProducedRegst("out_" + std::to_string(i));
+    std::string blob_name = "out_" + std::to_string(i);
+    std::shared_ptr<RegstDesc> out_regst = GetProducedRegst(blob_name);
     CHECK(out_regst.get() != nullptr);
-    out_regst->AddLbi(reduce_split_op->BnInOp2Lbi(reduce_split_op->output_bns().Get(i)));
-    node->BindBnWithRegst(reduce_split_op->output_bns().Get(i), out_regst);
+    out_regst->AddLbi(reduce_split_op->BnInOp2Lbi(blob_name));
+    node->BindBnWithRegst(blob_name, out_regst);
   }
   node->InferBlobDescs(parallel_ctx());
 }
 
 void ReduceSplitCompTaskNode::EnableMemSharingInReduce(const ReduceMemSharingCtx& ctx) {
   CHECK_EQ(GetRankCtx().TotalSegmentCount(), 1);
-  size_t split_num = GetDataRegstDescCnt(produced_regsts());
+  std::shared_ptr<Operator> reduce_split_op = this->logical_node()->SoleOp();
   int64_t offset = 0;
-  FOR_RANGE(int32_t, idx, 0, split_num) {
-    RegstDesc* split_out_regst = GetProducedRegst("out_" + std::to_string(idx)).get();
-    ctx.EnableMemSharing4Regst(split_out_regst, offset);
-    offset += InferRegstSize(*split_out_regst);
+  for (int i = 0; i < reduce_split_op->output_bns().size(); ++i) {
+    RegstDesc* out_regst = GetProducedRegst("out_" + std::to_string(i)).get();
+    ctx.EnableMemSharing4Regst(out_regst, offset);
+    offset += InferRegstSize(*out_regst);
   }
 }
 

--- a/oneflow/core/job/job_builder.cpp
+++ b/oneflow/core/job/job_builder.cpp
@@ -4,49 +4,62 @@
 
 namespace oneflow {
 
-std::function<const ParallelConf*(const std::string&)> MakeGetterParallelConf4OpName(
-    const Placement& placement) {
-  auto op_name2parallel_conf = std::make_shared<HashMap<std::string, const ParallelConf*>>();
-  for (const auto& placement_group : placement.placement_group()) {
-    for (const std::string& op_name : placement_group.op_set().op_name()) {
-      const ParallelConf* parallel_conf = &placement_group.parallel_conf();
+std::function<const ParallelConf *(const std::string &)> MakeGetterParallelConf4OpName(
+    const Placement &placement) {
+  auto op_name2parallel_conf = std::make_shared<HashMap<std::string, const ParallelConf *>>();
+  for (const auto &placement_group : placement.placement_group()) {
+    for (const std::string &op_name : placement_group.op_set().op_name()) {
+      const ParallelConf *parallel_conf = &placement_group.parallel_conf();
       CHECK(op_name2parallel_conf->emplace(op_name, parallel_conf).second);
     }
   }
-  return [op_name2parallel_conf](const std::string& op_name) {
+  return [op_name2parallel_conf](const std::string &op_name) {
     return op_name2parallel_conf->at(op_name);
   };
 }
 
-JobBuilder::JobBuilder(Job* job) : job_(job) {
+JobBuilder::JobBuilder(Job *job) : job_(job) {
   FOR_RANGE(int32_t, i, 0, job->net().op_size()) {
     CHECK(op_name2op_conf_.emplace(job->net().op(i).name(), job->mutable_net()->mutable_op(i))
               .second);
   }
   FOR_RANGE(int32_t, i, 0, job->placement().placement_group_size()) {
-    auto* placemnt_group = job->mutable_placement()->mutable_placement_group(i);
-    for (const auto& op_name : placemnt_group->op_set().op_name()) {
+    auto *placemnt_group = job->mutable_placement()->mutable_placement_group(i);
+    for (const auto &op_name : placemnt_group->op_set().op_name()) {
       CHECK(
           op_name2parallel_conf_.emplace(op_name, placemnt_group->mutable_parallel_conf()).second);
     }
   }
+  auto *sbp_conf = job->mutable_sbp_conf();
+  for (auto &pair : *(sbp_conf->mutable_op_name2sbp_signature_conf())) {
+    op_name2sbp_signature_conf_.emplace(pair.first, &pair.second);
+  }
+  for (auto &pair : *(job->mutable_helper()->mutable_lbn2batch_axis())) {
+    lbn2batch_axis_.emplace(pair.first, &pair.second);
+  }
+  auto *helper_conf = job->mutable_helper();
+  for (auto &pair : *(helper_conf->mutable_op_name2op_time_shape())) {
+    op_name2time_shapes_.emplace(pair.first, &pair.second);
+  }
 }
 
-const OperatorConf& JobBuilder::OpConf4OpName(const std::string& op_name) const {
+OperatorConf *JobBuilder::MutableOpConf4OpName(const std::string &op_name) {
+  const auto &it = op_name2op_conf_.find(op_name);
+  CHECK(it != op_name2op_conf_.end());
+  return it->second;
+}
+
+const OperatorConf &JobBuilder::OpConf4OpName(const std::string &op_name) const {
   return *op_name2op_conf_.at(op_name);
 }
 
-const ParallelConf& JobBuilder::ParallelConf4OpName(const std::string& op_name) const {
-  return *op_name2parallel_conf_.at(op_name);
-}
-
-void JobBuilder::AddOps(const ParallelConf& parallel_conf,
-                        const std::vector<OperatorConf>& op_confs) {
-  auto* placemnt_group = job_->mutable_placement()->add_placement_group();
+void JobBuilder::AddOps(const ParallelConf &parallel_conf,
+                        const std::vector<OperatorConf> &op_confs) {
+  auto *placemnt_group = job_->mutable_placement()->add_placement_group();
   *placemnt_group->mutable_parallel_conf() = parallel_conf;
-  for (const auto& op_conf : op_confs) {
+  for (const auto &op_conf : op_confs) {
     CHECK(op_name2op_conf_.find(op_conf.name()) == op_name2op_conf_.end());
-    OperatorConf* mut_op_conf = job_->mutable_net()->add_op();
+    OperatorConf *mut_op_conf = job_->mutable_net()->add_op();
     *mut_op_conf = op_conf;
     CHECK(op_name2op_conf_.emplace(op_conf.name(), mut_op_conf).second);
     placemnt_group->mutable_op_set()->add_op_name(op_conf.name());
@@ -55,53 +68,85 @@ void JobBuilder::AddOps(const ParallelConf& parallel_conf,
   }
 }
 
-PlacementGroup* JobBuilder::FindPlacementGroup(const std::string& op_name) const {
+PlacementGroup *JobBuilder::FindPlacementGroup(const std::string &op_name) const {
   FOR_RANGE(int32_t, i, 0, job_->mutable_placement()->placement_group_size()) {
-    PlacementGroup* const cur_pg = job_->mutable_placement()->mutable_placement_group(i);
-    const auto& op_names = cur_pg->op_set().op_name();
+    PlacementGroup *const cur_pg = job_->mutable_placement()->mutable_placement_group(i);
+    const auto &op_names = cur_pg->op_set().op_name();
     if (std::find(op_names.begin(), op_names.end(), op_name) != op_names.end()) { return cur_pg; }
   }
   UNIMPLEMENTED();
   return nullptr;
 }
 
-void JobBuilder::MutParallelConfOnlyOnce(const std::string& op_name,
-                                         const ParallelConf& parallel_conf) {
+void JobBuilder::MutParallelConfOnlyOnce(const std::string &op_name,
+                                         const ParallelConf &parallel_conf) {
   CHECK(modified_parallel_conf_op_names_.emplace(op_name).second);
-  PlacementGroup* placement_group = FindPlacementGroup(op_name);
+  PlacementGroup *placement_group = FindPlacementGroup(op_name);
   {
-    auto* const op_names = placement_group->mutable_op_set()->mutable_op_name();
-    Erase<PbRpf<std::string>>(*op_names, [&](const std::string& x) { return x == op_name; });
-    Placement* const placement = job_->mutable_placement();
+    auto *const op_names = placement_group->mutable_op_set()->mutable_op_name();
+    Erase<PbRpf<std::string>>(*op_names, [&](const std::string &x) { return x == op_name; });
+    Placement *const placement = job_->mutable_placement();
     if (op_names->size() > 0) { placement_group = placement->mutable_placement_group()->Add(); }
   }
   placement_group->mutable_op_set()->add_op_name(op_name);
   *placement_group->mutable_parallel_conf() = parallel_conf;
 }
 
-void JobBuilder::DelOps(const std::vector<OperatorConf>& op_confs) {
-  for (const auto& op_conf : op_confs) {
-    const std::string& op_name = op_conf.name();
-    op_name2op_conf_.erase(op_name);
-    auto* op_list = job_->mutable_net()->mutable_op();
-    auto it = std::remove_if(op_list->begin(), op_list->end(),
-                             [&](const OperatorConf& conf) { return conf.name() == op_name; });
-    if (it != op_list->end()) { op_list->erase(it); }
+void JobBuilder::RemoveOpByName(const std::string &op_name) {
+  // Update net
+  DLNetConf net = job_->net();
+  job_->mutable_net()->clear_op();
+  for (const OperatorConf &op_conf : net.op()) {
+    if (op_conf.name() != op_name) { *(job_->mutable_net()->add_op()) = op_conf; }
   }
+  // Update placement
+  auto placement_group = job_->placement().placement_group();
+  job_->mutable_placement()->clear_placement_group();
+  for (const PlacementGroup &place : placement_group) {
+    PlacementGroup p;
+    OpNameSet *op_set = p.mutable_op_set();
+    for (const std::string &name : place.op_set().op_name()) {
+      if (name != op_name) { op_set->add_op_name(name); }
+    }
+
+    *(p.mutable_parallel_conf()) = place.parallel_conf();
+    if (op_set->op_name().size() > 0) { *(job_->mutable_placement()->add_placement_group()) = p; }
+  }
+  // Update Sbp
+  auto *sbp_conf = job_->mutable_sbp_conf()->mutable_op_name2sbp_signature_conf();
+  if (sbp_conf->count(op_name) > 0) { sbp_conf->erase(op_name); }
+  // Update time shape
+  auto *time_shape_conf = job_->mutable_helper()->mutable_op_name2op_time_shape();
+  if (time_shape_conf->count(op_name) > 0) { time_shape_conf->erase(op_name); }
+  // Update batch dim lbis
+  // Update builder
+  JobBuilder builder(job_);
+  op_name2op_conf_.swap(builder.op_name2op_conf_);
+  op_name2parallel_conf_.swap(builder.op_name2parallel_conf_);
+  op_name2sbp_signature_conf_.swap(builder.op_name2sbp_signature_conf_);
+  lbn2batch_axis_.swap(builder.lbn2batch_axis_);
 }
 
-void JobBuilder::MutOpsOnlyOnce(const std::vector<OperatorConf>& op_confs) {
-  for (const auto& op_conf : op_confs) {
+void JobBuilder::DelOps(const std::vector<std::string> &op_names) {
+  for (const auto &op_name : op_names) { RemoveOpByName(op_name); }
+}
+
+void JobBuilder::DelOps(const std::vector<OperatorConf> &op_confs) {
+  for (const auto &op_conf : op_confs) { RemoveOpByName(op_conf.name()); }
+}
+
+void JobBuilder::MutOpsOnlyOnce(const std::vector<OperatorConf> &op_confs) {
+  for (const auto &op_conf : op_confs) {
     CHECK(modified_op_conf_op_names_.emplace(op_conf.name()).second);
     op_name2op_conf_.at(op_conf.name())->CopyFrom(op_conf);
   }
 }
 
-void JobBuilder::AddOrMutOpsOnlyOnce(const ParallelConf& parallel_conf,
-                                     const std::vector<OperatorConf>& op_confs) {
+void JobBuilder::AddOrMutOpsOnlyOnce(const ParallelConf &parallel_conf,
+                                     const std::vector<OperatorConf> &op_confs) {
   std::vector<OperatorConf> add_ops;
   std::vector<OperatorConf> mut_ops;
-  for (const auto& op_conf : op_confs) {
+  for (const auto &op_conf : op_confs) {
     if (op_name2op_conf_.find(op_conf.name()) == op_name2op_conf_.end()) {
       add_ops.push_back(op_conf);
     } else {
@@ -112,23 +157,113 @@ void JobBuilder::AddOrMutOpsOnlyOnce(const ParallelConf& parallel_conf,
   MutOpsOnlyOnce(mut_ops);
 }
 
-void JobBuilder::ForEachOperator(const std::function<void(const Operator&)>& Handler) const {
-  for (const auto& pair : op_name2op_conf_) {
+void JobBuilder::ForEachOperator(const std::function<void(const Operator &)> &Handler) const {
+  for (const auto &pair : op_name2op_conf_) {
     DeviceType device_type = ParallelDesc(*op_name2parallel_conf_.at(pair.first)).device_type();
     std::shared_ptr<Operator> op = ConstructOp(*pair.second, device_type, &GlobalJobDesc());
     Handler(*op);
   }
 }
 
-SbpParallel* JobBuilder::MutSbpParallel4Oba(const OpBlobArg& oba) const {
-  auto* sbp_sig = &(*job_->mutable_sbp_conf()->mutable_op_name2sbp_signature_conf())[oba.op_name()];
+ParallelConf *JobBuilder::MutableParallelConf4OpName(const std::string &op_name) {
+  const auto &it = op_name2parallel_conf_.find(op_name);
+  CHECK(it != op_name2parallel_conf_.end());
+  return it->second;
+}
+
+const ParallelConf &JobBuilder::ParallelConf4OpName(const std::string &op_name) const {
+  return *op_name2parallel_conf_.at(op_name);
+}
+
+void JobBuilder::AddParallelConf4OpName(const std::string &op_name,
+                                        const ParallelConf &parallel_conf) {
+  bool update = (op_name2parallel_conf_.count(op_name) == 0);
+  if (update) {
+    // update `op_name2parallel_conf_`
+    PlacementGroup *group = job_->mutable_placement()->add_placement_group();
+    group->mutable_op_set()->add_op_name(op_name);
+    *(group->mutable_parallel_conf()) = parallel_conf;
+    op_name2parallel_conf_[op_name] = group->mutable_parallel_conf();
+  }
+}
+
+SbpParallel *JobBuilder::MutSbpParallel4Oba(const OpBlobArg &oba) const {
+  auto *sbp_sig = &(*job_->mutable_sbp_conf()->mutable_op_name2sbp_signature_conf())[oba.op_name()];
   return &(*sbp_sig->mutable_bn_in_op2sbp_parallel())[oba.bn_in_op()];
 }
 
-void JobBuilder::BindIdenticalSbpOpBlobArgPair(const OpBlobArg& first, const OpBlobArg& second) {
-  auto* pair = job_->mutable_helper()->mutable_identical_sbp_oba_pairs()->mutable_pair()->Add();
+void JobBuilder::BindIdenticalSbpOpBlobArgPair(const OpBlobArg &first, const OpBlobArg &second) {
+  auto *pair = job_->mutable_helper()->mutable_identical_sbp_oba_pairs()->mutable_pair()->Add();
   *pair->mutable_first() = first;
   *pair->mutable_second() = second;
+}
+
+SbpSignature *JobBuilder::MutableSbpSignature4OpName(const std::string &op_name) {
+  const auto &it = op_name2sbp_signature_conf_.find(op_name);
+  CHECK(it != op_name2sbp_signature_conf_.end());
+  return it->second;
+}
+
+const SbpSignature &JobBuilder::SbpSignature4OpName(const std::string &op_name) const {
+  const auto &it = op_name2sbp_signature_conf_.find(op_name);
+  CHECK(it != op_name2sbp_signature_conf_.end());
+  return *(it->second);
+}
+
+void JobBuilder::AddSbpSignature4OpName(const std::string &op_name,
+                                        const SbpSignature &sbp_signature) {
+  const auto &it = op_name2sbp_signature_conf_.find(op_name);
+  if (it != op_name2sbp_signature_conf_.end()) {
+    *(it->second) = sbp_signature;
+    return;
+  }
+
+  auto *op_name2sbp_signature_conf = job_->mutable_sbp_conf()->mutable_op_name2sbp_signature_conf();
+  (*op_name2sbp_signature_conf)[op_name] = sbp_signature;
+  op_name2sbp_signature_conf_.emplace(op_name, &(*op_name2sbp_signature_conf)[op_name]);
+}
+
+OpTimeShape *JobBuilder::MutableTimeShape4OpName(const std::string &op_name) {
+  const auto &it = op_name2time_shapes_.find(op_name);
+  CHECK(it != op_name2time_shapes_.end());
+  return it->second;
+}
+
+const OpTimeShape &JobBuilder::TimeShape4OpName(const std::string &op_name) const {
+  const auto &it = op_name2time_shapes_.find(op_name);
+  CHECK(it != op_name2time_shapes_.end());
+  return *(it->second);
+}
+
+void JobBuilder::AddTimeShape4OpName(const std::string &op_name, const OpTimeShape &time_shape) {
+  bool update = (op_name2time_shapes_.count(op_name) == 0);
+  if (update) {
+    auto *time_shape_conf = job_->mutable_helper()->mutable_op_name2op_time_shape();
+    (*time_shape_conf)[op_name] = time_shape;
+    op_name2time_shapes_[op_name] = &((*time_shape_conf)[op_name]);
+  }
+}
+
+OptInt64 *JobBuilder::MutableBatchAxis4Lbn(const std::string &lbn) {
+  const auto &it = lbn2batch_axis_.find(lbn);
+  CHECK(it != lbn2batch_axis_.end());
+  return it->second;
+}
+
+const OptInt64 &JobBuilder::BatchAxis4Lbn(const std::string &lbn) const {
+  const auto &it = lbn2batch_axis_.find(lbn);
+  CHECK(it != lbn2batch_axis_.end());
+  return *(it->second);
+}
+
+void JobBuilder::AddBatchAxis4Lbn(const std::string &lbn, const OptInt64 &axis) {
+  bool update =
+      (lbn2batch_axis_.count(lbn) == 0) || (lbn2batch_axis_[lbn]->value() != axis.value());
+  if (update) {
+    auto *batch_axis = job_->mutable_helper()->mutable_lbn2batch_axis();
+    (*batch_axis)[lbn] = axis;
+    lbn2batch_axis_[lbn] = &((*batch_axis)[lbn]);
+  }
 }
 
 }  // namespace oneflow

--- a/oneflow/core/job/job_builder.h
+++ b/oneflow/core/job/job_builder.h
@@ -8,8 +8,8 @@ namespace oneflow {
 
 const static std::string kProducedLbi2ConsumedDiffLbi = "produced_lbi2consumed_diff_lbi";
 
-std::function<const ParallelConf*(const std::string&)> MakeGetterParallelConf4OpName(
-    const Placement& placement);
+std::function<const ParallelConf *(const std::string &)> MakeGetterParallelConf4OpName(
+    const Placement &placement);
 
 class SbpParallel;
 class LogicalBlobId;
@@ -18,34 +18,60 @@ class Operator;
 class JobBuilder final {
  public:
   OF_DISALLOW_COPY_AND_MOVE(JobBuilder);
-  explicit JobBuilder(Job* job);
+  explicit JobBuilder(Job *job);
   ~JobBuilder() = default;
 
-  const Job& job() const { return *job_; }
-  JobHelperConf* mutable_helper() { return job_->mutable_helper(); }
-  SbpConf* mutable_sbp_conf() { return job_->mutable_sbp_conf(); }
+  const Job &job() const { return *job_; }
+  JobHelperConf *mutable_helper() { return job_->mutable_helper(); }
+  SbpConf *mutable_sbp_conf() { return job_->mutable_sbp_conf(); }
 
-  const OperatorConf& OpConf4OpName(const std::string& op_name) const;
-  const ParallelConf& ParallelConf4OpName(const std::string& op_name) const;
-  void AddOps(const ParallelConf& parallel_conf, const std::vector<OperatorConf>& op_confs);
-  void MutOpsOnlyOnce(const std::vector<OperatorConf>& op_confs);
-  void MutParallelConfOnlyOnce(const std::string& op_name, const ParallelConf& parallel_conf);
-  void AddOrMutOpsOnlyOnce(const ParallelConf& parallel_conf,
-                           const std::vector<OperatorConf>& op_confs);
-  void DelOps(const std::vector<OperatorConf>& op_confs);
-  SbpParallel* MutSbpParallel4Oba(const OpBlobArg& oba) const;
-  void BindIdenticalSbpOpBlobArgPair(const OpBlobArg& first, const OpBlobArg& second);
+  const OperatorConf &OpConf4OpName(const std::string &op_name) const;
+  OperatorConf *MutableOpConf4OpName(const std::string &op_name);
 
-  void ForEachOperator(const std::function<void(const Operator&)>& Handler) const;
+  void AddOps(const ParallelConf &parallel_conf, const std::vector<OperatorConf> &op_confs);
+  void MutOpsOnlyOnce(const std::vector<OperatorConf> &op_confs);
+  void MutParallelConfOnlyOnce(const std::string &op_name, const ParallelConf &parallel_conf);
+  void AddOrMutOpsOnlyOnce(const ParallelConf &parallel_conf,
+                           const std::vector<OperatorConf> &op_confs);
+
+  void RemoveOpByName(const std::string &op_name);
+  void DelOps(const std::vector<std::string> &op_names);
+  void DelOps(const std::vector<OperatorConf> &op_confs);
+
+  SbpParallel *MutSbpParallel4Oba(const OpBlobArg &oba) const;
+  void BindIdenticalSbpOpBlobArgPair(const OpBlobArg &first, const OpBlobArg &second);
+
+  void ForEachOperator(const std::function<void(const Operator &)> &Handler) const;
+
+  const ParallelConf &ParallelConf4OpName(const std::string &op_name) const;
+  ParallelConf *MutableParallelConf4OpName(const std::string &op_name);
+  void AddParallelConf4OpName(const std::string &op_name, const ParallelConf &parallel_conf);
+
+  const SbpSignature &SbpSignature4OpName(const std::string &op_name) const;
+  SbpSignature *MutableSbpSignature4OpName(const std::string &op_name);
+  void AddSbpSignature4OpName(const std::string &op_name, const SbpSignature &sbp_signature);
+
+  const OpTimeShape &TimeShape4OpName(const std::string &op_name) const;
+  OpTimeShape *MutableTimeShape4OpName(const std::string &op_name);
+  void AddTimeShape4OpName(const std::string &op_name, const OpTimeShape &time_shape);
+
+  const OptInt64 &BatchAxis4Lbn(const std::string &lbn) const;
+  OptInt64 *MutableBatchAxis4Lbn(const std::string &lbn);
+  void AddBatchAxis4Lbn(const std::string &lbn, const OptInt64 &axis);
+  bool HasBatchAxis4Lbn(const std::string &lbn) const { return lbn2batch_axis_.count(lbn) > 0; }
 
  private:
-  PlacementGroup* FindPlacementGroup(const std::string& op_name) const;
+  PlacementGroup *FindPlacementGroup(const std::string &op_name) const;
 
-  Job* job_;
-  HashMap<std::string, OperatorConf*> op_name2op_conf_;
-  HashMap<std::string, ParallelConf*> op_name2parallel_conf_;
+  Job *job_;
+  HashMap<std::string, OperatorConf *> op_name2op_conf_;
+  HashMap<std::string, ParallelConf *> op_name2parallel_conf_;
   HashSet<std::string> modified_op_conf_op_names_;
   HashSet<std::string> modified_parallel_conf_op_names_;
+
+  HashMap<std::string, SbpSignature *> op_name2sbp_signature_conf_;
+  HashMap<std::string, OpTimeShape *> op_name2time_shapes_;
+  HashMap<std::string, OptInt64 *> lbn2batch_axis_;
 };
 
 }  // namespace oneflow

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -7,6 +7,7 @@ import "oneflow/core/record/image.proto";
 import "oneflow/core/record/record.proto";
 import "oneflow/core/job/resource.proto";
 import "oneflow/core/register/logical_blob_id.proto";
+import "oneflow/core/job/sbp_parallel.proto";
 
 enum ActivationType {
   kNone = 0;
@@ -1481,6 +1482,34 @@ message LearningRateScheduleOpConf {
   optional WarmupConf warmup_conf = 5;
 }
 
+message XlaLaunchOpConf {
+  message Argument {
+    required string name = 1;
+    required string in = 2;
+    required string out = 3;
+    required DeviceType device_type = 4;
+    optional bool is_mutable = 5 [default = false];
+  }
+  message ResourceScope {
+    message Shape {
+      required ShapeProto shape = 1;
+      required DataType data_type = 2;
+    }
+    map<string, Shape> shapes = 1;
+    map<string, OptInt64> batch_axis = 2;
+    map<string, SbpParallel> sbp_signatures = 3;
+  }
+  message Attribute {
+    repeated Argument argument = 1;
+    repeated OperatorConf node = 2;
+    required ResourceScope resource_scope = 3;
+    optional bool is_model_update = 4 [default = false];
+  }
+  repeated string in = 1;
+  repeated string out = 2;
+  required Attribute attr = 3;
+}
+
 message NcclBoxingReduceScatterOpConf {
   required LogicalBlobId lbi = 1;
 }
@@ -1641,6 +1670,7 @@ message OperatorConf {
     GatherMs0OpConf gather_ms0_conf = 305;
     GatherMs0GradOpConf gather_ms0_grad_conf = 306;
 
+    XlaLaunchOpConf xla_launch_conf = 410;
     // math op
     BroadcastAddOpConf broadcast_add_conf = 500;
     BroadcastSubOpConf broadcast_sub_conf = 501;

--- a/oneflow/core/register/blob_desc.h
+++ b/oneflow/core/register/blob_desc.h
@@ -14,6 +14,7 @@ namespace oneflow {
 class BlobDesc {
  public:
   // OF_DISALLOW_COPY_AND_MOVE(BlobDesc);
+  BlobDesc() : BlobDesc(DataType::kInvalidDataType) {}
   ~BlobDesc() = default;
 
   explicit BlobDesc(DataType data_type);

--- a/oneflow/python/ops/op_util.py
+++ b/oneflow/python/ops/op_util.py
@@ -5,6 +5,7 @@ from oneflow.core.operator.op_conf_pb2 import OperatorConf
 
 def IsOpConfOnlyCpuSupported(op_conf):
     assert isinstance(op_conf, OperatorConf)
+    """
     global _cpu_only_op_type_cases
     if _cpu_only_op_type_cases == None:
         _cpu_only_op_type_cases = set()
@@ -13,4 +14,9 @@ def IsOpConfOnlyCpuSupported(op_conf):
                 _cpu_only_op_type_cases.add(field.number)
     op_type_field = op_conf.WhichOneof("op_type")
     return OperatorConf.DESCRIPTOR.fields_by_name[op_type_field].number in _cpu_only_op_type_cases
-_cpu_only_op_type_cases = None
+    """
+    op_type_field = op_conf.WhichOneof("op_type")
+    field_number = OperatorConf.DESCRIPTOR.fields_by_name[op_type_field].number
+    return c_api_util.IsOpTypeCaseCpuSupportOnly(field_number)
+    
+# _cpu_only_op_type_cases = None


### PR DESCRIPTION
这个PR主要提交的是对oneflow core目录下的代码进行的改动。
- protobuf
   1. 增加了一个以field_name为输入的GetMessageInPbMessage接口。
   2. GetMessageInPbMessage/SetMessageInPbMessage支持std::vector模版，比如
    ```c++
    GetMessageInPbMessage<std::vector<std::string>>(...)
   ```
  3. GetMessageInPbMessage/SetMessageInPbMessage支持DataType和ShapeProto。
- normal_forward_compute_task_node.cpp和optimizer_compute_task_node.cpp
   op被聚合后，op与op之间的连边不再只有一条，也就是说task node的输入边可能绑定了多个register，因此将ConsumeAllRegsts中的消费SoleRegst改成了消费所有的Regst。
- reduce_split_compute_task_node.cpp
   op被聚合后，reduce_split op可能有多条出边连到了同一个op，以前的代码在处理这种情况时有问题。现在改成每个out bn对应一个regist，task node的每条出边可以绑定多个regist，并且不影响regist的mem sharing。
- compile.cpp和job_complete.cpp
   增加了XLA相关pass的执行。
- job_builder.cpp
   增加了RemoveOpByName、ParallelConf4OpName/MutableParallelConf4OpName/AddParallelConf4OpName等一序列接口，方便XLA根据合并子图的graph重建job。
- op_conf.proto
  增加了XlaLaunchOpConf message以及在OperatorConf中增加了XlaLaunchOp
- op_util.py
  WITH_XLA=OFF时，XlaLaunchOp不会注册，导致python IsOpConfOnlyCpuSupported查询XlaLaunchOp出错，已fix。
