### PR TITLE
refactor object_msg

### DIFF
--- a/oneflow/core/common/cached_object_msg_allocator.cpp
+++ b/oneflow/core/common/cached_object_msg_allocator.cpp
@@ -9,74 +9,71 @@ int RoundUpShift(std::size_t size) { return (static_cast<int>(std::log2(size)) +
 
 }  // namespace
 
-ObjMsgMemBlock* ObjMsgMemBlock::PlacementNew(char* mem_ptr,
-                                             OBJECT_MSG_TYPE(ObjMsgChunk) * obj_msg_chunk) {
+ObjMsgMemBlock* ObjMsgMemBlock::PlacementNew(char* mem_ptr, ObjMsgChunk* obj_msg_chunk) {
   ObjMsgMemBlock* ret = new (mem_ptr) ObjMsgMemBlock();
   ret->chunk_ = obj_msg_chunk;
   return ret;
 }
 
-void OBJECT_MSG_TYPE(ObjMsgChunk)::__Init__(OBJECT_MSG_TYPE(ObjMsgSizedMemPool) * mem_pool,
-                                            int64_t mem_size) {
+void ObjMsgChunk::__Init__(ObjMsgSizedMemPool* mem_pool, int64_t mem_size) {
   set_mem_size(mem_size);
   char* mem_ptr = mut_allocator()->Allocate(sizeof(ObjMsgMemBlock) + mem_size);
   set_mem_block(ObjMsgMemBlock::PlacementNew(mem_ptr, this));
   set_mem_pool(mem_pool);
 }
 
-void OBJECT_MSG_TYPE(ObjMsgChunk)::__Delete__() {
+void ObjMsgChunk::__Delete__() {
   mut_allocator()->Deallocate(reinterpret_cast<char*>(mutable_mem_block()),
                               sizeof(ObjMsgMemBlock) + this->mem_size());
 }
 
-void OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::__Init__(int64_t fixed_mem_size, int64_t prefetch_cnt) {
+void ObjMsgSizedMemPool::__Init__(int64_t fixed_mem_size, int64_t prefetch_cnt) {
   set_mem_block_size(fixed_mem_size);
   set_prefetch_cnt(prefetch_cnt);
   Prefetch();
 }
 
-void OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::__Delete__() { CHECK(occupied_chunk_list().empty()); }
+void ObjMsgSizedMemPool::__Delete__() { CHECK(occupied_chunk_list().empty()); }
 
-char* OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::Allocate(std ::mutex* mutex) {
+char* ObjMsgSizedMemPool::Allocate(std ::mutex* mutex) {
   if (mutex == nullptr) { return Allocate(); }
   std::unique_lock<std::mutex> lock(*mutex);
   return Allocate();
 }
 
-char* OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::Allocate() {
+char* ObjMsgSizedMemPool::Allocate() {
   if (free_chunk_list().empty()) { Prefetch(); }
   auto chunk = mut_free_chunk_list()->MoveFrontToDstBack(mut_occupied_chunk_list());
   return chunk->mutable_mem_block()->mem_ptr();
 }
 
-void OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::Deallocate(std ::mutex* mutex, char* ptr) {
+void ObjMsgSizedMemPool::Deallocate(std ::mutex* mutex, char* ptr) {
   if (mutex == nullptr) { return Deallocate(ptr); }
   std::unique_lock<std::mutex> lock(*mutex);
   return Deallocate(ptr);
 }
 
-void OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::Deallocate(char* ptr) {
+void ObjMsgSizedMemPool::Deallocate(char* ptr) {
   auto* chunk =
       StructField<ObjMsgMemBlock, char, ObjMsgMemBlock::MemPtrOffset()>::StructPtr4FieldPtr(ptr)
           ->mut_chunk();
   mut_occupied_chunk_list()->MoveToDstBack(chunk, mut_free_chunk_list());
 }
 
-void OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::Prefetch() {
+void ObjMsgSizedMemPool::Prefetch() {
   ObjMsgChunkList free_list;
   Prefetch(&free_list);
   AppendToFreeList(&free_list);
 }
 
-void OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::Prefetch(ObjMsgChunkList* free_list) {
+void ObjMsgSizedMemPool::Prefetch(ObjMsgChunkList* free_list) {
   for (int64_t i = 0; i < prefetch_cnt(); ++i) {
-    auto chunk = OBJECT_MSG_PTR(ObjMsgChunk)::New(mut_allocator());
-    chunk->__Init__(this, mem_block_size());
+    auto chunk = ObjectMsgPtr<ObjMsgChunk>::NewFrom(mut_allocator(), this, mem_block_size());
     free_list->PushBack(chunk.Mutable());
   }
 }
 
-void OBJECT_MSG_TYPE(ObjMsgSizedMemPool)::AppendToFreeList(ObjMsgChunkList* free_list) {
+void ObjMsgSizedMemPool::AppendToFreeList(ObjMsgChunkList* free_list) {
   free_list->MoveTo(mut_free_chunk_list());
 }
 
@@ -98,8 +95,8 @@ void CachedObjectMsgAllocatorBase::Prefetch() {
   CHECK_LT(kMemSizeShiftMin, mem_size_shift_max_);
   allocators_.resize(mem_size_shift_max_ - kMemSizeShiftMin + 1);
   for (int i = kMemSizeShiftMin; i <= mem_size_shift_max_; ++i) {
-    auto mem_pool = OBJECT_MSG_PTR(ObjMsgSizedMemPool)::New(backend_allocator_);
-    mem_pool->__Init__(1 << i, prefetch_cnt_);
+    auto mem_pool =
+        ObjectMsgPtr<ObjMsgSizedMemPool>::NewFrom(backend_allocator_, 1 << i, prefetch_cnt_);
     allocators_.at(i - kMemSizeShiftMin) = mem_pool;
   }
 }

--- a/oneflow/core/common/cached_object_msg_allocator.h
+++ b/oneflow/core/common/cached_object_msg_allocator.h
@@ -7,13 +7,13 @@
 
 namespace oneflow {
 
-class OBJECT_MSG_TYPE(ObjMsgChunk);
+class ObjMsgChunk;
 
 struct ObjMsgMemBlock final {
  public:
-  static ObjMsgMemBlock* PlacementNew(char* mem_ptr, OBJECT_MSG_TYPE(ObjMsgChunk) * obj_msg_chunk);
+  static ObjMsgMemBlock* PlacementNew(char* mem_ptr, ObjMsgChunk* obj_msg_chunk);
 
-  OBJECT_MSG_TYPE(ObjMsgChunk) * mut_chunk() { return chunk_; }
+  ObjMsgChunk* mut_chunk() { return chunk_; }
 
   char* mem_ptr() { return &mem_ptr_[0]; }
 
@@ -22,22 +22,22 @@ struct ObjMsgMemBlock final {
     return (int)(long long)&((ObjMsgMemBlock*)nullptr)->mem_ptr_[0];
   }
 
-  OBJECT_MSG_TYPE(ObjMsgChunk) * chunk_;
+  ObjMsgChunk* chunk_;
   char mem_ptr_[0];
 };
 
-class OBJECT_MSG_TYPE(ObjMsgSizedMemPool);
+class ObjMsgSizedMemPool;
 
 // clang-format off
 BEGIN_OBJECT_MSG(ObjMsgChunk);
  public:
-  void __Init__(OBJECT_MSG_TYPE(ObjMsgSizedMemPool)* mem_pool, int64_t mem_size);
+  void __Init__(ObjMsgSizedMemPool* mem_pool, int64_t mem_size);
   void __Delete__();
 
   // fields
   OBJECT_MSG_DEFINE_OPTIONAL(int64_t, mem_size);
-  OBJECT_MSG_DEFINE_RAW_PTR(ObjMsgMemBlock*, mem_block);
-  OBJECT_MSG_DEFINE_RAW_PTR(OBJECT_MSG_TYPE(ObjMsgSizedMemPool)*, mem_pool);
+  OBJECT_MSG_DEFINE_RAW_PTR(ObjMsgMemBlock, mem_block);
+  OBJECT_MSG_DEFINE_RAW_PTR(ObjMsgSizedMemPool, mem_pool);
 
   // links
   OBJECT_MSG_DEFINE_LIST_LINK(list);
@@ -93,7 +93,7 @@ class CachedObjectMsgAllocatorBase : public ObjectMsgAllocator {
   ObjectMsgAllocator* backend_allocator_;
   std::size_t mem_size_shift_max_;
   int64_t prefetch_cnt_;
-  std::vector<OBJECT_MSG_PTR(ObjMsgSizedMemPool)> allocators_;
+  std::vector<ObjectMsgPtr<ObjMsgSizedMemPool>> allocators_;
 };
 
 class CachedObjectMsgAllocator : public CachedObjectMsgAllocatorBase {

--- a/oneflow/core/common/dss.h
+++ b/oneflow/core/common/dss.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include "oneflow/core/common/preprocessor.h"
+#include "oneflow/core/common/struct_traits.h"
 
 namespace oneflow {
 
@@ -15,12 +16,6 @@ namespace oneflow {
 #define DSS_DEFINE_UNION_FIELD_VISITOR(field_counter, field_case, type7field7case_tuple_seq) \
   _DSS_DEFINE_UNION_FIELD_VISITOR(field_counter, field_case, type7field7case_tuple_seq)
 #define DSS_GET_FIELD_COUNTER() __COUNTER__
-
-#define DSS_DEFINE_GETTER(field_type, field_name) _DSS_DEFINE_GETTER(field_type, field_name)
-
-#define DSS_DEFINE_MUTABLE(field_type, field_name) _DSS_DEFINE_MUTABLE(field_type, field_name)
-#define DSS_DEFINE_SETTER(is_scalar, field_type, field_name) \
-  _DSS_DEFINE_SETTER(is_scalar, field_type, field_name)
 
 // details
 
@@ -36,6 +31,18 @@ namespace oneflow {
         default:;                                                                             \
       }                                                                                       \
     }                                                                                         \
+  };                                                                                          \
+  template<template<int, class, class> class F, typename WalkCtxType, typename DssFieldType,  \
+           typename fake>                                                                     \
+  struct __DSS__VisitFieldUntil<field_counter, F, WalkCtxType, DssFieldType, fake> {          \
+    template<typename __DssFieldType>                                                         \
+    using PartialF = F<field_counter, WalkCtxType, __DssFieldType>;                           \
+    static bool Call(WalkCtxType* ctx, DssFieldType* field_ptr, const char* __field_name__) { \
+      switch (field_ptr->field_case) {                                                        \
+        OF_PP_FOR_EACH_TUPLE(_DSS_MAKE_UNION_FIELD_VISITOR_ENTRY, type7field7case_tuple_seq)  \
+        default:;                                                                             \
+      }                                                                                       \
+    }                                                                                         \
   };
 
 #define _DSS_MAKE_UNION_FIELD_VISITOR_ENTRY(field_type, field_name, field_case_value) \
@@ -44,73 +51,102 @@ namespace oneflow {
     return PartialF<field_type>::Call(ctx, &field_ptr->field_name, case_field_name);  \
   }
 
-#define _BEGIN_DSS(field_counter, type, base_byte_size)                                       \
- public:                                                                                      \
-  template<template<int, class, class> class F, typename WalkCtxType>                         \
-  void __WalkField__(WalkCtxType* ctx) {                                                      \
-    __DSS__FieldIter<field_counter, F, WalkCtxType>::Call(ctx, this);                         \
-  }                                                                                           \
-                                                                                              \
- private:                                                                                     \
-  using __DssSelfType__ = type;                                                               \
-  template<int tpl_fld_counter, template<int, class, class> class F, typename WalkCtxType,    \
-           typename DssFieldType, typename fake = void>                                       \
-  struct __DSS__VisitField {                                                                  \
-    static void Call(WalkCtxType* ctx, DssFieldType* field_ptr, const char* __field_name__) { \
-      F<tpl_fld_counter, WalkCtxType, DssFieldType>::Call(ctx, field_ptr, __field_name__);    \
-    }                                                                                         \
-  };                                                                                          \
-  template<int tpl_fld_counter, template<int, class, class> class F, typename WalkCtxType,    \
-           typename fake = void>                                                              \
-  struct __DSS__FieldIter {                                                                   \
-    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {                               \
-      __DSS__FieldIter<tpl_fld_counter + 1, F, WalkCtxType>::Call(ctx, self);                 \
-    }                                                                                         \
-  };                                                                                          \
-  template<int tpl_fld_counter, template<int, class, class> class F, typename WalkCtxType,    \
-           typename fake = void>                                                              \
-  struct __DSS__FieldReverseIter {                                                            \
-    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {                               \
-      __DSS__FieldReverseIter<tpl_fld_counter - 1, F, WalkCtxType>::Call(ctx, self);          \
-    }                                                                                         \
-  };                                                                                          \
-  template<template<int, class, class> class F, typename WalkCtxType, typename fake>          \
-  struct __DSS__FieldReverseIter<field_counter, F, WalkCtxType, fake> {                       \
-    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {}                              \
-  };                                                                                          \
-  template<int tpl_fld_counter, typename fake = void>                                         \
-  struct __DSS__FieldAlign4Counter {                                                          \
-    constexpr static int Get() { return 1; }                                                  \
-  };                                                                                          \
-                                                                                              \
-  template<int tpl_fld_counter, typename fake = void>                                         \
-  struct __DSS__FieldSize4Counter {                                                           \
-    constexpr static int Get() { return base_byte_size; }                                     \
-  };                                                                                          \
-                                                                                              \
-  template<int tpl_fld_counter, typename fake = void>                                         \
-  struct __DSS__FieldOffset4Counter {                                                         \
-    constexpr static int Get() {                                                              \
-      return __DSS__FieldOffset4Counter<tpl_fld_counter - 1, fake>::Get();                    \
-    }                                                                                         \
-  };                                                                                          \
-  template<typename fake>                                                                     \
-  struct __DSS__FieldOffset4Counter<field_counter, fake> {                                    \
-    constexpr static int Get() { return base_byte_size; }                                     \
-  };                                                                                          \
-                                                                                              \
-  template<int tpl_fld_counter, typename fake = void>                                         \
-  struct __DSS__AccumulatedAlignedSize4Counter {                                              \
-    constexpr static int Get() {                                                              \
-      return ConstExprRoundUp<                                                                \
-          __DSS__AccumulatedAlignedSize4Counter<tpl_fld_counter - 1, fake>::Get()             \
-              + __DSS__FieldSize4Counter<tpl_fld_counter - 1, fake>::Get(),                   \
-          __DSS__FieldAlign4Counter<tpl_fld_counter, fake>::Get()>();                         \
-    }                                                                                         \
-  };                                                                                          \
-  template<typename fake>                                                                     \
-  struct __DSS__AccumulatedAlignedSize4Counter<field_counter, fake> {                         \
-    constexpr static int Get() { return 0; }                                                  \
+#define _BEGIN_DSS(field_counter, type, base_byte_size)                                           \
+ public:                                                                                          \
+  template<template<int, class, class> class F, typename WalkCtxType>                             \
+  void __WalkField__(WalkCtxType* ctx) {                                                          \
+    __DSS__FieldIter<field_counter, F, WalkCtxType>::Call(ctx, this);                             \
+  }                                                                                               \
+  template<template<int, class, class> class F, typename WalkCtxType>                             \
+  bool __WalkFieldUntil__(WalkCtxType* ctx) {                                                     \
+    return __DSS__FieldIterUntil<field_counter, F, WalkCtxType>::Call(ctx, this);                 \
+  }                                                                                               \
+                                                                                                  \
+ private:                                                                                         \
+  using __DssSelfType__ = type;                                                                   \
+  template<int tpl_fld_counter, template<int, class, class> class F, typename WalkCtxType,        \
+           typename DssFieldType, typename fake = void>                                           \
+  struct __DSS__VisitField {                                                                      \
+    static void Call(WalkCtxType* ctx, DssFieldType* field_ptr, const char* __field_name__) {     \
+      F<tpl_fld_counter, WalkCtxType, DssFieldType>::Call(ctx, field_ptr, __field_name__);        \
+    }                                                                                             \
+  };                                                                                              \
+  template<int tpl_fld_counter, template<int, class, class> class F, typename WalkCtxType,        \
+           typename DssFieldType, typename fake = void>                                           \
+  struct __DSS__VisitFieldUntil {                                                                 \
+    static bool Call(WalkCtxType* ctx, DssFieldType* field_ptr, const char* __field_name__) {     \
+      return F<tpl_fld_counter, WalkCtxType, DssFieldType>::Call(ctx, field_ptr, __field_name__); \
+    }                                                                                             \
+  };                                                                                              \
+  template<int tpl_fld_counter, template<int, class, class> class F, typename WalkCtxType,        \
+           typename fake = void>                                                                  \
+  struct __DSS__FieldIter {                                                                       \
+    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {                                   \
+      __DSS__FieldIter<tpl_fld_counter + 1, F, WalkCtxType>::Call(ctx, self);                     \
+    }                                                                                             \
+  };                                                                                              \
+  template<int tpl_fld_counter, template<int, class, class> class F, typename WalkCtxType,        \
+           typename fake = void>                                                                  \
+  struct __DSS__FieldIterUntil {                                                                  \
+    static bool Call(WalkCtxType* ctx, __DssSelfType__* self) {                                   \
+      return __DSS__FieldIterUntil<tpl_fld_counter + 1, F, WalkCtxType>::Call(ctx, self);         \
+    }                                                                                             \
+  };                                                                                              \
+  template<int tpl_fld_counter, template<int, class, class> class F, typename WalkCtxType,        \
+           typename fake = void>                                                                  \
+  struct __DSS__FieldReverseIter {                                                                \
+    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {                                   \
+      __DSS__FieldReverseIter<tpl_fld_counter - 1, F, WalkCtxType>::Call(ctx, self);              \
+    }                                                                                             \
+  };                                                                                              \
+  template<template<int, class, class> class F, typename WalkCtxType, typename fake>              \
+  struct __DSS__FieldReverseIter<field_counter, F, WalkCtxType, fake> {                           \
+    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {}                                  \
+  };                                                                                              \
+  template<int tpl_fld_counter, typename fake = void>                                             \
+  struct __DSS__FieldAlign4Counter {                                                              \
+    constexpr static int Get() { return 1; }                                                      \
+  };                                                                                              \
+                                                                                                  \
+  template<int tpl_fld_counter, typename fake = void>                                             \
+  struct __DSS__FieldSize4Counter {                                                               \
+    constexpr static int Get() { return base_byte_size; }                                         \
+  };                                                                                              \
+                                                                                                  \
+  template<int tpl_fld_counter, typename fake = void>                                             \
+  struct __DSS__FieldOffset4Counter {                                                             \
+    constexpr static int Get() {                                                                  \
+      return __DSS__FieldOffset4Counter<tpl_fld_counter - 1, fake>::Get();                        \
+    }                                                                                             \
+  };                                                                                              \
+  template<typename fake>                                                                         \
+  struct __DSS__FieldOffset4Counter<field_counter, fake> {                                        \
+    constexpr static int Get() { return base_byte_size; }                                         \
+  };                                                                                              \
+                                                                                                  \
+  template<int tpl_fld_counter, typename fake = void>                                             \
+  struct __DSS__AccFieldCount4Counter {                                                           \
+    constexpr static int Get() {                                                                  \
+      return __DSS__AccFieldCount4Counter<tpl_fld_counter - 1, fake>::Get();                      \
+    }                                                                                             \
+  };                                                                                              \
+  template<typename fake>                                                                         \
+  struct __DSS__AccFieldCount4Counter<field_counter, fake> {                                      \
+    constexpr static int Get() { return 0; }                                                      \
+  };                                                                                              \
+                                                                                                  \
+  template<int tpl_fld_counter, typename fake = void>                                             \
+  struct __DSS__AccumulatedAlignedSize4Counter {                                                  \
+    constexpr static int Get() {                                                                  \
+      return ConstExprRoundUp<                                                                    \
+          __DSS__AccumulatedAlignedSize4Counter<tpl_fld_counter - 1, fake>::Get()                 \
+              + __DSS__FieldSize4Counter<tpl_fld_counter - 1, fake>::Get(),                       \
+          __DSS__FieldAlign4Counter<tpl_fld_counter, fake>::Get()>();                             \
+    }                                                                                             \
+  };                                                                                              \
+  template<typename fake>                                                                         \
+  struct __DSS__AccumulatedAlignedSize4Counter<field_counter, fake> {                             \
+    constexpr static int Get() { return 0; }                                                      \
   };
 
 #define DSS_ASSERT_VERBOSE(dss_type)                                        \
@@ -118,49 +154,66 @@ namespace oneflow {
       __LINE__) ") carefully\n"                                             \
                 "    non " dss_type " member found before line " OF_PP_STRINGIZE(__LINE__) "\n\n"
 
-#define _DSS_DEFINE_FIELD(field_counter, dss_type, field)                                    \
- public:                                                                                     \
-  template<typename Enabled = void>                                                          \
-  constexpr static int OF_PP_CAT(field, DssFieldOffset)() {                                  \
-    return offsetof(__DssSelfType__, field);                                                 \
-  }                                                                                          \
-                                                                                             \
- private:                                                                                    \
-  template<template<int, class, class> class F, typename WalkCtxType, typename fake>         \
-  struct __DSS__FieldIter<field_counter, F, WalkCtxType, fake> {                             \
-    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {                              \
-      const char* __field_name__ = OF_PP_STRINGIZE(field);                                   \
-      __DSS__VisitField<field_counter, F, WalkCtxType, decltype(self->field)>::Call(         \
-          ctx, &self->field, __field_name__);                                                \
-      __DSS__FieldIter<field_counter + 1, F, WalkCtxType>::Call(ctx, self);                  \
-    }                                                                                        \
-  };                                                                                         \
-  template<template<int, class, class> class F, typename WalkCtxType, typename fake>         \
-  struct __DSS__FieldReverseIter<field_counter, F, WalkCtxType, fake> {                      \
-    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {                              \
-      const char* __field_name__ = OF_PP_STRINGIZE(field);                                   \
-      __DSS__VisitField<field_counter, F, WalkCtxType, decltype(self->field)>::Call(         \
-          ctx, &self->field, __field_name__);                                                \
-      __DSS__FieldReverseIter<field_counter - 1, F, WalkCtxType>::Call(ctx, self);           \
-    }                                                                                        \
-  };                                                                                         \
-  template<typename fake>                                                                    \
-  struct __DSS__FieldAlign4Counter<field_counter, fake> {                                    \
-    constexpr static int Get() { return alignof(((__DssSelfType__*)nullptr)->field); }       \
-  };                                                                                         \
-  template<typename fake>                                                                    \
-  struct __DSS__FieldSize4Counter<field_counter, fake> {                                     \
-    constexpr static int Get() { return sizeof(((__DssSelfType__*)nullptr)->field); }        \
-  };                                                                                         \
-  template<typename fake>                                                                    \
-  struct __DSS__FieldOffset4Counter<field_counter, fake> {                                   \
-    constexpr static int Get() { return offsetof(__DssSelfType__, field); }                  \
-  };                                                                                         \
-  static void OF_PP_CAT(__DSS__StaticAssertFieldCounter, field_counter)() {                  \
-    static const int kAccSize = __DSS__AccumulatedAlignedSize4Counter<field_counter>::Get(); \
-    static_assert(kAccSize == __DSS__FieldOffset4Counter<field_counter>::Get(),              \
-                  DSS_ASSERT_VERBOSE(dss_type));                                             \
-  }
+#define _DSS_DEFINE_FIELD(field_counter, dss_type, field)                                     \
+ public:                                                                                      \
+  template<typename Enabled = void>                                                           \
+  constexpr static int OF_PP_CAT(field, DssFieldOffset)() {                                   \
+    return offsetof(__DssSelfType__, field);                                                  \
+  }                                                                                           \
+                                                                                              \
+ private:                                                                                     \
+  template<template<int, class, class> class F, typename WalkCtxType, typename fake>          \
+  struct __DSS__FieldIter<field_counter, F, WalkCtxType, fake> {                              \
+    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {                               \
+      const char* __field_name__ = OF_PP_STRINGIZE(field);                                    \
+      __DSS__VisitField<field_counter, F, WalkCtxType, decltype(self->field)>::Call(          \
+          ctx, &self->field, __field_name__);                                                 \
+      __DSS__FieldIter<field_counter + 1, F, WalkCtxType>::Call(ctx, self);                   \
+    }                                                                                         \
+  };                                                                                          \
+  template<template<int, class, class> class F, typename WalkCtxType, typename fake>          \
+  struct __DSS__FieldIterUntil<field_counter, F, WalkCtxType, fake> {                         \
+    static bool Call(WalkCtxType* ctx, __DssSelfType__* self) {                               \
+      const char* __field_name__ = OF_PP_STRINGIZE(field);                                    \
+      bool end =                                                                              \
+          __DSS__VisitFieldUntil<field_counter, F, WalkCtxType, decltype(self->field)>::Call( \
+              ctx, &self->field, __field_name__);                                             \
+      if (end) { return true; }                                                               \
+      return __DSS__FieldIterUntil<field_counter + 1, F, WalkCtxType>::Call(ctx, self);       \
+    }                                                                                         \
+  };                                                                                          \
+  template<template<int, class, class> class F, typename WalkCtxType, typename fake>          \
+  struct __DSS__FieldReverseIter<field_counter, F, WalkCtxType, fake> {                       \
+    static void Call(WalkCtxType* ctx, __DssSelfType__* self) {                               \
+      const char* __field_name__ = OF_PP_STRINGIZE(field);                                    \
+      __DSS__VisitField<field_counter, F, WalkCtxType, decltype(self->field)>::Call(          \
+          ctx, &self->field, __field_name__);                                                 \
+      __DSS__FieldReverseIter<field_counter - 1, F, WalkCtxType>::Call(ctx, self);            \
+    }                                                                                         \
+  };                                                                                          \
+  template<typename fake>                                                                     \
+  struct __DSS__FieldAlign4Counter<field_counter, fake> {                                     \
+    constexpr static int Get() { return alignof(((__DssSelfType__*)nullptr)->field); }        \
+  };                                                                                          \
+  template<typename fake>                                                                     \
+  struct __DSS__FieldSize4Counter<field_counter, fake> {                                      \
+    constexpr static int Get() { return sizeof(((__DssSelfType__*)nullptr)->field); }         \
+  };                                                                                          \
+  template<typename fake>                                                                     \
+  struct __DSS__FieldOffset4Counter<field_counter, fake> {                                    \
+    constexpr static int Get() { return offsetof(__DssSelfType__, field); }                   \
+  };                                                                                          \
+  static void OF_PP_CAT(__DSS__StaticAssertFieldCounter, field_counter)() {                   \
+    static const int kAccSize = __DSS__AccumulatedAlignedSize4Counter<field_counter>::Get();  \
+    static_assert(kAccSize == __DSS__FieldOffset4Counter<field_counter>::Get(),               \
+                  DSS_ASSERT_VERBOSE(dss_type));                                              \
+  }                                                                                           \
+  template<typename fake>                                                                     \
+  struct __DSS__AccFieldCount4Counter<field_counter, fake> {                                  \
+    constexpr static int Get() {                                                              \
+      return __DSS__AccFieldCount4Counter<field_counter - 1, fake>::Get() + 1;                \
+    }                                                                                         \
+  };
 
 #define _END_DSS(field_counter, dss_type, type)                                       \
  public:                                                                              \
@@ -168,11 +221,18 @@ namespace oneflow {
   void __ReverseWalkField__(WalkCtxType* ctx) {                                       \
     __DSS__FieldReverseIter<field_counter, F, WalkCtxType>::Call(ctx, this);          \
   }                                                                                   \
+  constexpr static int __DSS__FieldCount() {                                          \
+    return __DSS__AccFieldCount4Counter<field_counter>::Get();                        \
+  }                                                                                   \
                                                                                       \
  private:                                                                             \
   template<template<int, class, class> class F, typename WalkCtxType, typename fake>  \
   struct __DSS__FieldIter<field_counter, F, WalkCtxType, fake> {                      \
     static void Call(WalkCtxType* ctx, type* self) {}                                 \
+  };                                                                                  \
+  template<template<int, class, class> class F, typename WalkCtxType, typename fake>  \
+  struct __DSS__FieldIterUntil<field_counter, F, WalkCtxType, fake> {                 \
+    static bool Call(WalkCtxType* ctx, type* self) { return false; }                  \
   };                                                                                  \
   static void __DSS__StaticAssertStructSize() {                                       \
     static const int kSize =                                                          \
@@ -180,32 +240,6 @@ namespace oneflow {
                          alignof(type)>();                                            \
     static_assert((kSize == 0 && sizeof(type) == 1) || (kSize == sizeof(type)),       \
                   DSS_ASSERT_VERBOSE(dss_type));                                      \
-  }
-
-#define _DSS_DEFINE_GETTER(field_type, field_name)                                          \
-  const typename std::conditional<std::is_pointer<field_type>::value,                       \
-                                  std::remove_pointer<field_type>::type, field_type>::type& \
-  field_name() const {                                                                      \
-    return GetterTrait<std::is_pointer<field_type>::value>::Call(this->field_name##_);      \
-  }
-
-#define _DSS_DEFINE_MUTABLE(field_type, field_name)                                      \
-  typename std::conditional<std::is_pointer<field_type>::value,                          \
-                            std::remove_pointer<field_type>::type, field_type>::type*    \
-      mut_##field_name() {                                                               \
-    return MutableTrait<std::is_pointer<field_type>::value>::Call(&this->field_name##_); \
-  }                                                                                      \
-  typename std::conditional<std::is_pointer<field_type>::value,                          \
-                            std::remove_pointer<field_type>::type, field_type>::type*    \
-      mutable_##field_name() {                                                           \
-    return MutableTrait<std::is_pointer<field_type>::value>::Call(&this->field_name##_); \
-  }
-
-#define _DSS_DEFINE_SETTER(is_scalar, field_type, field_name)                      \
-  template<typename T>                                                             \
-  void set_##field_name(const T& val) {                                            \
-    static_assert(is_scalar<T>::value, "setter doesn't support non-scalar field"); \
-    *this->mutable_##field_name() = val;                                           \
   }
 
 template<int x, int y>

--- a/oneflow/core/common/dss_test.cpp
+++ b/oneflow/core/common/dss_test.cpp
@@ -18,6 +18,8 @@ struct Foo {
   END_DSS(DSS_GET_FIELD_COUNTER(), "demo dss", Foo);
 };
 
+static_assert(Foo::__DSS__FieldCount() == 3, "field count error in dss");
+
 struct Bar {
   BEGIN_DSS(DSS_GET_FIELD_COUNTER(), Foo, 0);
 
@@ -38,19 +40,6 @@ template<typename T>
 struct IsScalar {
   static const bool value =
       std::is_arithmetic<T>::value || std::is_enum<T>::value || std::is_same<T, std::string>::value;
-};
-
-struct FooBar {
-  DSS_DEFINE_GETTER(int, x);
-  DSS_DEFINE_MUTABLE(int, x);
-  DSS_DEFINE_SETTER(IsScalar, int, x);
-
-  DSS_DEFINE_GETTER(Foo*, foo);
-  DSS_DEFINE_MUTABLE(Foo*, foo);
-  DSS_DEFINE_SETTER(IsScalar, Foo*, foo);
-
-  int x_;
-  Foo* foo_;
 };
 
 template<int field_counter, typename WalkCtxType, typename FieldType>
@@ -101,12 +90,27 @@ struct FilterPointerFieldName {
   }
 };
 
+template<int field_counter, typename WalkCtxType, typename FieldType>
+struct FilterPointerFieldNameUntil {
+  static bool Call(WalkCtxType* ctx, FieldType* field, const char* field_name) {
+    return true;
+    PushBackPtrFieldName<std::is_pointer<FieldType>::value>::Call(ctx, field_name);
+  }
+};
+
 TEST(DSS, filter_field) {
   Foo foo;
   std::vector<std::string> field_names;
   foo.__WalkField__<FilterPointerFieldName>(&field_names);
   ASSERT_EQ(field_names.size(), 1);
   ASSERT_TRUE(field_names[0] == "z");
+}
+
+TEST(DSS, filter_field_until) {
+  Foo foo;
+  std::vector<std::string> field_names;
+  ASSERT_TRUE(foo.__WalkFieldUntil__<FilterPointerFieldNameUntil>(&field_names));
+  ASSERT_TRUE(field_names.empty());
 }
 
 #define DSS_DEFINE_TEST_UNION_FIELD(field_counter)                   \

--- a/oneflow/core/common/embedded_list.h
+++ b/oneflow/core/common/embedded_list.h
@@ -156,7 +156,7 @@ class EmbeddedListHead {
 
  private:
   EmbeddedListLink container_;
-  std::size_t size_;
+  volatile std::size_t size_;
 };
 
 }  // namespace oneflow

--- a/oneflow/core/common/embedded_skiplist.h
+++ b/oneflow/core/common/embedded_skiplist.h
@@ -219,7 +219,7 @@ class EmbeddedSkipListHead {
   int size_shift() const { return std::log2(size_ + 1); }
 
   EmbeddedSkipListLink<max_level> skiplist_head_;
-  std::size_t size_;
+  volatile std::size_t size_;
 };
 
 }  // namespace oneflow

--- a/oneflow/core/common/flat_msg.h
+++ b/oneflow/core/common/flat_msg.h
@@ -2,57 +2,63 @@
 #define ONEFLOW_CORE_COMMON_FLAT_MSG_H_
 
 #include <array>
+#include <cstring>
 #include <glog/logging.h>
 #include "oneflow/core/common/preprocessor.h"
 #include "oneflow/core/common/dss.h"
 
 namespace oneflow {
 
-#define BEGIN_FLAT_MSG(struct_name)                                    \
-  struct FLAT_MSG_TYPE(struct_name) final {                            \
-    static const bool __is_flat_message_type__ = true;                 \
-    BEGIN_DSS(DSS_GET_FIELD_COUNTER(), FLAT_MSG_TYPE(struct_name), 0); \
-    FLAT_MSG_DEFINE_BASIC_METHODS(FLAT_MSG_TYPE(struct_name));         \
-    FLAT_MSG_DEFINE_DEFAULT(FLAT_MSG_TYPE(struct_name));
+#define BEGIN_FLAT_MSG(struct_name)                     \
+  struct struct_name final {                            \
+    using self_type = struct_name;                      \
+    static const bool __is_flat_message_type__ = true;  \
+    BEGIN_DSS(DSS_GET_FIELD_COUNTER(), struct_name, 0); \
+    FLAT_MSG_DEFINE_BASIC_METHODS(struct_name);         \
+    FLAT_MSG_DEFINE_DEFAULT(struct_name);
 
 #define END_FLAT_MSG(struct_name)                                               \
   static_assert(__is_flat_message_type__, "this struct is not a flat message"); \
-  END_DSS(DSS_GET_FIELD_COUNTER(), "flat message", FLAT_MSG_TYPE(struct_name)); \
+  END_DSS(DSS_GET_FIELD_COUNTER(), "flat message", struct_name);                \
   }                                                                             \
   ;
-
-#define FLAT_MSG(struct_name) FlatMsg<FLAT_MSG_TYPE(struct_name)>
 
 #define FLAT_MSG_DEFINE_OPTIONAL(field_type, field_name)                        \
   static_assert(__is_flat_message_type__, "this struct is not a flat message"); \
   FLAT_MSG_DEFINE_ONEOF(OF_PP_CAT(__flat_msg_optional__, field_name),           \
                         FLAT_MSG_ONEOF_FIELD(field_type, field_name))
 
-#define FLAT_MSG_DEFINE_ONEOF(oneof_name, type_and_field_name_seq)              \
-  static_assert(__is_flat_message_type__, "this struct is not a flat message"); \
-  FLAT_MSG_DEFINE_ONEOF_ENUM_TYPE(oneof_name, type_and_field_name_seq);         \
-  FLAT_MSG_DEFINE_ONEOF_UNION(oneof_name, type_and_field_name_seq);             \
-  FLAT_MSG_DEFINE_ONEOF_ACCESSOR(oneof_name, type_and_field_name_seq)           \
+#define FLAT_MSG_DEFINE_ONEOF(oneof_name, type_and_field_name_seq) \
+  _FLAT_MSG_DEFINE_ONEOF(_FLAT_MSG_DEFINE_NOTHING, oneof_name, type_and_field_name_seq);
+
+#define FLAT_MSG_DEFINE_STRICT_ONEOF(oneof_name, type_and_field_name_seq) \
+  _FLAT_MSG_DEFINE_ONEOF(_FLAT_MSG_DEFINE_ONEOF_VALUE4TYPE, oneof_name, type_and_field_name_seq);
+
+#define _FLAT_MSG_DEFINE_ONEOF(define_field_value4field_type, oneof_name, type_and_field_name_seq) \
+  static_assert(__is_flat_message_type__, "this struct is not a flat message");                    \
+  FLAT_MSG_DEFINE_ONEOF_ENUM_TYPE(oneof_name, type_and_field_name_seq);                            \
+  FLAT_MSG_DEFINE_ONEOF_UNION(define_field_value4field_type, oneof_name, type_and_field_name_seq); \
+  FLAT_MSG_DEFINE_ONEOF_ACCESSOR(oneof_name, type_and_field_name_seq)                              \
   FLAT_MSG_DSS_DEFINE_UION_FIELD(DSS_GET_FIELD_COUNTER(), oneof_name, type_and_field_name_seq);
 
-#define FLAT_MSG_DEFINE_REPEATED(field_type, field_name, max_size)                  \
-  static_assert(__is_flat_message_type__, "this struct is not a flat message");     \
-  _FLAT_MSG_DEFINE_REPEATED_FIELD(FLAT_MSG_TYPE(field_type), field_name, max_size); \
+#define FLAT_MSG_DEFINE_REPEATED(field_type, field_name, max_size)                        \
+  static_assert(__is_flat_message_type__, "this struct is not a flat message");           \
+  _FLAT_MSG_DEFINE_REPEATED_FIELD(FLAT_MSG_TYPE_CHECK(field_type), field_name, max_size); \
   DSS_DEFINE_FIELD(DSS_GET_FIELD_COUNTER(), "flat message", OF_PP_CAT(field_name, _));
 
+#define FLAT_MSG_DEFINE_COMPARE_OPERATORS_BY_MEMCMP() _FLAT_MSG_DEFINE_COMPARE_OPERATORS_BY_MEMCMP()
+
 #define FLAT_MSG_ONEOF_FIELD(field_type, field_name) \
-  OF_PP_MAKE_TUPLE_SEQ(FLAT_MSG_TYPE(field_type), field_name)
+  OF_PP_MAKE_TUPLE_SEQ(FLAT_MSG_TYPE_CHECK(field_type), field_name)
 
-#define FLAT_MSG_ONEOF_ENUM_TYPE(field_type, oneof_name) \
-  FLAT_MSG_TYPE(field_type)::_FLAT_MSG_ONEOF_ENUM_TYPE(oneof_name)
+#define FLAT_MSG_ONEOF_CASE(oneof_name) _FLAT_MSG_ONEOF_ENUM_TYPE(oneof_name)
 
-#define FLAT_MSG_ONEOF_ENUM_VALUE(field_type, field) \
-  FLAT_MSG_TYPE(field_type)::_FLAT_MSG_ONEOF_ENUM_VALUE(field)
+#define FLAT_MSG_ONEOF_CASE_VALUE(field) _FLAT_MSG_ONEOF_ENUM_VALUE(field)
 
 #define FLAT_MSG_ONEOF_NOT_SET_VALUE(field_type, oneof_name) \
-  FLAT_MSG_TYPE(field_type)::_FLAT_MSG_ONEOF_NOT_SET_VALUE(oneof_name)
+  field_type::_FLAT_MSG_ONEOF_NOT_SET_VALUE(oneof_name)
 
-#define FLAT_MSG_TYPE(type_name) OF_PP_CAT(__flat_message_type__, type_name)
+#define FLAT_MSG_TYPE_CHECK(type_name) FlatMsgSelfType<type_name>::type
 
 // details
 
@@ -65,16 +71,34 @@ namespace oneflow {
 #define FLAT_MSG_MAKE_UNION_TYPE7FIELD4CASE(field_type, field_name) \
   OF_PP_MAKE_TUPLE_SEQ(field_type, OF_PP_CAT(field_name, _), _FLAT_MSG_ONEOF_ENUM_VALUE(field_name))
 
+template<typename T, typename Enabled = void>
+struct FlatMsgSelfType {
+  static_assert(T::__is_flat_message_type__, "T is not a flat message type");
+  using type = T;
+};
+
+template<typename T>
+struct FlatMsgSelfType<
+    T, typename std::enable_if<std::is_arithmetic<T>::value || std::is_enum<T>::value>::type> {
+  using type = T;
+};
+
 template<typename T>
 struct FlatMsg final {
+  using value_type = typename FLAT_MSG_TYPE_CHECK(T);
   FlatMsg() { msg_.clear(); }
 
-  const T& Get() const { return msg_; }
-  T* Mutable() { return &msg_; }
+  const value_type& operator*() const { return msg_; }
+  value_type& operator*() { return msg_; }
+  const value_type* operator->() const { return &msg_; }
+  value_type* operator->() { return &msg_; }
+
+  const value_type& Get() const { return msg_; }
+  value_type* Mutable() { return &msg_; }
 
  private:
   union {
-    T msg_;
+    value_type msg_;
   };
 };
 
@@ -104,20 +128,7 @@ struct FlatMsgGetDefault<true> final {
   }
 };
 
-#define DEFINE_FLAT_MSG_TYPE(type_name) typedef type_name FLAT_MSG_TYPE(type_name)
-DEFINE_FLAT_MSG_TYPE(char);
-DEFINE_FLAT_MSG_TYPE(int8_t);
-DEFINE_FLAT_MSG_TYPE(uint8_t);
-DEFINE_FLAT_MSG_TYPE(int16_t);
-DEFINE_FLAT_MSG_TYPE(uint16_t);
-DEFINE_FLAT_MSG_TYPE(int32_t);
-DEFINE_FLAT_MSG_TYPE(uint32_t);
-DEFINE_FLAT_MSG_TYPE(int64_t);
-DEFINE_FLAT_MSG_TYPE(uint64_t);
-DEFINE_FLAT_MSG_TYPE(float);
-DEFINE_FLAT_MSG_TYPE(double);
-
-#define _FLAT_MSG_ONEOF_CASE(oneof_name) OF_PP_CAT(oneof_name, _case)
+#define _FLAT_MSG_ONEOF_CASE_NAME(oneof_name) OF_PP_CAT(oneof_name, _case)
 
 #define _FLAT_MSG_ONEOF_ENUM_VALUE(field) SNAKE_TO_CAMEL(field)
 
@@ -127,11 +138,12 @@ DEFINE_FLAT_MSG_TYPE(double);
 
 #define FLAT_MSG_DEFINE_BASIC_METHODS(T) _FLAT_MSG_DEFINE_BASIC_METHODS(T)
 
-#define _FLAT_MSG_DEFINE_BASIC_METHODS(T)                                                       \
- public:                                                                                        \
-  void clear() { std::memset(reinterpret_cast<void*>(this), 0, sizeof(T)); }                    \
-  void operator=(const T& rhs) {                                                                \
-    std::memcpy(reinterpret_cast<void*>(this), reinterpret_cast<const void*>(&rhs), sizeof(T)); \
+#define _FLAT_MSG_DEFINE_BASIC_METHODS(T)                                           \
+ public:                                                                            \
+  void clear() { std::memset(reinterpret_cast<void*>(this), 0, sizeof(T)); }        \
+  void CopyFrom(const self_type& rhs) {                                             \
+    std::memcpy(reinterpret_cast<void*>(this), reinterpret_cast<const void*>(&rhs), \
+                sizeof(self_type));                                                 \
   }
 
 #define FLAT_MSG_DEFINE_ONEOF_ENUM_TYPE(oneof_name, type_and_field_name_seq)     \
@@ -149,56 +161,149 @@ DEFINE_FLAT_MSG_TYPE(double);
   OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(MAKE_FLAT_MSG_ONEOF_ACCESSOR, (_FLAT_MSG_ONEOF_ENUM_VALUE), \
                                    (oneof_name), type_and_field_name_seq)
 
-#define MAKE_FLAT_MSG_ONEOF_ACCESSOR(get_enum_value, oneof_name, pair)                    \
- public:                                                                                  \
-  const OF_PP_PAIR_FIRST(pair) & OF_PP_PAIR_SECOND(pair)() const {                        \
-    if (OF_PP_CAT(has_, OF_PP_PAIR_SECOND(pair))()) {                                     \
-      return OF_PP_CAT(oneof_name, _).OF_PP_CAT(OF_PP_PAIR_SECOND(pair), _);              \
-    }                                                                                     \
-    return FlatMsgGetDefault<FlatMsgIsScalar<OF_PP_PAIR_FIRST(pair)>::value>::Call(       \
-        &OF_PP_CAT(oneof_name, _).OF_PP_CAT(OF_PP_PAIR_SECOND(pair), _));                 \
-  }                                                                                       \
-  bool OF_PP_CAT(has_, OF_PP_PAIR_SECOND(pair))() const {                                 \
-    return _FLAT_MSG_ONEOF_CASE(oneof_name)() == get_enum_value(OF_PP_PAIR_SECOND(pair)); \
-  }                                                                                       \
-  void OF_PP_CAT(clear_, OF_PP_PAIR_SECOND(pair))() {                                     \
-    if (!OF_PP_CAT(has_, OF_PP_PAIR_SECOND(pair))()) { return; }                          \
-    OF_PP_CAT(set_, _FLAT_MSG_ONEOF_CASE(oneof_name))                                     \
-    (_FLAT_MSG_ONEOF_NOT_SET_VALUE(oneof_name));                                          \
-  }                                                                                       \
-  OF_PP_PAIR_FIRST(pair) * OF_PP_CAT(mut_, OF_PP_PAIR_SECOND(pair))() {                   \
-    CHECK(OF_PP_CAT(has_, OF_PP_PAIR_SECOND(pair))());                                    \
-    return &OF_PP_CAT(oneof_name, _).OF_PP_CAT(OF_PP_PAIR_SECOND(pair), _);               \
-  }                                                                                       \
-  OF_PP_PAIR_FIRST(pair) * OF_PP_CAT(mutable_, OF_PP_PAIR_SECOND(pair))() {               \
-    OF_PP_CAT(set_, _FLAT_MSG_ONEOF_CASE(oneof_name))                                     \
-    (get_enum_value(OF_PP_PAIR_SECOND(pair)));                                            \
-    return &OF_PP_CAT(oneof_name, _).OF_PP_CAT(OF_PP_PAIR_SECOND(pair), _);               \
-  }                                                                                       \
-  void OF_PP_CAT(set_, OF_PP_PAIR_SECOND(pair))(const OF_PP_PAIR_FIRST(pair) & val) {     \
-    *OF_PP_CAT(mutable_, OF_PP_PAIR_SECOND(pair))() = val;                                \
+#define MAKE_FLAT_MSG_ONEOF_ACCESSOR(get_enum_value, oneof_name, pair)                         \
+ public:                                                                                       \
+  const OF_PP_PAIR_FIRST(pair) & OF_PP_PAIR_SECOND(pair)() const {                             \
+    if (OF_PP_CAT(has_, OF_PP_PAIR_SECOND(pair))()) {                                          \
+      return OF_PP_CAT(oneof_name, _).OF_PP_CAT(OF_PP_PAIR_SECOND(pair), _);                   \
+    }                                                                                          \
+    return FlatMsgGetDefault<FlatMsgIsScalar<OF_PP_PAIR_FIRST(pair)>::value>::Call(            \
+        &OF_PP_CAT(oneof_name, _).OF_PP_CAT(OF_PP_PAIR_SECOND(pair), _));                      \
+  }                                                                                            \
+  bool OF_PP_CAT(has_, OF_PP_PAIR_SECOND(pair))() const {                                      \
+    return _FLAT_MSG_ONEOF_CASE_NAME(oneof_name)() == get_enum_value(OF_PP_PAIR_SECOND(pair)); \
+  }                                                                                            \
+  void OF_PP_CAT(clear_, OF_PP_PAIR_SECOND(pair))() {                                          \
+    if (!OF_PP_CAT(has_, OF_PP_PAIR_SECOND(pair))()) { return; }                               \
+    OF_PP_CAT(set_, _FLAT_MSG_ONEOF_CASE_NAME(oneof_name))                                     \
+    (_FLAT_MSG_ONEOF_NOT_SET_VALUE(oneof_name));                                               \
+  }                                                                                            \
+  OF_PP_PAIR_FIRST(pair) * OF_PP_CAT(mut_, OF_PP_PAIR_SECOND(pair))() {                        \
+    CHECK(OF_PP_CAT(has_, OF_PP_PAIR_SECOND(pair))());                                         \
+    return &OF_PP_CAT(oneof_name, _).OF_PP_CAT(OF_PP_PAIR_SECOND(pair), _);                    \
+  }                                                                                            \
+  OF_PP_PAIR_FIRST(pair) * OF_PP_CAT(mutable_, OF_PP_PAIR_SECOND(pair))() {                    \
+    OF_PP_CAT(set_, _FLAT_MSG_ONEOF_CASE_NAME(oneof_name))                                     \
+    (get_enum_value(OF_PP_PAIR_SECOND(pair)));                                                 \
+    return &OF_PP_CAT(oneof_name, _).OF_PP_CAT(OF_PP_PAIR_SECOND(pair), _);                    \
+  }                                                                                            \
+  void OF_PP_CAT(set_, OF_PP_PAIR_SECOND(pair))(const OF_PP_PAIR_FIRST(pair) & val) {          \
+    *OF_PP_CAT(mutable_, OF_PP_PAIR_SECOND(pair))() = val;                                     \
   }
 
-#define FLAT_MSG_DEFINE_ONEOF_UNION(oneof_name, type_and_field_name_seq)             \
- private:                                                                            \
-  struct {                                                                           \
-    union {                                                                          \
-      OF_PP_FOR_EACH_TUPLE(MAKE_FLAT_MSG_ONEOF_UNION_FIELD, type_and_field_name_seq) \
-    };                                                                               \
-    _FLAT_MSG_ONEOF_ENUM_TYPE(oneof_name) case_;                                     \
-  } OF_PP_CAT(oneof_name, _);
+#define FLAT_MSG_DEFINE_ONEOF_UNION(define_field_value4field_type, oneof_name,             \
+                                    type_and_field_name_seq)                               \
+ public:                                                                                   \
+  struct OF_PP_CAT(oneof_name, _OneofType) {                                               \
+   public:                                                                                 \
+    using self_oneof_type = OF_PP_CAT(oneof_name, _OneofType);                             \
+    using self_oneof_case_type = _FLAT_MSG_ONEOF_ENUM_TYPE(oneof_name);                    \
+    template<self_oneof_case_type oneof_case, typename Enabled = void>                     \
+    struct FieldType4FieldValueStruct {};                                                  \
+    template<self_oneof_case_type oneof_case, typename Enabled = void>                     \
+    struct HasStruct {};                                                                   \
+    template<self_oneof_case_type oneof_case, typename Enabled = void>                     \
+    struct GetStruct {};                                                                   \
+    template<self_oneof_case_type oneof_case, typename Enabled = void>                     \
+    struct MutableStruct {};                                                               \
+    OF_PP_FOR_EACH_TUPLE(_MAKE_FLAT_MSG_ONEOF_TEMPLATE_ACCESSOR, type_and_field_name_seq); \
+    define_field_value4field_type(type_and_field_name_seq);                                \
+    template<self_oneof_case_type oneof_case>                                              \
+    bool Has() const {                                                                     \
+      return HasStruct<oneof_case>::Call(*this);                                           \
+    }                                                                                      \
+    template<self_oneof_case_type oneof_case>                                              \
+    const typename FieldType4FieldValueStruct<oneof_case>::type& Get() const {             \
+      return GetStruct<oneof_case>::Call(*this);                                           \
+    }                                                                                      \
+    template<self_oneof_case_type oneof_case>                                              \
+    typename FieldType4FieldValueStruct<oneof_case>::type* Mutable() {                     \
+      return MutableStruct<oneof_case>::Call(this);                                        \
+    }                                                                                      \
+                                                                                           \
+    union {                                                                                \
+      OF_PP_FOR_EACH_TUPLE(MAKE_FLAT_MSG_ONEOF_UNION_FIELD, type_and_field_name_seq)       \
+    };                                                                                     \
+    self_oneof_case_type case_;                                                            \
+  };                                                                                       \
+                                                                                           \
+ private:                                                                                  \
+  OF_PP_CAT(oneof_name, _OneofType) OF_PP_CAT(oneof_name, _);                              \
+                                                                                           \
+ public:                                                                                   \
+  const OF_PP_CAT(oneof_name, _OneofType) & oneof_name() const {                           \
+    return OF_PP_CAT(oneof_name, _);                                                       \
+  }                                                                                        \
+  OF_PP_CAT(oneof_name, _OneofType) * OF_PP_CAT(mutable_, oneof_name)() {                  \
+    return &OF_PP_CAT(oneof_name, _);                                                      \
+  }
+
+#define _MAKE_FLAT_MSG_ONEOF_TEMPLATE_ACCESSOR(field_type, field_name)                 \
+ public:                                                                               \
+  template<typename Enabled>                                                           \
+  struct FieldType4FieldValueStruct<_FLAT_MSG_ONEOF_ENUM_VALUE(field_name), Enabled> { \
+    using type = field_type;                                                           \
+  };                                                                                   \
+  template<typename Enabled>                                                           \
+  struct HasStruct<_FLAT_MSG_ONEOF_ENUM_VALUE(field_name), Enabled> {                  \
+    static bool Call(const self_oneof_type& self) {                                    \
+      return self.case_ == _FLAT_MSG_ONEOF_ENUM_VALUE(field_name);                     \
+    }                                                                                  \
+  };                                                                                   \
+  template<typename Enabled>                                                           \
+  struct GetStruct<_FLAT_MSG_ONEOF_ENUM_VALUE(field_name), Enabled> {                  \
+    static const field_type& Call(const self_oneof_type& self) {                       \
+      return self.OF_PP_CAT(field_name, _);                                            \
+    }                                                                                  \
+  };                                                                                   \
+  template<typename Enabled>                                                           \
+  struct MutableStruct<_FLAT_MSG_ONEOF_ENUM_VALUE(field_name), Enabled> {              \
+    static field_type* Call(self_oneof_type* self) {                                   \
+      self->case_ = _FLAT_MSG_ONEOF_ENUM_VALUE(field_name);                            \
+      return &self->OF_PP_CAT(field_name, _);                                          \
+    }                                                                                  \
+  };
+
+#define _FLAT_MSG_DEFINE_NOTHING(type_and_field_name_seq)
+
+#define _FLAT_MSG_DEFINE_ONEOF_VALUE4TYPE(type_and_field_name_seq)                \
+ public:                                                                          \
+  template<typename T, typename Enabled = void>                                   \
+  struct FieldValue4FieldType {};                                                 \
+  OF_PP_FOR_EACH_TUPLE(_MAKE_FLAT_MSG_ONEOF_VALUE4TYPE, type_and_field_name_seq); \
+  template<typename T>                                                            \
+  bool HasField() const {                                                         \
+    return Has<FieldValue4FieldType<T>::value>();                                 \
+  }                                                                               \
+  template<typename T>                                                            \
+  const T& GetField() const {                                                     \
+    return Get<FieldValue4FieldType<T>::value>();                                 \
+  }                                                                               \
+  template<typename T>                                                            \
+  T* MutableField() {                                                             \
+    return Mutable<FieldValue4FieldType<T>::value>();                             \
+  }
+
+#define _MAKE_FLAT_MSG_ONEOF_VALUE4TYPE(field_type, field_name)                       \
+  template<typename Enabled>                                                          \
+  struct FieldValue4FieldType<field_type, Enabled> {                                  \
+    static const self_oneof_case_type value = _FLAT_MSG_ONEOF_ENUM_VALUE(field_name); \
+  };
 
 #define MAKE_FLAT_MSG_ONEOF_UNION_FIELD(field_type, field_name) field_type OF_PP_CAT(field_name, _);
 
 #define SNAKE_TO_CAMEL(name) OF_PP_CAT(__FlatMsgSnakeToCamel__, name)
 
-#define _FLAT_MSG_DEFINE_ONEOF_CASE_ACCESSOR(oneof_name, T)                         \
- public:                                                                            \
-  T OF_PP_CAT(oneof_name, _case)() const { return OF_PP_CAT(oneof_name, _).case_; } \
-                                                                                    \
- private:                                                                           \
-  void OF_PP_CAT(set_, OF_PP_CAT(oneof_name, _case))(T val) {                       \
-    OF_PP_CAT(oneof_name, _).case_ = val;                                           \
+#define _FLAT_MSG_DEFINE_ONEOF_CASE_ACCESSOR(oneof_name, T)                             \
+ public:                                                                                \
+  T OF_PP_CAT(oneof_name, _case)() const { return OF_PP_CAT(oneof_name, _).case_; }     \
+  bool OF_PP_CAT(has_, oneof_name)() const {                                            \
+    return OF_PP_CAT(oneof_name, _).case_ != _FLAT_MSG_ONEOF_NOT_SET_VALUE(oneof_name); \
+  }                                                                                     \
+                                                                                        \
+ private:                                                                               \
+  void OF_PP_CAT(set_, OF_PP_CAT(oneof_name, _case))(T val) {                           \
+    OF_PP_CAT(oneof_name, _).case_ = val;                                               \
   }
 
 #define _FLAT_MSG_DEFINE_REPEATED_FIELD(T, field_name, N)                                         \
@@ -218,9 +323,45 @@ DEFINE_FLAT_MSG_TYPE(double);
  private:                                                                                         \
   FlatMsgRepeatedField<T, N> OF_PP_CAT(field_name, _)
 
+#define _FLAT_MSG_DEFINE_COMPARE_OPERATORS_BY_MEMCMP()                                           \
+ public:                                                                                         \
+  bool operator<(const self_type& rhs) const {                                                   \
+    return std::memcmp(reinterpret_cast<const void*>(this), reinterpret_cast<const void*>(&rhs), \
+                       sizeof(self_type))                                                        \
+           < 0;                                                                                  \
+  }                                                                                              \
+  bool operator<=(const self_type& rhs) const {                                                  \
+    return std::memcmp(reinterpret_cast<const void*>(this), reinterpret_cast<const void*>(&rhs), \
+                       sizeof(self_type))                                                        \
+           <= 0;                                                                                 \
+  }                                                                                              \
+  bool operator==(const self_type& rhs) const {                                                  \
+    return std::memcmp(reinterpret_cast<const void*>(this), reinterpret_cast<const void*>(&rhs), \
+                       sizeof(self_type))                                                        \
+           == 0;                                                                                 \
+  }                                                                                              \
+  bool operator!=(const self_type& rhs) const {                                                  \
+    return std::memcmp(reinterpret_cast<const void*>(this), reinterpret_cast<const void*>(&rhs), \
+                       sizeof(self_type))                                                        \
+           != 0;                                                                                 \
+  }                                                                                              \
+  bool operator>(const self_type& rhs) const {                                                   \
+    return std::memcmp(reinterpret_cast<const void*>(this), reinterpret_cast<const void*>(&rhs), \
+                       sizeof(self_type))                                                        \
+           > 0;                                                                                  \
+  }                                                                                              \
+  bool operator>=(const self_type& rhs) const {                                                  \
+    return std::memcmp(reinterpret_cast<const void*>(this), reinterpret_cast<const void*>(&rhs), \
+                       sizeof(self_type))                                                        \
+           >= 0;                                                                                 \
+  }
+
 template<typename T, std::size_t N>
 class FlatMsgRepeatedField final {
  public:
+  using value_type = T;
+  static const int capacity = N;
+
   bool empty() const { return size_ == 0; }
 
   std::size_t size() const { return size_; }

--- a/oneflow/core/common/flat_msg_test.cpp
+++ b/oneflow/core/common/flat_msg_test.cpp
@@ -32,7 +32,8 @@ END_FLAT_MSG(TestOptional)
 // clang-format on
 
 TEST(FlatMsg, optional) {
-  FLAT_MSG(TestOptional) foo_box;
+  static_assert(std::is_trivial<TestOptional>::value, "TestOptional is not trivial");
+  FlatMsg<TestOptional> foo_box;
   auto& foo = *foo_box.Mutable();
   ASSERT_TRUE(!foo.has_bar());
   ASSERT_EQ(foo.bar(), 0);
@@ -55,7 +56,7 @@ END_FLAT_MSG(FooOneof)
 // clang-format on
 
 TEST(FlatMsg, oneof) {
-  FLAT_MSG(FooOneof) foo_box;
+  FlatMsg<FooOneof> foo_box;
   auto& foo = *foo_box.Mutable();
   ASSERT_TRUE(GetFieldNames(&foo).empty());
   ASSERT_TRUE(!foo.has_bar());
@@ -63,8 +64,8 @@ TEST(FlatMsg, oneof) {
   foo.mutable_case_0();
   CheckSoleFieldName(&foo, "case_0_");
   ASSERT_TRUE(foo.has_case_0());
-  FLAT_MSG_ONEOF_ENUM_TYPE(FooOneof, type) x = foo.type_case();
-  ASSERT_TRUE(x == FLAT_MSG_ONEOF_ENUM_VALUE(FooOneof, case_0));
+  FooOneof::FLAT_MSG_ONEOF_CASE(type) x = foo.type_case();
+  ASSERT_TRUE(x == FooOneof::FLAT_MSG_ONEOF_CASE_VALUE(case_0));
   *foo.mutable_case_1() = 9527;
   CheckSoleFieldName(&foo, "case_1_");
   ASSERT_TRUE(foo.has_case_1());
@@ -79,7 +80,7 @@ END_FLAT_MSG(FooRepeated)
 // clang-format on
 
 TEST(FlatMsg, repeated) {
-  FLAT_MSG(FooRepeated) foo_box;
+  FlatMsg<FooRepeated> foo_box;
   auto& foo = *foo_box.Mutable();
   ASSERT_EQ(foo.bar_size(), 0);
   ASSERT_EQ(foo.bar().size(), 0);
@@ -108,7 +109,7 @@ END_FLAT_MSG(TestTemplateFlatMsg);
 // clang-format on
 
 TEST(FlatMsg, flat_msg_template) {
-  FLAT_MSG(TestTemplateFlatMsg<1024>) foo;
+  FlatMsg<TestTemplateFlatMsg<1024>> foo;
   ASSERT_TRUE(foo.Get().char_field().empty());
 }
 

--- a/oneflow/core/common/flat_msg_view.h
+++ b/oneflow/core/common/flat_msg_view.h
@@ -1,0 +1,185 @@
+#ifndef ONEFLOW_CORE_COMMON_FLAT_MSG_VIEW_H_
+#define ONEFLOW_CORE_COMMON_FLAT_MSG_VIEW_H_
+
+#include "oneflow/core/common/dss.h"
+#include "oneflow/core/common/flat_msg.h"
+
+namespace oneflow {
+
+#define BEGIN_FLAT_MSG_VIEW(struct_name)                    \
+  struct struct_name final {                                \
+    using self_type = struct_name;                          \
+    static const bool __is_flat_message_view_type__ = true; \
+    FLAT_MSG_VIEW_DEFINE_BASIC_METHODS(struct_name);        \
+    BEGIN_DSS(DSS_GET_FIELD_COUNTER(), struct_name, 0);
+
+#define END_FLAT_MSG_VIEW(struct_name)                                                    \
+  static_assert(__is_flat_message_view_type__, "this struct is not a flat message view"); \
+  END_DSS(DSS_GET_FIELD_COUNTER(), "flat message view", struct_name);                     \
+  }                                                                                       \
+  ;
+
+#define FLAT_MSG_VIEW_DEFINE_PATTERN(flat_msg_field_type, field_name)                     \
+  static_assert(__is_flat_message_view_type__, "this struct is not a flat message view"); \
+  _FLAT_MSG_VIEW_DEFINE_PATTERN(FLAT_MSG_TYPE_CHECK(flat_msg_field_type), field_name);    \
+  DSS_DEFINE_FIELD(DSS_GET_FIELD_COUNTER(), "flat message view", OF_PP_CAT(field_name, _));
+
+// details
+
+#define _FLAT_MSG_VIEW_DEFINE_PATTERN(field_type, field_name)                        \
+ public:                                                                             \
+  const field_type& field_name() const { return *OF_PP_CAT(field_name, _); }         \
+  field_type* OF_PP_CAT(mut_, field_name)() { return OF_PP_CAT(field_name, _); }     \
+  field_type* OF_PP_CAT(mutable_, field_name)() { return OF_PP_CAT(field_name, _); } \
+  template<typename T>                                                               \
+  void OF_PP_CAT(set_, field_name)(T val) {                                          \
+    static_assert(std::is_arithmetic<T>::value || std::is_enum<T>::value,            \
+                  "only scalar fields have setter");                                 \
+    *OF_PP_CAT(mut_, field_name)() = val;                                            \
+  }                                                                                  \
+                                                                                     \
+ private:                                                                            \
+  field_type* OF_PP_CAT(field_name, _);
+
+#define FLAT_MSG_VIEW_DEFINE_BASIC_METHODS(T)                                                 \
+ public:                                                                                      \
+  void Clear() { std::memset(reinterpret_cast<void*>(this), 0, sizeof(T)); }                  \
+  template<typename FlatMsgOneofField, typename RepeatedFlatMsgT>                             \
+  bool MatchOneof(RepeatedFlatMsgT* repeated_flat_msg) {                                      \
+    return FlatMsgViewUtil<self_type, FlatMsgOneofField, RepeatedFlatMsgT>::Match(            \
+        this, repeated_flat_msg);                                                             \
+  }                                                                                           \
+  template<typename RepeatedFlatMsgT>                                                         \
+  bool Match(RepeatedFlatMsgT* repeated_flat_msg) {                                           \
+    using OneofField = StructField<typename RepeatedFlatMsgT::value_type,                     \
+                                   typename RepeatedFlatMsgT::value_type::__OneofType,        \
+                                   RepeatedFlatMsgT::value_type::__DssFieldOffset()>;         \
+    return MatchOneof<OneofField>(repeated_flat_msg);                                         \
+  }                                                                                           \
+  template<typename FlatMsgOneofField, typename RepeatedFlatMsgT>                             \
+  void InitOneof(RepeatedFlatMsgT* repeated_flat_msg) {                                       \
+    FlatMsgViewUtil<self_type, FlatMsgOneofField, RepeatedFlatMsgT>::Init(this,               \
+                                                                          repeated_flat_msg); \
+  }                                                                                           \
+  template<typename RepeatedFlatMsgT>                                                         \
+  void Init(RepeatedFlatMsgT* repeated_flat_msg) {                                            \
+    using OneofField = StructField<typename RepeatedFlatMsgT::value_type,                     \
+                                   typename RepeatedFlatMsgT::value_type::__OneofType,        \
+                                   RepeatedFlatMsgT::value_type::__DssFieldOffset()>;         \
+    return InitOneof<OneofField>(repeated_flat_msg);                                          \
+  }
+
+template<typename FlatMsgOneofField, typename RepeatedFlatMsgT>
+class FlatMsgViewFieldMatchCtx {
+ public:
+  static_assert(std::is_same<typename RepeatedFlatMsgT::value_type,
+                             typename FlatMsgOneofField::struct_type>::value,
+                "invalid view match");
+  FlatMsgViewFieldMatchCtx(const FlatMsgViewFieldMatchCtx&) = delete;
+  FlatMsgViewFieldMatchCtx(FlatMsgViewFieldMatchCtx&&) = delete;
+  FlatMsgViewFieldMatchCtx(RepeatedFlatMsgT* repeated_flag_msg)
+      : repeated_flag_msg_(repeated_flag_msg), field_index_(0) {}
+  ~FlatMsgViewFieldMatchCtx() = default;
+
+  typename RepeatedFlatMsgT::value_type* MutableFlatMsg() {
+    return repeated_flag_msg_->Mutable(field_index_);
+  }
+  typename FlatMsgOneofField::field_type* MutableOneof() {
+    return FlatMsgOneofField::FieldPtr4StructPtr(MutableFlatMsg());
+  }
+  void increase_field_index() { ++field_index_; }
+
+ private:
+  RepeatedFlatMsgT* repeated_flag_msg_;
+  int field_index_;
+};
+
+template<int field_counter, typename WalkCtxType, typename FieldPtrT>
+struct FlatMsgViewFieldMatcher {
+  static bool Call(WalkCtxType* ctx, FieldPtrT* field, const char* field_name) {
+    using FieldType = typename std::remove_pointer<FieldPtrT>::type;
+    auto* oneof = ctx->MutableOneof();
+    if (!oneof->template HasField<FieldType>()) { return true; }
+    *field = oneof->template MutableField<FieldType>();
+    ctx->increase_field_index();
+    return false;
+  }
+};
+
+template<typename FlatMsgOneofField, typename RepeatedFlatMsgT>
+class FlatMsgViewFieldInitCtx {
+ public:
+  static_assert(std::is_same<typename RepeatedFlatMsgT::value_type,
+                             typename FlatMsgOneofField::struct_type>::value,
+                "invalid view match");
+  FlatMsgViewFieldInitCtx(const FlatMsgViewFieldInitCtx&) = delete;
+  FlatMsgViewFieldInitCtx(FlatMsgViewFieldInitCtx&&) = delete;
+  FlatMsgViewFieldInitCtx(RepeatedFlatMsgT* repeated_flag_msg)
+      : repeated_flag_msg_(repeated_flag_msg) {}
+  ~FlatMsgViewFieldInitCtx() = default;
+
+  typename RepeatedFlatMsgT::value_type* AddFlatMsg() { return repeated_flag_msg_->Add(); }
+  typename FlatMsgOneofField::field_type* AddOneof() {
+    return FlatMsgOneofField::FieldPtr4StructPtr(AddFlatMsg());
+  }
+
+ private:
+  RepeatedFlatMsgT* repeated_flag_msg_;
+};
+
+template<int field_counter, typename WalkCtxType, typename FieldPtrT>
+struct FlatMsgViewFieldIniter {
+  static void Call(WalkCtxType* ctx, FieldPtrT* field, const char* field_name) {
+    using FieldType = typename std::remove_pointer<FieldPtrT>::type;
+    auto* oneof = ctx->AddOneof();
+    *field = oneof->template MutableField<FieldType>();
+  }
+};
+
+template<typename FlatMsgViewT, typename FlatMsgOneofField, typename RepeatedFlatMsgT>
+struct FlatMsgViewUtil {
+  static_assert(std::is_same<typename RepeatedFlatMsgT::value_type,
+                             typename FlatMsgOneofField::struct_type>::value,
+                "invalid view match");
+  static_assert(FlatMsgViewT::__DSS__FieldCount() <= RepeatedFlatMsgT::capacity,
+                "invalid capacity");
+  static bool Match(FlatMsgViewT* flat_msg_view, RepeatedFlatMsgT* repeated_flat_msg) {
+    if (repeated_flat_msg->size() != FlatMsgViewT::__DSS__FieldCount()) { return false; }
+    FlatMsgViewFieldMatchCtx<FlatMsgOneofField, RepeatedFlatMsgT> ctx(repeated_flat_msg);
+    return !flat_msg_view->template __WalkFieldUntil__<FlatMsgViewFieldMatcher>(&ctx);
+  }
+  static void Init(FlatMsgViewT* flat_msg_view, RepeatedFlatMsgT* repeated_flat_msg) {
+    CHECK(repeated_flat_msg->empty());
+    FlatMsgViewFieldInitCtx<FlatMsgOneofField, RepeatedFlatMsgT> ctx(repeated_flat_msg);
+    flat_msg_view->template __WalkField__<FlatMsgViewFieldIniter>(&ctx);
+    CHECK_EQ(repeated_flat_msg->size(), FlatMsgViewT::__DSS__FieldCount());
+  }
+};
+
+template<typename T>
+struct FlatMsgView final {
+  static_assert(T::__is_flat_message_view_type__, "T is not a flat message view type");
+  FlatMsgView() { view_.Clear(); }
+  ~FlatMsgView() = default;
+  template<typename RepeatedT>
+  explicit FlatMsgView(RepeatedT* repeated_flag_msg) {
+    view_.Clear();
+    view_.Init(repeated_flag_msg);
+  }
+
+  const T& operator*() const { return view_; }
+  T& operator*() { return view_; }
+  const T* operator->() const { return &view_; }
+  T* operator->() { return &view_; }
+
+  const T& Get() const { return view_; }
+  T* Mutable() { return &view_; }
+
+ private:
+  union {
+    T view_;
+  };
+};
+}
+
+#endif  // ONEFLOW_CORE_COMMON_FLAT_MSG_VIEW_H_

--- a/oneflow/core/common/flat_msg_view_test.cpp
+++ b/oneflow/core/common/flat_msg_view_test.cpp
@@ -1,0 +1,95 @@
+#include "oneflow/core/common/flat_msg_view.h"
+#include "oneflow/core/common/util.h"
+
+namespace oneflow {
+
+namespace test {
+
+namespace {
+
+// clang-format off
+BEGIN_FLAT_MSG(VariantFoo);
+  FLAT_MSG_DEFINE_STRICT_ONEOF(_,
+    FLAT_MSG_ONEOF_FIELD(int8_t, int8_value)
+    FLAT_MSG_ONEOF_FIELD(int16_t, int16_value)
+    FLAT_MSG_ONEOF_FIELD(int32_t, int32_value)
+    FLAT_MSG_ONEOF_FIELD(float, float_value));
+END_FLAT_MSG(VariantFoo);
+// clang-format on
+
+// clang-format off
+BEGIN_FLAT_MSG(DefaultOneofNameVariantFoo);
+  FLAT_MSG_DEFINE_STRICT_ONEOF(_,
+    FLAT_MSG_ONEOF_FIELD(int8_t, int8_value)
+    FLAT_MSG_ONEOF_FIELD(int16_t, int16_value)
+    FLAT_MSG_ONEOF_FIELD(int32_t, int32_value)
+    FLAT_MSG_ONEOF_FIELD(float, float_value));
+END_FLAT_MSG(DefaultOneofNameVariantFoo);
+// clang-format on
+
+using TestOneofField =
+    StructField<VariantFoo, VariantFoo::__OneofType, VariantFoo::__DssFieldOffset()>;
+
+// clang-format off
+BEGIN_FLAT_MSG(VariantList);
+  FLAT_MSG_DEFINE_REPEATED(VariantFoo, foo, 16);
+END_FLAT_MSG(VariantList);
+// clang-format on
+
+// clang-format off
+BEGIN_FLAT_MSG(DefaultOneofNameVariantFooList);
+  FLAT_MSG_DEFINE_REPEATED(DefaultOneofNameVariantFoo, foo, 16);
+END_FLAT_MSG(DefaultOneofNameVariantFooList);
+// clang-format on
+
+// clang-format off
+BEGIN_FLAT_MSG_VIEW(ViewFoo);
+  FLAT_MSG_VIEW_DEFINE_PATTERN(int32_t, int32_value);
+  FLAT_MSG_VIEW_DEFINE_PATTERN(int16_t, int16_value);
+  FLAT_MSG_VIEW_DEFINE_PATTERN(float, float_value);
+END_FLAT_MSG_VIEW(ViewFoo);
+// clang-format on
+
+TEST(FlatMsgView, match_success) {
+  FlatMsg<VariantList> variant_list;
+  variant_list.Mutable()->mutable_foo()->Add()->set_int32_value(30);
+  variant_list.Mutable()->mutable_foo()->Add()->set_int16_value(40);
+  variant_list.Mutable()->mutable_foo()->Add()->set_float_value(50.0);
+  FlatMsgView<ViewFoo> view;
+  ASSERT_TRUE(view->template MatchOneof<TestOneofField>(variant_list.Mutable()->mutable_foo()));
+  ASSERT_EQ(view->int32_value(), 30);
+  ASSERT_EQ(view->int16_value(), 40);
+  ASSERT_EQ(view->float_value(), 50.0);
+}
+
+TEST(FlatMsgView, match_failed) {
+  FlatMsg<VariantList> variant_list;
+  variant_list.Mutable()->mutable_foo()->Add()->set_int16_value(40);
+  variant_list.Mutable()->mutable_foo()->Add()->set_int32_value(30);
+  variant_list.Mutable()->mutable_foo()->Add()->set_float_value(50.0);
+  FlatMsgView<ViewFoo> view;
+  ASSERT_TRUE(!view->template MatchOneof<TestOneofField>(variant_list.Mutable()->mutable_foo()));
+}
+
+TEST(FlatMsgView, init) {
+  FlatMsg<DefaultOneofNameVariantFooList> variant_list;
+  {
+    FlatMsgView<ViewFoo> mut_view(variant_list.Mutable()->mutable_foo());
+    mut_view->set_int32_value(30);
+    mut_view->set_int16_value(40);
+    mut_view->set_float_value(50.0);
+  }
+  {
+    FlatMsgView<ViewFoo> view;
+    ASSERT_TRUE(view->Match(variant_list.Mutable()->mutable_foo()));
+    ASSERT_EQ(view->int32_value(), 30);
+    ASSERT_EQ(view->int16_value(), 40);
+    ASSERT_EQ(view->float_value(), 50.0);
+  }
+}
+
+}  // namespace
+
+}  // namespace test
+
+}  // namespace oneflow

--- a/oneflow/core/common/object_msg.h
+++ b/oneflow/core/common/object_msg.h
@@ -3,8 +3,11 @@
 
 #include "oneflow/core/common/object_msg_core.h"
 #include "oneflow/core/common/object_msg_raw_ptr.h"
+#include "oneflow/core/common/object_msg_wrapper.h"
 #include "oneflow/core/common/object_msg_flat.h"
 #include "oneflow/core/common/object_msg_list.h"
+#include "oneflow/core/common/object_msg_mutexed_list.h"
+#include "oneflow/core/common/object_msg_condition_list.h"
 #include "oneflow/core/common/object_msg_map.h"
 
 #endif  // ONEFLOW_CORE_COMMON_OBJECT_MSG_H_

--- a/oneflow/core/common/object_msg_basic_test.cpp
+++ b/oneflow/core/common/object_msg_basic_test.cpp
@@ -21,6 +21,8 @@ TEST(ObjectMsgStruct, ref_cnt) {
 }
 
 class TestNew final : public ObjectMsgStruct {
+ public:
+  static const bool __is_object_message_type__ = true;
   BEGIN_DSS(DSS_GET_FIELD_COUNTER(), TestNew, sizeof(ObjectMsgStruct));
   OBJECT_MSG_DEFINE_INIT();
   OBJECT_MSG_DEFINE_DELETE();

--- a/oneflow/core/common/object_msg_condition_list.h
+++ b/oneflow/core/common/object_msg_condition_list.h
@@ -1,0 +1,150 @@
+#ifndef ONEFLOW_CORE_COMMON_CONDITION_LIST_H_
+#define ONEFLOW_CORE_COMMON_CONDITION_LIST_H_
+
+#include <mutex>
+#include <condition_variable>
+#include "oneflow/core/common/object_msg_list.h"
+
+namespace oneflow {
+
+#define OBJECT_MSG_DEFINE_CONDITION_LIST_HEAD(elem_type, elem_field_name, field_name)         \
+  static_assert(__is_object_message_type__, "this struct is not a object message");           \
+  _OBJECT_MSG_DEFINE_CONDITION_LIST_HEAD(DSS_GET_FIELD_COUNTER(), elem_type, elem_field_name, \
+                                         field_name);
+
+#define OBJECT_MSG_CONDITION_LIST(obj_msg_type, obj_msg_field)                              \
+  ObjectMsgConditionList<StructField<OBJECT_MSG_TYPE_CHECK(obj_msg_type), EmbeddedListLink, \
+                                     OBJECT_MSG_TYPE_CHECK(obj_msg_type)::OF_PP_CAT(        \
+                                         obj_msg_field, _DssFieldOffset)()>>
+
+// details
+
+#define _OBJECT_MSG_DEFINE_CONDITION_LIST_HEAD(field_counter, elem_type, elem_field_name, \
+                                               field_name)                                \
+  _OBJECT_MSG_DEFINE_CONDITION_LIST_HEAD_FIELD(elem_type, elem_field_name, field_name)    \
+  OBJECT_MSG_OVERLOAD_INIT(field_counter, ObjectMsgEmbeddedConditionListHeadInit);        \
+  OBJECT_MSG_OVERLOAD_DELETE(field_counter, ObjectMsgEmbeddedConditionListHeadDelete);    \
+  DSS_DEFINE_FIELD(field_counter, "object message", OF_PP_CAT(field_name, _));
+
+#define _OBJECT_MSG_DEFINE_CONDITION_LIST_HEAD_FIELD(elem_type, elem_field_name, field_name)   \
+ public:                                                                                       \
+  using OF_PP_CAT(field_name, _ObjectMsgListType) = TrivialObjectMsgConditionList<StructField< \
+      OBJECT_MSG_TYPE_CHECK(elem_type), EmbeddedListLink,                                      \
+      OBJECT_MSG_TYPE_CHECK(elem_type)::OF_PP_CAT(elem_field_name, _DssFieldOffset)()>>;       \
+  const OF_PP_CAT(field_name, _ObjectMsgListType) & field_name() const {                       \
+    return OF_PP_CAT(field_name, _);                                                           \
+  }                                                                                            \
+  OF_PP_CAT(field_name, _ObjectMsgListType) * OF_PP_CAT(mut_, field_name)() {                  \
+    return &OF_PP_CAT(field_name, _);                                                          \
+  }                                                                                            \
+  OF_PP_CAT(field_name, _ObjectMsgListType) * OF_PP_CAT(mutable_, field_name)() {              \
+    return &OF_PP_CAT(field_name, _);                                                          \
+  }                                                                                            \
+                                                                                               \
+ private:                                                                                      \
+  OF_PP_CAT(field_name, _ObjectMsgListType) OF_PP_CAT(field_name, _);
+
+template<typename WalkCtxType, typename PtrFieldType>
+struct ObjectMsgEmbeddedConditionListHeadInit {
+  static void Call(WalkCtxType* ctx, PtrFieldType* field, const char* field_name) {
+    field->__Init__();
+  }
+};
+
+template<typename WalkCtxType, typename PtrFieldType>
+struct ObjectMsgEmbeddedConditionListHeadDelete {
+  static void Call(WalkCtxType* ctx, PtrFieldType* field, const char* field_name) {
+    field->__Delete__();
+  }
+};
+
+enum ObjectMsgConditionListStatus {
+  kObjectMsgConditionListStatusSuccess = 0,
+  kObjectMsgConditionListStatusErrorClosed
+};
+
+template<typename LinkField>
+class TrivialObjectMsgConditionList {
+ public:
+  using value_type = typename LinkField::struct_type;
+
+  void __Init__() {
+    list_head_.__Init__();
+    is_closed_ = false;
+    new (mutex_buff_) std::mutex();
+    new (cond_buff_) std::condition_variable();
+  }
+
+  ObjectMsgConditionListStatus EmplaceBack(ObjectMsgPtr<value_type>&& ptr) {
+    std::unique_lock<std::mutex> lock(*mut_mutex());
+    if (is_closed_) { return kObjectMsgConditionListStatusErrorClosed; }
+    list_head_.EmplaceBack(std::move(ptr));
+    mut_cond()->notify_one();
+    return kObjectMsgConditionListStatusSuccess;
+  }
+  ObjectMsgConditionListStatus PopFront(ObjectMsgPtr<value_type>* ptr) {
+    std::unique_lock<std::mutex> lock(*mut_mutex());
+    mut_cond()->wait(lock, [this]() { return (!list_head_.empty()) || is_closed_; });
+    if (list_head_.empty()) { return kObjectMsgConditionListStatusErrorClosed; }
+    *ptr = list_head_.PopFront();
+    return kObjectMsgConditionListStatusSuccess;
+  }
+
+  ObjectMsgConditionListStatus MoveFrom(TrivialObjectMsgList<LinkField>* src) {
+    std::unique_lock<std::mutex> lock(*mut_mutex());
+    if (is_closed_) { return kObjectMsgConditionListStatusErrorClosed; }
+    src->MoveToDstBack(&list_head_);
+    mut_cond()->notify_one();
+    return kObjectMsgConditionListStatusSuccess;
+  }
+
+  ObjectMsgConditionListStatus MoveTo(TrivialObjectMsgList<LinkField>* dst) {
+    std::unique_lock<std::mutex> lock(*mut_mutex());
+    mut_cond()->wait(lock, [this]() { return (!list_head_.empty()) || is_closed_; });
+    if (list_head_.empty()) { return kObjectMsgConditionListStatusErrorClosed; }
+    list_head_.MoveToDstBack(dst);
+    return kObjectMsgConditionListStatusSuccess;
+  }
+
+  void Close() {
+    std::unique_lock<std::mutex> lock(*mut_mutex());
+    is_closed_ = true;
+    mut_cond()->notify_all();
+  }
+
+  void __Delete__() {
+    list_head_.Clear();
+    using namespace std;
+    mut_mutex()->mutex::~mutex();
+    mut_cond()->condition_variable::~condition_variable();
+  }
+
+ private:
+  std::mutex* mut_mutex() { return reinterpret_cast<std::mutex*>(&mutex_buff_[0]); }
+  std::condition_variable* mut_cond() {
+    return reinterpret_cast<std::condition_variable*>(&cond_buff_[0]);
+  }
+
+  TrivialObjectMsgList<LinkField> list_head_;
+  union {
+    char mutex_buff_[sizeof(std::mutex)];
+    int64_t mutex_buff_align_;
+  };
+  union {
+    char cond_buff_[sizeof(std::condition_variable)];
+    int64_t cond_buff_align_;
+  };
+  bool is_closed_;
+};
+
+template<typename LinkField>
+class ObjectMsgConditionList : public TrivialObjectMsgConditionList<LinkField> {
+ public:
+  ObjectMsgConditionList(const ObjectMsgConditionList&) = delete;
+  ObjectMsgConditionList(ObjectMsgConditionList&&) = delete;
+  ObjectMsgConditionList() { this->__Init__(); }
+  ~ObjectMsgConditionList() { this->__Delete__(); }
+};
+}
+
+#endif  // ONEFLOW_CORE_COMMON_CONDITION_LIST_H_

--- a/oneflow/core/common/object_msg_condition_list_test.cpp
+++ b/oneflow/core/common/object_msg_condition_list_test.cpp
@@ -1,0 +1,79 @@
+#include "oneflow/core/common/object_msg.h"
+#include "oneflow/core/common/util.h"
+#include "oneflow/core/common/range.h"
+
+namespace oneflow {
+
+namespace test {
+
+namespace {
+
+// clang-format off
+BEGIN_OBJECT_MSG(Foo);
+  // fields
+  OBJECT_MSG_DEFINE_OPTIONAL(int, x);
+
+  // links
+  OBJECT_MSG_DEFINE_LIST_LINK(link);
+END_OBJECT_MSG(Foo);
+// clang-format on
+
+// clang-format off
+BEGIN_OBJECT_MSG(FooList);
+  // links
+  OBJECT_MSG_DEFINE_CONDITION_LIST_HEAD(Foo, link, list);
+END_OBJECT_MSG(FooList);
+// clang-format on
+
+using ConditionListFoo = OBJECT_MSG_CONDITION_LIST(Foo, link);
+
+void CallFromSenderThread(ConditionListFoo* condition_list, Range range) {
+  for (int i = range.begin(); i < range.end(); ++i) {
+    auto foo = ObjectMsgPtr<Foo>::New();
+    foo->set_x(i);
+    if (condition_list->EmplaceBack(std::move(foo)) != kObjectMsgConditionListStatusSuccess) {
+      break;
+    }
+  }
+}
+
+void CallFromReceiverThread(std::vector<int>* visit, ConditionListFoo* condition_list) {
+  ObjectMsgPtr<Foo> foo;
+  while (condition_list->PopFront(&foo) == kObjectMsgConditionListStatusSuccess) {
+    ++visit->at(foo->x());
+  }
+}
+
+TEST(ObjectMsgConditionList, 30sender40receiver) {
+  ConditionListFoo condition_list;
+  std::vector<std::thread> senders;
+  std::vector<std::thread> receivers;
+  int sender_num = 30;
+  int receiver_num = 40;
+  int range_num = 200;
+  std::vector<std::vector<int>> visits;
+  for (int i = 0; i < receiver_num; ++i) {
+    std::vector<int> visit_i;
+    for (int j = 0; j < range_num; j++) { visit_i.push_back(0); }
+    visits.push_back(visit_i);
+  }
+  for (int i = 0; i < sender_num; ++i) {
+    senders.push_back(std::thread(CallFromSenderThread, &condition_list, Range(0, range_num)));
+  }
+  for (int i = 0; i < receiver_num; ++i) {
+    receivers.push_back(std::thread(CallFromReceiverThread, &visits[i], &condition_list));
+  }
+  for (std::thread& this_thread : senders) { this_thread.join(); }
+  condition_list.Close();
+  for (std::thread& this_thread : receivers) { this_thread.join(); }
+  for (int i = 0; i < range_num; ++i) {
+    int visit_count = 0;
+    for (int j = 0; j < receiver_num; j++) { visit_count += visits[j][i]; }
+    ASSERT_EQ(visit_count, sender_num);
+  }
+}
+}  // namespace
+
+}  // namespace test
+
+}  // namespace oneflow

--- a/oneflow/core/common/object_msg_flat.h
+++ b/oneflow/core/common/object_msg_flat.h
@@ -12,23 +12,50 @@ namespace oneflow {
 
 // details
 
-#define _OBJECT_MSG_DEFINE_FLAT_MSG(field_counter, field_type, field_name) \
-  _OBJECT_MSG_DEFINE_FLAT_MSG_FIELD(FLAT_MSG_TYPE(field_type), field_name) \
-  OBJECT_MSG_OVERLOAD_INIT(field_counter, ObjectMsgFlatMsgInit);           \
-  OBJECT_MSG_OVERLOAD_DELETE(field_counter, ObjectMsgFlatMsgDelete);       \
+#define _OBJECT_MSG_DEFINE_FLAT_MSG(field_counter, field_type, field_name)       \
+  _OBJECT_MSG_DEFINE_FLAT_MSG_FIELD(FLAT_MSG_TYPE_CHECK(field_type), field_name) \
+  OBJECT_MSG_OVERLOAD_INIT(field_counter, ObjectMsgFlatMsgInit);                 \
+  OBJECT_MSG_OVERLOAD_DELETE(field_counter, ObjectMsgFlatMsgDelete);             \
   DSS_DEFINE_FIELD(field_counter, "object message", OF_PP_CAT(field_name, _));
 
-#define _OBJECT_MSG_DEFINE_FLAT_MSG_FIELD(field_type, field_name)            \
- public:                                                                     \
-  static_assert(field_type::__is_flat_message_type__,                        \
-                OF_PP_STRINGIZE(field_type) "is not a flat message type");   \
-  bool OF_PP_CAT(has_, field_name)() { return true; }                        \
-  DSS_DEFINE_GETTER(field_type, field_name);                                 \
-  void OF_PP_CAT(clear_, field_name)() { OF_PP_CAT(field_name, _).clear(); } \
-  DSS_DEFINE_MUTABLE(field_type, field_name);                                \
-                                                                             \
- private:                                                                    \
+#define _OBJECT_MSG_DEFINE_FLAT_MSG_FIELD(field_type, field_name)                     \
+ public:                                                                              \
+  static_assert(std::is_trivial<field_type>::value,                                   \
+                OF_PP_STRINGIZE(field_type) " is not trivial");                       \
+  bool OF_PP_CAT(has_, field_name)() {                                                \
+    return ObjectMsgFlatMsgHas<std::is_enum<field_type>::value, field_type>::Call(    \
+        OF_PP_CAT(field_name, _));                                                    \
+  }                                                                                   \
+  const field_type& field_name() const { return OF_PP_CAT(field_name, _); }           \
+  void OF_PP_CAT(clear_, field_name)() {                                              \
+    ObjectMsgFlatMsgClear<std::is_enum<field_type>::value, field_type>::Call(         \
+        &OF_PP_CAT(field_name, _));                                                   \
+  }                                                                                   \
+  field_type* OF_PP_CAT(mut_, field_name)() { return &OF_PP_CAT(field_name, _); }     \
+  field_type* OF_PP_CAT(mutable_, field_name)() { return &OF_PP_CAT(field_name, _); } \
+                                                                                      \
+ private:                                                                             \
   field_type OF_PP_CAT(field_name, _);
+
+template<bool is_enum, typename T>
+struct ObjectMsgFlatMsgHas {
+  static bool Call(const T& val) { return true; }
+};
+
+template<typename T>
+struct ObjectMsgFlatMsgHas<true, T> {
+  static bool Call(const T& val) { return val == static_cast<T>(0); }
+};
+
+template<bool is_enum, typename T>
+struct ObjectMsgFlatMsgClear {
+  static void Call(T* ptr) { ptr->clear(); }
+};
+
+template<typename T>
+struct ObjectMsgFlatMsgClear<true, T> {
+  static void Call(T* ptr) { *ptr = static_cast<T>(0); }
+};
 
 template<typename WalkCtxType, typename PtrFieldType>
 struct ObjectMsgFlatMsgInit {

--- a/oneflow/core/common/object_msg_list.h
+++ b/oneflow/core/common/object_msg_list.h
@@ -14,6 +14,11 @@ namespace oneflow {
   static_assert(__is_object_message_type__, "this struct is not a object message"); \
   _OBJECT_MSG_DEFINE_LIST_HEAD(DSS_GET_FIELD_COUNTER(), elem_type, elem_field_name, field_name);
 
+#define OBJECT_MSG_LIST(obj_msg_type, obj_msg_field)                                      \
+  ObjectMsgList<StructField<OBJECT_MSG_TYPE_CHECK(obj_msg_type), EmbeddedListLink,        \
+                            OBJECT_MSG_TYPE_CHECK(obj_msg_type)::OF_PP_CAT(obj_msg_field, \
+                                                                           _DssFieldOffset)()>>
+
 #define OBJECT_MSG_LIST_FOR_EACH(list_ptr, elem)                            \
   for (ObjectMsgPtr<std::remove_pointer<decltype((list_ptr)->End())>::type> \
            elem = (list_ptr)->Begin(),                                      \
@@ -21,7 +26,12 @@ namespace oneflow {
        elem.Mutable() != (list_ptr)->End();                                 \
        elem = __next_elem__, __next_elem__ = (list_ptr)->Next(__next_elem__.Mutable()))
 
-#define OBJECT_MSG_LIST_FOR_EACH_UNSAFE(list_ptr, elem) \
+#define OBJECT_MSG_LIST_FOR_EACH_PTR(list_ptr, elem)                       \
+  for (decltype((list_ptr)->End()) elem = (list_ptr)->Begin(),             \
+                                   __next_elem__ = (list_ptr)->Next(elem); \
+       elem != nullptr; elem = __next_elem__, __next_elem__ = (list_ptr)->Next(__next_elem__))
+
+#define OBJECT_MSG_LIST_FOR_EACH_UNSAFE_PTR(list_ptr, elem) \
   for (auto* elem = (list_ptr)->Begin(); elem != (list_ptr)->End(); elem = (list_ptr)->Next(elem))
 
 // details
@@ -32,22 +42,23 @@ namespace oneflow {
   OBJECT_MSG_OVERLOAD_DELETE(field_counter, ObjectMsgEmbeddedListHeadDelete);               \
   DSS_DEFINE_FIELD(field_counter, "object message", OF_PP_CAT(field_name, _));
 
-#define _OBJECT_MSG_DEFINE_LIST_HEAD_FIELD(elem_type, elem_field_name, field_name)             \
- public:                                                                                       \
-  using OF_PP_CAT(field_name, _ObjectMsgListType) = TrivialObjectMsgList<                      \
-      StructField<OBJECT_MSG_TYPE(elem_type), EmbeddedListLink,                                \
-                  OBJECT_MSG_TYPE(elem_type)::OF_PP_CAT(elem_field_name, _DssFieldOffset)()>>; \
-  const OF_PP_CAT(field_name, _ObjectMsgListType) & field_name() const {                       \
-    return OF_PP_CAT(field_name, _);                                                           \
-  }                                                                                            \
-  OF_PP_CAT(field_name, _ObjectMsgListType) * OF_PP_CAT(mut_, field_name)() {                  \
-    return &OF_PP_CAT(field_name, _);                                                          \
-  }                                                                                            \
-  OF_PP_CAT(field_name, _ObjectMsgListType) * OF_PP_CAT(mutable_, field_name)() {              \
-    return &OF_PP_CAT(field_name, _);                                                          \
-  }                                                                                            \
-                                                                                               \
- private:                                                                                      \
+#define _OBJECT_MSG_DEFINE_LIST_HEAD_FIELD(elem_type, elem_field_name, field_name)         \
+ public:                                                                                   \
+  using OF_PP_CAT(field_name, _ObjectMsgListType) =                                        \
+      TrivialObjectMsgList<StructField<OBJECT_MSG_TYPE_CHECK(elem_type), EmbeddedListLink, \
+                                       OBJECT_MSG_TYPE_CHECK(elem_type)::OF_PP_CAT(        \
+                                           elem_field_name, _DssFieldOffset)()>>;          \
+  const OF_PP_CAT(field_name, _ObjectMsgListType) & field_name() const {                   \
+    return OF_PP_CAT(field_name, _);                                                       \
+  }                                                                                        \
+  OF_PP_CAT(field_name, _ObjectMsgListType) * OF_PP_CAT(mut_, field_name)() {              \
+    return &OF_PP_CAT(field_name, _);                                                      \
+  }                                                                                        \
+  OF_PP_CAT(field_name, _ObjectMsgListType) * OF_PP_CAT(mutable_, field_name)() {          \
+    return &OF_PP_CAT(field_name, _);                                                      \
+  }                                                                                        \
+                                                                                           \
+ private:                                                                                  \
   OF_PP_CAT(field_name, _ObjectMsgListType) OF_PP_CAT(field_name, _);
 
 #define _OBJECT_MSG_DEFINE_LIST_LINK(field_counter, field_name)               \
@@ -56,14 +67,14 @@ namespace oneflow {
   OBJECT_MSG_OVERLOAD_DELETE(field_counter, ObjectMsgEmbeddedListLinkDelete); \
   DSS_DEFINE_FIELD(field_counter, "object message", OF_PP_CAT(field_name, _));
 
-#define _OBJECT_MSG_DEFINE_LIST_LINK_FIELD(field_name) \
- private:                                              \
+#define _OBJECT_MSG_DEFINE_LIST_LINK_FIELD(field_name)         \
+ public:                                                       \
+  bool OF_PP_CAT(is_, OF_PP_CAT(field_name, _empty))() const { \
+    return OF_PP_CAT(field_name, _).empty();                   \
+  }                                                            \
+                                                               \
+ private:                                                      \
   EmbeddedListLink OF_PP_CAT(field_name, _);
-
-#define OBJECT_MSG_LIST(obj_msg_type, obj_msg_field)               \
-  ObjectMsgList<                                                   \
-      StructField<OBJECT_MSG_TYPE(obj_msg_type), EmbeddedListLink, \
-                  OBJECT_MSG_TYPE(obj_msg_type)::OF_PP_CAT(obj_msg_field, _DssFieldOffset)()>>
 
 template<typename WalkCtxType, typename PtrFieldType>
 struct ObjectMsgEmbeddedListHeadInit {
@@ -130,6 +141,11 @@ class TrivialObjectMsgList {
     MoveToDstBack(begin, dst);
     return begin;
   }
+  value_type* MoveBackToDstBack(TrivialObjectMsgList* dst) {
+    value_type* begin = list_head_.Last();
+    MoveToDstBack(begin, dst);
+    return begin;
+  }
 
   void PushBack(value_type* ptr) {
     list_head_.PushBack(ptr);
@@ -141,25 +157,33 @@ class TrivialObjectMsgList {
     ObjectMsgPtrUtil::Ref(ptr);
   }
 
-  void Erase(value_type* ptr) {
+  void EmplaceBack(ObjectMsgPtr<value_type>&& ptr) {
+    value_type* raw_ptr = nullptr;
+    ptr.__UnsafeMoveTo__(&raw_ptr);
+    list_head_.PushBack(raw_ptr);
+  }
+
+  void EmplaceFront(ObjectMsgPtr<value_type>&& ptr) {
+    value_type* raw_ptr = nullptr;
+    ptr.__UnsafeMoveTo__(&raw_ptr);
+    list_head_.PushFront(ptr);
+  }
+
+  ObjectMsgPtr<value_type> Erase(value_type* ptr) {
     list_head_.Erase(ptr);
-    ObjectMsgPtrUtil::ReleaseRef(ptr);
+    return ObjectMsgPtr<value_type>::__UnsafeMove__(ptr);
   }
 
   ObjectMsgPtr<value_type> PopBack() {
-    ObjectMsgPtr<value_type> ptr;
-    if (list_head_.empty()) { return ptr; }
-    ptr.Reset(list_head_.PopBack());
-    ObjectMsgPtrUtil::ReleaseRef(ptr.Mutable());
-    return ptr;
+    value_type* raw_ptr = nullptr;
+    if (!list_head_.empty()) { raw_ptr = list_head_.PopBack(); }
+    return ObjectMsgPtr<value_type>::__UnsafeMove__(raw_ptr);
   }
 
   ObjectMsgPtr<value_type> PopFront() {
-    ObjectMsgPtr<value_type> ptr;
-    if (list_head_.empty()) { return ptr; }
-    ptr.Reset(list_head_.PopFront());
-    ObjectMsgPtrUtil::ReleaseRef(ptr.Mutable());
-    return ptr;
+    value_type* raw_ptr = nullptr;
+    if (!list_head_.empty()) { raw_ptr = list_head_.PopFront(); }
+    return ObjectMsgPtr<value_type>::__UnsafeMove__(raw_ptr);
   }
 
   void MoveTo(TrivialObjectMsgList* list) { MoveToDstBack(list); }

--- a/oneflow/core/common/object_msg_list_test.cpp
+++ b/oneflow/core/common/object_msg_list_test.cpp
@@ -8,7 +8,7 @@ namespace test {
 // clang-format off
 BEGIN_OBJECT_MSG(TestListItem)
   OBJECT_MSG_DEFINE_LIST_LINK(foo_list);
-  OBJECT_MSG_DEFINE_RAW_PTR(int*, cnt);
+  OBJECT_MSG_DEFINE_RAW_PTR(int, cnt);
 
  public:
   void __Delete__() {
@@ -25,10 +25,10 @@ TEST(ObjectMsgList, empty) {
 
 TEST(ObjectMsgList, empty_Begin) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  OBJECT_MSG_PTR(TestListItem) obj_ptr;
+  ObjectMsgPtr<TestListItem> obj_ptr;
   obj_ptr = foo_list.Begin();
   ASSERT_TRUE(!obj_ptr);
-  OBJECT_MSG_PTR(TestListItem) next;
+  ObjectMsgPtr<TestListItem> next;
   obj_ptr = foo_list.Begin();
   next = foo_list.Next(obj_ptr.Mutable());
   ASSERT_TRUE(!obj_ptr);
@@ -36,8 +36,8 @@ TEST(ObjectMsgList, empty_Begin) {
 
 TEST(ObjectMsgList, empty_Next) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  OBJECT_MSG_PTR(TestListItem) obj_ptr;
-  OBJECT_MSG_PTR(TestListItem) next;
+  ObjectMsgPtr<TestListItem> obj_ptr;
+  ObjectMsgPtr<TestListItem> next;
   obj_ptr = foo_list.Begin();
   next = foo_list.Next(obj_ptr.Mutable());
   ASSERT_TRUE(!obj_ptr);
@@ -52,12 +52,12 @@ TEST(ObjectMsgList, empty_Next) {
 
 TEST(ObjectMsgList, PushFront) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushFront(item0.Mutable());
   foo_list.PushFront(item1.Mutable());
-  OBJECT_MSG_PTR(TestListItem) obj_ptr;
-  OBJECT_MSG_PTR(TestListItem) next;
+  ObjectMsgPtr<TestListItem> obj_ptr;
+  ObjectMsgPtr<TestListItem> next;
   obj_ptr = foo_list.Begin();
   next = foo_list.Next(obj_ptr.Mutable());
   ASSERT_TRUE(obj_ptr == item1);
@@ -68,20 +68,20 @@ TEST(ObjectMsgList, destructor) {
   int elem_cnt = 2;
   {
     OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-    auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
+    auto item0 = ObjectMsgPtr<TestListItem>::New();
     item0->set_cnt(&elem_cnt);
-    auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+    auto item1 = ObjectMsgPtr<TestListItem>::New();
     item1->set_cnt(&elem_cnt);
     foo_list.PushFront(item0.Mutable());
     foo_list.PushFront(item1.Mutable());
   }
   ASSERT_EQ(elem_cnt, 0);
   elem_cnt = 2;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
   {
     OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
     item0->set_cnt(&elem_cnt);
-    auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+    auto item1 = ObjectMsgPtr<TestListItem>::New();
     item1->set_cnt(&elem_cnt);
     foo_list.PushFront(item0.Mutable());
     foo_list.PushFront(item1.Mutable());
@@ -91,12 +91,12 @@ TEST(ObjectMsgList, destructor) {
 
 TEST(ObjectMsgList, PushBack) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
-  OBJECT_MSG_PTR(TestListItem) obj_ptr;
-  OBJECT_MSG_PTR(TestListItem) next;
+  ObjectMsgPtr<TestListItem> obj_ptr;
+  ObjectMsgPtr<TestListItem> next;
   obj_ptr = foo_list.Begin();
   next = foo_list.Next(obj_ptr.Mutable());
   ASSERT_TRUE(obj_ptr == item0);
@@ -105,15 +105,15 @@ TEST(ObjectMsgList, PushBack) {
 
 TEST(ObjectMsgList, Erase) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
   ASSERT_EQ(item1->ref_cnt(), 2);
   foo_list.Erase(item1.Mutable());
   ASSERT_EQ(item1->ref_cnt(), 1);
-  OBJECT_MSG_PTR(TestListItem) obj_ptr;
-  OBJECT_MSG_PTR(TestListItem) next;
+  ObjectMsgPtr<TestListItem> obj_ptr;
+  ObjectMsgPtr<TestListItem> next;
   obj_ptr = foo_list.Begin();
   next = foo_list.Next(obj_ptr.Mutable());
   ASSERT_TRUE(obj_ptr == item0);
@@ -122,15 +122,15 @@ TEST(ObjectMsgList, Erase) {
 
 TEST(ObjectMsgList, PopBack) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
   ASSERT_EQ(item1->ref_cnt(), 2);
   foo_list.PopBack();
   ASSERT_EQ(item1->ref_cnt(), 1);
-  OBJECT_MSG_PTR(TestListItem) obj_ptr;
-  OBJECT_MSG_PTR(TestListItem) next;
+  ObjectMsgPtr<TestListItem> obj_ptr;
+  ObjectMsgPtr<TestListItem> next;
   obj_ptr = foo_list.Begin();
   next = foo_list.Next(obj_ptr.Mutable());
   ASSERT_TRUE(obj_ptr == item0);
@@ -139,15 +139,15 @@ TEST(ObjectMsgList, PopBack) {
 
 TEST(ObjectMsgList, PopFront) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
   ASSERT_EQ(item0->ref_cnt(), 2);
   foo_list.PopFront();
   ASSERT_EQ(item0->ref_cnt(), 1);
-  OBJECT_MSG_PTR(TestListItem) obj_ptr;
-  OBJECT_MSG_PTR(TestListItem) next;
+  ObjectMsgPtr<TestListItem> obj_ptr;
+  ObjectMsgPtr<TestListItem> next;
   obj_ptr = foo_list.Begin();
   next = foo_list.Next(obj_ptr.Mutable());
   ASSERT_TRUE(!next);
@@ -155,8 +155,8 @@ TEST(ObjectMsgList, PopFront) {
 
 TEST(ObjectMsgList, Clear) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
   ASSERT_EQ(item0->ref_cnt(), 2);
@@ -167,14 +167,14 @@ TEST(ObjectMsgList, Clear) {
   ASSERT_EQ(item1->ref_cnt(), 1);
 }
 
-TEST(ObjectMsgList, FOR_EACH_UNSAFE) {
+TEST(ObjectMsgList, FOR_EACH_UNSAFE_PTR) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
   int i = 0;
-  OBJECT_MSG_LIST_FOR_EACH_UNSAFE(&foo_list, item) {
+  OBJECT_MSG_LIST_FOR_EACH_UNSAFE_PTR(&foo_list, item) {
     if (i == 0) {
       ASSERT_TRUE(item == item0.Mutable());
     } else if (i == 1) {
@@ -187,8 +187,8 @@ TEST(ObjectMsgList, FOR_EACH_UNSAFE) {
 
 TEST(ObjectMsgList, FOR_EACH) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
   int i = 0;
@@ -215,10 +215,10 @@ END_OBJECT_MSG(TestObjectMsgListHead);
 // clang-format on
 
 TEST(ObjectMsg, OBJECT_MSG_DEFINE_LIST_HEAD) {
-  auto foo_list_head = OBJECT_MSG_PTR(TestObjectMsgListHead)::New();
+  auto foo_list_head = ObjectMsgPtr<TestObjectMsgListHead>::New();
   auto& foo_list = *foo_list_head->mutable_foo_list();
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
   ASSERT_EQ(item0->ref_cnt(), 2);
@@ -247,16 +247,16 @@ END_OBJECT_MSG(TestObjectMsgListHeadWrapper);
 // clang-format on
 
 TEST(ObjectMsg, nested_list_delete) {
-  auto foo_list_head = OBJECT_MSG_PTR(TestObjectMsgListHeadWrapper)::New();
+  auto foo_list_head = ObjectMsgPtr<TestObjectMsgListHeadWrapper>::New();
   auto& foo_list = *foo_list_head->mutable_head()->mutable_foo_list();
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
   ASSERT_EQ(item0->ref_cnt(), 2);
   ASSERT_EQ(item1->ref_cnt(), 2);
   int i = 0;
-  OBJECT_MSG_LIST_FOR_EACH_UNSAFE(&foo_list, item) {
+  OBJECT_MSG_LIST_FOR_EACH_UNSAFE_PTR(&foo_list, item) {
     if (i == 0) {
       ASSERT_TRUE(item == item0.Mutable());
     } else if (i == 1) {
@@ -273,10 +273,14 @@ TEST(ObjectMsg, nested_list_delete) {
 TEST(ObjectMsg, MoveTo) {
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list;
   OBJECT_MSG_LIST(TestListItem, foo_list) foo_list0;
-  auto item0 = OBJECT_MSG_PTR(TestListItem)::New();
-  auto item1 = OBJECT_MSG_PTR(TestListItem)::New();
+  auto item0 = ObjectMsgPtr<TestListItem>::New();
+  auto item1 = ObjectMsgPtr<TestListItem>::New();
+  ASSERT_EQ(item0->is_foo_list_empty(), true);
+  ASSERT_EQ(item1->is_foo_list_empty(), true);
   foo_list.PushBack(item0.Mutable());
   foo_list.PushBack(item1.Mutable());
+  ASSERT_EQ(item0->is_foo_list_empty(), false);
+  ASSERT_EQ(item1->is_foo_list_empty(), false);
   ASSERT_EQ(foo_list.size(), 2);
   ASSERT_EQ(foo_list0.empty(), true);
   ASSERT_EQ(item0->ref_cnt(), 2);

--- a/oneflow/core/common/object_msg_map.h
+++ b/oneflow/core/common/object_msg_map.h
@@ -4,6 +4,8 @@
 #include "oneflow/core/common/object_msg_skiplist.h"
 
 #define OBJECT_MSG_DEFINE_MAP_KEY(T, field_name) OBJECT_MSG_DEFINE_SKIPLIST_KEY(20, T, field_name)
+#define OBJECT_MSG_DEFINE_MAP_FLAT_MSG_KEY(T, field_name) \
+  OBJECT_MSG_DEFINE_SKIPLIST_FLAT_MSG_KEY(20, T, field_name)
 #define OBJECT_MSG_DEFINE_MAP_HEAD(elem_type, elem_field_name, field_name) \
   OBJECT_MSG_DEFINE_SKIPLIST_HEAD(elem_type, elem_field_name, field_name)
 #define OBJECT_MSG_MAP(elem_type, elem_field_name) OBJECT_MSG_SKIPLIST(elem_type, elem_field_name)

--- a/oneflow/core/common/object_msg_mutexed_list.h
+++ b/oneflow/core/common/object_msg_mutexed_list.h
@@ -1,0 +1,115 @@
+#ifndef ONEFLOW_CORE_COMMON_MUTEXED_LIST_H_
+#define ONEFLOW_CORE_COMMON_MUTEXED_LIST_H_
+
+#include <mutex>
+#include "oneflow/core/common/object_msg_list.h"
+
+namespace oneflow {
+
+#define OBJECT_MSG_DEFINE_MUTEXED_LIST_HEAD(elem_type, elem_field_name, field_name)         \
+  static_assert(__is_object_message_type__, "this struct is not a object message");         \
+  _OBJECT_MSG_DEFINE_MUTEXED_LIST_HEAD(DSS_GET_FIELD_COUNTER(), elem_type, elem_field_name, \
+                                       field_name);
+
+#define OBJECT_MSG_MUTEXED_LIST(obj_msg_type, obj_msg_field)                              \
+  ObjectMsgMutexedList<StructField<OBJECT_MSG_TYPE_CHECK(obj_msg_type), EmbeddedListLink, \
+                                   OBJECT_MSG_TYPE_CHECK(obj_msg_type)::OF_PP_CAT(        \
+                                       obj_msg_field, _DssFieldOffset)()>>
+
+// details
+
+#define _OBJECT_MSG_DEFINE_MUTEXED_LIST_HEAD(field_counter, elem_type, elem_field_name, \
+                                             field_name)                                \
+  _OBJECT_MSG_DEFINE_MUTEXED_LIST_HEAD_FIELD(elem_type, elem_field_name, field_name)    \
+  OBJECT_MSG_OVERLOAD_INIT(field_counter, ObjectMsgEmbeddedMutexedListHeadInit);        \
+  OBJECT_MSG_OVERLOAD_DELETE(field_counter, ObjectMsgEmbeddedMutexedListHeadDelete);    \
+  DSS_DEFINE_FIELD(field_counter, "object message", OF_PP_CAT(field_name, _));
+
+#define _OBJECT_MSG_DEFINE_MUTEXED_LIST_HEAD_FIELD(elem_type, elem_field_name, field_name)        \
+ public:                                                                                          \
+  using OF_PP_CAT(field_name, _ObjectMsgListType) =                                               \
+      TrivialObjectMsgMutexedList<StructField<OBJECT_MSG_TYPE_CHECK(elem_type), EmbeddedListLink, \
+                                              OBJECT_MSG_TYPE_CHECK(elem_type)::OF_PP_CAT(        \
+                                                  elem_field_name, _DssFieldOffset)()>>;          \
+  const OF_PP_CAT(field_name, _ObjectMsgListType) & field_name() const {                          \
+    return OF_PP_CAT(field_name, _);                                                              \
+  }                                                                                               \
+  OF_PP_CAT(field_name, _ObjectMsgListType) * OF_PP_CAT(mut_, field_name)() {                     \
+    return &OF_PP_CAT(field_name, _);                                                             \
+  }                                                                                               \
+  OF_PP_CAT(field_name, _ObjectMsgListType) * OF_PP_CAT(mutable_, field_name)() {                 \
+    return &OF_PP_CAT(field_name, _);                                                             \
+  }                                                                                               \
+                                                                                                  \
+ private:                                                                                         \
+  OF_PP_CAT(field_name, _ObjectMsgListType) OF_PP_CAT(field_name, _);
+
+template<typename WalkCtxType, typename PtrFieldType>
+struct ObjectMsgEmbeddedMutexedListHeadInit {
+  static void Call(WalkCtxType* ctx, PtrFieldType* field, const char* field_name) {
+    field->__Init__();
+  }
+};
+
+template<typename WalkCtxType, typename PtrFieldType>
+struct ObjectMsgEmbeddedMutexedListHeadDelete {
+  static void Call(WalkCtxType* ctx, PtrFieldType* field, const char* field_name) {
+    field->Clear();
+  }
+};
+
+template<typename LinkField>
+class TrivialObjectMsgMutexedList {
+ public:
+  using value_type = typename LinkField::struct_type;
+
+  std::size_t size() const { return list_head_.size(); }
+  bool empty() const { return list_head_.empty(); }
+
+  void __Init__() { list_head_.__Init__(); }
+
+  void EmplaceBack(ObjectMsgPtr<value_type>&& ptr) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return list_head_.EmplaceBack(std::move(ptr));
+  }
+  void EmplaceFront(ObjectMsgPtr<value_type>&& ptr) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return list_head_.EmplaceFront(std::move(ptr));
+  }
+  ObjectMsgPtr<value_type> PopBack() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return list_head_.PopBack();
+  }
+  ObjectMsgPtr<value_type> PopFront() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return list_head_.PopFront();
+  }
+
+  void MoveFrom(TrivialObjectMsgList<LinkField>* src) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    src->MoveToDstBack(&list_head_);
+  }
+
+  void MoveTo(TrivialObjectMsgList<LinkField>* dst) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    list_head_.MoveToDstBack(dst);
+  }
+
+  void Clear() { list_head_.Clear(); }
+
+ private:
+  TrivialObjectMsgList<LinkField> list_head_;
+  std::mutex mutex_;
+};
+
+template<typename LinkField>
+class ObjectMsgMutexedList : public TrivialObjectMsgMutexedList<LinkField> {
+ public:
+  ObjectMsgMutexedList(const ObjectMsgMutexedList&) = delete;
+  ObjectMsgMutexedList(ObjectMsgMutexedList&&) = delete;
+  ObjectMsgMutexedList() { this->__Init__(); }
+  ~ObjectMsgMutexedList() { this->Clear(); }
+};
+}
+
+#endif  // ONEFLOW_CORE_COMMON_MUTEXED_LIST_H_

--- a/oneflow/core/common/object_msg_raw_ptr.h
+++ b/oneflow/core/common/object_msg_raw_ptr.h
@@ -1,6 +1,7 @@
 #ifndef ONEFLOW_CORE_COMMON_OBJECT_MSG_RAW_PTR_H_
 #define ONEFLOW_CORE_COMMON_OBJECT_MSG_RAW_PTR_H_
 
+#include "oneflow/core/common/struct_traits.h"
 #include "oneflow/core/common/object_msg_core.h"
 
 namespace oneflow {
@@ -16,18 +17,17 @@ namespace oneflow {
   OBJECT_MSG_OVERLOAD_DELETE(field_counter, ObjectMsgRawPtrDelete);       \
   DSS_DEFINE_FIELD(field_counter, "object message", OF_PP_CAT(field_name, _));
 
-#define _OBJECT_MSG_DEFINE_RAW_PTR_FIELD(field_type, field_name)                       \
- public:                                                                               \
-  static_assert(std::is_pointer<field_type>::value,                                    \
-                OF_PP_STRINGIZE(field_type) "is not a pointer");                       \
-  bool OF_PP_CAT(has_, field_name)() { return OF_PP_CAT(field_name, _) != nullptr; }   \
-  void OF_PP_CAT(set_, field_name)(field_type val) { OF_PP_CAT(field_name, _) = val; } \
-  void OF_PP_CAT(clear_, field_name)() { OF_PP_CAT(set_, field_name)(nullptr); }       \
-  DSS_DEFINE_GETTER(field_type, field_name);                                           \
-  DSS_DEFINE_MUTABLE(field_type, field_name);                                          \
-                                                                                       \
- private:                                                                              \
-  field_type OF_PP_CAT(field_name, _);
+#define _OBJECT_MSG_DEFINE_RAW_PTR_FIELD(field_type, field_name)                           \
+ public:                                                                                   \
+  ConstType<field_type>& field_name() const { return *OF_PP_CAT(field_name, _); }          \
+  bool OF_PP_CAT(has_, field_name)() const { return OF_PP_CAT(field_name, _) != nullptr; } \
+  void OF_PP_CAT(set_, field_name)(field_type * val) { OF_PP_CAT(field_name, _) = val; }   \
+  void OF_PP_CAT(clear_, field_name)() { OF_PP_CAT(set_, field_name)(nullptr); }           \
+  field_type* OF_PP_CAT(mut_, field_name)() { return OF_PP_CAT(field_name, _); }           \
+  field_type* OF_PP_CAT(mutable_, field_name)() { return OF_PP_CAT(field_name, _); }       \
+                                                                                           \
+ private:                                                                                  \
+  field_type* OF_PP_CAT(field_name, _);
 
 template<typename WalkCtxType, typename PtrFieldType>
 struct ObjectMsgRawPtrInit {

--- a/oneflow/core/common/object_msg_raw_ptr_test.cpp
+++ b/oneflow/core/common/object_msg_raw_ptr_test.cpp
@@ -1,0 +1,8 @@
+#include "oneflow/core/common/object_msg_raw_ptr.h"
+#include "oneflow/core/common/util.h"
+
+namespace oneflow {
+
+namespace test {}  // namespace test
+
+}  // namespace oneflow

--- a/oneflow/core/common/object_msg_skiplist.h
+++ b/oneflow/core/common/object_msg_skiplist.h
@@ -6,9 +6,15 @@
 
 namespace oneflow {
 
-#define OBJECT_MSG_DEFINE_SKIPLIST_KEY(max_level, T, field_name)                    \
-  static_assert(__is_object_message_type__, "this struct is not a object message"); \
-  _OBJECT_MSG_DEFINE_SKIPLIST_KEY(DSS_GET_FIELD_COUNTER(), max_level, T, field_name);
+#define OBJECT_MSG_DEFINE_SKIPLIST_KEY(max_level, T, field_name)                                \
+  static_assert(__is_object_message_type__, "this struct is not a object message");             \
+  _OBJECT_MSG_DEFINE_SKIPLIST_KEY(DSS_GET_FIELD_COUNTER(), max_level, OBJECT_MSG_TYPE_CHECK(T), \
+                                  field_name);
+
+#define OBJECT_MSG_DEFINE_SKIPLIST_FLAT_MSG_KEY(max_level, T, field_name)                     \
+  static_assert(__is_object_message_type__, "this struct is not a object message");           \
+  _OBJECT_MSG_DEFINE_SKIPLIST_KEY(DSS_GET_FIELD_COUNTER(), max_level, FLAT_MSG_TYPE_CHECK(T), \
+                                  field_name);
 
 #define OBJECT_MSG_DEFINE_SKIPLIST_HEAD(elem_type, elem_field_name, field_name)     \
   static_assert(__is_object_message_type__, "this struct is not a object message"); \
@@ -64,10 +70,11 @@ namespace oneflow {
  private:                                                                                          \
   EmbeddedSkipListKey<key_type, max_level> OF_PP_CAT(field_name, _);
 
-#define OBJECT_MSG_SKIPLIST_ELEM_STRUCT_FIELD(elem_type, elem_field_name)                        \
-  StructField<OBJECT_MSG_TYPE(elem_type),                                                        \
-              OBJECT_MSG_TYPE(elem_type)::OF_PP_CAT(elem_field_name, _ObjectMsgSkipListKeyType), \
-              OBJECT_MSG_TYPE(elem_type)::OF_PP_CAT(elem_field_name, _DssFieldOffset)()>
+#define OBJECT_MSG_SKIPLIST_ELEM_STRUCT_FIELD(elem_type, elem_field_name)             \
+  StructField<OBJECT_MSG_TYPE_CHECK(elem_type),                                       \
+              OBJECT_MSG_TYPE_CHECK(elem_type)::OF_PP_CAT(elem_field_name,            \
+                                                          _ObjectMsgSkipListKeyType), \
+              OBJECT_MSG_TYPE_CHECK(elem_type)::OF_PP_CAT(elem_field_name, _DssFieldOffset)()>
 
 template<typename WalkCtxType, typename PtrFieldType>
 struct ObjectMsgEmbeddedSkipListHeadInit {
@@ -113,6 +120,7 @@ class TrivialObjectMsgSkipList {
     ret.Reset(skiplist_head_.Find(key));
     return ret;
   }
+  elem_type* FindPtr(const key_type& key) { return skiplist_head_.Find(key); }
   bool EqualsEnd(const ObjectMsgPtr<elem_type>& ptr) { return !ptr; }
   void Erase(const key_type& key) { ObjectMsgPtrUtil::ReleaseRef(skiplist_head_.Erase(key)); }
   void Erase(elem_type* elem_ptr) {

--- a/oneflow/core/common/object_msg_skiplist_test.cpp
+++ b/oneflow/core/common/object_msg_skiplist_test.cpp
@@ -7,8 +7,8 @@ namespace test {
 
 // clang-format off
 BEGIN_OBJECT_MSG(ObjectMsgSkipListFoo);
-  OBJECT_MSG_DEFINE_MAP_KEY(int, foo_map_key);
-  OBJECT_MSG_DEFINE_RAW_PTR(int*, is_deleted);
+  OBJECT_MSG_DEFINE_MAP_KEY(int32_t, foo_map_key);
+  OBJECT_MSG_DEFINE_RAW_PTR(int, is_deleted);
   void __Delete__() {
     if (has_is_deleted()) { ++*mutable_is_deleted(); }
   }
@@ -29,7 +29,7 @@ TEST(ObjectMsgSkipList, empty) {
 
 TEST(ObjectMsgSkipList, insert_naive) {
   OBJECT_MSG_MAP(ObjectMsgSkipListFoo, foo_map_key) foo_map;
-  auto elem0 = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+  auto elem0 = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
   elem0->set_foo_map_key(0);
   foo_map.Insert(elem0.Mutable());
   ASSERT_EQ(foo_map.size(), 1);
@@ -45,7 +45,7 @@ TEST(ObjectMsgSkipList, insert_naive) {
 
 TEST(ObjectMsgSkipList, erase_by_key) {
   OBJECT_MSG_MAP(ObjectMsgSkipListFoo, foo_map_key) foo_map;
-  auto elem0 = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+  auto elem0 = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
   elem0->set_foo_map_key(0);
   foo_map.Insert(elem0.Mutable());
   ASSERT_EQ(foo_map.size(), 1);
@@ -57,7 +57,7 @@ TEST(ObjectMsgSkipList, erase_by_key) {
 
 TEST(ObjectMsgSkipList, erase_by_elem) {
   OBJECT_MSG_MAP(ObjectMsgSkipListFoo, foo_map_key) foo_map;
-  auto elem0 = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+  auto elem0 = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
   elem0->set_foo_map_key(0);
   foo_map.Insert(elem0.Mutable());
   ASSERT_EQ(foo_map.size(), 1);
@@ -69,16 +69,16 @@ TEST(ObjectMsgSkipList, erase_by_elem) {
 
 TEST(ObjectMsgSkipList, insert_many) {
   OBJECT_MSG_MAP(ObjectMsgSkipListFoo, foo_map_key) foo_map;
-  OBJECT_MSG_PTR(ObjectMsgSkipListFoo) exists[100];
+  ObjectMsgPtr<ObjectMsgSkipListFoo> exists[100];
   for (int i = 0; i < 100; ++i) {
-    exists[i] = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+    exists[i] = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
     int key = i - 50;
     if (key >= 0) { ++key; }
     exists[i]->set_foo_map_key(key);
     foo_map.Insert(exists[i].Mutable());
     ASSERT_TRUE(foo_map.Find(key) == exists[i]);
   }
-  auto elem0 = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+  auto elem0 = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
   elem0->set_foo_map_key(0);
   foo_map.Insert(elem0.Mutable());
   ASSERT_EQ(foo_map.size(), 101);
@@ -96,16 +96,16 @@ TEST(ObjectMsgSkipList, insert_many) {
 
 TEST(ObjectMsgSkipList, erase_many_by_key) {
   OBJECT_MSG_MAP(ObjectMsgSkipListFoo, foo_map_key) foo_map;
-  OBJECT_MSG_PTR(ObjectMsgSkipListFoo) exists[100];
+  ObjectMsgPtr<ObjectMsgSkipListFoo> exists[100];
   for (int i = 0; i < 100; ++i) {
-    exists[i] = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+    exists[i] = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
     int key = i - 50;
     if (key >= 0) { ++key; }
     exists[i]->set_foo_map_key(key);
     foo_map.Insert(exists[i].Mutable());
     ASSERT_TRUE(foo_map.Find(key) == exists[i]);
   }
-  auto elem0 = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+  auto elem0 = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
   elem0->set_foo_map_key(0);
   foo_map.Insert(elem0.Mutable());
   ASSERT_EQ(foo_map.size(), 101);
@@ -119,16 +119,16 @@ TEST(ObjectMsgSkipList, erase_many_by_key) {
 
 TEST(ObjectMsgSkipList, erase_many_by_elem) {
   OBJECT_MSG_MAP(ObjectMsgSkipListFoo, foo_map_key) foo_map;
-  OBJECT_MSG_PTR(ObjectMsgSkipListFoo) exists[100];
+  ObjectMsgPtr<ObjectMsgSkipListFoo> exists[100];
   for (int i = 0; i < 100; ++i) {
-    exists[i] = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+    exists[i] = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
     int key = i - 50;
     if (key >= 0) { ++key; }
     exists[i]->set_foo_map_key(key);
     foo_map.Insert(exists[i].Mutable());
     ASSERT_TRUE(foo_map.Find(key) == exists[i]);
   }
-  auto elem0 = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+  auto elem0 = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
   elem0->set_foo_map_key(0);
   foo_map.Insert(elem0.Mutable());
   ASSERT_EQ(foo_map.size(), 101);
@@ -143,11 +143,11 @@ TEST(ObjectMsgSkipList, erase_many_by_elem) {
 TEST(ObjectMsgSkipList, MAP_HEAD) {
   int elem_cnt = 0;
   {
-    auto foo_map_container = OBJECT_MSG_PTR(ObjectMsgSkipListFooContainer)::New();
+    auto foo_map_container = ObjectMsgPtr<ObjectMsgSkipListFooContainer>::New();
     auto& foo_map = *foo_map_container->mutable_foo_map();
-    OBJECT_MSG_PTR(ObjectMsgSkipListFoo) exists[100];
+    ObjectMsgPtr<ObjectMsgSkipListFoo> exists[100];
     for (int i = 0; i < 100; ++i) {
-      exists[i] = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+      exists[i] = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
       int key = i - 50;
       if (key >= 0) { ++key; }
       exists[i]->set_foo_map_key(key);
@@ -156,7 +156,7 @@ TEST(ObjectMsgSkipList, MAP_HEAD) {
       ASSERT_TRUE(foo_map.Find(key) == exists[i]);
       ASSERT_EQ(exists[i]->ref_cnt(), 2);
     }
-    auto elem0 = OBJECT_MSG_PTR(ObjectMsgSkipListFoo)::New();
+    auto elem0 = ObjectMsgPtr<ObjectMsgSkipListFoo>::New();
     elem0->set_foo_map_key(0);
     elem0->set_is_deleted(&elem_cnt);
     foo_map.Insert(elem0.Mutable());

--- a/oneflow/core/common/object_msg_test.cpp
+++ b/oneflow/core/common/object_msg_test.cpp
@@ -12,7 +12,7 @@ BEGIN_OBJECT_MSG(ObjectMsgFoo)
   OBJECT_MSG_DEFINE_OPTIONAL(int32_t, foo);
   OBJECT_MSG_DEFINE_OPTIONAL(int16_t, bar);
   OBJECT_MSG_DEFINE_OPTIONAL(int64_t, foobar);
-  OBJECT_MSG_DEFINE_RAW_PTR(std::string*, is_deleted);
+  OBJECT_MSG_DEFINE_RAW_PTR(std::string, is_deleted);
 
  public:
   void __Delete__();
@@ -20,12 +20,12 @@ BEGIN_OBJECT_MSG(ObjectMsgFoo)
 END_OBJECT_MSG(ObjectMsgFoo)
 // clang-format on
 
-void OBJECT_MSG_TYPE(ObjectMsgFoo)::__Delete__() {
+void ObjectMsgFoo::__Delete__() {
   if (mutable_is_deleted()) { *mutable_is_deleted() = "deleted"; }
 }
 
 TEST(OBJECT_MSG, naive) {
-  auto foo = OBJECT_MSG_PTR(ObjectMsgFoo)::New();
+  auto foo = ObjectMsgPtr<ObjectMsgFoo>::New();
   foo->set_bar(9527);
   ASSERT_TRUE(foo->bar() == 9527);
 }
@@ -33,7 +33,7 @@ TEST(OBJECT_MSG, naive) {
 TEST(OBJECT_MSG, __delete__) {
   std::string is_deleted;
   {
-    auto foo = OBJECT_MSG_PTR(ObjectMsgFoo)::New();
+    auto foo = ObjectMsgPtr<ObjectMsgFoo>::New();
     foo->set_bar(9527);
     foo->set_is_deleted(&is_deleted);
     ASSERT_EQ(foo->bar(), 9527);
@@ -44,7 +44,7 @@ TEST(OBJECT_MSG, __delete__) {
 // clang-format off
 BEGIN_OBJECT_MSG(ObjectMsgBar)
   OBJECT_MSG_DEFINE_OPTIONAL(ObjectMsgFoo, foo);
-  OBJECT_MSG_DEFINE_RAW_PTR(std::string*, is_deleted);
+  OBJECT_MSG_DEFINE_RAW_PTR(std::string, is_deleted);
 
  public:
   void __Delete__(){
@@ -54,7 +54,7 @@ END_OBJECT_MSG(ObjectMsgBar)
 // clang-format on
 
 TEST(OBJECT_MSG, nested_objects) {
-  auto bar = OBJECT_MSG_PTR(ObjectMsgBar)::New();
+  auto bar = ObjectMsgPtr<ObjectMsgBar>::New();
   bar->mutable_foo()->set_bar(9527);
   ASSERT_TRUE(bar->foo().bar() == 9527);
 }
@@ -63,7 +63,7 @@ TEST(OBJECT_MSG, nested_delete) {
   std::string bar_is_deleted;
   std::string is_deleted;
   {
-    auto bar = OBJECT_MSG_PTR(ObjectMsgBar)::New();
+    auto bar = ObjectMsgPtr<ObjectMsgBar>::New();
     bar->set_is_deleted(&bar_is_deleted);
     auto* foo = bar->mutable_foo();
     foo->set_bar(9527);
@@ -93,7 +93,7 @@ END_OBJECT_MSG(TestPtrOneof)
 // clang-format on
 
 TEST(OBJECT_MSG, oneof_get) {
-  auto test_oneof = OBJECT_MSG_PTR(TestPtrOneof)::New();
+  auto test_oneof = ObjectMsgPtr<TestPtrOneof>::New();
   auto& obj = *test_oneof;
   const auto* default_foo_ptr = &obj.foo();
   ASSERT_EQ(obj.foo().x(), 0);
@@ -105,7 +105,7 @@ TEST(OBJECT_MSG, oneof_get) {
 };
 
 TEST(OBJECT_MSG, oneof_release) {
-  auto test_oneof = OBJECT_MSG_PTR(TestPtrOneof)::New();
+  auto test_oneof = ObjectMsgPtr<TestPtrOneof>::New();
   auto& obj = *test_oneof;
   const auto* default_foo_ptr = &obj.foo();
   ASSERT_EQ(obj.foo().x(), 0);
@@ -126,8 +126,34 @@ TEST(OBJECT_MSG, oneof_release) {
   }
 };
 
+TEST(OBJECT_MSG, oneof_reset) {
+  auto test_oneof = ObjectMsgPtr<TestPtrOneof>::New();
+  auto& obj = *test_oneof;
+  const auto* default_foo_ptr = &obj.foo();
+  ASSERT_EQ(obj.foo().x(), 0);
+  obj.mutable_foo();
+  ASSERT_EQ(obj.foo().x(), 0);
+  ASSERT_NE(default_foo_ptr, &obj.foo());
+  {
+    auto another_oneof = ObjectMsgPtr<TestPtrOneof>::New();
+    std::string is_delete;
+    obj.mutable_foo()->set_is_deleted(&is_delete);
+    another_oneof->reset_foo(obj.mut_foo());
+    obj.mutable_int_field();
+    ASSERT_EQ(is_delete, "");
+    another_oneof->mutable_int_field();
+    ASSERT_EQ(is_delete, "deleted");
+  }
+  {
+    std::string is_delete;
+    obj.mutable_foo()->set_is_deleted(&is_delete);
+    obj.mutable_int_field();
+    ASSERT_EQ(is_delete, "deleted");
+  }
+};
+
 TEST(OBJECT_MSG, oneof_clear) {
-  auto test_oneof = OBJECT_MSG_PTR(TestPtrOneof)::New();
+  auto test_oneof = ObjectMsgPtr<TestPtrOneof>::New();
   auto& obj = *test_oneof;
   const auto* default_foo_ptr = &obj.foo();
   ASSERT_EQ(obj.foo().x(), 0);
@@ -148,7 +174,7 @@ TEST(OBJECT_MSG, oneof_clear) {
 };
 
 TEST(OBJECT_MSG, oneof_set) {
-  auto test_oneof = OBJECT_MSG_PTR(TestPtrOneof)::New();
+  auto test_oneof = ObjectMsgPtr<TestPtrOneof>::New();
   auto& obj = *test_oneof;
   const auto* default_foo_ptr = &obj.foo();
   ASSERT_EQ(obj.foo().x(), 0);
@@ -183,7 +209,7 @@ END_OBJECT_MSG(ObjectMsgContainerDemo)
 // clang-format on
 
 TEST(OBJECT_MSG, flat_msg_field) {
-  auto obj = OBJECT_MSG_PTR(ObjectMsgContainerDemo)::New();
+  auto obj = ObjectMsgPtr<ObjectMsgContainerDemo>::New();
   ASSERT_TRUE(obj->has_flat_field());
   ASSERT_TRUE(!obj->flat_field().has_int32_field());
   obj->mutable_flat_field()->set_int32_field(33);

--- a/oneflow/core/common/object_msg_wrapper.h
+++ b/oneflow/core/common/object_msg_wrapper.h
@@ -1,0 +1,46 @@
+#ifndef ONEFLOW_CORE_COMMON_OBJECT_MSG_WRAPPER_H_
+#define ONEFLOW_CORE_COMMON_OBJECT_MSG_WRAPPER_H_
+
+#include <glog/logging.h>
+#include "oneflow/core/common/object_msg_core.h"
+
+namespace oneflow {
+
+// clang-format off
+template<typename CppObjectT>
+BEGIN_OBJECT_MSG(Wrapper4CppObject);
+ public:
+  template<typename NewCppObjectT>
+  void __Init__(const NewCppObjectT& NewCppObject) {
+    set_obj(NewCppObject(mut_allocator(), mutable_obj_size()));
+    CHECK_GE(obj_size(), 0);
+  }
+  void __Init__() {
+    __Init__([](ObjectMsgAllocator* allocator, int32_t* obj_size){
+        *obj_size = sizeof(CppObjectT);
+        char* mem_ptr = allocator->Allocate(sizeof(CppObjectT));
+        return new (mem_ptr) CppObjectT();
+    });
+  }
+  void __Delete__() {
+    if (obj_size() == 0) { return; }
+    mut_allocator()->Deallocate(reinterpret_cast<char*>(mutable_obj()), obj_size());
+  }
+
+  const CppObjectT& operator*() const { return obj(); }
+  CppObjectT& operator*() { return *mutable_obj(); }
+
+  const CppObjectT* operator->() const { return &obj(); }
+  CppObjectT* operator->() { return mutable_obj(); }
+
+  const CppObjectT& Get() const { return obj(); }
+  CppObjectT* Mutable() { return mutable_obj(); }
+
+  OBJECT_MSG_DEFINE_RAW_PTR(CppObjectT, obj);
+  OBJECT_MSG_DEFINE_OPTIONAL(int32_t, obj_size);
+END_OBJECT_MSG(Wrapper4CppObject);
+// clang-format on
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_COMMON_OBJECT_MSG_WRAPPER_H_

--- a/oneflow/core/common/static_counter.h
+++ b/oneflow/core/common/static_counter.h
@@ -1,0 +1,35 @@
+#ifndef ONEFLOW_CORE_COMMON_STATIC_COUNTER_H_
+#define ONEFLOW_CORE_COMMON_STATIC_COUNTER_H_
+
+namespace oneflow {
+
+#define STATIC_COUNTER(counter_name) _STATIC_COUNTER_NAME(counter_name)<_AUTO_INCREMENT()>::value
+
+#define DEFINE_STATIC_COUNTER(counter_name) _DEFINE_STATIC_COUNTER(_AUTO_INCREMENT(), counter_name)
+
+#define INCREASE_STATIC_COUNTER(counter_name) \
+  _INCREASE_STATIC_COUNTER(_AUTO_INCREMENT(), counter_name)
+
+// details
+
+#define _STATIC_COUNTER_NAME(counter_name) StaticCounter_##counter_name
+#define _AUTO_INCREMENT() __COUNTER__
+
+#define _DEFINE_STATIC_COUNTER(auto_counter, counter_name)                               \
+  template<int tpl_counter, typename Enabled = void>                                     \
+  struct _STATIC_COUNTER_NAME(counter_name) {                                            \
+    static const int value = _STATIC_COUNTER_NAME(counter_name)<tpl_counter - 1>::value; \
+  };                                                                                     \
+  template<typename Enabled>                                                             \
+  struct _STATIC_COUNTER_NAME(counter_name)<auto_counter, Enabled> {                     \
+    static const int value = 0;                                                          \
+  };
+
+#define _INCREASE_STATIC_COUNTER(auto_counter, counter_name)                                  \
+  template<typename Enabled>                                                                  \
+  struct _STATIC_COUNTER_NAME(counter_name)<auto_counter, Enabled> {                          \
+    static const int value = _STATIC_COUNTER_NAME(counter_name)<auto_counter - 1>::value + 1; \
+  };
+}
+
+#endif  // ONEFLOW_CORE_COMMON_STATIC_COUNTER_H_

--- a/oneflow/core/common/static_counter_test.cpp
+++ b/oneflow/core/common/static_counter_test.cpp
@@ -1,0 +1,28 @@
+#include "oneflow/core/common/static_counter.h"
+#include "oneflow/core/common/util.h"
+
+namespace oneflow {
+
+namespace test {
+
+namespace {
+
+DEFINE_STATIC_COUNTER(static_counter);
+
+TEST(StaticCounter, eq0) { static_assert(STATIC_COUNTER(static_counter) == 0, ""); }
+
+INCREASE_STATIC_COUNTER(static_counter);
+
+TEST(StaticCounter, eq1) { static_assert(STATIC_COUNTER(static_counter) == 1, ""); }
+
+TEST(StaticCounter, eq1_again) { static_assert(STATIC_COUNTER(static_counter) == 1, ""); }
+
+INCREASE_STATIC_COUNTER(static_counter);
+
+TEST(StaticCounter, eq2) { static_assert(STATIC_COUNTER(static_counter) == 2, ""); }
+
+}  // namespace
+
+}  // namespace test
+
+}  // namespace oneflow

--- a/oneflow/core/common/struct_traits.h
+++ b/oneflow/core/common/struct_traits.h
@@ -2,6 +2,7 @@
 #define ONEFLOW_CORE_COMMON_STRUCT_MACRO_TRAITS_H_
 
 #include <cstddef>
+#include <type_traits>
 #include "oneflow/core/common/preprocessor.h"
 
 namespace oneflow {
@@ -10,6 +11,9 @@ namespace oneflow {
   StructField<T, STRUCT_FIELD_TYPE(T, field), STRUCT_FIELD_OFFSET(T, field)>
 #define STRUCT_FIELD_TYPE(T, field) decltype(((T*)nullptr)->field)
 #define STRUCT_FIELD_OFFSET(T, field) offsetof(T, field)
+
+#define PUBLIC public:
+#define PRIVATE public:
 
 // details
 template<typename T, typename F, int offset>
@@ -25,6 +29,26 @@ struct StructField {
     return (F*)(((char*)struct_ptr) + offset_value);
   }
 };
+
+template<typename X, typename Y>
+struct ComposeStructField {
+  static_assert(std::is_same<typename X::field_type, typename Y::struct_type>::value,
+                "invalid type");
+  using type = StructField<typename X::struct_type, typename Y::field_type,
+                           X::offset_value + Y::offset_value>;
+};
+
+template<typename T>
+struct ConstStruct {
+  using type = const T;
+};
+template<typename T>
+struct ConstStruct<const T> {
+  using type = const T;
+};
+
+template<typename T>
+using ConstType = typename ConstStruct<T>::type;
 }
 
 #endif  // ONEFLOW_CORE_COMMON_STRUCT_MACRO_TRAITS_H_

--- a/oneflow/core/common/struct_traits_test.cpp
+++ b/oneflow/core/common/struct_traits_test.cpp
@@ -3,6 +3,10 @@
 
 namespace oneflow {
 
+namespace test {
+
+namespace {
+
 struct OneflowTestNamespaceFoo {
   OneflowTestNamespaceFoo() : x(0), bar(0), const_bar(0) {}
 
@@ -46,5 +50,27 @@ TEST(StructField, const_struct_const_field) {
   ASSERT_EQ(struct_ptr, &foo);
   ASSERT_EQ(field_ptr, bar);
 }
+
+struct X {
+  int a;
+  int b;
+};
+
+struct Y {
+  int c;
+  X d;
+};
+
+TEST(StructField, compose) {
+  using BFieldInY = typename ComposeStructField<STRUCT_FIELD(Y, d), STRUCT_FIELD(X, b)>::type;
+  Y y;
+  int* field_b = &y.d.b;
+  ASSERT_EQ(BFieldInY::FieldPtr4StructPtr(&y), field_b);
+  ASSERT_EQ(BFieldInY::StructPtr4FieldPtr(field_b), &y);
+}
+
+}  // namespace
+
+}  // namespace test
 
 }  // namespace oneflow


### PR DESCRIPTION
重构object msg，主要添加了两种list的定义方法
1) OBJECT_MSG_DEFINE_MUTEXED_LIST_HEAD，带锁保护的list
2) OBJECT_MSG_DEFINE_CONDITION_LIST_HEAD，就是内嵌的Channel