### PR TITLE
remove data_type() interface in user kernel registry context

### DIFF
--- a/oneflow/core/framework/kernel_registration.h
+++ b/oneflow/core/framework/kernel_registration.h
@@ -24,7 +24,6 @@ class KernelRegContext {
   virtual ~KernelRegContext() = default;
 
   virtual DeviceType device() const = 0;
-  virtual DataType data_type() const = 0;
   virtual const ParallelContext& parallel_ctx() const = 0;
   virtual const TensorDesc* TensorDesc4ArgNameAndIndex(const std::string&, int32_t) const = 0;
 

--- a/oneflow/core/kernel/user_kernel.cpp
+++ b/oneflow/core/kernel/user_kernel.cpp
@@ -61,7 +61,6 @@ class UserKernelRegContext final : public user_op::KernelRegContext {
     CHECK(kernel_conf.has_user_conf());
 
     device_ = kernel_conf.op_attribute().op_conf().device_type();
-    data_type_ = kernel_conf.data_type();
     parallel_ctx_ = kernel_conf.user_conf().parallel_ctx();
 
     for (const auto& pair : kernel_conf.user_conf().bn_in_op2blob_desc()) {
@@ -71,7 +70,6 @@ class UserKernelRegContext final : public user_op::KernelRegContext {
   ~UserKernelRegContext() = default;
 
   DeviceType device() const override { return device_; }
-  DataType data_type() const override { return data_type_; }
   const ParallelContext& parallel_ctx() const override { return parallel_ctx_; }
   const user_op::TensorDesc* TensorDesc4ArgNameAndIndex(const std::string& arg_name,
                                                         int32_t index) const override {
@@ -82,7 +80,6 @@ class UserKernelRegContext final : public user_op::KernelRegContext {
 
  private:
   DeviceType device_;
-  DataType data_type_;
   ParallelContext parallel_ctx_;
   HashMap<std::pair<std::string, int32_t>, user_op::TensorDesc> arg2tensor_desc_;
 };

--- a/oneflow/core/operator/user_op.cpp
+++ b/oneflow/core/operator/user_op.cpp
@@ -64,15 +64,6 @@ class UserOpKernelRegContext final : public user_op::KernelRegContext {
     parallel_ctx_ = parallel_ctx;
 
     {
-      BlobDesc* first_blob_desc =
-          FindValidBlobDescOfBnsInOp(GetBlobDesc4BnInOp, user_op->input_bns());
-      if (!first_blob_desc) {
-        first_blob_desc = FindValidBlobDescOfBnsInOp(GetBlobDesc4BnInOp, user_op->output_bns());
-      }
-      if (first_blob_desc) { data_type_ = first_blob_desc->data_type(); }
-    }
-
-    {
 #define INSERT_TO_ARG2TENSOR_DESC(prefix)                                                      \
   for (const auto& bn : user_op->prefix##_bns()) {                                             \
     const BlobDesc* blob_desc = GetBlobDesc4BnInOp(bn);                                        \
@@ -91,7 +82,6 @@ class UserOpKernelRegContext final : public user_op::KernelRegContext {
   ~UserOpKernelRegContext() = default;
 
   DeviceType device() const override { return device_; }
-  DataType data_type() const override { return data_type_; }
   const ParallelContext& parallel_ctx() const override { return *parallel_ctx_; }
   const user_op::TensorDesc* TensorDesc4ArgNameAndIndex(const std::string& arg_name,
                                                         int32_t index) const override {
@@ -102,7 +92,6 @@ class UserOpKernelRegContext final : public user_op::KernelRegContext {
 
  private:
   DeviceType device_;
-  DataType data_type_;
   const ParallelContext* parallel_ctx_;
   HashMap<std::pair<std::string, int32_t>, user_op::TensorDesc> arg2tensor_desc_;
 };

--- a/oneflow/customized/kernels/test_kernels.cpp
+++ b/oneflow/customized/kernels/test_kernels.cpp
@@ -87,7 +87,10 @@ class TestSourceKernel final : public user_op::OpKernel {
 REGISTER_USER_KERNEL("TestSource")
     .SetCreateFn([](const user_op::KernelInitContext& ctx) { return new TestSourceKernel(ctx); })
     .SetIsMatchedPred([](const user_op::KernelRegContext& ctx) {
-      if (ctx.device() == DeviceType::kCPU && ctx.data_type() == DataType::kFloat) { return true; }
+      const user_op::TensorDesc* out_tensor = ctx.TensorDesc4ArgNameAndIndex("out", 0);
+      if (ctx.device() == DeviceType::kCPU && out_tensor->data_type() == DataType::kFloat) {
+        return true;
+      }
       return false;
     })
     .SetInferTmpSizeFn([](user_op::InferContext*) { return 0; });
@@ -115,7 +118,10 @@ REGISTER_USER_KERNEL("TestMultiOutputOrder")
       return new TestMultiOutputOrderKernel(ctx);
     })
     .SetIsMatchedPred([](const user_op::KernelRegContext& ctx) {
-      if (ctx.device() == DeviceType::kGPU && ctx.data_type() == DataType::kFloat) { return true; }
+      const user_op::TensorDesc* in_tensor = ctx.TensorDesc4ArgNameAndIndex("in", 0);
+      if (ctx.device() == DeviceType::kGPU && in_tensor->data_type() == DataType::kFloat) {
+        return true;
+      }
       return false;
     });
 


### PR DESCRIPTION
去掉了 UserKernel注册时 SetIsMatchedPred 中调用 KernelRegContext 的data_type() 接口。

如果需要根据某些输入输出的blob的data_type来判断是否match，可以取出对应的blob，参考TestSource和TestMultiOutputOrder  user op