### PR TITLE
call random_uniform_initializer with wrong parameter

### DIFF
--- a/oneflow/python/test/ops/test_slice_v2.py
+++ b/oneflow/python/test/ops/test_slice_v2.py
@@ -195,7 +195,7 @@ def test_slice_grad(test_case):
         x = flow.get_variable(
             shape=(2, 5, 4),
             dtype=flow.float,
-            initializer=flow.random_uniform_initializer(2),
+            initializer=flow.random_uniform_initializer(0, 1),
             name="variable",
         )
         x = flow.identity(x)


### PR DESCRIPTION
flow.random_uniform_initializer 函数，要求 minval <= maxval，原来只传一个参数2 ，导致 minval > maxval

```python
@oneflow_export("random_uniform_initializer")
def random_uniform_initializer(
    minval: float = 0, maxval: float = 1, dtype: dtype_util.dtype = dtype_util.float
) -> op_conf_util.InitializerConf:
```