### PR TITLE
fix fixed_vector::erase

### DIFF
--- a/oneflow/core/common/fixed_vector.h
+++ b/oneflow/core/common/fixed_vector.h
@@ -177,6 +177,7 @@ class fixed_vector final {
     return pos;
   }
   iterator erase(iterator first, iterator last) {
+    if (first >= last) { return last; }
     MoveNToBegin(last, last - first);
     return first;
   }


### PR DESCRIPTION
fixed_vector::erase接口first >= last的时候存在bug
cppreference: If [first, last) is an empty range, then last is returned.