### PR TITLE
fix cocoapi build command

### DIFF
--- a/cmake/third_party/cocoapi.cmake
+++ b/cmake/third_party/cocoapi.cmake
@@ -24,7 +24,8 @@ ExternalProject_Add(cocoapi
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE 1
-    BUILD_COMMAND gcc -fPIC -O3 -c common/maskApi.c -o maskApi.o && ar rcs ${COCOAPI_LIBRARY_NAME} maskApi.o
+    BUILD_COMMAND ${CMAKE_C_COMPILER} -fPIC -O3 -c common/maskApi.c -o maskApi.o &&
+        ${CMAKE_AR} rcs ${COCOAPI_LIBRARY_NAME} maskApi.o
     INSTALL_COMMAND ""
 )
 


### PR DESCRIPTION
使用cmake变量CMAKE_C_COMPILER和CMAKE_AR替代gcc和ar