### PR TITLE
ibv_fork_init

### DIFF
--- a/oneflow/core/comm_network/ibverbs/ibverbs_comm_network.cpp
+++ b/oneflow/core/comm_network/ibverbs/ibverbs_comm_network.cpp
@@ -16,6 +16,10 @@ std::string GenConnInfoKey(int64_t src_machine_id, int64_t dst_machine_id) {
   return "IBVerbsConnInfo/" + std::to_string(src_machine_id) + "/" + std::to_string(dst_machine_id);
 }
 
+void IBVForkInit() {
+  if (ibv_fork_init() != 0) { LOG(ERROR) << "ibv_fork_init failed"; }
+}
+
 }  // namespace
 
 IBVerbsCommNet::~IBVerbsCommNet() {
@@ -139,6 +143,8 @@ void IBVerbsCommNet::PollCQ() {
 }
 
 const int32_t IBVerbsCommNet::max_poll_wc_num_ = 32;
+
+COMMAND(IBVForkInit());
 
 }  // namespace oneflow
 


### PR DESCRIPTION
在OneFlow多机运行时调用fork会导致不可预期的后果，通常表现为死锁。原因是libibverbs默认情况下无法正确处理fork，需要调用[ibv_fork_init](https://github.com/linux-rdma/rdma-core/blob/master/libibverbs/man/ibv_fork_init.3.md)之后才能正确处理fork。这个问题有三个解决办法:
1. OneFlow使用调用`ibv_fork_init`，但是文档中提到这个调用会导致一定的开销，也提到这个开销一般并不严重
2. 可以使用环境变量`RDMAV_FORK_SAFE` 或者`IBV_FORK_SAFE`达到和1相同的效果
3. 避免使用fork

考虑到可能很少有用户能知道这个问题，所以还是1可行性高一点。