### PR TITLE
PATHS->HINTS

### DIFF
--- a/cmake/third_party/FindCuDNN.cmake
+++ b/cmake/third_party/FindCuDNN.cmake
@@ -21,11 +21,11 @@ else()
 endif()
 
 find_path(CUDNN_INCLUDE_DIR cudnn.h
-    PATHS ${CUDNN_ROOT_DIR} ${CUDA_TOOLKIT_ROOT_DIR}
+    HINTS ${CUDNN_ROOT_DIR} ${CUDA_TOOLKIT_ROOT_DIR}
     PATH_SUFFIXES cuda/include include)
 
 find_library(CUDNN_LIBRARY ${__cudnn_libname}
-    PATHS ${CUDNN_ROOT_DIR} ${CUDA_TOOLKIT_ROOT_DIR}
+	HINTS ${CUDNN_ROOT_DIR} ${CUDA_TOOLKIT_ROOT_DIR}
     PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
 
 find_package_handle_standard_args(


### PR DESCRIPTION
根据cmake文档`https://cmake.org/cmake/help/v3.16/command/find_path.html`，find_path搜索优先级 `HINTS` > `系统路径` > `PATHS`，使用PATHS会导致无论是否指定`CUDNN_ROOT_DIR`或者`CUDA_TOOLKIT_ROOT_DIR`始终找到的是`/usr/local/cuda`下面的`cudnn`