### PR TITLE
logical blob_desc signature

### DIFF
--- a/oneflow/core/graph/op_graph.cpp
+++ b/oneflow/core/graph/op_graph.cpp
@@ -564,10 +564,10 @@ void OpGraph::InferLogicalBlobDesc(const Job& job) const {
   }
   TopoForEachNode([&](OpNode* op_node) {
     // infer batch_axis
-    auto BatchAxis4BnInOp = [&](const std::string& bn) -> OptInt64* {
+    const auto& BatchAxis4BnInOp = [&](const std::string& bn) -> OptInt64* {
       return op_node->MutProducerOpNode4BnInOp(bn)->MutBatchAxis4Lbi(op_node->op().BnInOp2Lbi(bn));
     };
-    auto LogicalBlobDesc4Ibn = [&](const std::string& ibn) -> const BlobDesc& {
+    const auto& LogicalBlobDesc4Ibn = [&](const std::string& ibn) -> const BlobDesc& {
       const auto& ibns = op_node->op().input_bns();
       CHECK(std::find(ibns.begin(), ibns.end(), ibn) != ibns.end());
       return op_node->LogicalBlobDesc4Lbi(op_node->op().BnInOp2Lbi(ibn));
@@ -593,6 +593,11 @@ void OpGraph::InferLogicalBlobDesc(const Job& job) const {
     UpdateJobParallelViewConf(*op_node, oba2sbp_identical_obas, &job_parallel_view_conf);
     // infer logical_blob_desc
     InferOpNodeLogicalBlobDesc(op_node);
+    // Fill logical blob_desc signature.
+    CHECK_JUST(op_node->mut_op()->FillLogicalBlobDescSignature(
+        [&](const std::string& bn_in_op) -> Maybe<const BlobDesc*> {
+          return &op_node->LogicalBlobDesc4Lbi(op_node->op().BnInOp2Lbi(bn_in_op));
+        }));
   });
   // fix sbp_signature
   {

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -500,6 +500,13 @@ Maybe<OpAttribute> JobBuildAndInferCtx::AddAndInferOp(const OperatorConf& op_con
   parallel_ctx.set_parallel_num(1);
   JUST(op->InferOutBlobDescsIf(GetBlobDesc4BnInOp, &parallel_ctx, CHECK_JUST(op->sbp_signature()),
                                [](OpContext*) {}));
+  // Fill logical blob_desc signature.
+  JUST(op->FillLogicalBlobDescSignature([&](const std::string& bn_in_op) -> Maybe<const BlobDesc*> {
+    const auto* blob_desc = GetBlobDesc4BnInOp(bn_in_op);
+    CHECK_NOTNULL_OR_RETURN(blob_desc);
+    return blob_desc;
+  }));
+  // Infer ParallelDesc for output blobs.
   auto ParallelDesc4Obn = [&](const std::string& obn) -> ParallelDesc* {
     const auto& lbi = op->BnInOp2Lbi(obn);
     auto iter = lbi2parallel_desc_from_producer_view_.find(lbi);

--- a/oneflow/core/operator/op_attribute.proto
+++ b/oneflow/core/operator/op_attribute.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 package oneflow;
 
 import "oneflow/core/register/logical_blob_id.proto";
+import "oneflow/core/register/blob_desc.proto";
 import "oneflow/core/operator/op_conf.proto";
 import "oneflow/core/operator/arg_modifier_signature.proto";
 import "oneflow/core/job/sbp_parallel.proto";
@@ -22,4 +23,5 @@ message OpAttribute {
   optional MirroredSignature mirrored_signature = 103;
   optional BlobLastUsedSignature blob_last_used_signature = 104;
   optional BlobBackwardUsedSignature blob_backward_used_signature = 105;
+  optional BlobDescSignature logical_blob_desc_signature = 106;
 }

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -108,6 +108,14 @@ Maybe<void> Operator::InferOutBlobDescs(
   return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature, EnrollOpCtx);
 }
 
+Maybe<void> Operator::FillLogicalBlobDescSignature(
+    const std::function<Maybe<const BlobDesc*>(const std::string&)>& BlobDesc4BnInOp) {
+  auto* map = op_attribute_.mutable_logical_blob_desc_signature()->mutable_bn_in_op2blob_desc();
+  for (const auto& ibn : input_bns()) { JUST(BlobDesc4BnInOp(ibn))->ToProto(&(*map)[ibn]); }
+  for (const auto& obn : output_bns()) { JUST(BlobDesc4BnInOp(obn))->ToProto(&(*map)[obn]); }
+  return Maybe<void>::Ok();
+}
+
 Maybe<void> Operator::InferOutParallelDescIf(
     std::function<ParallelDesc*(const std::string&)> ParallelDesc4Obn,
     std::function<const BlobDesc*(const std::string&)> LogicalBlobDesc4Ibn,

--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -174,7 +174,6 @@ class Operator {
   std::shared_ptr<OpAttribute> GetOpAttributeWithoutOpNameAndLbn() const;
 
   Maybe<const SbpSignature*> sbp_signature() const;
-  // TODO(lixinqi) It's dangerous to expose mut_sbp_signature()
   SbpSignature* mut_sbp_signature() { return op_attribute_.mutable_sbp_signature(); }
   BlobLastUsedSignature* mut_blob_last_used_signature() {
     return op_attribute_.mutable_blob_last_used_signature();
@@ -182,6 +181,8 @@ class Operator {
   BlobBackwardUsedSignature* mut_blob_backward_used_signature() {
     return op_attribute_.mutable_blob_backward_used_signature();
   }
+  Maybe<void> FillLogicalBlobDescSignature(
+      const std::function<Maybe<const BlobDesc*>(const std::string&)>& BlobDesc4BnInOp);
 
  protected:
   virtual Maybe<void> GetSbpSignatures(

--- a/oneflow/core/register/blob_desc.proto
+++ b/oneflow/core/register/blob_desc.proto
@@ -11,3 +11,7 @@ message BlobDescProto {
   required bool is_dynamic = 5;
   required bool header_is_opaque = 6;
 }
+
+message BlobDescSignature {
+  map<string, BlobDescProto> bn_in_op2blob_desc = 1;
+}


### PR DESCRIPTION
添加 op_attribute.logical_blob_desc_signature。理由如下：
1. 这本来就应该是op_attribute最重要的字段，相当于c++参数的类型
2. 有了它之后可以省去大量往python所导出的有瑕疵的api