### PR TITLE
Revert "fix building error and warning in gcc10 (#3361)"

### DIFF
--- a/oneflow/core/common/cached_object_msg_allocator.h
+++ b/oneflow/core/common/cached_object_msg_allocator.h
@@ -34,7 +34,7 @@ struct ObjMsgMemBlock final {
 
   template<typename Enabled = void>
   static constexpr int MemPtrOffset() {
-    return offsetof(ObjMsgMemBlock, mem_ptr_);
+    return (int)(long long)&((ObjMsgMemBlock*)nullptr)->mem_ptr_[0];
   }
 
   ObjMsgChunk* chunk_;

--- a/oneflow/core/common/shared_or_plain.h
+++ b/oneflow/core/common/shared_or_plain.h
@@ -57,7 +57,6 @@ class SharedOrPlain final {
 template<typename S, typename P>
 SharedOrPlain<S, P>::SharedOrPlain(const SharedOrPlain& rhs) {
   if (rhs.IsPlain()) {
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
     std::memcpy(this, &rhs, sizeof(*this));
   } else {
     shared_ptr_ = rhs.shared_ptr_;


### PR DESCRIPTION
This reverts commit e338a5f347f92c397c6667b4e2baeff2d0e38a03.

To compile OneFlow with gcc 10, please checkout the branch dev_gcc_10