### PR TITLE
PruneParallelCastOpsPass

### DIFF
--- a/oneflow/core/job/job.proto
+++ b/oneflow/core/job/job.proto
@@ -116,6 +116,7 @@ message JobConfigProto {
   optional bool enable_non_distributed_optimizer = 506 [default = false];
   optional int64 non_distributed_optimizer_group_size_mbyte = 507 [default = 100];
   optional bool disable_all_reduce_sequence = 508 [default = false];
+  optional bool prune_parallel_cast_ops = 509 [default = false];
 
   optional bool cudnn_conv_enable_true_half = 600 [default = false];
   optional bool enable_float_compute_for_half_gemm = 601 [default = true];

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -59,6 +59,7 @@ Maybe<void> JobBuildAndInferCtx::Complete() {
     DoPass("AddAllReduceGroupPass");
     DoPass("AddLbiDiffWatcherOpConfs");
     DoPass("SequentializeAllReduceGroupPass");
+    DoPass("PruneParallelCastOpsPass");
   }
   DoPass("DumpTimeShapeAndBlobParallelConfPass");
   return Maybe<void>::Ok();

--- a/oneflow/core/job/job_desc.h
+++ b/oneflow/core/job/job_desc.h
@@ -57,6 +57,7 @@ class JobDesc final {
     return job_conf_.non_distributed_optimizer_group_size_mbyte();
   }
   bool disable_all_reduce_sequence() const { return job_conf_.disable_all_reduce_sequence(); }
+  bool prune_parallel_cast_ops() const { return job_conf_.prune_parallel_cast_ops(); }
   int64_t all_reduce_group_num() const;
   int64_t all_reduce_group_min_byte() const;
   float all_reduce_group_size_warmup() const;

--- a/oneflow/core/job_completer/prune_parallel_cast_op_pass.cpp
+++ b/oneflow/core/job_completer/prune_parallel_cast_op_pass.cpp
@@ -1,0 +1,76 @@
+#include "oneflow/core/job_completer/op_graph_pass.h"
+#include "oneflow/core/register/runtime_blob_desc.h"
+
+namespace oneflow {
+
+namespace {
+
+class PruneParallelCastOpsPass final : public OpGraphPass {
+ public:
+  PruneParallelCastOpsPass() = default;
+  ~PruneParallelCastOpsPass() override = default;
+  bool IsEnabled() const override { return GlobalJobDesc().prune_parallel_cast_ops(); }
+  void Apply(const OpGraph& op_graph, JobBuilder* job_builder) const override;
+};
+
+void PruneParallelCastOpsPass::Apply(const OpGraph& op_graph, JobBuilder* job_builder) const {
+  HashMap<std::string, OperatorConf> op_name2op_conf;
+  HashMap<std::string, SbpSignature> op_name2sbp_signature;
+  HashSet<std::string> ctrl_in_op_names;
+  op_graph.ForEachNode([&](const OpNode* op_node) {
+    for (const std::string& ctrl_in_op_name : op_node->op().op_conf().ctrl_in_op_name()) {
+      ctrl_in_op_names.insert(ctrl_in_op_name);
+    }
+  });
+  op_graph.ForEachNode([&](const OpNode* op_node) {
+    const OperatorConf& op_conf = op_node->op().op_conf();
+    if (!op_conf.has_parallel_cast_conf()) { return; }
+    if (!op_conf.ctrl_in_op_name().empty()) { return; }
+    if (ctrl_in_op_names.find(op_conf.name()) != ctrl_in_op_names.end()) { return; }
+    if (op_node->in_edges().size() != 1) { return; }
+    const OpNode* producer = op_node->SoleInEdge()->src_node();
+    const LogicalBlobId& parallel_cast_in_lbi = op_node->op().BnInOp2Lbi("in");
+    const LogicalBlobId& parallel_cast_out_lbi = op_node->op().BnInOp2Lbi("out");
+    const SbpParallel& parallel_cast_sbp_parallel = op_node->SbpParallel4Lbi(parallel_cast_in_lbi);
+    const SbpParallel& producer_sbp_parallel = producer->SbpParallel4Lbi(parallel_cast_in_lbi);
+    if (op_node->parallel_desc() != producer->parallel_desc()) { return; }
+    if (parallel_cast_sbp_parallel != producer_sbp_parallel) { return; }
+    for (const OpEdge* out_edge : op_node->out_edges()) {
+      const OpNode* consumer = out_edge->dst_node();
+      if (consumer->op().op_conf().has_parallel_cast_conf()) { return; }
+      if (consumer->parallel_desc() != op_node->parallel_desc()) { return; }
+      if (consumer->SbpParallel4Lbi(parallel_cast_out_lbi) != parallel_cast_sbp_parallel) {
+        return;
+      }
+    }
+    op_name2sbp_signature[producer->op().op_name()] = producer->sbp_signature();
+    for (const OpEdge* out_edge : op_node->out_edges()) {
+      const OpNode* consumer = out_edge->dst_node();
+      const std::string& consumer_op_name = consumer->op().op_name();
+      op_name2sbp_signature[consumer_op_name] = consumer->sbp_signature();
+      if (op_name2op_conf.find(consumer_op_name) == op_name2op_conf.end()) {
+        op_name2op_conf[consumer_op_name] = consumer->op().op_conf();
+      }
+      OperatorConf& consumer_op_conf = op_name2op_conf.at(consumer_op_name);
+      PbMessage* conf =
+          MutableMessageInPbMessage(&consumer_op_conf, consumer_op_conf.op_type_case());
+      for (const std::string& ibn : consumer->op().input_bns()) {
+        if (consumer->op().BnInOp2Lbi(ibn) == parallel_cast_out_lbi) {
+          ReplaceStrValInPbFdOrPbRpf(conf, ibn, GenLogicalBlobName(parallel_cast_out_lbi),
+                                     GenLogicalBlobName(parallel_cast_in_lbi));
+        }
+      }
+    }
+    job_builder->DelOps({op_conf});
+  });
+  for (const auto& pair : op_name2op_conf) { job_builder->MutOpsOnlyOnce({pair.second}); }
+  for (const auto& pair : op_name2sbp_signature) {
+    job_builder->AddSbpSignature4OpName(pair.first, pair.second);
+  }
+}
+
+}  // namespace
+
+REGISTER_FUNCTION_PASS("PruneParallelCastOpsPass", PruneParallelCastOpsPass);
+
+}  // namespace oneflow

--- a/oneflow/python/framework/function_util.py
+++ b/oneflow/python/framework/function_util.py
@@ -218,6 +218,10 @@ def set_enable_non_distributed_optimizer(func_desc, value = True):
 def set_disable_all_reduce_sequence(func_desc, value = True):
     func_desc.job_config_proto.disable_all_reduce_sequence = value
 
+@oneflow_function_config('prune_parallel_cast_ops')
+def set_prune_parallel_cast_ops(func_desc, value=True):
+    func_desc.job_config_proto.prune_parallel_cast_ops = value
+
 @oneflow_function_config('non_distributed_optimizer_group_size_mbyte')
 def set_non_distributed_optimizer_group_size_mbyte(func_desc, value):
     func_desc.job_config_proto.non_distributed_optimizer_group_size_mbyte = value


### PR DESCRIPTION
添加`PruneParallelCastOpsPass`，开启后将移除不必要的ParallelCastOp
ParallelCastOp用来指导前后向Op推到SbpParallel，一旦SbpParallel确定，ParallelCastOp就可以优化掉了。优化掉ParallelCastOp在两个场景下有意义：1) 类似W&D一个batch执行时间很短的网络;2) 网络中有大量的ParallelCastOp
符合条件的ParallelCastOp才会被删除
* 上游与下游所有节点对应的ParallelConf和SbpParallel相同
* 下游不包括ParallelCastOp，删除连续的两个Op可能出现Bug
* ParallelCastOp没有ctrl_in_op，也不是其他Op的ctrl_in
符合条件的ParallelCastOp被删除，下游节点直接消费上游节点，对应的SbpParallel写入到SbpSignature