### PR TITLE
Fix unittest import conflict for py2

### DIFF
--- a/oneflow/python/framework/unittest.py
+++ b/oneflow/python/framework/unittest.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import inspect
 from oneflow.python.oneflow_export import oneflow_export


### PR DESCRIPTION
这个文件和unitest模块同名，python2的import会优先导入本地的unittest文件，导致unittest.TestCase爆错“'module' object has no attribute 'TestCase'”。
