### PR TITLE
Add ToInterfaceSubTskGphBuilder

### DIFF
--- a/oneflow/core/graph/boxing/to_interface_sub_task_graph_builder.cpp
+++ b/oneflow/core/graph/boxing/to_interface_sub_task_graph_builder.cpp
@@ -1,0 +1,72 @@
+#include "oneflow/core/graph/boxing/to_interface_sub_task_graph_builder.h"
+#include "oneflow/core/graph/boxing/sub_task_graph_builder_util.h"
+#include "oneflow/core/graph/slice_boxing_task_node.h"
+
+namespace oneflow {
+
+Maybe<void> ToInterfaceSubTskGphBuilder::Build(
+    SubTskGphBuilderCtx* ctx, const std::vector<CompTaskNode*>& sorted_src_comp_tasks,
+    const std::vector<CompTaskNode*>& sorted_dst_comp_tasks, const ParallelDesc& src_parallel_desc,
+    const ParallelDesc& dst_parallel_desc, const LogicalBlobId& lbi,
+    const BlobDesc& logical_blob_desc, const SbpParallel& src_sbp_parallel,
+    const SbpParallel& dst_sbp_parallel) const {
+  const LogicalNode* dst_logical_node = sorted_dst_comp_tasks.front()->logical_node();
+  if (dst_logical_node->op_vec().size() != 1) { return Error::BoxingNotSupported(); }
+  if (!IsClassRegistered<IsInterfaceOpConf4OpTypeCase>(
+          dst_logical_node->SoleOp()->op_conf().op_type_case())) {
+    return Error::BoxingNotSupported();
+  }
+  if ((src_parallel_desc.parallel_num() == 1 || src_sbp_parallel.has_broadcast_parallel())
+      && (dst_parallel_desc.parallel_num() == 1 || dst_sbp_parallel.has_broadcast_parallel())) {
+    std::vector<CompTaskNode*> nearest_src_comp_tasks;
+    for (CompTaskNode* dst_node : sorted_dst_comp_tasks) {
+      CompTaskNode* nearest_src_node =
+          SubTskGphBuilderUtil::FindNearestNode(sorted_src_comp_tasks, dst_node);
+      CHECK_NOTNULL(nearest_src_node);
+      if (SubTskGphBuilderUtil::IsOnSameGPU(nearest_src_node, dst_node)) {
+        Connect<TaskNode>(nearest_src_node, ctx->task_graph()->NewEdge(), dst_node);
+      } else {
+        TaskNode* proxy =
+            ctx->GetProxyNode(nearest_src_node, nearest_src_node->MemZoneId121(),
+                              dst_node->machine_id(), Global<IDMgr>::Get()->CpuMemZoneId());
+        Connect<TaskNode>(proxy, ctx->task_graph()->NewEdge(), dst_node);
+      }
+    }
+    return Maybe<void>::Ok();
+  } else if ((src_parallel_desc.parallel_num() == 1 || src_sbp_parallel.has_broadcast_parallel())
+             && (dst_parallel_desc.parallel_num() > 1 || dst_sbp_parallel.has_split_parallel())) {
+    const TensorSliceView in_slice =
+        SubTskGphBuilderUtil::GetBroadcastTensorSliceView(logical_blob_desc);
+    const std::vector<TensorSliceView> out_slices = SubTskGphBuilderUtil::GetTensorSliceView(
+        dst_parallel_desc.parallel_num(), dst_sbp_parallel, logical_blob_desc);
+    FOR_RANGE(int64_t, out_id, 0, dst_parallel_desc.parallel_num()) {
+      const TensorSliceView& out_slice = out_slices.at(out_id);
+      CompTaskNode* dst_node = sorted_dst_comp_tasks.at(out_id);
+      const int64_t nearest_idx =
+          SubTskGphBuilderUtil::FindNearestNodeIndex(sorted_src_comp_tasks, dst_node);
+      CompTaskNode* src_node = sorted_src_comp_tasks.at(nearest_idx);
+      SliceBoxingTaskNode* slice_node = ctx->task_graph()->NewNode<SliceBoxingTaskNode>();
+      const auto src_machine_id = src_parallel_desc.MachineIdForParallelId(0);
+      if (src_parallel_desc.device_type() == DeviceType::kCPU) {
+        slice_node->Init(lbi, out_slice, kSliceBoxingTaskModeCopy, src_machine_id,
+                         Global<IDMgr>::Get()->PickCpuThrdIdEvenly(src_machine_id));
+      } else if (src_parallel_desc.device_type() == DeviceType::kGPU) {
+        slice_node->Init(lbi, out_slice, kSliceBoxingTaskModeCopy, src_machine_id,
+                         Global<IDMgr>::Get()->GetGpuD2HThrdId(src_node->GpuPhyId()),
+                         Global<IDMgr>::Get()->CpuMemZoneId());
+      } else {
+        UNIMPLEMENTED();
+      }
+      slice_node->ConnectToSrcNodeWithSlice(src_node, ctx->task_graph()->NewEdge(), in_slice);
+      TaskNode* proxy =
+          ctx->GetProxyNode(slice_node, slice_node->MemZoneId121(), dst_node->machine_id(),
+                            Global<IDMgr>::Get()->CpuMemZoneId());
+      Connect<TaskNode>(proxy, ctx->task_graph()->NewEdge(), dst_node);
+    }
+    return Maybe<void>::Ok();
+  } else {
+    return Error::BoxingNotSupported();
+  }
+}
+
+}  // namespace oneflow

--- a/oneflow/core/graph/boxing/to_interface_sub_task_graph_builder.h
+++ b/oneflow/core/graph/boxing/to_interface_sub_task_graph_builder.h
@@ -1,0 +1,25 @@
+#ifndef ONEFLOW_CORE_GRAPH_BOXING_TO_INTERFACE_SUB_TASK_GRAPH_BUILDER_H_
+#define ONEFLOW_CORE_GRAPH_BOXING_TO_INTERFACE_SUB_TASK_GRAPH_BUILDER_H_
+
+#include "oneflow/core/graph/boxing/sub_task_graph_builder.h"
+
+namespace oneflow {
+
+class ToInterfaceSubTskGphBuilder final : public SubTskGphBuilder {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(ToInterfaceSubTskGphBuilder);
+  ToInterfaceSubTskGphBuilder() = default;
+  ~ToInterfaceSubTskGphBuilder() override = default;
+
+  Maybe<void> Build(SubTskGphBuilderCtx* ctx,
+                    const std::vector<CompTaskNode*>& sorted_src_comp_tasks,
+                    const std::vector<CompTaskNode*>& sorted_dst_comp_tasks,
+                    const ParallelDesc& src_parallel_desc, const ParallelDesc& dst_parallel_desc,
+                    const LogicalBlobId& lbi, const BlobDesc& logical_blob_desc,
+                    const SbpParallel& src_sbp_parallel,
+                    const SbpParallel& dst_sbp_parallel) const override;
+};
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_GRAPH_BOXING_TO_INTERFACE_SUB_TASK_GRAPH_BUILDER_H_

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -20,6 +20,7 @@
 #include "oneflow/core/graph/boxing/slice_boxing_sub_task_graph_builder.h"
 #include "oneflow/core/graph/boxing/naive_b2b_sub_task_graph_builder.h"
 #include "oneflow/core/graph/boxing/one_to_one_sub_task_graph_builder.h"
+#include "oneflow/core/graph/boxing/to_interface_sub_task_graph_builder.h"
 #include "oneflow/core/graph/boxing/sub_task_graph_builder_util.h"
 #include "oneflow/core/graph/boxing_identity_compute_task_node.h"
 
@@ -157,6 +158,7 @@ TaskGraph::TaskGraph(std::unique_ptr<const LogicalGraph>&& logical_gph) {
   if (GlobalJobDesc().use_boxing_v2()) {
     sub_tsk_gph_builder_ctx_.reset(new SubTskGphBuilderCtx(this));
     std::vector<std::shared_ptr<SubTskGphBuilder>> builders;
+    builders.emplace_back(new ToInterfaceSubTskGphBuilder());
     builders.emplace_back(new OneToOneSubTskGphBuilder());
     builders.emplace_back(new CollectiveBoxingSubTskGphBuilder());
     builders.emplace_back(new SliceBoxingSubTskGphBuilder());


### PR DESCRIPTION
与
```c++
TaskNode* TaskGraph::TryAddCopyH2DTaskTo(TaskNode* task) {
  if (IsInterfaceTask(task)) { return nullptr; }
  if (IsClassRegistered<TickTockTaskType>(task->GetTaskType())) { return nullptr; }
  CHECK_EQ(task->device_type(), DeviceType::kGPU);
  CopyHdTaskNode* copy_task = NewNode<CopyHdTaskNode>();
  copy_task->Init(CopyHdOpConf::H2D, task->machine_id(), task->GpuPhyId());
  return copy_task;
}
```
中针对`IsInterfaceTask`的处理相似，针对目的为`InterfaceOp`的boxing省略掉最后copy到GPU的步骤，由`InterfaceOp`自己完成，目前仅支持针对 model io 的 B2B 与 B2S
