### PR TITLE
simple fix for gcc 5.4

### DIFF
--- a/oneflow/customized/ops/conv_op.cpp
+++ b/oneflow/customized/ops/conv_op.cpp
@@ -144,7 +144,7 @@ Maybe<void> CheckAttr(const user_op::UserOpDefWrapper& def,
   if (is_checked) {
     return Maybe<void>::Ok();
   } else {
-    return oneflow::Error::CheckFailed() << err;
+    return oneflow::Error::CheckFailed() << err.str();
   }
 }
 


### PR DESCRIPTION
https://github.com/Oneflow-Inc/oneflow/pull/2766/files#r424207121

gcc 5.4 把 stringstream 用 << 传给 ostream 会报错，所以用 `.str()` 把 stringstream 变成 string