### PR TITLE
[quickfix] remove global code in test_constant.py

### DIFF
--- a/oneflow/python/test/ops/test_constant.py
+++ b/oneflow/python/test/ops/test_constant.py
@@ -8,8 +8,6 @@ from test_util import GenArgList
 from test_util import GetSavePath
 from test_util import Save
 
-os.environ["ENABLE_USER_OP"] = "True"
-
 func_config = flow.FunctionConfig()
 func_config.default_data_type(flow.float)
 
@@ -44,5 +42,3 @@ def test_constant(test_case):
     for arg in GenArgList(arg_dict):
         compare_with_tensorflow(*arg)
 
-
-test_constant(1)


### PR DESCRIPTION
test_constant.py 里的这两条语句会在被 load 的时候无条件执行，1node_test.py 这个文件在跑 test 之前 load 所有 py 文件，所以这导致 ENABLE_USER_OP 跑测试的时候被无条件设置成了 True、`test_constant(1)` 也被无条件的跑了一遍