### PR TITLE
fix the bug that bn beta/gamma initializer is not used in inference mode

### DIFF
--- a/oneflow/python/ops/layers.py
+++ b/oneflow/python/ops/layers.py
@@ -375,7 +375,7 @@ def batch_normalization(
                 when "trainable" is False')
 
     if os.getenv("ENABLE_USER_OP") == 'True':
-        if center or trainable:
+        if center:
             beta = flow.get_variable(
                 name=name + "-beta",
                 shape=params_shape,
@@ -388,7 +388,7 @@ def batch_normalization(
         else:
             beta = flow.constant(0, dtype=inputs.dtype, shape=params_shape)
 
-        if scale or trainable:
+        if scale:
             gamma = flow.get_variable(
                 name=name + "-gamma",
                 shape=params_shape,


### PR DESCRIPTION
@guo-ran 发现 bn user op 在读取预训练模型的情况下和非 user op 结果不一致。原因是 python 端的判断条件不对导致 initializer 只在 trainable 是 True 的时候才使用，这里修复了这个问题。后续会找时间给 bn 添加对应的单测