### PR TITLE
Fix CUDNN_STATUS_NOT_SUPPORTED error for bn

### DIFF
--- a/oneflow/customized/kernels/normalization_kernel.cpp
+++ b/oneflow/customized/kernels/normalization_kernel.cpp
@@ -50,7 +50,7 @@ class NormalizationUserKernel<DeviceType::kGPU, T> final : public user_op::OpKer
     int32_t n, c, h, w;
     cudnnTensorFormat_t format;
 
-    if (axis != 0 && x->shape().Count(axis + 1) == 1) {
+    if (axis != 0 && x->shape().Count(axis + 1) == 1 && !training) {
       n = x->shape().At(0);
       h = x->shape().Count(1, axis);
       w = 1;


### PR DESCRIPTION
应该是`cudnnBatchNormalizationForwardInference`接口不支持 n >= 65536 的情形，之前我们处理NHWC输入时会将NHW乘在一起，导致n过大，在Inference时报错，没有在cudnn文档中注意到类似的限制，但是看到pytorch也有处理过类似问题　https://github.com/pytorch/pytorch/issues/16365。
初步解决方案是把batch单独处理，当C在输入最后一维时使用NHWC格式，因为目前并没有发现这个bug影响训练且发现NHWC会导致训练变慢，所以仅针对Inference使用NHWC。