### PR TITLE
rename ForeignWorkerWatcher to ForeignWorkerCallback

### DIFF
--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -358,7 +358,7 @@ void WatchBlob(vm::Instruction* instruction) {
   auto* blob_object = instruction->mut_operand_type(args->blob())->Mut<BlobObject>();
   OfBlob of_blob(device_ctx, blob_object->mut_blob());
   int64_t of_blob_ptr = reinterpret_cast<int64_t>(&of_blob);
-  Global<ForeignWorkerWatcher>::Get()->Call(args->unique_callback_id(), of_blob_ptr);
+  Global<ForeignWorkerCallback>::Get()->Call(args->unique_callback_id(), of_blob_ptr);
 }
 
 void WatchBlobHeaderInstructionType::Infer(vm::Instruction* instruction) const {

--- a/oneflow/core/job/foreign_watcher.h
+++ b/oneflow/core/job/foreign_watcher.h
@@ -13,10 +13,10 @@ class ForeignWatcher {
   virtual void Call(const std::string& handler_uuid, int64_t ofblob_ptr) const { UNIMPLEMENTED(); }
 };
 
-class ForeignWorkerWatcher {
+class ForeignWorkerCallback {
  public:
-  ForeignWorkerWatcher() = default;
-  virtual ~ForeignWorkerWatcher() = default;
+  ForeignWorkerCallback() = default;
+  virtual ~ForeignWorkerCallback() = default;
 
   virtual void Call(int64_t unique_id, int64_t ofblob_ptr) const { UNIMPLEMENTED(); }
 };

--- a/oneflow/python/eager/eager_physical_blob.py
+++ b/oneflow/python/eager/eager_physical_blob.py
@@ -4,7 +4,7 @@ import oneflow.python.framework.blob_trait as blob_trait
 import oneflow.python.eager.object_dict as object_dict
 import oneflow.python.eager.blob_cache as blob_cache_util
 import oneflow.python.eager.vm_util as vm_util
-import oneflow.python.eager.physical_blob_watcher as physical_blob_watcher
+import oneflow.python.eager.physical_blob_callback as physical_blob_callback
 import oneflow.python.lib.core.async_util as async_util
 
 class EagerPhysicalBlob(blob_trait.BlobOperatorTrait, blob_trait.BlobHeaderTrait):
@@ -58,14 +58,14 @@ def _FetchBlobHeader(blob_object):
     def AsyncFetchBlobHeader(Yield):
         fetcher = _MakeFetherEagerPhysicalBlobHeaderFromOfBlob(Yield)
         vm_util.PhysicalRun(lambda builder: builder.WatchBlobHeader(blob_object, fetcher))
-        physical_blob_watcher.DeleteRegisteredCallback(fetcher)
+        physical_blob_callback.DeleteRegisteredCallback(fetcher)
     return async_util.Await(1, AsyncFetchBlobHeader)[0]
 
 def _FetchBlobBody(blob_object):
     def AsyncFetchBlobBody(Yield):
         fetcher = MakeFetherEagerPhysicalBlobBodyFromOfBlob(Yield)
         vm_util.PhysicalRun(lambda builder: builder.WatchBlobBody(blob_object, fetcher))
-        physical_blob_watcher.DeleteRegisteredCallback(fetcher)
+        physical_blob_callback.DeleteRegisteredCallback(fetcher)
     return async_util.Await(1, AsyncFetchBlobBody)[0]
 
 def _MakeFetherEagerPhysicalBlobHeaderFromOfBlob(Yield):

--- a/oneflow/python/eager/physical_blob_callback.py
+++ b/oneflow/python/eager/physical_blob_callback.py
@@ -20,9 +20,9 @@ def DeleteRegisteredCallback(cb):
     assert id(cb) in unique_id2handler
     del unique_id2handler[id(cb)]
 
-class _WorkerWatcher(oneflow_internal.ForeignWorkerWatcher):
+class _WorkerCallback(oneflow_internal.ForeignWorkerCallback):
     def __init__(self):
-        oneflow_internal.ForeignWorkerWatcher.__init__(self)
+        oneflow_internal.ForeignWorkerCallback.__init__(self)
 
     def Call(self, unique_id, of_blob_ptr):
         try:
@@ -40,5 +40,5 @@ def _WatcherHandler(unique_id, of_blob_ptr):
 
 unique_id2handler = {}
 # static lifetime 
-_worker_watcher = _WorkerWatcher()
-c_api_util.RegisterWorkerWatcherOnlyOnce(_worker_watcher)
+_worker_callback = _WorkerCallback()
+c_api_util.RegisterWorkerCallbackOnlyOnce(_worker_callback)

--- a/oneflow/python/eager/vm_util.py
+++ b/oneflow/python/eager/vm_util.py
@@ -10,7 +10,7 @@ import oneflow.python.eager.symbol as symbol_util
 import oneflow.python.eager.symbol_dict as symbol_dict
 import oneflow.python.eager.object as object_util
 import oneflow.python.eager.object_dict as object_dict
-import oneflow.python.eager.physical_blob_watcher as physical_blob_watcher
+import oneflow.python.eager.physical_blob_callback as physical_blob_callback
 import oneflow
 
 def PhysicalRun(build):
@@ -244,7 +244,7 @@ class InstructionsBuilder(object):
         self.eager_symbol_list_.eager_symbol.append(eager_symbol)
 
     def _WatchBlob(self, instruction_name, blob_object, fetcher):
-        unique_callback_id = physical_blob_watcher.GetIdForRegisteredCallback(fetcher)
+        unique_callback_id = physical_blob_callback.GetIdForRegisteredCallback(fetcher)
         instruction = instr_util.InstructionProto()
         device_tag = blob_object.parallel_desc_symbol.device_tag
         instruction.instr_type_name = "%s.%s"%(device_tag, instruction_name)

--- a/oneflow/python/framework/c_api_util.py
+++ b/oneflow/python/framework/c_api_util.py
@@ -20,8 +20,8 @@ def RegisterWatcherOnlyOnce(watcher):
     error = text_format.Parse(error_str, error_util.ErrorProto())
     if error.HasField("error_type"): raise JobBuildAndInferError(error)
 
-def RegisterWorkerWatcherOnlyOnce(watcher):
-    error_str = oneflow_internal.RegisterWorkerWatcherOnlyOnce(watcher)
+def RegisterWorkerCallbackOnlyOnce(callback):
+    error_str = oneflow_internal.RegisterWorkerCallbackOnlyOnce(callback)
     error = text_format.Parse(error_str, error_util.ErrorProto())
     if error.HasField("error_type"): raise JobBuildAndInferError(error)
 

--- a/oneflow/python/oneflow_internal.h
+++ b/oneflow/python/oneflow_internal.h
@@ -3,8 +3,10 @@
 #include "oneflow/core/job/resource_desc.h"
 #include "oneflow/core/job/resource_desc.h"
 
-void RegisterWorkerWatcherOnlyOnce(oneflow::ForeignWorkerWatcher* watcher, std::string* error_str) {
-  return oneflow::RegisterWorkerWatcherOnlyOnce(watcher).GetDataAndSerializedErrorProto(error_str);
+void RegisterWorkerCallbackOnlyOnce(oneflow::ForeignWorkerCallback* callback,
+                                    std::string* error_str) {
+  return oneflow::RegisterWorkerCallbackOnlyOnce(callback).GetDataAndSerializedErrorProto(
+      error_str);
 }
 
 void RegisterWatcherOnlyOnce(oneflow::ForeignWatcher* watcher, std::string* error_str) {

--- a/oneflow/python/oneflow_internal.i
+++ b/oneflow/python/oneflow_internal.i
@@ -18,7 +18,7 @@
 %shared_ptr(oneflow::ForeignJobInstance);
 %feature("director") oneflow::ForeignJobInstance;
 %feature("director") oneflow::ForeignWatcher;
-%feature("director") oneflow::ForeignWorkerWatcher;
+%feature("director") oneflow::ForeignWorkerCallback;
 %feature("director:except") {
   if ($error != NULL) { LOG(FATAL) << "Swig::DirectorMethodException"; }
 }

--- a/oneflow/python/oneflow_internal_helper.h
+++ b/oneflow/python/oneflow_internal_helper.h
@@ -28,10 +28,11 @@
 
 namespace oneflow {
 
-Maybe<void> RegisterWorkerWatcherOnlyOnce(ForeignWorkerWatcher* watcher) {
-  CHECK_ISNULL_OR_RETURN(Global<ForeignWorkerWatcher>::Get()) << "foreign woker watcher registered";
+Maybe<void> RegisterWorkerCallbackOnlyOnce(ForeignWorkerCallback* callback) {
+  CHECK_ISNULL_OR_RETURN(Global<ForeignWorkerCallback>::Get())
+      << "foreign woker callback registered";
   // no delete
-  Global<ForeignWorkerWatcher>::SetAllocated(watcher);
+  Global<ForeignWorkerCallback>::SetAllocated(callback);
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
将physical_blob_watcher.py更改为physical_blob_callback.py
  1.1、_WorkerWatcher 变更为：_WorkerCallback
  1.2、_worker_watcher变更为：_worker_callback
  1.3、RegisterWorkerWatcherOnlyOnce变更为：RegisterWorkerCallbackOnlyOnce
  1.4、ForeignWorkerWatcher变更为：ForeignWorkerCallback
    1.4.1、foreign_watcher.h里的ForeignWorkerWatcher变更为：ForeignWorkerCallback
    1.4.2、opkernel_instruction_type.cpp里的ForeignWorkerWatcher变更为：ForeignWorkerCallback
    1.4.3、oneflow_internal.i里的ForeignWorkerWatcher变更为：ForeignWorkerCallback
    1.4.4、oneflow_internal.h里的ForeignWorkerWatcher变更为：ForeignWorkerCallback
    1.4.5、oneflow_internal_helper.h里的ForeignWorkerWatcher变更为：ForeignWorkerCallback/
  1.5、eager_physical_blob.py/vm_util.py里的physical_blob_watcher更改为：physical_blob_callback