### PR TITLE
Fix compiling error on gcc 5.4 ubuntu 16.04

### DIFF
--- a/oneflow/core/common/embedded_list_test.cpp
+++ b/oneflow/core/common/embedded_list_test.cpp
@@ -1,5 +1,6 @@
 // include sstream first to avoid some compiling error 
 // caused by the following trick
+// reference: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65899
 #include <sstream>
 #define private public
 #include "oneflow/core/common/embedded_list.h"

--- a/oneflow/core/common/nd_index_offset_helper_test.cpp
+++ b/oneflow/core/common/nd_index_offset_helper_test.cpp
@@ -1,5 +1,6 @@
 // include sstream first to avoid some compiling error 
 // caused by the following trick
+// reference: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65899
 #include <sstream>
 #define private public
 #include "oneflow/core/common/nd_index_offset_helper.h"

--- a/oneflow/core/common/object_msg_basic_test.cpp
+++ b/oneflow/core/common/object_msg_basic_test.cpp
@@ -1,5 +1,6 @@
 // include sstream first to avoid some compiling error 
 // caused by the following trick
+// reference: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65899
 #include <sstream>
 #define private public
 #include "oneflow/core/common/util.h"


### PR DESCRIPTION
在 ubuntu 16.04 gcc 5.4 上，编译 unit test 时报错，错误信息

> In file included from ../third_party/glog/include/glog/logging.h:44:0,
>                  from ../oneflow/core/common/util.h:7,
>                  from ../oneflow/core/common/data_type.h:11,
>                  from ../oneflow/core/common/nd_index_offset_helper.h:4,
>                  from ../oneflow/core/common/nd_index_offset_helper_test.cpp:2:
> /usr/include/c++/5/sstream:300:7: error: ‘struct std::__cxx11::basic_stringbuf<_CharT, _Traits, _Alloc>::__xfer_bufptrs’ redeclared with different access
>        struct __xfer_bufptrs

具体原因和解决方法都在 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65899 里有说明