### PR TITLE
TCP_NODELAY & TCP_QUICKACK

### DIFF
--- a/oneflow/core/comm_network/epoll/epoll_comm_network.cpp
+++ b/oneflow/core/comm_network/epoll/epoll_comm_network.cpp
@@ -6,6 +6,8 @@
 
 #ifdef PLATFORM_POSIX
 
+#include <netinet/tcp.h>
+
 namespace oneflow {
 
 namespace {
@@ -136,6 +138,8 @@ void EpollCommNet::InitSockets() {
     auto peer_machine = Global<ResourceDesc>::Get()->machine(peer_id);
     sockaddr_in peer_sockaddr = GetSockAddr(peer_machine.addr(), peer_port);
     int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    const int val = 1;
+    PCHECK(setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char*)&val, sizeof(int)) == 0);
     PCHECK(connect(sockfd, reinterpret_cast<sockaddr*>(&peer_sockaddr), sizeof(peer_sockaddr))
            == 0);
     CHECK(sockfd2helper_.emplace(sockfd, NewSocketHelper(sockfd)).second);

--- a/oneflow/core/comm_network/epoll/socket_read_helper.cpp
+++ b/oneflow/core/comm_network/epoll/socket_read_helper.cpp
@@ -4,6 +4,8 @@
 
 #ifdef PLATFORM_POSIX
 
+#include <netinet/tcp.h>
+
 namespace oneflow {
 
 SocketReadHelper::~SocketReadHelper() {
@@ -37,6 +39,8 @@ bool SocketReadHelper::MsgBodyReadHandle() {
 
 bool SocketReadHelper::DoCurRead(void (SocketReadHelper::*set_cur_read_done)()) {
   ssize_t n = read(sockfd_, read_ptr_, read_size_);
+  const int val = 1;
+  PCHECK(setsockopt(sockfd_, IPPROTO_TCP, TCP_QUICKACK, (char*)&val, sizeof(int)) == 0);
   if (n == read_size_) {
     (this->*set_cur_read_done)();
     return true;


### PR DESCRIPTION
Socket性能调优， 通过开启发送端的TCP_NODELAY和接收端的TCP_QUICKACK减少延迟，暂时还不能确定修改对吞吐量带来的影响。