### PR TITLE
disable cpu KeepHeaderOnlyOp

### DIFF
--- a/oneflow/core/job_completer/add_keep_header_only_op_conf.cpp
+++ b/oneflow/core/job_completer/add_keep_header_only_op_conf.cpp
@@ -6,6 +6,7 @@ namespace oneflow {
 void AddKeepHeaderOnlyOp(const OpGraph& op_graph, JobBuilder* job_builder) {
   std::vector<OperatorConf> op_confs;
   op_graph.TopoForEachNode([&](OpNode* node) {
+    if (node->parallel_desc().device_type() == DeviceType::kCPU) { return; }
     const PbRpf<std::string>& ibns = node->op().input_bns();
     std::vector<std::string> header_only_ibns;
     for (const std::string& ibn : ibns) {


### PR DESCRIPTION
给CPU Op启用KeepHeaderOnlyOp会出错，因为在`oneflow/core/register/register_manager.cpp:103`
```
void RegstMgr::NewBlobsInOneRegst(const std::vector<LbiBlobDescPair>& lbis, Regst* regst,
                                  const RtRegstDesc* rt_regst_desc, char* main_mem_ptr,
                                  char* separated_header_mem_ptr) {
  size_t separated_header_mem_size = rt_regst_desc->SeparatedHeaderByteSize4OneRegst();
  const RtBlobDesc* packed_blob_desc = rt_regst_desc->packed_blob_desc();
  char* cur_body_pointer = nullptr;
  char* cur_header_pointer = nullptr;
  if (separated_header_mem_size > 0) {
    MemoryCase host_mem_case;
    host_mem_case.mutable_host_mem();
    if (separated_header_mem_ptr == nullptr) {
      separated_header_mem_ptr =
          Global<MemoryAllocator>::Get()->Allocate(host_mem_case, separated_header_mem_size);
    }
    regst->packed_blob_.reset(new Blob(regst->regst_desc()->mem_case(), packed_blob_desc,
                                       separated_header_mem_ptr, main_mem_ptr));
    cur_header_pointer = separated_header_mem_ptr;
    cur_body_pointer = main_mem_ptr;
  } else {
    CHECK(separated_header_mem_ptr == nullptr);
    regst->packed_blob_.reset(
        new Blob(regst->regst_desc()->mem_case(), packed_blob_desc, main_mem_ptr));
    cur_header_pointer = main_mem_ptr;
    if (main_mem_ptr == nullptr) {
      cur_body_pointer = nullptr;
    } else {
      cur_body_pointer = main_mem_ptr + packed_blob_desc->ByteSizeOfBlobHeader();
    }
  }
  rt_regst_desc->ForEachBlobDescOffsetInOnRegst(
      lbis, [&](const LbiBlobDescPair& lbi, int64_t body_offset, int64_t header_offset) {
        const RtBlobDesc* blob_desc = rt_regst_desc->GetRtBlobDescFromLbi(lbi.lbi());
        std::unique_ptr<Blob> blob_ptr;
        if (cur_body_pointer == nullptr) {
          CHECK(rt_regst_desc->is_body_disabled());
          blob_ptr = std::move(std::make_unique<Blob>(regst->regst_desc()->mem_case(), blob_desc,
                                                      cur_header_pointer + header_offset, nullptr));
        } else {
          CHECK(rt_regst_desc->is_body_disabled() == false);
          blob_ptr = std::move(std::make_unique<Blob>(regst->regst_desc()->mem_case(), blob_desc,
                                                      cur_header_pointer + header_offset,
                                                      cur_body_pointer + body_offset));
          InitOFRecordBlobIfNeed(blob_ptr.get());
        }
        CHECK(regst->lbi2blob_.emplace(lbi.lbi(), std::move(blob_ptr)).second);
      });
}
```
其中的`CHECK(rt_regst_desc->is_body_disabled() == false);`失败，而`KeepHeaderOnlyOp`的register应该是`is_body_disabled`，也就是说此时`cur_body_pointer`不是`nullptr`，即`main_mem_ptr`不是`nullptr`，`main_mem_ptr`来自`oneflow/core/register/register_manager.cpp:56`
```
void RegstMgr::NewRegsts(const RegstDescProto& regst_desc_proto,
                         std::function<void(Regst*)> OneRegstDone) {
  const int64_t regst_desc_id = regst_desc_proto.regst_desc_id();
  const RegstDescTypeProto& regst_desc_type = regst_desc_proto.regst_desc_type();
  const RtRegstDesc* rt_regst_desc = regst_desc_id2rt_regst_desc_.at(regst_desc_id).get();
  char* main_mem_ptr = nullptr;
  char* separated_header_mem_ptr = nullptr;
  int64_t mem_block_id = regst_desc_proto.mem_block_id();
  int64_t header_block_id = regst_desc_proto.separated_header_mem_block_id();
  if (mem_block_id != -1 && mem_block_id2ptr_.find(mem_block_id) != mem_block_id2ptr_.end()) {
    main_mem_ptr = mem_block_id2ptr_.at(mem_block_id) + regst_desc_proto.mem_block_offset();
  }
  if (header_block_id != -1 && mem_block_id2ptr_.find(header_block_id) != mem_block_id2ptr_.end()) {
    separated_header_mem_ptr = mem_block_id2ptr_.at(header_block_id);
  }
  std::vector<LbiBlobDescPair> lbi_pairs;
  if (regst_desc_type.has_data_regst_desc()) {
    for (const LbiBlobDescPair& pair : regst_desc_type.data_regst_desc().lbi2blob_desc()) {
      lbi_pairs.push_back(pair);
    }
    std::sort(lbi_pairs.begin(), lbi_pairs.end(), &CompareLbiBlobDescPair);
    CHECK(!lbi_pairs.empty());
  }
  for (int64_t i = 0; i < rt_regst_desc->register_num(); ++i) {
    Regst* regst = new Regst;
    regst->set_regst_desc(rt_regst_desc);
    if (regst_desc_type.has_data_regst_desc()) {
      NewBlobsInOneRegst(lbi_pairs, regst, rt_regst_desc, main_mem_ptr, separated_header_mem_ptr);
      if (rt_regst_desc->mem_case().has_host_mem()
          && rt_regst_desc->mem_case().host_mem().used_by_network()) {
        CheckBlobInRegstNotDisabled(regst_desc_proto);
        regst->comm_net_token_ = Global<CommNet>::Get()->RegisterMemory(
            main_mem_ptr, rt_regst_desc->MainByteSize4OneRegst());
      }
      if (main_mem_ptr != nullptr) { main_mem_ptr += rt_regst_desc->MainByteSize4OneRegst(); }
      if (separated_header_mem_ptr != nullptr) {
        separated_header_mem_ptr += rt_regst_desc->SeparatedHeaderByteSize4OneRegst();
      }
    } else if (regst_desc_type.has_ctrl_regst_desc()) {
      // do nothing
    } else {
      UNIMPLEMENTED();
    }
    OneRegstDone(regst);
  }
}
```
其中的
```
  if (mem_block_id != -1 && mem_block_id2ptr_.find(mem_block_id) != mem_block_id2ptr_.end()) {
    main_mem_ptr = mem_block_id2ptr_.at(mem_block_id) + regst_desc_proto.mem_block_offset();
  }
```
也就是KeepHeaderOnly register对应的mem_block_id2ptr_存在。而根据`oneflow/core/register/register_manager.cpp:24`
```
  for (const ChunkProto& chunk : plan.block_chunk_list().chunk()) {
    if (chunk.machine_id() != this_machine_id) { continue; }
    if (chunk.mem_size() == 0) { continue; }
    char* chunk_ptr = Global<MemoryAllocator>::Get()->Allocate(chunk.mem_case(), chunk.mem_size());
    CHECK(chunk_id2ptr.emplace(chunk.chunk_id(), chunk_ptr).second);
  }
```
只有`mem_size`为0的mem_block才不会在`mem_block_id2ptr_`插入对应的值，而根据`oneflow/core/register/runtime_register_desc.cpp:45`
```
size_t RtRegstDesc::MainByteSize4OneRegst() const {
  if (packed_blob_desc_->is_body_disabled()) {
    if (mem_case_.has_device_cuda_mem()) {
      return 0;
    } else {
      return packed_blob_desc_->ByteSizeOfBlobHeader();
    }
  } else {
    if (mem_case_.has_device_cuda_mem()) {
      return packed_blob_desc_->AlignedByteSizeOfBlobBody();
    } else {
      return packed_blob_desc_->AlignedTotalByteSize();
    }
  }
}
```
返回的是` return packed_blob_desc_->ByteSizeOfBlobHeader();`并不是0，所以出现上述错误。
临时性的解决方案是禁用CPU上面KeepHeaderOnlyOp。
