### PR TITLE
BugFix: keep header only op multi input/output

### DIFF
--- a/oneflow/core/operator/keep_header_only_op.cpp
+++ b/oneflow/core/operator/keep_header_only_op.cpp
@@ -22,6 +22,15 @@ Maybe<void> KeepHeaderOnlyOp::InferBlobDescs(
   return Maybe<void>::Ok();
 }
 
+Maybe<void> KeepHeaderOnlyOp::InferBatchAxis(
+    std::function<OptInt64*(const std::string&)> BatchAxis4BnInOp) const {
+  size_t in_num = GetPbRpfFromCustomizedConf<std::string>("in").size();
+  for (size_t i = 0; i < in_num; ++i) {
+    *BatchAxis4BnInOp(GenRepeatedBn("out", i)) = *BatchAxis4BnInOp(GenRepeatedBn("in", i));
+  }
+  return Maybe<void>::Ok();
+}
+
 Maybe<void> KeepHeaderOnlyOp::GetSbpSignatures(
     const std::function<Maybe<const BlobDesc*>(const std::string&)>& LogicalBlobDesc4Ibn,
     SbpSignatureList* sbp_sig_list) const {

--- a/oneflow/core/operator/keep_header_only_op.h
+++ b/oneflow/core/operator/keep_header_only_op.h
@@ -20,9 +20,7 @@ class KeepHeaderOnlyOp final : public Operator {
 
  private:
   Maybe<void> InferBatchAxis(
-      std::function<OptInt64*(const std::string&)> BatchAxis4BnInOp) const override {
-    return NaiveInferBatchAxis(BatchAxis4BnInOp);
-  }
+      std::function<OptInt64*(const std::string&)> BatchAxis4BnInOp) const override;
 
   Maybe<void> GetSbpSignatures(
       const std::function<Maybe<const BlobDesc*>(const std::string&)>& LogicalBlobDesc4Ibn,


### PR DESCRIPTION
1.  修复keep header only op 在InferBatchAxis时调用Navie接口的BUG
2.  由于ComputePackedBlob时，纯header的多个blob无法计算其 packed blob，故在job_completer构图时对于同一个node对应多个keep header需求的情况，拆成多个keep header only op，使得keep header only强制是单in/单out的构图。