### PR TITLE
fix curand_init

### DIFF
--- a/oneflow/customized/kernels/random_mask_generator.cu
+++ b/oneflow/customized/kernels/random_mask_generator.cu
@@ -37,7 +37,9 @@ __device__ int8_t GenMask(curandState* state, const float rate) {
 
 __global__ void SetupKernel(int64_t seed, curandState* state) {
   const int id = blockIdx.x * blockDim.x + threadIdx.x;
-  curand_init(seed, id, 0, &state[id]);
+  size_t local_seed = (static_cast<size_t>(seed) + 0x9e3779b9U + (static_cast<size_t>(id) << 6U)
+                       + (static_cast<size_t>(id) >> 2U));
+  curand_init(local_seed, 0, 0, &state[id]);
 }
 
 __global__ void GenerateGpu(curandState* state, const int64_t n, const float rate, int8_t* mask) {


### PR DESCRIPTION
参考：https://docs.nvidia.com/cuda/curand/device-api-overview.html#performance-notes
> State setup can be an expensive operation. One way to speed up the setup is to use different seeds for each thread and a constant sequence number of 0. This can be especially helpful if many generators need to be created. While faster to set up, this method provides less guarantees about the mathematical properties of the generated sequences. If there happens to be a bad interaction between the hash function that initializes the generator state from the seed and the periodicity of the generators, there might be threads with highly correlated outputs for some seed values. We do not know of any problem values; if they do exist they are likely to be rare.

实际测试遇到的问题是curand_init使用sequence消耗过多内存