### PR TITLE
Fix compile warning

### DIFF
--- a/oneflow/core/kernel/user_kernel.cpp
+++ b/oneflow/core/kernel/user_kernel.cpp
@@ -85,8 +85,7 @@ class UserKernelContext final : public user_op::KernelContext {
   explicit UserKernelContext(DeviceCtx* device_ctx, const KernelConf& kernel_conf)
       : user_op::KernelContext(user_op::UserOpConfWrapper(kernel_conf.op_attribute().op_conf())),
         device_ctx_(device_ctx),
-        base_ctx_(std::move(UserKernelBaseContext(kernel_conf))),
-        arg2tensor_() {
+        base_ctx_(std::move(UserKernelBaseContext(kernel_conf))) {
     auto InitInOrOut = [&](const PbMap<std::string, UserOpConf::ListString>& arg_map) {
       for (auto it = arg_map.begin(); it != arg_map.end(); ++it) {
         const std::string& arg_name = it->first;


### PR DESCRIPTION
修复 https://github.com/Oneflow-Inc/oneflow/blob/6cb213a7b74084575e28ba6af38da043206f9b9a/oneflow/core/kernel/user_kernel.cpp#L89 处的compile warning问题，成员声明顺序与初始化列表顺序不同，所以去掉空的arg2tensor_的初始化（默认行为就是空的初始化）