### PR TITLE
fix complie bug of KernelRegContext.device() to device_type()

### DIFF
--- a/oneflow/customized/kernels/arg_sort_kernel.cpp
+++ b/oneflow/customized/kernels/arg_sort_kernel.cpp
@@ -51,7 +51,7 @@ class CpuArgSortKernel final : public user_op::OpKernel {
       })                                                                              \
       .SetIsMatchedPred([](const oneflow::user_op::KernelRegContext& ctx) {           \
         const user_op::TensorDesc* in_desc = ctx.TensorDesc4ArgNameAndIndex("in", 0); \
-        return ctx.device() == DeviceType::kCPU                                       \
+        return ctx.device_type() == DeviceType::kCPU                                  \
                && in_desc->data_type() == GetDataType<dtype>::value;                  \
       });
 

--- a/oneflow/customized/kernels/arg_sort_kernel.cu
+++ b/oneflow/customized/kernels/arg_sort_kernel.cu
@@ -97,7 +97,7 @@ class GpuArgSortKernel final : public user_op::OpKernel {
       })                                                                                           \
       .SetIsMatchedPred([](const oneflow::user_op::KernelRegContext& ctx) {                        \
         const user_op::TensorDesc* in_desc = ctx.TensorDesc4ArgNameAndIndex("in", 0);              \
-        return ctx.device() == DeviceType::kGPU                                                    \
+        return ctx.device_type() == DeviceType::kGPU                                               \
                && in_desc->data_type() == GetDataType<dtype>::value;                               \
       })                                                                                           \
       .SetInferTmpSizeFn([](oneflow::user_op::InferContext* ctx) {                                 \

--- a/oneflow/customized/kernels/heap_selection_top_k_kernel.cu
+++ b/oneflow/customized/kernels/heap_selection_top_k_kernel.cu
@@ -199,15 +199,15 @@ class GpuHeapSelectionTopKKernel final : public user_op::OpKernel {
   };
 };
 
-#define REGISTER_GPU_HEAP_SELECTION_TOP_K_KERNEL(dtype)                               \
-  REGISTER_USER_KERNEL("top_k")                                                       \
-      .SetCreateFn([](const oneflow::user_op::KernelInitContext& ctx) {               \
-        return new GpuHeapSelectionTopKKernel<dtype>(ctx);                            \
-      })                                                                              \
-      .SetIsMatchedPred([](const oneflow::user_op::KernelRegContext& ctx) {           \
-        const user_op::TensorDesc* in_desc = ctx.TensorDesc4ArgNameAndIndex("in", 0); \
-        return ctx.device() == DeviceType::kGPU && ctx.GetAttr<int32_t>("k") <= 128   \
-               && in_desc->data_type() == GetDataType<dtype>::value;                  \
+#define REGISTER_GPU_HEAP_SELECTION_TOP_K_KERNEL(dtype)                                  \
+  REGISTER_USER_KERNEL("top_k")                                                          \
+      .SetCreateFn([](const oneflow::user_op::KernelInitContext& ctx) {                  \
+        return new GpuHeapSelectionTopKKernel<dtype>(ctx);                               \
+      })                                                                                 \
+      .SetIsMatchedPred([](const oneflow::user_op::KernelRegContext& ctx) {              \
+        const user_op::TensorDesc* in_desc = ctx.TensorDesc4ArgNameAndIndex("in", 0);    \
+        return ctx.device_type() == DeviceType::kGPU && ctx.GetAttr<int32_t>("k") <= 128 \
+               && in_desc->data_type() == GetDataType<dtype>::value;                     \
       });
 
 REGISTER_GPU_HEAP_SELECTION_TOP_K_KERNEL(float)

--- a/oneflow/customized/kernels/radix_sort_top_k_kernel.cu
+++ b/oneflow/customized/kernels/radix_sort_top_k_kernel.cu
@@ -99,7 +99,7 @@ class GpuRadixSortTopKKernel final : public user_op::OpKernel {
       })                                                                                         \
       .SetIsMatchedPred([](const oneflow::user_op::KernelRegContext& ctx) {                      \
         const user_op::TensorDesc* in_desc = ctx.TensorDesc4ArgNameAndIndex("in", 0);            \
-        return ctx.device() == DeviceType::kGPU && ctx.GetAttr<int32_t>("k") > 128               \
+        return ctx.device_type() == DeviceType::kGPU && ctx.GetAttr<int32_t>("k") > 128          \
                && in_desc->data_type() == GetDataType<dtype>::value;                             \
       })                                                                                         \
       .SetInferTmpSizeFn([](oneflow::user_op::InferContext* ctx) {                               \

--- a/oneflow/customized/kernels/sort_kernel.cpp
+++ b/oneflow/customized/kernels/sort_kernel.cpp
@@ -42,7 +42,7 @@ class CpuSortKernel final : public user_op::OpKernel {
       })                                                                                \
       .SetIsMatchedPred([](const oneflow::user_op::KernelRegContext& ctx) {             \
         const user_op::TensorDesc* out_desc = ctx.TensorDesc4ArgNameAndIndex("out", 0); \
-        return ctx.device() == DeviceType::kCPU                                         \
+        return ctx.device_type() == DeviceType::kCPU                                    \
                && out_desc->data_type() == GetDataType<dtype>::value;                   \
       });
 

--- a/oneflow/customized/kernels/sort_kernel.cu
+++ b/oneflow/customized/kernels/sort_kernel.cu
@@ -43,7 +43,7 @@ class GpuSortKernel final : public user_op::OpKernel {
       })                                                                                    \
       .SetIsMatchedPred([](const oneflow::user_op::KernelRegContext& ctx) {                 \
         const user_op::TensorDesc* out_desc = ctx.TensorDesc4ArgNameAndIndex("out", 0);     \
-        return ctx.device() == DeviceType::kGPU                                             \
+        return ctx.device_type() == DeviceType::kGPU                                        \
                && out_desc->data_type() == GetDataType<dtype>::value;                       \
       })                                                                                    \
       .SetInferTmpSizeFn([](oneflow::user_op::InferContext* ctx) {                          \

--- a/oneflow/customized/kernels/top_k_kernel.cpp
+++ b/oneflow/customized/kernels/top_k_kernel.cpp
@@ -89,7 +89,7 @@ class TopKCpuKernel final : public user_op::OpKernel {
       })                                                                                    \
       .SetIsMatchedPred([](const oneflow::user_op::KernelRegContext& ctx) {                 \
         const user_op::TensorDesc* in_desc = ctx.TensorDesc4ArgNameAndIndex("in", 0);       \
-        return ctx.device() == DeviceType::kCPU                                             \
+        return ctx.device_type() == DeviceType::kCPU                                        \
                && in_desc->data_type() == GetDataType<dtype>::value;                        \
       })                                                                                    \
       .SetInferTmpSizeFn([](oneflow::user_op::InferContext* ctx) {                          \

--- a/oneflow/customized/ops/arg_sort_op.cpp
+++ b/oneflow/customized/ops/arg_sort_op.cpp
@@ -19,8 +19,8 @@ REGISTER_USER_OP("arg_sort")
       return Maybe<void>::Ok();
     })
     .SetGetSbpFn([](user_op::SbpContext* ctx) -> Maybe<void> {
-      // The current implementation can only do arg_sort in the last dimension and should use Broadcast
-      // (by default) instead of Split for that dimension
+      // The current implementation can only do arg_sort in the last dimension and should use
+      // Broadcast (by default) instead of Split for that dimension
       const int32_t num_axes =
           ctx->LogicalTensorDesc4InputArgNameAndIndex("in", 0).shape().NumAxes();
       if (num_axes > 1) {


### PR DESCRIPTION
修复因为 #2657 合并比 #2650 晚导致接口更新不及时的编译BUG。

@ScXfjiang 另外你的文件oneflow/customized/ops/arg_sort_op.cpp 有format问题，这里一并修复了