### PR TITLE
[draft] Refactor reduce axes semantic

### DIFF
--- a/oneflow/core/common/shape.proto
+++ b/oneflow/core/common/shape.proto
@@ -13,3 +13,7 @@ message ShapeSignature {
 message ShapeSignatureList {
   repeated ShapeSignature shape_signature = 1;
 }
+
+message AxesProto {
+  repeated int64 axes = 1;
+}

--- a/oneflow/core/framework/attr_value_accessor.cpp
+++ b/oneflow/core/framework/attr_value_accessor.cpp
@@ -37,6 +37,19 @@ void AttrValAccessor<Shape>::Attr(const Shape& cpp_val, UserOpAttrVal* attr_val)
   cpp_val.ToProto(attr_val->mutable_at_shape());
 }
 
+template<>
+AxisVector AttrValAccessor<AxisVector>::Attr(const UserOpAttrVal& val) {
+  return AxisVector(val.at_axes().axes().begin(), val.at_axes().axes().end());
+}
+template<>
+void AttrValAccessor<AxisVector>::Attr(const AxisVector& cpp_val, UserOpAttrVal* attr_val) {
+  AxesProto* mut_at_axes = attr_val->mutable_at_axes();
+  mut_at_axes->clear_axes();
+  for (int64_t axis : cpp_val) {
+    mut_at_axes->add_axes(axis);
+  }
+}
+
 // List of Basic Attr
 #define LIST_BASIC_ATTR_SEQ_ENTRY(field, cpp_type, attr_type)                                   \
   template<>                                                                                    \

--- a/oneflow/core/framework/user_op_attr.h
+++ b/oneflow/core/framework/user_op_attr.h
@@ -21,7 +21,9 @@ namespace user_op {
 
 #define ENUM_ATTR_SEQ OF_PP_MAKE_TUPLE_SEQ(at_data_type, DataType, UserOpAttrType::kAtDataType)
 
-#define MESSAGE_ATTR_SEQ OF_PP_MAKE_TUPLE_SEQ(at_shape, Shape, UserOpAttrType::kAtShape)
+#define MESSAGE_ATTR_SEQ                                          \
+  OF_PP_MAKE_TUPLE_SEQ(at_shape, Shape, UserOpAttrType::kAtShape) \
+  OF_PP_MAKE_TUPLE_SEQ(at_shape, AxisVector, UserOpAttrType::kAtAxes)
 
 #define LIST_BASIC_ATTR_SEQ                                                               \
   OF_PP_MAKE_TUPLE_SEQ(at_list_int32, std::vector<int32_t>, UserOpAttrType::kAtListInt32) \

--- a/oneflow/core/framework/user_op_attr.proto
+++ b/oneflow/core/framework/user_op_attr.proto
@@ -18,6 +18,7 @@ enum UserOpAttrType {
   kAtListFloat = 11;
   kAtListDataType = 12;
   kAtListShape = 13;
+  kAtAxes = 14;
 }
 
 message UserOpAttrVal {
@@ -50,5 +51,6 @@ message UserOpAttrVal {
     ListFloat at_list_float = 11;
     ListDataType at_list_data_type = 12;
     ListShape at_list_shape = 13;
+    AxesProto at_axes = 14;
   }
 }

--- a/oneflow/core/operator/broadcast_like_op.cpp
+++ b/oneflow/core/operator/broadcast_like_op.cpp
@@ -25,8 +25,8 @@ Maybe<void> BroadcastLikeOp::GetSbpSignatures(
     const std::function<Maybe<const BlobDesc*>(const std::string&)>& LogicalBlobDesc4Ibn,
     SbpSignatureList* sbp_sig_list) const {
   int32_t num_axes = JUST(LogicalBlobDesc4Ibn("like"))->shape().NumAxes();
-  auto IsReducedAxis = ReduceSbpUtil::MakePredicatorIsReducedAxis(
-      op_conf().broadcast_like_conf().reduced_axis(), num_axes);
+  auto IsReducedAxis =
+      ReduceSbpUtil::MakePredicatorIsReducedAxis(op_conf().broadcast_like_conf().reduced_axis());
   FOR_RANGE(int64_t, i, 0, num_axes) {
     if (IsReducedAxis(i)) {
       SbpSignatureBuilder()

--- a/oneflow/core/operator/broadcast_to_compatible_with_op.cpp
+++ b/oneflow/core/operator/broadcast_to_compatible_with_op.cpp
@@ -80,19 +80,24 @@ class BroadcastToCompatibleWithOp final : public Operator {
   Maybe<void> GetSbpSignatures(
       const std::function<Maybe<const BlobDesc*>(const std::string&)>& LogicalBlobDesc4Ibn,
       SbpSignatureList* sbp_sig_list) const override {
-    const Shape& y_shape = JUST(LogicalBlobDesc4Ibn("y"))->shape();
-    int64_t broadcast_num_axes = y_shape.NumAxes();
+    Shape broadcasted_shape {1};
+    for (const std::string ibn : input_bns()) {
+      const Shape& input_shape = JUST(LogicalBlobDesc4Ibn(ibn))->shape();
+      GetBroadcastShape(broadcasted_shape, input_shape, &broadcasted_shape);
+    }
+
+    const int64_t broadcast_num_axes = broadcasted_shape.NumAxes();
     HashMap<std::string, Shape> ibn2extend_shape;
-    for (const std::string bn : input_bns()) {
-      const Shape& input_shape = JUST(LogicalBlobDesc4Ibn(bn))->shape();
+    for (const std::string ibn : input_bns()) {
+      const Shape& input_shape = JUST(LogicalBlobDesc4Ibn(ibn))->shape();
       CHECK_OR_RETURN(
           ibn2extend_shape
-              .emplace(bn, CreateLeftExtendedShape(ShapeView(input_shape), broadcast_num_axes))
+              .emplace(ibn, CreateLeftExtendedShape(ShapeView(input_shape), broadcast_num_axes))
               .second);
     }
 
     FOR_RANGE(int64_t, i, 0, broadcast_num_axes) {
-      if (y_shape.At(i) == 1) { continue; }
+      if (broadcasted_shape.At(i) == 1) { continue; }
       SbpSignature sbp_sig;
       for (const auto& pair : ibn2extend_shape) {
         if (pair.second.At(i) == 1) {

--- a/oneflow/core/operator/reduce_mean_op.cpp
+++ b/oneflow/core/operator/reduce_mean_op.cpp
@@ -56,7 +56,7 @@ Maybe<void> ReduceMeanOp::GetSbpSignatures(
     SbpSignatureList* sbp_sig_list) const {
   int32_t num_axes = JUST(LogicalBlobDesc4Ibn("in"))->shape().NumAxes();
   auto IsReducedAxis =
-      ReduceSbpUtil::MakePredicatorIsReducedAxis(op_conf().reduce_mean_conf().axis(), num_axes);
+      ReduceSbpUtil::MakePredicatorIsReducedAxis(op_conf().reduce_mean_conf().axis());
   FOR_RANGE(int64_t, i, 0, num_axes) {
     if (IsReducedAxis(i)) {
       SbpSignatureBuilder()

--- a/oneflow/core/operator/reduce_sbp_util.cpp
+++ b/oneflow/core/operator/reduce_sbp_util.cpp
@@ -9,20 +9,24 @@ bool ReduceSbpUtil::IsReduceAxisSplitted(const SbpInferHint& ibn_hint,
   return reduced_axes.find(ibn_hint.sbp_parallel().split_parallel().axis()) != reduced_axes.end();
 }
 
-std::function<bool(int32_t)> ReduceSbpUtil::MakePredicatorIsReducedAxis(const PbRf<int32_t>& axes,
-                                                                        int32_t num_axes) {
-  HashSet<int32_t> axes_set = {axes.begin(), axes.end()};
-  return MakePredicatorIsReducedAxis(axes_set, num_axes);
+std::function<bool(int64_t)> ReduceSbpUtil::MakePredicatorIsReducedAxis(const PbRf<int32_t>& axes) {
+  HashSet<int64_t> axes_set = {axes.begin(), axes.end()};
+  return MakePredicatorIsReducedAxis(axes_set);
 }
 
-std::function<bool(int32_t)> ReduceSbpUtil::MakePredicatorIsReducedAxis(
-    const HashSet<int32_t>& axes, int32_t num_axes) {
-  auto axis_set = std::make_shared<HashSet<int32_t>>(axes);
-  if (axis_set->empty()) {
-    return [](int32_t axis) { return true; };
-  } else {
-    return [axis_set](int32_t axis) -> bool { return axis_set->find(axis) != axis_set->end(); };
-  }
+std::function<bool(int64_t)> ReduceSbpUtil::MakePredicatorIsReducedAxis(const AxisVector& axes) {
+  auto axes_vec_ptr = std::make_shared<AxisVector>(axes);
+  return [axes_vec_ptr](int64_t axis) -> bool {
+    return std::find(axes_vec_ptr->begin(), axes_vec_ptr->end(), axis) != axes_vec_ptr->end();
+  };
+}
+
+std::function<bool(int64_t)> ReduceSbpUtil::MakePredicatorIsReducedAxis(
+    const HashSet<int64_t>& axes) {
+  auto axes_set_ptr = std::make_shared<HashSet<int64_t>>(axes);
+  return [axes_set_ptr](int64_t axis) -> bool {
+    return axes_set_ptr->find(axis) != axes_set_ptr->end();
+  };
 }
 
 }  // namespace oneflow

--- a/oneflow/core/operator/reduce_sbp_util.h
+++ b/oneflow/core/operator/reduce_sbp_util.h
@@ -10,10 +10,9 @@ namespace oneflow {
 struct ReduceSbpUtil final {
   static bool IsReduceAxisSplitted(const SbpInferHint& ibn_hint,
                                    const HashSet<int64_t>& reduced_axes);
-  static std::function<bool(int32_t)> MakePredicatorIsReducedAxis(const HashSet<int32_t>& axes,
-                                                                  int32_t num_axes);
-  static std::function<bool(int32_t)> MakePredicatorIsReducedAxis(const PbRf<int32_t>& axes,
-                                                                  int32_t num_axes);
+  static std::function<bool(int64_t)> MakePredicatorIsReducedAxis(const PbRf<int32_t>& axes);
+  static std::function<bool(int64_t)> MakePredicatorIsReducedAxis(const AxisVector& axes);
+  static std::function<bool(int64_t)> MakePredicatorIsReducedAxis(const HashSet<int64_t>& axes);
 };
 
 }  // namespace oneflow

--- a/oneflow/core/operator/reduce_sum_like_op.cpp
+++ b/oneflow/core/operator/reduce_sum_like_op.cpp
@@ -42,7 +42,7 @@ Maybe<void> ReduceSumLikeOp::GetSbpSignatures(
     SbpSignatureList* sbp_sig_list) const {
   int32_t num_axes = JUST(LogicalBlobDesc4Ibn("x"))->shape().NumAxes();
   auto IsReducedAxis =
-      ReduceSbpUtil::MakePredicatorIsReducedAxis(op_conf().reduce_sum_like_conf().axis(), num_axes);
+      ReduceSbpUtil::MakePredicatorIsReducedAxis(op_conf().reduce_sum_like_conf().axis());
   FOR_RANGE(int64_t, i, 0, num_axes) {
     if (IsReducedAxis(i)) {
       SbpSignatureBuilder()

--- a/oneflow/core/operator/reduce_sum_op.cpp
+++ b/oneflow/core/operator/reduce_sum_op.cpp
@@ -59,9 +59,9 @@ Maybe<void> ReduceSumOp::InferBatchAxis(
 Maybe<void> ReduceSumOp::GetSbpSignatures(
     const std::function<Maybe<const BlobDesc*>(const std::string&)>& LogicalBlobDesc4Ibn,
     SbpSignatureList* sbp_sig_list) const {
-  int32_t num_axes = JUST(LogicalBlobDesc4Ibn("in"))->shape().NumAxes();
+  int64_t num_axes = JUST(LogicalBlobDesc4Ibn("in"))->shape().NumAxes();
   auto IsReducedAxis =
-      ReduceSbpUtil::MakePredicatorIsReducedAxis(op_conf().reduce_sum_conf().axis(), num_axes);
+      ReduceSbpUtil::MakePredicatorIsReducedAxis(op_conf().reduce_sum_conf().axis());
   int32_t num_reduced_axes = 0;
   FOR_RANGE(int64_t, i, 0, num_axes) {
     if (IsReducedAxis(i)) {

--- a/oneflow/customized/kernels/reduce_like_kernels.cpp
+++ b/oneflow/customized/kernels/reduce_like_kernels.cpp
@@ -5,13 +5,18 @@ namespace oneflow {
 
 namespace {
 
+template<DeviceType device_type, typename T>
+bool IsKernelMatched(const user_op::KernelRegContext& ctx) {
+  const user_op::TensorDesc* y_desc = ctx.TensorDesc4ArgNameAndIndex("y", 0);
+  return ctx.device_type() == device_type && y_desc->data_type() == GetDataType<T>::value;
+}
+
 size_t ReduceSumLikeInferTmpSize(user_op::InferContext* ctx) {
-  if (ctx->Attr<std::vector<int32_t>>("axis").empty()) { return 0; }
+  const auto& reduce_axes_vec = ctx->Attr<AxisVector>("reduce_axes");
+  if (reduce_axes_vec.empty()) { return 0; }
   const user_op::TensorDesc* tensor_desc_x = ctx->TensorDesc4ArgNameAndIndex("x", 0);
   return tensor_desc_x->shape().elem_cnt() * GetSizeOfDataType(tensor_desc_x->data_type());
 }
-
-}  // namespace
 
 template<DeviceType device_type, typename T>
 class ReduceSumLikeOpKernel final : public user_op::OpKernel {
@@ -23,34 +28,31 @@ class ReduceSumLikeOpKernel final : public user_op::OpKernel {
   void Compute(user_op::KernelComputeContext* ctx) const override {
     user_op::Tensor* tensor_x = ctx->Tensor4ArgNameAndIndex("x", 0);
     user_op::Tensor* tensor_y = ctx->Tensor4ArgNameAndIndex("y", 0);
-    const auto& axis = ctx->Attr<std::vector<int32_t>>("axis");
-    if (axis.empty()) {
-      CHECK_EQ(tensor_x->shape(), tensor_x->shape());
+    const auto& reduce_axes_vec = ctx->Attr<AxisVector>("reduce_axes");
+    if (reduce_axes_vec.empty()) {
+      CHECK_EQ(tensor_x->shape(), tensor_y->shape());
       Memcpy<device_type>(ctx->device_ctx(), tensor_y->mut_dptr(), tensor_x->dptr(),
                           tensor_x->shape().elem_cnt() * GetSizeOfDataType(tensor_x->data_type()));
     } else {
       user_op::Tensor* tensor_tmp = ctx->Tensor4ArgNameAndIndex("tmp_buffer", 0);
-      T* temp_storage = static_cast<T*>(tensor_tmp->mut_dptr());
+      T* temp_storage = tensor_tmp->mut_dptr<T>();
+      int64_t num_axes = tensor_x->shape().NumAxes();
+      Shape y_extend_shape = CreateLeftExtendedShape(tensor_y->shape(), num_axes);
       NdarrayUtil<device_type, T>::ReduceSum(
-          ctx->device_ctx(),
-          XpuVarNdarray<T>(CreateReducedShape(tensor_x->shape(), {axis.begin(), axis.end()}),
-                           tensor_y->mut_dptr<T>()),
-          XpuVarNdarray<const T>(tensor_x->shape(), tensor_x->mut_dptr<T>(),
-                                 tensor_x->shape().NumAxes()),
-          XpuVarNdarray<T>(tensor_x->shape(), temp_storage, tensor_x->shape().NumAxes()));
+          ctx->device_ctx(), XpuVarNdarray<T>(y_extend_shape, tensor_y->mut_dptr<T>()),
+          XpuVarNdarray<const T>(tensor_x->shape(), tensor_x->dptr<T>()),
+          XpuVarNdarray<T>(tensor_x->shape(), temp_storage));
     }
   }
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-#define REGISTER_REDUCE_SUM_LIKE_KERNEL(device, data_type_pair)                            \
-  REGISTER_USER_KERNEL("reduce_sum_like")                                                  \
-      .SetCreateFn<ReduceSumLikeOpKernel<device, OF_PP_PAIR_FIRST(data_type_pair)>>()      \
-      .SetIsMatchedPred([](const user_op::KernelRegContext& ctx) {                         \
-        const user_op::TensorDesc* y_tensor_desc = ctx.TensorDesc4ArgNameAndIndex("y", 0); \
-        return ctx.device_type() == device                                                 \
-               && y_tensor_desc->data_type() == OF_PP_PAIR_SECOND(data_type_pair);         \
-      })                                                                                   \
+}  // namespace
+
+#define REGISTER_REDUCE_SUM_LIKE_KERNEL(device, dtype_pair)                       \
+  REGISTER_USER_KERNEL("reduce_sum_like")                                         \
+      .SetCreateFn<ReduceSumLikeOpKernel<device, OF_PP_PAIR_FIRST(dtype_pair)>>() \
+      .SetIsMatchedPred(IsKernelMatched<device, OF_PP_PAIR_FIRST(dtype_pair)>)    \
       .SetInferTmpSizeFn(ReduceSumLikeInferTmpSize);
 
 OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_REDUCE_SUM_LIKE_KERNEL, DEVICE_TYPE_SEQ,

--- a/oneflow/customized/ops/bias_add_op.cpp
+++ b/oneflow/customized/ops/bias_add_op.cpp
@@ -43,20 +43,19 @@ REGISTER_USER_OP_GRAD("bias_add")
         op.BindGradTensorWithOpInput(op.GetGradTensorWithOpOutput("out", 0), "a", 0);
       }
       if (op.NeedGenGradTensor4OpInput("b", 0)) {
-        user_op::UserOpConfWrapperBuilder builder(op.op_name() + "_grad");
-        auto grad_op_builder = builder.Op("reduce_sum")
-                                   .Input("input_tensor", op.GetGradTensorWithOpOutput("out", 0))
-                                   .Output("output_tensor");
-
         const int32_t bias_add_axis = op.attr<int32_t>("axis");
-        const int32_t num_axes = op.TensorDesc4ArgNameAndIndex("a", 0).shape().NumAxes();
-        std::vector<int32_t> reduce_sum_axes;
-        FOR_RANGE(int32_t, i, 0, num_axes) {
-          if (i != bias_add_axis) { reduce_sum_axes.push_back(i); }
+        const int64_t num_axes = op.TensorDesc4ArgNameAndIndex("a", 0).shape().NumAxes();
+        AxisVector reduce_axes_vec;
+        FOR_RANGE(int64_t, i, 0, num_axes) {
+          if (i != bias_add_axis) { reduce_axes_vec.push_back(i); }
         }
-        grad_op_builder.Attr("axis", reduce_sum_axes);
-        grad_op_builder.Attr("keepdims", false);
-        const auto grad_op = grad_op_builder.Build();
+        user_op::UserOpConfWrapperBuilder builder(op.op_name() + "_grad");
+        auto grad_op = builder.Op("reduce_sum")
+                           .Input("input_tensor", op.GetGradTensorWithOpOutput("out", 0))
+                           .Output("output_tensor")
+                           .Attr("reduce_axes", reduce_axes_vec)
+                           .Attr("keep_dims", false)
+                           .Build();
         AddOp(grad_op);
         op.BindGradTensorWithOpInput(grad_op.output("output_tensor", 0), "b", 0);
       }

--- a/oneflow/customized/ops/reduce_like_ops.cpp
+++ b/oneflow/customized/ops/reduce_like_ops.cpp
@@ -3,54 +3,76 @@
 
 namespace oneflow {
 
+namespace {
+
+bool IsReduceAxesLegal(const AxisVector& reduce_axes_vec, const Shape& reduce_shape,
+                       const Shape& broadcast_shape) {
+  if (reduce_axes_vec.empty()) { return reduce_shape == broadcast_shape; }
+  Shape reduced_shape = CreateReducedShape(ShapeView(broadcast_shape), reduce_axes_vec);
+  if (broadcast_shape.NumAxes() > reduce_shape.NumAxes()) {
+    reduced_shape = reduced_shape.RemoveOnes(reduce_axes_vec);
+  }
+  return reduced_shape == reduce_shape;
+}
+
+Maybe<void> InferTensorDesc(user_op::InferContext* ctx) {
+  const Shape* x_shape = ctx->Shape4ArgNameAndIndex("x", 0);
+  const Shape* like_shape = ctx->Shape4ArgNameAndIndex("like", 0);
+  const auto& reduce_axes_vec = ctx->Attr<AxisVector>("reduce_axes");
+  CHECK_OR_RETURN(IsReduceAxesLegal(reduce_axes_vec, *like_shape, *x_shape));
+  *ctx->Shape4ArgNameAndIndex("y", 0) = *like_shape;
+  *ctx->Dtype4ArgNameAndIndex("y", 0) = *ctx->Dtype4ArgNameAndIndex("x", 0);
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> InferBatchAxis(user_op::BatchAxisContext* ctx) {
+  *ctx->BatchAxis4ArgNameAndIndex("y", 0) = *ctx->BatchAxis4ArgNameAndIndex("like", 0);
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> GetSbpSignature(user_op::SbpContext* ctx) {
+  const auto& x_desc = ctx->LogicalTensorDesc4InputArgNameAndIndex("x", 0);
+  const int64_t num_axes = x_desc.shape().NumAxes();
+  const auto& reduce_axes_vec = ctx->Attr<AxisVector>("reduce_axes");
+  auto IsReducedAxis = ReduceSbpUtil::MakePredicatorIsReducedAxis(reduce_axes_vec);
+  int64_t num_reduced_axes = 0;
+  FOR_RANGE(int64_t, i, 0, num_axes) {
+    if (IsReducedAxis(i)) {
+      ctx->NewBuilder()
+          .Split(user_op::OpArg("x", 0), i)
+          .Broadcast(user_op::OpArg("like", 0))
+          .PartialSum(user_op::OpArg("y", 0))
+          .Build();
+      num_reduced_axes += 1;
+    } else {
+      ctx->NewBuilder()
+          .Split(user_op::OpArg("x", 0), i)
+          .Split(user_op::OpArg("like", 0), i - num_reduced_axes)
+          .Split(user_op::OpArg("y", 0), i - num_reduced_axes)
+          .Build();
+    }
+  }
+  return Maybe<void>::Ok();
+}
+
+void SetInputArgModifier(user_op::GetInputArgModifier GetInputArgModifierFn,
+                         const user_op::UserOpConfWrapper& op_conf) {
+  user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
+  CHECK(like_arg_modifier != nullptr);
+  like_arg_modifier->set_use_header_only(true);
+  like_arg_modifier->set_requires_grad(false);
+}
+
+}  // namespace
+
 REGISTER_USER_OP("reduce_sum_like")
     .Input("x")
     .Input("like")
     .Output("y")
-    .Attr("axis", UserOpAttrType::kAtListInt32)
-    .SetTensorDescInferFn([](user_op::InferContext* ctx) -> Maybe<void> {
-      const user_op::TensorDesc* x_tensor = ctx->TensorDesc4ArgNameAndIndex("x", 0);
-      const user_op::TensorDesc* like_tensor = ctx->TensorDesc4ArgNameAndIndex("like", 0);
-      const auto& axis = ctx->Attr<std::vector<int32_t>>("axis");
-      if (axis.empty()) { CHECK_EQ_OR_RETURN(x_tensor->shape(), like_tensor->shape()); }
-      CHECK_EQ_OR_RETURN(x_tensor->data_type(), like_tensor->data_type());
-      user_op::TensorDesc* y_tensor = ctx->TensorDesc4ArgNameAndIndex("y", 0);
-      *y_tensor = *like_tensor;
-      return Maybe<void>::Ok();
-    })
-    .SetBatchAxisInferFn([](user_op::BatchAxisContext* ctx) -> Maybe<void> {
-      *ctx->BatchAxis4ArgNameAndIndex("y", 0) = *ctx->BatchAxis4ArgNameAndIndex("like", 0);
-      return Maybe<void>::Ok();
-    })
-    .SetGetSbpFn([](user_op::SbpContext* ctx) -> Maybe<void> {
-      int32_t num_axes = 0;
-      HashSet<int32_t> conf_axes;
-      {
-        const auto& in_tensor = ctx->LogicalTensorDesc4InputArgNameAndIndex("x", 0);
-        num_axes = in_tensor.shape().NumAxes();
-        const auto& reduced_axes = ctx->Attr<std::vector<int32_t>>("axis");
-        conf_axes = {reduced_axes.begin(), reduced_axes.end()};
-      }
-      auto IsReducedAxis = ReduceSbpUtil::MakePredicatorIsReducedAxis(conf_axes, num_axes);
-      FOR_RANGE(int64_t, i, 0, num_axes) {
-        if (IsReducedAxis(i)) {
-          ctx->NewBuilder()
-              .Split(user_op::OpArg("x", 0), i)
-              .Broadcast(user_op::OpArg("like", 0))
-              .PartialSum(user_op::OpArg("y", 0))
-              .Build();
-        } else {
-          ctx->NewBuilder().Split(ctx->inputs(), i).Split(ctx->outputs(), i).Build();
-        }
-      }
-      return Maybe<void>::Ok();
-    })
-    .SetInputArgModifyFn([](user_op::GetInputArgModifier GetInputArgModifierFn,
-                            const user_op::UserOpConfWrapper&) {
-      user_op::InputArgModifier* like_arg_modifier = GetInputArgModifierFn("like", 0);
-      CHECK(like_arg_modifier != nullptr);
-      like_arg_modifier->set_use_header_only(true);
-      like_arg_modifier->set_requires_grad(false);
-    });
+    .Attr("reduce_axes", UserOpAttrType::kAtListInt64)
+    .SetTensorDescInferFn(InferTensorDesc)
+    .SetBatchAxisInferFn(InferBatchAxis)
+    .SetGetSbpFn(GetSbpSignature)
+    .SetInputArgModifyFn(SetInputArgModifier);
 
 }  // namespace oneflow

--- a/oneflow/customized/ops/scalar_by_tensor_op.cpp
+++ b/oneflow/customized/ops/scalar_by_tensor_op.cpp
@@ -63,13 +63,15 @@ REGISTER_USER_OP_GRAD("scalar_add_by_tensor")
         op.BindGradTensorWithOpInput(op.GetGradTensorWithOpOutput("y", 0), "x", 0);
       }
       if (op.NeedGenGradTensor4OpInput("scalar", 0)) {
+        AxisVector reduce_axes_vec(op.TensorDesc4ArgNameAndIndex("y", 0).shape().NumAxes());
+        std::iota(reduce_axes_vec.begin(), reduce_axes_vec.end(), 0);
         user_op::UserOpConfWrapperBuilder builder(op.op_name() + "scalar_grad");
         user_op::UserOpConfWrapper grad_op =
             builder.Op("reduce_sum")
                 .Input("input_tensor", op.GetGradTensorWithOpOutput("y", 0))
                 .Output("output_tensor")
-                .Attr("axis", std::vector<int32_t>())
-                .Attr("keepdims", false)
+                .Attr("reduce_axes", reduce_axes_vec)
+                .Attr("keep_dims", false)
                 .Build();
         op.BindGradTensorWithOpInput(grad_op.output("output_tensor", 0), "scalar", 0);
         AddOp(grad_op);
@@ -97,13 +99,15 @@ REGISTER_USER_OP_GRAD("scalar_sub_by_tensor")
         op.BindGradTensorWithOpInput(op.GetGradTensorWithOpOutput("y", 0), "x", 0);
       }
       if (op.NeedGenGradTensor4OpInput("scalar", 0)) {
+        AxisVector reduce_axes_vec(op.TensorDesc4ArgNameAndIndex("y", 0).shape().NumAxes());
+        std::iota(reduce_axes_vec.begin(), reduce_axes_vec.end(), 0);
         user_op::UserOpConfWrapperBuilder builder0(op.op_name() + "scalar_grad_reduce_sum");
         user_op::UserOpConfWrapper scalar_grad_reduce_sum_op =
             builder0.Op("reduce_sum")
                 .Input("input_tensor", op.GetGradTensorWithOpOutput("y", 0))
                 .Output("output_tensor")
-                .Attr("axis", std::vector<int32_t>())
-                .Attr("keepdims", false)
+                .Attr("reduce_axes", reduce_axes_vec)
+                .Attr("keep_dims", false)
                 .Build();
         user_op::UserOpConfWrapperBuilder builder1(op.op_name() + "scalar_grad_scalar_mul");
         user_op::UserOpConfWrapper scalar_grad_scalar_mul_op =
@@ -154,6 +158,7 @@ REGISTER_USER_OP_GRAD("scalar_mul_by_tensor")
         AddOp(grad_op);
       }
       if (op.NeedGenGradTensor4OpInput("scalar", 0)) {
+        int64_t num_axes = op.TensorDesc4ArgNameAndIndex("y", 0).shape().NumAxes();
         user_op::UserOpConfWrapperBuilder builder0(op.op_name() + "scalar_grad_multiply");
         user_op::UserOpConfWrapper scalar_grad_multiply_op =
             builder0.Op("multiply")
@@ -161,13 +166,15 @@ REGISTER_USER_OP_GRAD("scalar_mul_by_tensor")
                 .Input("y", op.input("x", 0))
                 .Output("out")
                 .Build();
+        AxisVector reduce_axes_vec(num_axes);
+        std::iota(reduce_axes_vec.begin(), reduce_axes_vec.end(), 0);
         user_op::UserOpConfWrapperBuilder builder1(op.op_name() + "scalar_grad_reduce_sum");
         user_op::UserOpConfWrapper scalar_grad_reduce_sum_op =
             builder1.Op("reduce_sum")
                 .Input("input_tensor", scalar_grad_multiply_op.output("out", 0))
                 .Output("output_tensor")
-                .Attr("axis", std::vector<int32_t>())
-                .Attr("keepdims", false)
+                .Attr("reduce_axes", reduce_axes_vec)
+                .Attr("keep_dims", false)
                 .Build();
         op.BindGradTensorWithOpInput(scalar_grad_reduce_sum_op.output("output_tensor", 0), "scalar",
                                      0);


### PR DESCRIPTION
重构 reduce axes 的语义，当将一个张量reduce成标量时配置的 reduce axes 不再为空，而是range(0, len(shape))。reduce axes 为空时，代表没有reduce，等于identity操作。

- [x] 修改 reduce axes 为空时的特判
- [x] 增加 AxisVector 类型的 Attr
- [x] 重构 ReduceSbpUtil::MakePredicatorIsReducedAxis
- [ ] 删除 CreateReducedShapeOrOnesShape
- [ ] 修复以前的一些bug和改进旧的写法
- [ ] 重构相关 python api