### PR TITLE
Update the download url of half.cmake

### DIFF
--- a/cmake/third_party/half.cmake
+++ b/cmake/third_party/half.cmake
@@ -2,7 +2,7 @@ include (ExternalProject)
 
 set(HALF_INCLUDE_DIR ${THIRD_PARTY_DIR}/half/include)
 
-set(HALF_URL http://cfhcable.dl.sourceforge.net/project/half/half/1.12.0/half-1.12.0.zip)
+set(HALF_URL https://raw.githubusercontent.com/Oneflow-Inc/ThirdPartyLib/master/half-2.1.0.zip)
 set(HALF_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/half/src/half)
 
 set(HALF_HEADERS


### PR DESCRIPTION
之前的half.cmake的下载地址已失效，故将Half.zip放到Oneflow-Inc/ThirdPartyLib方便加速下载