### PR TITLE
replace np.ndarray with np.zeros when creating ndarray

### DIFF
--- a/oneflow/python/framework/ofblob.py
+++ b/oneflow/python/framework/ofblob.py
@@ -83,9 +83,7 @@ class OfBlob(object):
             shape_tensor = np.zeros(self.num_axes, dtype=np.int64)
             oneflow_api.OfBlob_CurTensorCopyShapeTo(self.of_blob_ptr_, shape_tensor)
             shape = tuple(shape_tensor.tolist())
-            tensor = np.zeros(
-                shape, dtype=convert_of_dtype_to_numpy_dtype(self.dtype)
-            )
+            tensor = np.zeros(shape, dtype=convert_of_dtype_to_numpy_dtype(self.dtype))
             copy_method(self.of_blob_ptr_, tensor)
             tensor_list.append(tensor)
             oneflow_api.OfBlob_IncTensorIterator(self.of_blob_ptr_)


### PR DESCRIPTION
https://docs.scipy.org/doc/numpy-1.17.0/reference/generated/numpy.ndarray.html#numpy.ndarray
> Arrays should be constructed using array, zeros or empty (refer to the See Also section below). The parameters given here refer to a low-level method (ndarray(…)) for instantiating an array.
- numpy 官方推荐用 array, zeros or empty 这几个接口创建新的 ndarray
- 在之前的调试过程中，发现 `np.ndarray` 这个接口返回的可能不是0，给debug带来一些困扰