### PR TITLE
return debug message to python frontend when user_op kernel lookup fa…

### DIFF
--- a/oneflow/core/common/error.cpp
+++ b/oneflow/core/common/error.cpp
@@ -65,6 +65,24 @@ Error Error::BoxingNotSupported() {
   return error;
 }
 
+Error Error::OpKernelNotFoundError(const std::vector<std::string>& error_msgs) {
+  auto error = std::make_shared<ErrorProto>();
+  auto* op_kernel_not_found_error = error->mutable_op_kernel_not_found_error();
+  for (const auto& msg : error_msgs) {
+    op_kernel_not_found_error->add_op_kernels_not_found_debug_str(msg);
+  }
+  return error;
+}
+
+Error Error::MultipleOpKernelsMatchedError(const std::vector<std::string>& error_msgs) {
+  auto error = std::make_shared<ErrorProto>();
+  auto* multiple_op_kernels_matched_error = error->mutable_multiple_op_kernels_matched_error();
+  for (const auto& msg : error_msgs) {
+    multiple_op_kernels_matched_error->add_matched_op_kernels_debug_str(msg);
+  }
+  return error;
+}
+
 Error Error::GradientFunctionNotFound() {
   auto error = std::make_shared<ErrorProto>();
   error->mutable_gradient_function_not_found_error();

--- a/oneflow/core/common/error.h
+++ b/oneflow/core/common/error.h
@@ -2,6 +2,7 @@
 #define ONEFLOW_CORE_COMMON_ERROR_H_
 
 #include <sstream>
+#include <vector>
 #include "oneflow/core/common/error.pb.h"
 
 namespace oneflow {
@@ -21,6 +22,8 @@ class Error final {
   static Error Todo();
   static Error Unimplemented();
   static Error BoxingNotSupported();
+  static Error OpKernelNotFoundError(const std::vector<std::string>& error_msgs);
+  static Error MultipleOpKernelsMatchedError(const std::vector<std::string>& error_msgs);
 
   // gradient
   static Error GradientFunctionNotFound();

--- a/oneflow/core/common/error.proto
+++ b/oneflow/core/common/error.proto
@@ -77,6 +77,14 @@ enum BoxingError {
 
 message GradientFunctionNotFoundError { }
 
+message OpKernelNotFoundError {
+  repeated string op_kernels_not_found_debug_str = 1;
+}
+
+message MultipleOpKernelsMatchedError {
+  repeated string matched_op_kernels_debug_str = 1;
+}
+
 message UnkownError { }
 
 message ErrorStackFrame {
@@ -97,6 +105,8 @@ message ErrorProto {
     UnimplementedError unimplemented_error = 18;
     BoxingError boxing_error = 19;
     GradientFunctionNotFoundError gradient_function_not_found_error = 20;
+    OpKernelNotFoundError op_kernel_not_found_error = 21;
+    MultipleOpKernelsMatchedError multiple_op_kernels_matched_error = 22;
     UnkownError unknown_error = 100;
   }
 }

--- a/oneflow/core/framework/kernel_registration.h
+++ b/oneflow/core/framework/kernel_registration.h
@@ -92,8 +92,8 @@ class KernelRegistryWrapperBuilder final {
   KernelRegistryWrapper wrapper_;
 };
 
-const KernelRegistrationVal* LookUpInKernelRegistry(const std::string& op_type_name,
-                                                    const KernelRegContext&);
+Maybe<const KernelRegistrationVal*> LookUpInKernelRegistry(const std::string& op_type_name,
+                                                           const KernelRegContext&);
 
 std::vector<std::string> GetAllUserOpInKernelRegistry();
 

--- a/oneflow/core/graph/op_graph.h
+++ b/oneflow/core/graph/op_graph.h
@@ -119,7 +119,8 @@ class OpEdge final : public Edge<OpNode, OpEdge> {
 class OpGraph final : public Graph<OpNode, OpEdge> {
  public:
   OF_DISALLOW_COPY_AND_MOVE(OpGraph);
-  explicit OpGraph(const Job& job) { Init(job); }
+  explicit OpGraph(const Job& job) { CHECK_JUST(Init(job)); }
+  explicit OpGraph() = default;
   ~OpGraph() override = default;
 
   Maybe<void> ForEachOpNode(const std::function<Maybe<void>(const OpNode&)>& DoEach) const;
@@ -153,8 +154,9 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
   void DumpOpTimeShape(Job* job) const;
   void DumpBatchAxisLbi(Job* job) const;
 
+  Maybe<void> Init(const Job& job);
+
  private:
-  void Init(const Job& job);
   void InitNodes(const Job& job);
   void InitEdges();
   void InitProducerOpName2CtrlConsumerOpNames(const Job& job);
@@ -163,8 +165,8 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
   void InferTimeShape() const;
   void InferOpNodeSbpSignature(OpNode* op_node, const SbpSignature& sbp_sig_conf) const;
   void InferOpNodeMirroredSignature(OpNode* op_node, bool is_mirrored_parallel_view_conf) const;
-  void InferOpNodeLogicalBlobDesc(OpNode* op_node) const;
-  void InferLogicalBlobDesc(const Job& job) const;
+  Maybe<void> InferOpNodeLogicalBlobDesc(OpNode* op_node) const;
+  Maybe<void> InferLogicalBlobDesc(const Job& job) const;
   bool IsBatchAxisBlob(const std::string& op_name, const LogicalBlobId& lbi) const;
   std::string GetOpNameKey(const std::string& op_name, const LogicalBlobId& lbi) const;
   LogicalBlobId GetLogicalBlobIdKey(const std::string& op_name, const LogicalBlobId& lbi) const;

--- a/oneflow/core/job_completer/op_graph_pass.h
+++ b/oneflow/core/job_completer/op_graph_pass.h
@@ -18,7 +18,8 @@ class OpGraphPass {
   }
   virtual bool IsEnabled() const { return true; }
   virtual Maybe<void> Apply(Job* job) const {
-    const OpGraph op_graph(*job);
+    OpGraph op_graph;
+    JUST(op_graph.Init(*job));
     return Apply(op_graph, job);
   }
   virtual Maybe<void> Apply(const OpGraph& op_graph, Job* job) const {

--- a/oneflow/core/kernel/user_kernel.cpp
+++ b/oneflow/core/kernel/user_kernel.cpp
@@ -379,8 +379,9 @@ class UserKernel final : public Kernel {
     {
       const std::string& op_type_name =
           kernel_conf().op_attribute().op_conf().user_conf().op_type_name();
-      const auto* kernel_reg_val = user_op::LookUpInKernelRegistry(
-          op_type_name, UserKernelRegContext(kernel_conf(), job_desc()));
+      const user_op::KernelRegistrationVal* kernel_reg_val =
+          CHECK_JUST(user_op::LookUpInKernelRegistry(
+              op_type_name, UserKernelRegContext(kernel_conf(), job_desc())));
       CHECK_NOTNULL(kernel_reg_val);
       kernel_.reset(kernel_reg_val->create_fn());
     }
@@ -449,8 +450,8 @@ EagerKernel::EagerKernel(const JobDesc* job_desc, const KernelConf& kernel_conf)
 
 void EagerKernel::InitOpKernel(const KernelConf& kernel_conf) {
   const std::string& op_type_name = kernel_conf.op_attribute().op_conf().user_conf().op_type_name();
-  auto kernel_reg_val =
-      user_op::LookUpInKernelRegistry(op_type_name, UserKernelRegContext(kernel_conf, job_desc()));
+  auto kernel_reg_val = CHECK_JUST(
+      user_op::LookUpInKernelRegistry(op_type_name, UserKernelRegContext(kernel_conf, job_desc())));
   CHECK_NOTNULL(kernel_reg_val);
   kernel_.reset(kernel_reg_val->create_fn());
 }

--- a/oneflow/core/operator/user_op.cpp
+++ b/oneflow/core/operator/user_op.cpp
@@ -282,13 +282,12 @@ Maybe<void> UserOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> 
                                    const SbpSignature* sbp_signature,
                                    std::function<void(OpContext*)> EnrollOpCtx) const {
   JUST(InferOutBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature, EnrollOpCtx));
-
   // tmp buffer size must be inferred after out shape/dtype
   UserOpInferContext infer_ctx(op_conf(), parallel_ctx, sbp_signature, job_desc(),
                                GetBlobDesc4BnInOp);
-  const user_op::KernelRegistrationVal* kernel_reg_val = user_op::LookUpInKernelRegistry(
+  const user_op::KernelRegistrationVal* kernel_reg_val = JUST(user_op::LookUpInKernelRegistry(
       op_conf().user_conf().op_type_name(),
-      UserOpKernelRegContext(this, GetBlobDesc4BnInOp, parallel_ctx));
+      UserOpKernelRegContext(this, GetBlobDesc4BnInOp, parallel_ctx)));
   CHECK_OR_RETURN(kernel_reg_val != nullptr)
       << "cannot find op_type: " << op_conf().user_conf().op_type_name() << " in kernel registry !";
 


### PR DESCRIPTION
在 Session 初始化的时候，若 user_op kernel 查找出错，则把错误信息返回给python 前端，出错信息示例：

```bash
Traceback (most recent call last):
  File "test_op.py", line 45, in <module>
    loss = train_job(images, labels).get()
  File "/home/liangdp/oneflow/oneflow/build/python_scripts/oneflow/python/framework/function_util.py", line 76, in Func
    return _RunJob(sess, job_func, *args)
  File "/home/liangdp/oneflow/oneflow/build/python_scripts/oneflow/python/framework/function_util.py", line 138, in _RunJob
    return session.TryInit().Run(job_func, *args)
  File "/home/liangdp/oneflow/oneflow/build/python_scripts/oneflow/python/framework/session_util.py", line 95, in TryInit
    self.Init()
  File "/home/liangdp/oneflow/oneflow/build/python_scripts/oneflow/python/framework/session_util.py", line 105, in Init
    compiler.Compile(func_desc, self.config_proto_)
  File "/home/liangdp/oneflow/oneflow/build/python_scripts/oneflow/python/framework/compiler.py", line 35, in Compile
    c_api_util.CurJobBuildAndInferCtx_Complete()
  File "/home/liangdp/oneflow/oneflow/build/python_scripts/oneflow/python/framework/c_api_util.py", line 160, in CurJobBuildAndInferCtx_Complete
    raise JobBuildAndInferError(error)
oneflow.python.framework.job_build_and_infer_error.JobBuildAndInferError: 
msg: Cannot find the kernel satisfies current Op node.  The info of Op node are 
 op_name: Conv2d_5_0
 op_type_name: conv2d
 DeviceType_Name: kCPU
 DataType_Name of weight_0: kFloat
 DataType_Name of in_0: kFloat
 DataType_Name of out_0: kFloat
("device_type == 2"[False] and "tensor 'in' data_type == 2")
("device_type == 2"[False] and "tensor 'in' data_type == 3")
("device_type == 2"[False] and "tensor 'in' data_type == 9")
(("device_type == 1"[True] and "groups == 1"[True]) and "tensor 'in' data_type == 2"[True])
(("device_type == 1"[True] and "groups == 1"[True]) and "tensor 'in' data_type == 3"[False])

stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/operator/user_op.cpp:323"
  function: "InferBlobDescs"
}
stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/graph/op_graph.cpp:529"
  function: "InferOpNodeLogicalBlobDesc"
}
stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/graph/op_graph.cpp:588"
  function: "operator()"
}
stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/graph/op_graph.cpp:629"
  function: "TopoForEachNodeWithErrorCaptured"
}
stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/graph/op_graph.cpp:610"
  function: "TopoForEachNodeWithErrorCaptured"
}
stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/graph/op_graph.cpp:588"
  function: "InferLogicalBlobDesc"
}
stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/graph/op_graph.cpp:367"
  function: "Init"
}
stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/job_completer/op_graph_pass.h:22"
  function: "Apply"
}
stack_frame {
  location: "/home/liangdp/oneflow/oneflow/oneflow/core/job/job_build_and_infer_ctx.cpp:853"
  function: "Complete"
}
user_op_kernel_lookup_error {
}
```

因为是强制让错误返回，所以可以看到有一个 kernel 是满足条件的：
```bash
(("device_type == 1"[True] and "groups == 1"[True]) and "tensor 'in' data_type == 2"[True])
```