### PR TITLE
add UserOpConfWrapper::input/output_size() for some op grad build graph

### DIFF
--- a/oneflow/core/framework/user_op_conf.cpp
+++ b/oneflow/core/framework/user_op_conf.cpp
@@ -49,6 +49,18 @@ bool UserOpConfWrapper::has_output(const std::string& arg_name, int32_t index) c
   return (it != op_conf_.user_conf().output().end());
 }
 
+int32_t UserOpConfWrapper::input_size(const std::string& arg_name) const {
+  auto it = op_conf_.user_conf().input().find(arg_name);
+  if (it == op_conf_.user_conf().input().end()) { return 0; }
+  return it->second.s_size();
+}
+
+int32_t UserOpConfWrapper::output_size(const std::string& arg_name) const {
+  auto it = op_conf_.user_conf().output().find(arg_name);
+  if (it == op_conf_.user_conf().output().end()) { return 0; }
+  return it->second.s_size();
+}
+
 #define OP_WRAPPER_ATTR_MEMBER_FUNC(field, cpp_type, attr_type)                                    \
   template<>                                                                                       \
   cpp_type UserOpConfWrapper::attr<cpp_type>(const std::string& attr_name) const {                 \

--- a/oneflow/core/framework/user_op_conf.h
+++ b/oneflow/core/framework/user_op_conf.h
@@ -26,6 +26,8 @@ class UserOpConfWrapper final {
   const std::string& output(const std::string& arg_name, int32_t index) const;
   bool has_input(const std::string& arg_name, int32_t index) const;
   bool has_output(const std::string& arg_name, int32_t index) const;
+  int32_t input_size(const std::string& arg_name) const;
+  int32_t output_size(const std::string& arg_name) const;
 
   template<typename T>
   T attr(const std::string& attr_name) const;
@@ -58,6 +60,8 @@ class UserOpWrapper final {
   const std::string& output(const std::string& arg_name, int32_t index) const {
     return conf_.output(arg_name, index);
   }
+  int32_t input_size(const std::string& arg_name) const { return conf_.input_size(arg_name); }
+  int32_t output_size(const std::string& arg_name) const { return conf_.output_size(arg_name); }
   template<typename T>
   T attr(const std::string& attr_name) const {
     return conf_.attr<T>(attr_name);


### PR DESCRIPTION
某些op（如concat）在构建后向图的时候，需要获取动态的 input/output_size 用于生成 grad op conf。