### PR TITLE
remove optional outputs in nn.bn

### DIFF
--- a/oneflow/python/ops/nn_ops.py
+++ b/oneflow/python/ops/nn_ops.py
@@ -172,8 +172,6 @@ def batch_normalization(
         .Input("gamma", [scale])
         .Input("beta", [offset])
         .Output("y")
-        .Output("mean")
-        .Output("inv_variance")
         .Attr("axis", axis, "AttrTypeInt32")
         .Attr("epsilon", variance_epsilon, "AttrTypeFloat")
         .Attr("training", False, "AttrTypeBool")


### PR DESCRIPTION
flow.nn.batch_normalization 是只有 training=False 的功能的，所以把两个 training=True 时才有用的 optional output 去掉了 