### PR TITLE
rename Read to ReadFully

### DIFF
--- a/oneflow/core/actor/act_event_logger.cpp
+++ b/oneflow/core/actor/act_event_logger.cpp
@@ -32,9 +32,9 @@ void ParseActEvents(const std::string& act_event_filepath,
                     std::list<std::unique_ptr<ActEvent>>* act_events) {
   PersistentInStream in_stream(LocalFS(), act_event_filepath);
   int64_t act_event_size;
-  while (!in_stream.Read(reinterpret_cast<char*>(&act_event_size), sizeof(act_event_size))) {
+  while (!in_stream.ReadFully(reinterpret_cast<char*>(&act_event_size), sizeof(act_event_size))) {
     std::vector<char> buffer(act_event_size);
-    CHECK(!in_stream.Read(buffer.data(), act_event_size));
+    CHECK(!in_stream.ReadFully(buffer.data(), act_event_size));
     auto act_event = std::make_unique<ActEvent>();
     act_event->ParseFromArray(buffer.data(), act_event_size);
     act_events->emplace_back(std::move(act_event));

--- a/oneflow/core/persistence/persistent_in_stream.cpp
+++ b/oneflow/core/persistence/persistent_in_stream.cpp
@@ -66,7 +66,7 @@ int32_t PersistentInStream::ReadLine(std::string* l) {
   return 0;
 }
 
-int32_t PersistentInStream::Read(char* s, size_t n) {
+int32_t PersistentInStream::ReadFully(char* s, size_t n) {
   if (IsEof()) { return -1; }
   while (n) {
     if (cur_buf_begin_ == cur_buf_end_) { UpdateBuffer(); }

--- a/oneflow/core/persistence/persistent_in_stream.h
+++ b/oneflow/core/persistence/persistent_in_stream.h
@@ -22,7 +22,7 @@ class PersistentInStream {
   // 0: success
   // -1: eof
   int32_t ReadLine(std::string* l);
-  int32_t Read(char* s, size_t n);
+  int32_t ReadFully(char* s, size_t n);
 
  private:
   bool IsEof() const;

--- a/oneflow/core/persistence/snapshot.cpp
+++ b/oneflow/core/persistence/snapshot.cpp
@@ -22,7 +22,7 @@ void SnapshotReader::Read(const std::string& key, Blob* blob) const {
   CHECK_EQ(SnapshotFS()->GetFileSize(path), blob_size)
       << "unexpected model snapshot size, path: " << path;
   PersistentInStream in_stream(SnapshotFS(), path);
-  in_stream.Read(blob->mut_dptr<char>(), blob_size);
+  in_stream.ReadFully(blob->mut_dptr<char>(), blob_size);
 }
 
 void SnapshotReader::Close() {}

--- a/oneflow/core/record/ofrecord_reader.cpp
+++ b/oneflow/core/record/ofrecord_reader.cpp
@@ -10,11 +10,11 @@ constexpr int64_t MAX_CHUNK_SIZE = 64 * 1024 * 1024;  // 64M
 namespace {
 
 bool ReadChunk(PersistentInStream* is, OFRecordChunk* chunk) {
-  if (is->Read(reinterpret_cast<char*>(&chunk->size), sizeof(int64_t)) == 0) {
+  if (is->ReadFully(reinterpret_cast<char*>(&chunk->size), sizeof(int64_t)) == 0) {
     CHECK_GE(chunk->size, 0);
     CHECK_LE(chunk->size, MAX_CHUNK_SIZE);
     chunk->data.reset(new char[chunk->size]);
-    CHECK_EQ(is->Read(chunk->data.get(), chunk->size), 0);
+    CHECK_EQ(is->ReadFully(chunk->data.get(), chunk->size), 0);
     return true;
   }
   return false;


### PR DESCRIPTION
PersistentInStream::Read重命名为ReadFully

原来的方法名称和行为不一致，常见Read方法应允许实际读取长度和参数n不一致并返回实际读取长度。目前Read方法的行为和readFully行为一致，所以重命名为ReadFully

https://docs.oracle.com/javase/7/docs/api/java/io/DataInputStream.html#readFully(byte[])

https://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html#read(byte[])

http://www.cplusplus.com/reference/cstdio/fread/

https://golang.org/pkg/io/#Reader