### PR TITLE
Fix internal compiler error with TensorRT >= 7.1.

### DIFF
--- a/oneflow/xrt/tensorrt/trt_builder.h
+++ b/oneflow/xrt/tensorrt/trt_builder.h
@@ -125,10 +125,10 @@ class TrtBuilder {
 
   nv::unique_ptr<nvinfer1::ICudaEngine> BuildCudaEngine();
 
-#define TRT_BUILDER_ADD_LAYER(Layer)                                          \
-  template<typename... Args>                                                  \
-  auto add##Layer(Args &&... args)->decltype(network_->add##Layer(args...)) { \
-    return network_->add##Layer(std::forward<Args>(args)...);                 \
+#define TRT_BUILDER_ADD_LAYER(Layer)                          \
+  template<typename... Args>                                  \
+  auto add##Layer(Args &&... args) {                          \
+    return network_->add##Layer(std::forward<Args>(args)...); \
   }
 
   FOREACH_TENSORRT_LAYER(TRT_BUILDER_ADD_LAYER);


### PR DESCRIPTION
解决使用最新的TensorRT版本编译时遇到的编译报错：Internal compiler error: Error reporting routines re-entered.