### PR TITLE
include blob.h in tensor.cpp instead of tensor.h

### DIFF
--- a/oneflow/core/framework/tensor.cpp
+++ b/oneflow/core/framework/tensor.cpp
@@ -1,4 +1,5 @@
 #include "oneflow/core/framework/tensor.h"
+#include "oneflow/core/register/blob.h"
 
 namespace oneflow {
 
@@ -16,6 +17,10 @@ Tensor::Tensor(Blob* blob) {
   data_type_ = blob->data_type();
   mem_case_ = &(blob->mem_case());
 }
+
+void Tensor::header_access_check() { this->blob_access_checker_->CheckHeaderMutable(); }
+
+void Tensor::body_access_check() { this->blob_access_checker_->CheckBodyMutable(); }
 
 void Tensor::CopyWithoutData(const Tensor& rhs) {
   dptr_ = rhs.dptr_;

--- a/oneflow/core/framework/tensor.h
+++ b/oneflow/core/framework/tensor.h
@@ -4,9 +4,10 @@
 #include "oneflow/core/common/data_type.h"
 #include "oneflow/core/common/shape_view.h"
 #include "oneflow/core/memory/memory_case.pb.h"
-#include "oneflow/core/register/blob.h"
-
 namespace oneflow {
+
+class Blob;
+class BlobAccessChecker;
 
 namespace user_op {
 
@@ -22,9 +23,10 @@ class Tensor final {
 
   const ShapeView& shape() const { return shape_; }
   MutShapeView* mut_shape() {
-    this->blob_access_checker_->CheckHeaderMutable();
+    this->header_access_check();
     return mut_shape_.get();
   }
+
   DataType data_type() const { return data_type_; }
   const MemoryCase& mem_case() const { return *mem_case_; }
 
@@ -36,7 +38,7 @@ class Tensor final {
 
   template<typename T = void>
   T* mut_dptr() {
-    this->blob_access_checker_->CheckBodyMutable();
+    this->body_access_check();
     CheckDataType<T>();
     return static_cast<T*>(dptr_);
   }
@@ -49,6 +51,9 @@ class Tensor final {
         << "tensor data_type " << data_type_ << " must match template data_type "
         << GetDataType<T>::value;
   }
+
+  void header_access_check();
+  void body_access_check();
 
   void* dptr_;
   ShapeView shape_;


### PR DESCRIPTION
把引用 `blob.h` 头文件的语句放到 `tensor.cpp` 文件中。