### PR TITLE
add UserOpConfWrapper in OpRegistration::SetInputArgModifyFn

### DIFF
--- a/oneflow/core/framework/op_registration.cpp
+++ b/oneflow/core/framework/op_registration.cpp
@@ -178,7 +178,7 @@ OpRegistryWrapper OpRegistryWrapperBuilder::Build() {
     wrapper_.reg_val.get_sbp_fn = GetSbpFnUtil::DefaultBroadcastToBroadcast;
   }
   if (wrapper_.reg_val.input_arg_modify_fn == nullptr) {
-    wrapper_.reg_val.input_arg_modify_fn = [](GetInputArgModifier) {};
+    wrapper_.reg_val.input_arg_modify_fn = [](GetInputArgModifier, const UserOpConfWrapper&) {};
   }
   return wrapper_;
 }

--- a/oneflow/core/framework/op_registration.h
+++ b/oneflow/core/framework/op_registration.h
@@ -29,7 +29,7 @@ using GetSbpFn = std::function<Maybe<void>(SbpContext*)>;
 using InputArgModifier = InputBlobModifier;
 using GetInputArgModifier =
     std::function<InputArgModifier*(const std::string& in_arg_name, int32_t in_arg_index)>;
-using InputArgModifyFn = std::function<void(GetInputArgModifier)>;
+using InputArgModifyFn = std::function<void(GetInputArgModifier, const UserOpConfWrapper&)>;
 
 struct OpRegistrationVal {
   UserOpDef op_def;

--- a/oneflow/core/operator/user_op.cpp
+++ b/oneflow/core/operator/user_op.cpp
@@ -297,6 +297,7 @@ void UserOp::InitFromOpConf() {
   EnrollTmpBn(GenRepeatedBn("tmp_buffer", 0));
   val_ = user_op::LookUpInOpRegistry(op_conf().user_conf().op_type_name());
   if (val_ != nullptr) {
+    user_op::UserOpConfWrapper user_conf_wrapper(op_conf());
     user_op::GetInputArgModifier GetInputArgModifierFn =
         [&](const std::string& in_arg_name, int32_t in_arg_index) -> user_op::InputArgModifier* {
       std::string ibn = GenRepeatedBn(in_arg_name, in_arg_index);
@@ -305,7 +306,7 @@ void UserOp::InitFromOpConf() {
       }
       return nullptr;
     };
-    val_->input_arg_modify_fn(GetInputArgModifierFn);
+    val_->input_arg_modify_fn(GetInputArgModifierFn, user_conf_wrapper);
   }
 }
 

--- a/oneflow/customized/ops/categorical_ordinal_encode_op.cpp
+++ b/oneflow/customized/ops/categorical_ordinal_encode_op.cpp
@@ -24,7 +24,8 @@ REGISTER_USER_OP("CategoricalOrdinalEncode")
       *ctx->Shape4ArgNameAndIndex("out", 0) = *ctx->Shape4ArgNameAndIndex("in", 0);
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* table = GetInputArgModifierFn("table", 0);
       table->set_is_mutable(true);
       table->set_requires_grad(false);

--- a/oneflow/customized/ops/conv_op.cpp
+++ b/oneflow/customized/ops/conv_op.cpp
@@ -288,7 +288,8 @@ REGISTER_USER_OP("conv_data_grad")
     .Attr("dilation_rate", UserOpAttrType::kAtListInt32)
     .Attr("groups", UserOpAttrType::kAtInt32)
     .SetCheckAttrFn(CheckAttr<0>)
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* x_like = GetInputArgModifierFn("x_like", 0);
       CHECK_NOTNULL(x_like);
       x_like->set_use_header_only(true);

--- a/oneflow/customized/ops/dropout_op.cpp
+++ b/oneflow/customized/ops/dropout_op.cpp
@@ -16,7 +16,8 @@ REGISTER_USER_OP("dropout")
       CHECK_EQ_OR_RETURN(*ctx->Dtype4ArgNameAndIndex("mask", 0), DataType::kInt8);
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* mask = GetInputArgModifierFn("mask", 0);
       mask->set_requires_grad(false);
     })
@@ -102,7 +103,8 @@ REGISTER_USER_OP("random_mask_like")
       *ctx->Dtype4ArgNameAndIndex("out", 0) = DataType::kInt8;
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
       CHECK(like_arg_modifier != nullptr);
       like_arg_modifier->set_use_header_only(true);

--- a/oneflow/customized/ops/generate_random_batch_permutation_indices_op.cpp
+++ b/oneflow/customized/ops/generate_random_batch_permutation_indices_op.cpp
@@ -35,7 +35,8 @@ REGISTER_USER_OP("generate_random_batch_permutation_indices")
       }
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       GetInputArgModifierFn("x", 0)->set_use_header_only(true);
     });
 

--- a/oneflow/customized/ops/nd_index_slice_ops.cpp
+++ b/oneflow/customized/ops/nd_index_slice_ops.cpp
@@ -232,7 +232,8 @@ REGISTER_USER_OP("scatter_nd_like")
           .Build();
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
       CHECK(like_arg_modifier != nullptr);
       like_arg_modifier->set_use_header_only(true);

--- a/oneflow/customized/ops/reshape_like_op.cpp
+++ b/oneflow/customized/ops/reshape_like_op.cpp
@@ -15,7 +15,8 @@ REGISTER_USER_OP("reshape_like")
       *ctx->Dtype4ArgNameAndIndex("out", 0) = *ctx->Dtype4ArgNameAndIndex("in", 0);
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
       CHECK(like_arg_modifier != nullptr);
       like_arg_modifier->set_use_header_only(true);

--- a/oneflow/customized/ops/slice_op.cpp
+++ b/oneflow/customized/ops/slice_op.cpp
@@ -109,7 +109,8 @@ REGISTER_USER_OP("slice_grad_v2")
       *ctx->Dtype4ArgNameAndIndex("dx", 0) = *like_data_type;
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
       CHECK(like_arg_modifier != nullptr);
       like_arg_modifier->set_use_header_only(true);

--- a/oneflow/customized/ops/test_ops.cpp
+++ b/oneflow/customized/ops/test_ops.cpp
@@ -118,7 +118,9 @@ REGISTER_USER_OP("TestReshapeLike4KeepHeaderOnly")
       *out_shape = *like_shape;
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper& conf) {
+      CHECK_EQ(conf.input_size("like"), 1);
       user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
       CHECK(like_arg_modifier != nullptr);
       like_arg_modifier->set_use_header_only(true);

--- a/oneflow/customized/ops/unsorted_segment_sum_op.cpp
+++ b/oneflow/customized/ops/unsorted_segment_sum_op.cpp
@@ -128,7 +128,8 @@ REGISTER_USER_OP("unsorted_segment_sum_like")
       *ctx->BatchAxis4ArgNameAndIndex("out", 0) = *ctx->BatchAxis4ArgNameAndIndex("like", 0);
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
       CHECK(like_arg_modifier != nullptr);
       like_arg_modifier->set_use_header_only(true);

--- a/oneflow/customized/ops/where_op.cpp
+++ b/oneflow/customized/ops/where_op.cpp
@@ -46,7 +46,8 @@ REGISTER_USER_OP("where")
     .Output("out")
     .SetTensorDescInferFn(InferWhereTensorDesc)
     .SetBatchAxisInferFn(user_op::BatchAxisInferFnUtil::NaiveInferBatchAxis)
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* cond_arg_modifier = GetInputArgModifierFn("condition", 0);
       cond_arg_modifier->set_requires_grad(false);
     })

--- a/oneflow/customized/ops/zero_like_op.cpp
+++ b/oneflow/customized/ops/zero_like_op.cpp
@@ -10,7 +10,8 @@ REGISTER_USER_OP("zero_like")
       *ctx->Dtype4ArgNameAndIndex("out", 0) = *ctx->Dtype4ArgNameAndIndex("like", 0);
       return Maybe<void>::Ok();
     })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn) {
+    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
+                            const user_op::UserOpConfWrapper&) {
       user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
       CHECK(like_arg_modifier != nullptr);
       like_arg_modifier->set_use_header_only(true);


### PR DESCRIPTION
给UserOp注册的SetInputArgModifyFn添加了UserOpConfWrapper 接口，用于获取op conf中的信息（如 Attr）