### PR TITLE
ensure sender can exit

### DIFF
--- a/oneflow/core/common/buffer.h
+++ b/oneflow/core/common/buffer.h
@@ -30,8 +30,8 @@ class Buffer final {
 template<typename T>
 BufferStatus Buffer<T>::Send(const T& item) {
   std::unique_lock<std::mutex> lock(mutex_);
+  cond_.wait(lock, [this]() { return queue_.size() < max_len_ || is_closed_; });
   if (is_closed_) { return kBufferStatusErrorClosed; }
-  cond_.wait(lock, [this]() { return queue_.size() < max_len_; });
   queue_.push(item);
   cond_.notify_one();
   return kBufferStatusSuccess;


### PR DESCRIPTION
确保buffer的sender在buffer 被close之后可以正常退出