### PR TITLE
tmp_regst_desc_id_vec_

### DIFF
--- a/oneflow/core/actor/actor.h
+++ b/oneflow/core/actor/actor.h
@@ -232,6 +232,7 @@ class Actor {
 
   std::deque<ActorMsg> async_msg_queue_;
   bool is_kernel_launch_synchronized_;
+  std::vector<int64_t> tmp_regst_desc_id_vec_;
 };
 
 std::unique_ptr<Actor> NewActor(const TaskProto&, const ThreadCtx&);


### PR DESCRIPTION
重用一个vector以减少vector构建和扩容的开销
预计开销差别在 100ns 和 5ns (一个vector)