### PR TITLE
Fix ctrl edge for collective boxing reduce/broadcast

### DIFF
--- a/oneflow/core/graph/boxing/collective_boxing_sub_task_graph_builder.cpp
+++ b/oneflow/core/graph/boxing/collective_boxing_sub_task_graph_builder.cpp
@@ -221,8 +221,11 @@ class NcclCollectiveBoxingReduceSubTskGphBuilder final : public SubTskGphBuilder
         NcclInitCollectiveNode(collective_node, src_parallel_desc, i, op_name, lbi,
                                logical_blob_desc, OpType::kOpTypeReduce, root_parallel_id);
         Connect<TaskNode>(src_node, ctx->task_graph()->NewEdge(), collective_node);
+        CompTaskNode* dst_node = sorted_dst_comp_tasks.front();
         if (i == root_parallel_id) {
-          CompTaskNode* dst_node = sorted_dst_comp_tasks.front();
+          Connect<TaskNode>(collective_node, ctx->task_graph()->NewEdge(), dst_node);
+        } else {
+          collective_node->BuildCtrlRegstDesc(dst_node);
           Connect<TaskNode>(collective_node, ctx->task_graph()->NewEdge(), dst_node);
         }
       }
@@ -338,6 +341,7 @@ class NcclCollectiveBoxingBroadcastSubTskGphBuilder final : public SubTskGphBuil
           Connect<TaskNode>(gpu_src_node, ctx->task_graph()->NewEdge(), collective_node);
         } else {
           gpu_src_node->BuildCtrlRegstDesc(collective_node);
+          Connect<TaskNode>(gpu_src_node, ctx->task_graph()->NewEdge(), collective_node);
         }
         Connect<TaskNode>(collective_node, ctx->task_graph()->NewEdge(), dst_node);
       }


### PR DESCRIPTION
broadcast/reduce节点在非root rank的device上会体现为source/sink节点，丢失拓扑关系，通过添加 ctrl edge 保证拓扑关系

