### PR TITLE
quick fix

### DIFF
--- a/cmake/third_party/opencv.cmake
+++ b/cmake/third_party/opencv.cmake
@@ -102,7 +102,7 @@ ExternalProject_Add(opencv
         -DBUILD_TBB:BOOL=ON
         -DBUILD_IPP_IW:BOOL=OFF
         -DWITH_ITT:BOOL=ON
-        -DLIB_SUFFIX:STRING=64
+        # -DLIB_SUFFIX:STRING=64
 )
 
 # put opencv includes in the 'THIRD_PARTY_DIR'


### PR DESCRIPTION
发现在 centos docker 加上这个参数会导致出现 `lib6464` 的目录，彻底解决之前因为大部分同学都是用centos build，先注释掉