### PR TITLE
Fix cudnn conv algo infer bug

### DIFF
--- a/oneflow/core/device/cudnn_conv_util.cpp
+++ b/oneflow/core/device/cudnn_conv_util.cpp
@@ -274,8 +274,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionFwdAlgoPerf_t> {
     CudaCheck(cudnnGetConvolutionForwardAlgorithm_v7(
         res->cudnn_handle(), args.xdesc.Get(), args.wdesc.Get(), args.cdesc.Get(), args.ydesc.Get(),
         perf_vec->capacity(), &found_algo_cnt, perf_vec->data()));
-    // this resize is from max_algo_cnt to found_algo_cnt (max_algo_cnt >= found_algo_cnt)
-    // that don't affect the existing elements in perf_vec
+    // vector::resize does not affect the first found_algo_cnt elements.
     perf_vec->resize(found_algo_cnt);
   }
 
@@ -288,8 +287,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionFwdAlgoPerf_t> {
         res->w_const_dptr(), args.cdesc.Get(), args.ydesc.Get(), res->y_mut_dptr(),
         perf_vec->capacity(), &found_algo_cnt, perf_vec->data(), res->ws_dptr(),
         args.params.max_ws_size));
-    // this resize is from max_algo_cnt to found_algo_cnt (max_algo_cnt >= found_algo_cnt)
-    // that don't affect the existing elements in perf_vec
+    // vector::resize does not affect the first found_algo_cnt elements.
     perf_vec->resize(found_algo_cnt);
   }
 };
@@ -311,8 +309,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdDataAlgoPerf_t> {
     CudaCheck(cudnnGetConvolutionBackwardDataAlgorithm_v7(
         res->cudnn_handle(), args.wdesc.Get(), args.ydesc.Get(), args.cdesc.Get(), args.xdesc.Get(),
         perf_vec->capacity(), &found_algo_cnt, perf_vec->data()));
-    // this resize is from max_algo_cnt to found_algo_cnt (max_algo_cnt >= found_algo_cnt)
-    // that don't affect the existing elements in perf_vec
+    // vector::resize does not affect the first found_algo_cnt elements.
     perf_vec->resize(found_algo_cnt);
   }
 
@@ -325,8 +322,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdDataAlgoPerf_t> {
         res->y_const_dptr(), args.cdesc.Get(), args.xdesc.Get(), res->x_mut_dptr(),
         perf_vec->capacity(), &found_algo_cnt, perf_vec->data(), res->ws_dptr(),
         args.params.max_ws_size));
-    // this resize is from max_algo_cnt to found_algo_cnt (max_algo_cnt >= found_algo_cnt)
-    // that don't affect the existing elements in perf_vec
+    // vector::resize does not affect the first found_algo_cnt elements.
     perf_vec->resize(found_algo_cnt);
   }
 };
@@ -349,8 +345,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdFilterAlgoPerf_t> {
     CudaCheck(cudnnGetConvolutionBackwardFilterAlgorithm_v7(
         res->cudnn_handle(), args.xdesc.Get(), args.ydesc.Get(), args.cdesc.Get(), args.wdesc.Get(),
         perf_vec->capacity(), &found_algo_cnt, perf_vec->data()));
-    // this resize is from max_algo_cnt to found_algo_cnt (max_algo_cnt >= found_algo_cnt)
-    // that don't affect the existing elements in perf_vec
+    // vector::resize does not affect the first found_algo_cnt elements.
     perf_vec->resize(found_algo_cnt);
   }
 
@@ -363,8 +358,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdFilterAlgoPerf_t> {
         res->y_const_dptr(), args.cdesc.Get(), args.wdesc.Get(), res->w_mut_dptr(),
         perf_vec->capacity(), &found_algo_cnt, perf_vec->data(), res->ws_dptr(),
         args.params.max_ws_size));
-    // this resize is from max_algo_cnt to found_algo_cnt (max_algo_cnt >= found_algo_cnt)
-    // that don't affect the existing elements in perf_vec
+    // vector::resize does not affect the first found_algo_cnt elements.
     perf_vec->resize(found_algo_cnt);
   }
 };


### PR DESCRIPTION
## 问题

在 720df9b 这个commit提交后，运行resnet50 benchmark发现变慢
commit_id: 720df9b 测试结果

![develop_720df9b_res50](https://user-images.githubusercontent.com/7133477/76922903-f50cc400-690c-11ea-9ac6-fea4dcba5da0.jpg)

前一个 commit_id: 7b50edc 测试结果

![develop_7b50edc_res50](https://user-images.githubusercontent.com/7133477/76922811-be36ae00-690c-11ea-900e-636ba2eed6d6.jpg)

从上图可以看出运行速度明显变慢

## 解决

加上log之运行发现

![develop_720df9b_res50_log](https://user-images.githubusercontent.com/7133477/76922875-e45c4e00-690c-11ea-9c5b-0c143f8f14e3.jpg)

所有算法全部是0，这明显是不正常的。

经过调试后发现下段代码
```
  static void HeuristicSearch(const CudnnConvArgs& args, CudnnConvResource* res,
                              std::vector<perf_t>* perf_vec) {
    int found_algo_cnt = 0;
    perf_vec->reserve(GetAlgoMaxCount(res));
    CudaCheck(cudnnGetConvolutionBackwardFilterAlgorithm_v7(
        res->cudnn_handle(), args.xdesc.Get(), args.ydesc.Get(), args.cdesc.Get(), args.wdesc.Get(),
        perf_vec->capacity(), &found_algo_cnt, perf_vec->data()));
    perf_vec->resize(found_algo_cnt);
  }
```
中第2个resize会使perf_vec中found_algo_cnt个元素全部重新构造一遍（默认构造），丢弃了之前搜索的结果，所以应该把第1个reserve换成resize，这样第2个resize的行为会变成 max_algo_cnt -> found_algo_cnt（之前是 0 -> found_algo_cnt）,这样不会触发重新的构造。

修改之后重新运行resnet50 benchmark发现速度已恢复为之前的水准

![fix_cudnn_conv_algo_infer](https://user-images.githubusercontent.com/7133477/76923589-c98ad900-690e-11ea-9eee-7b113bf7c22c.jpg)

![fix_cudnn_conv_algo_infer_log](https://user-images.githubusercontent.com/7133477/76923690-1b336380-690f-11ea-8d05-c7c05ce8f8ce.jpg)

log中打印出的算法经过与老版本的对比已经全部可以匹配上

## TODO

增加测试，比如在*_test.cpp中使用搜索算法给出的结果每个都跑一遍打印出运行速度等等，可在另外一个pr中添加该项测试