### PR TITLE
Replace git submodule with github release

### DIFF
--- a/cmake/third_party/cocoapi.cmake
+++ b/cmake/third_party/cocoapi.cmake
@@ -3,8 +3,7 @@ include (ExternalProject)
 set(COCOAPI_INCLUDE_DIR ${THIRD_PARTY_DIR}/cocoapi/include)
 set(COCOAPI_LIBRARY_DIR ${THIRD_PARTY_DIR}/cocoapi/lib)
 
-set(COCOAPI_URL https://github.com/cocodataset/cocoapi.git)
-set(COCOAPI_TAG ed842bffd41f6ff38707c4f0968d2cfd91088688)
+set(COCOAPI_URL https://github.com/Oneflow-Inc/cocoapi/archive/d1.tar.gz)
 set(COCOAPI_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cocoapi/src/cocoapi)
 set(COCOAPI_LIBRARY_NAME libcocoapi_static.a)
 
@@ -19,8 +18,7 @@ if(THIRD_PARTY)
 
 ExternalProject_Add(cocoapi
     PREFIX cocoapi
-    GIT_REPOSITORY ${COCOAPI_URL}
-    GIT_TAG ${COCOAPI_TAG}
+    URL ${COCOAPI_URL}
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE 1

--- a/cmake/third_party/cocoapi.cmake
+++ b/cmake/third_party/cocoapi.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(COCOAPI_INCLUDE_DIR ${THIRD_PARTY_DIR}/cocoapi/include)
 set(COCOAPI_LIBRARY_DIR ${THIRD_PARTY_DIR}/cocoapi/lib)
 
-set(COCOAPI_URL https://github.com/Oneflow-Inc/cocoapi/archive/d1.tar.gz)
+set(COCOAPI_URL https://github.com/Oneflow-Inc/cocoapi/archive/ed842bf.tar.gz)
 set(COCOAPI_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cocoapi/src/cocoapi)
 set(COCOAPI_LIBRARY_NAME libcocoapi_static.a)
 

--- a/cmake/third_party/cub.cmake
+++ b/cmake/third_party/cub.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(CUB_INCLUDE_DIR ${THIRD_PARTY_DIR}/cub/include)
 set(CUB_BUILD_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/cub/src/cub/cub)
 
-set(CUB_URL https://github.com/Oneflow-Inc/cub/archive/d1.tar.gz)
+set(CUB_URL https://github.com/Oneflow-Inc/cub/archive/v1.8.0.tar.gz)
 
 if(THIRD_PARTY)
 

--- a/cmake/third_party/cub.cmake
+++ b/cmake/third_party/cub.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(CUB_INCLUDE_DIR ${THIRD_PARTY_DIR}/cub/include)
 set(CUB_BUILD_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/cub/src/cub/cub)
 
-set(CUB_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/cub/src/cub)
+set(CUB_URL https://github.com/Oneflow-Inc/cub/archive/d1.tar.gz)
 
 if(THIRD_PARTY)
 

--- a/cmake/third_party/eigen.cmake
+++ b/cmake/third_party/eigen.cmake
@@ -7,7 +7,7 @@ if(WITH_XLA)
   #set(EIGEN_URL "https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/8071cda5714d.tar.gz")
   set(EIGEN_URL "https://bitbucket.org/eigen/eigen/get/8071cda5714d.tar.gz")
 else()
-  set(EIGEN_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/eigen/src/eigen)
+  set(EIGEN_URL https://github.com/Oneflow-Inc/eigen-git-mirror/archive/d1.tar.gz)
 endif()
 
 add_definitions(-DEIGEN_NO_AUTOMATIC_RESIZING -DEIGEN_USE_GPU)

--- a/cmake/third_party/eigen.cmake
+++ b/cmake/third_party/eigen.cmake
@@ -7,7 +7,7 @@ if(WITH_XLA)
   #set(EIGEN_URL "https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/8071cda5714d.tar.gz")
   set(EIGEN_URL "https://bitbucket.org/eigen/eigen/get/8071cda5714d.tar.gz")
 else()
-  set(EIGEN_URL https://github.com/Oneflow-Inc/eigen-git-mirror/archive/d1.tar.gz)
+  set(EIGEN_URL https://github.com/Oneflow-Inc/eigen-git-mirror/archive/e9e9548.tar.gz)
 endif()
 
 add_definitions(-DEIGEN_NO_AUTOMATIC_RESIZING -DEIGEN_USE_GPU)

--- a/cmake/third_party/gflags.cmake
+++ b/cmake/third_party/gflags.cmake
@@ -5,7 +5,7 @@ set(GFLAGS_LIBRARY_DIR ${THIRD_PARTY_DIR}/gflags/lib)
 
 set(gflags_HEADERS_DIR ${CMAKE_CURRENT_BINARY_DIR}/gflags/src/gflags/include)
 set(gflags_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/gflags/src/gflags/lib)
-set(gflags_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/gflags/src/gflags)
+set(gflags_URL https://github.com/Oneflow-Inc/gflags/archive/d1.tar.gz)
 
 if(WIN32)
     set(GFLAGS_BUILD_LIBRARY_DIR ${gflags_LIB_DIR}/${CMAKE_BUILD_TYPE})

--- a/cmake/third_party/gflags.cmake
+++ b/cmake/third_party/gflags.cmake
@@ -5,7 +5,7 @@ set(GFLAGS_LIBRARY_DIR ${THIRD_PARTY_DIR}/gflags/lib)
 
 set(gflags_HEADERS_DIR ${CMAKE_CURRENT_BINARY_DIR}/gflags/src/gflags/include)
 set(gflags_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/gflags/src/gflags/lib)
-set(gflags_URL https://github.com/Oneflow-Inc/gflags/archive/d1.tar.gz)
+set(gflags_URL https://github.com/Oneflow-Inc/gflags/archive/9314597.tar.gz)
 
 if(WIN32)
     set(GFLAGS_BUILD_LIBRARY_DIR ${gflags_LIB_DIR}/${CMAKE_BUILD_TYPE})

--- a/cmake/third_party/glog.cmake
+++ b/cmake/third_party/glog.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(GLOG_INCLUDE_DIR ${THIRD_PARTY_DIR}/glog/include)
 set(GLOG_LIBRARY_DIR ${THIRD_PARTY_DIR}/glog/lib)
 
-set(glog_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/glog/src/glog)
+set(glog_URL https://github.com/Oneflow-Inc/glog/archive/d1.tar.gz)
 
 if(WIN32)
     set(GLOG_BUILD_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/glog/src/glog/${CMAKE_BUILD_TYPE})

--- a/cmake/third_party/glog.cmake
+++ b/cmake/third_party/glog.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(GLOG_INCLUDE_DIR ${THIRD_PARTY_DIR}/glog/include)
 set(GLOG_LIBRARY_DIR ${THIRD_PARTY_DIR}/glog/lib)
 
-set(glog_URL https://github.com/Oneflow-Inc/glog/archive/d1.tar.gz)
+set(glog_URL https://github.com/Oneflow-Inc/glog/archive/4f3e18b.tar.gz)
 
 if(WIN32)
     set(GLOG_BUILD_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/glog/src/glog/${CMAKE_BUILD_TYPE})

--- a/cmake/third_party/googletest.cmake
+++ b/cmake/third_party/googletest.cmake
@@ -9,7 +9,7 @@ set(GOOGLEMOCK_LIBRARY_DIR ${THIRD_PARTY_DIR}/googlemock/lib)
 set(googletest_SRC_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googletest/include)
 set(googlemock_SRC_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googlemock/include)
 
-set(googletest_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/googletest/src/googletest)
+set(googletest_URL https://github.com/Oneflow-Inc/googletest/archive/d1.tar.gz)
 
 if(WIN32)
     set(GOOGLETEST_BUILD_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googlemock/gtest/${CMAKE_BUILD_TYPE})

--- a/cmake/third_party/googletest.cmake
+++ b/cmake/third_party/googletest.cmake
@@ -9,7 +9,7 @@ set(GOOGLEMOCK_LIBRARY_DIR ${THIRD_PARTY_DIR}/googlemock/lib)
 set(googletest_SRC_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googletest/include)
 set(googlemock_SRC_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googlemock/include)
 
-set(googletest_URL https://github.com/Oneflow-Inc/googletest/archive/d1.tar.gz)
+set(googletest_URL https://github.com/Oneflow-Inc/googletest/archive/release-1.8.0.tar.gz)
 
 if(WIN32)
     set(GOOGLETEST_BUILD_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googlemock/gtest/${CMAKE_BUILD_TYPE})

--- a/cmake/third_party/grpc.cmake
+++ b/cmake/third_party/grpc.cmake
@@ -4,7 +4,7 @@ set(GRPC_INCLUDE_DIR ${THIRD_PARTY_DIR}/grpc/include)
 set(GRPC_LIBRARY_DIR ${THIRD_PARTY_DIR}/grpc/lib)
 
 set(GRPC_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/include)
-set(GRPC_URL https://github.com/Oneflow-Inc/grpc/archive/d1.tar.gz)
+set(GRPC_URL https://github.com/Oneflow-Inc/grpc/archive/e0db46e.tar.gz)
 
 if(WIN32)
     set(GRPC_BUILD_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/${CMAKE_BUILD_TYPE})
@@ -33,7 +33,7 @@ if(THIRD_PARTY)
 ExternalProject_Add(
   nanopb
   PREFIX nanopb
-  URL https://github.com/Oneflow-Inc/nanopb/archive/d1.tar.gz
+  URL https://github.com/Oneflow-Inc/nanopb/archive/f8ac463.tar.gz
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""

--- a/cmake/third_party/libjpeg-turbo.cmake
+++ b/cmake/third_party/libjpeg-turbo.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(LIBJPEG_INCLUDE_DIR ${THIRD_PARTY_DIR}/libjpeg-turbo/include)
 set(LIBJPEG_LIBRARY_DIR ${THIRD_PARTY_DIR}/libjpeg-turbo/lib)
 
-set(LIBJPEG_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/libjpeg-turbo/src/libjpeg-turbo)
+set(LIBJPEG_URL https://github.com/Oneflow-Inc/libjpeg-turbo/archive/d1.tar.gz)
 
 if(WIN32)
 elseif(APPLE AND ("${CMAKE_GENERATOR}" STREQUAL "Xcode"))

--- a/cmake/third_party/libjpeg-turbo.cmake
+++ b/cmake/third_party/libjpeg-turbo.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(LIBJPEG_INCLUDE_DIR ${THIRD_PARTY_DIR}/libjpeg-turbo/include)
 set(LIBJPEG_LIBRARY_DIR ${THIRD_PARTY_DIR}/libjpeg-turbo/lib)
 
-set(LIBJPEG_URL https://github.com/Oneflow-Inc/libjpeg-turbo/archive/d1.tar.gz)
+set(LIBJPEG_URL https://github.com/Oneflow-Inc/libjpeg-turbo/archive/3041cf6.tar.gz)
 
 if(WIN32)
 elseif(APPLE AND ("${CMAKE_GENERATOR}" STREQUAL "Xcode"))

--- a/cmake/third_party/nccl.cmake
+++ b/cmake/third_party/nccl.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(NCCL_INCLUDE_DIR ${THIRD_PARTY_DIR}/nccl/include)
 set(NCCL_LIBRARY_DIR ${THIRD_PARTY_DIR}/nccl/lib)
 
-set(NCCL_URL https://github.com/Oneflow-Inc/nccl/archive/d1.tar.gz)
+set(NCCL_URL https://github.com/Oneflow-Inc/nccl/archive/ccb1298.tar.gz)
 set(NCCL_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/nccl/src/nccl/build)
 
 if(WIN32)

--- a/cmake/third_party/nccl.cmake
+++ b/cmake/third_party/nccl.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(NCCL_INCLUDE_DIR ${THIRD_PARTY_DIR}/nccl/include)
 set(NCCL_LIBRARY_DIR ${THIRD_PARTY_DIR}/nccl/lib)
 
-set(NCCL_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/nccl/src/nccl)
+set(NCCL_URL https://github.com/Oneflow-Inc/nccl/archive/d1.tar.gz)
 set(NCCL_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/nccl/src/nccl/build)
 
 if(WIN32)

--- a/cmake/third_party/opencv.cmake
+++ b/cmake/third_party/opencv.cmake
@@ -5,7 +5,7 @@ set(OPENCV_LIBRARY_DIR ${THIRD_PARTY_DIR}/opencv/lib)
 set(OPENCV_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencv/src/opencv/build/install)
 
 set(OPENCV_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencv/src/opencv/src)
-set(OPENCV_URL https://github.com/Oneflow-Inc/opencv/archive/d1.tar.gz)
+set(OPENCV_URL https://github.com/Oneflow-Inc/opencv/archive/51cef26.tar.gz)
 
 if(WIN32)
 elseif(APPLE AND ("${CMAKE_GENERATOR}" STREQUAL "Xcode"))

--- a/cmake/third_party/opencv.cmake
+++ b/cmake/third_party/opencv.cmake
@@ -5,7 +5,7 @@ set(OPENCV_LIBRARY_DIR ${THIRD_PARTY_DIR}/opencv/lib)
 set(OPENCV_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencv/src/opencv/build/install)
 
 set(OPENCV_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencv/src/opencv/src)
-set(OPENCV_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/opencv/src/opencv)
+set(OPENCV_URL https://github.com/Oneflow-Inc/opencv/archive/d1.tar.gz)
 
 if(WIN32)
 elseif(APPLE AND ("${CMAKE_GENERATOR}" STREQUAL "Xcode"))

--- a/cmake/third_party/protobuf.cmake
+++ b/cmake/third_party/protobuf.cmake
@@ -8,7 +8,7 @@ set(PROTOBUF_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/src)
 if(WITH_XLA)
   set(PROTOBUF_URL "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/310ba5ee72661c081129eb878c1bbcec936b20f0.tar.gz")
 else()
-  set(PROTOBUF_URL https://github.com/Oneflow-Inc/protobuf/archive/d1.tar.gz)
+  set(PROTOBUF_URL https://github.com/Oneflow-Inc/protobuf/archive/1d2c7b6.tar.gz)
 endif()
 
 if(WIN32)

--- a/cmake/third_party/protobuf.cmake
+++ b/cmake/third_party/protobuf.cmake
@@ -8,7 +8,7 @@ set(PROTOBUF_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/src)
 if(WITH_XLA)
   set(PROTOBUF_URL "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/310ba5ee72661c081129eb878c1bbcec936b20f0.tar.gz")
 else()
-  set(PROTOBUF_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/protobuf/src/protobuf)
+  set(PROTOBUF_URL https://github.com/Oneflow-Inc/protobuf/archive/d1.tar.gz)
 endif()
 
 if(WIN32)

--- a/cmake/third_party/re2.cmake
+++ b/cmake/third_party/re2.cmake
@@ -2,7 +2,6 @@ include(ExternalProject)
 
 SET(RE2_PROJECT re2)
 
-SET(RE2_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/re2)
 SET(RE2_INSTALL_DIR ${THIRD_PARTY_DIR}/re2)
 
 SET(RE2_INCLUDE_DIR ${RE2_INSTALL_DIR}/include CACHE PATH "" FORCE)
@@ -11,7 +10,8 @@ SET(RE2_LIBRARIES ${RE2_LIBRARY_DIR}/libre2.a)
 
 if (THIRD_PARTY)
     ExternalProject_Add(${RE2_PROJECT}
-        PREFIX ${RE2_SOURCE_DIR}
+        URL https://github.com/Oneflow-Inc/re2/archive/d1.tar.gz
+        PREFIX re2
         UPDATE_COMMAND ""
         CMAKE_ARGS
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/cmake/third_party/re2.cmake
+++ b/cmake/third_party/re2.cmake
@@ -10,7 +10,7 @@ SET(RE2_LIBRARIES ${RE2_LIBRARY_DIR}/libre2.a)
 
 if (THIRD_PARTY)
     ExternalProject_Add(${RE2_PROJECT}
-        URL https://github.com/Oneflow-Inc/re2/archive/d1.tar.gz
+        URL https://github.com/Oneflow-Inc/re2/archive/e17af77.tar.gz
         PREFIX re2
         UPDATE_COMMAND ""
         CMAKE_ARGS

--- a/cmake/third_party/zlib.cmake
+++ b/cmake/third_party/zlib.cmake
@@ -4,7 +4,7 @@ set(ZLIB_INCLUDE_DIR ${THIRD_PARTY_DIR}/zlib/include)
 set(ZLIB_LIBRARY_DIR ${THIRD_PARTY_DIR}/zlib/lib)
 
 set(ZLIB_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/zlib/install)
-set(ZLIB_URL https://github.com/Oneflow-Inc/zlib/archive/d1.tar.gz)
+set(ZLIB_URL https://github.com/Oneflow-Inc/zlib/archive/v1.2.8.tar.gz)
 
 if(WIN32)
     set(ZLIB_BUILD_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zlib/install/lib)

--- a/cmake/third_party/zlib.cmake
+++ b/cmake/third_party/zlib.cmake
@@ -4,7 +4,7 @@ set(ZLIB_INCLUDE_DIR ${THIRD_PARTY_DIR}/zlib/include)
 set(ZLIB_LIBRARY_DIR ${THIRD_PARTY_DIR}/zlib/lib)
 
 set(ZLIB_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/zlib/install)
-set(ZLIB_URL ${CMAKE_CURRENT_BINARY_DIR}/third_party/zlib/src/zlib)
+set(ZLIB_URL https://github.com/Oneflow-Inc/zlib/archive/d1.tar.gz)
 
 if(WIN32)
     set(ZLIB_BUILD_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zlib/install/lib)


### PR DESCRIPTION
问题：
1. 克隆很慢，因为git仓库有很多小文件，不利于网络传输
2. submodule 我们放在 build/third_party 目录下，不了解的用户有时候很容易误操作
3. 因为 submodule 的存在，为 oneflow 更新和添加第三方依赖也变得十分麻烦，还要提醒所有同事要运行更新 submodule 的 git 命令

解决方案：
1. 将用到的开源项目 fork 到 github 的 Oneflow-Inc 组织
2. 用之前使用的 github commit hash 生成一个 release
3. 在 oneflow 的 cmake 中使用生成的 release 的压缩包