### PR TITLE
Fix lambda return type deduction

### DIFF
--- a/oneflow/core/framework/user_op_conf.cpp
+++ b/oneflow/core/framework/user_op_conf.cpp
@@ -163,7 +163,7 @@ std::string UserOpWrapper::GetGradTensorWithOpOutput(const std::string& output_a
   return output_grad(output_arg_name, index);
 }
 
-void UserOpWrapper::BindGradTensorWithOpInput(const std::string logical_grad_blob_name,
+void UserOpWrapper::BindGradTensorWithOpInput(const std::string& logical_grad_blob_name,
                                               const std::string& input_arg_name,
                                               int32_t index) const {
   CHECK(NeedGenGradTensor4OpInput(input_arg_name, index));

--- a/oneflow/core/framework/user_op_conf.h
+++ b/oneflow/core/framework/user_op_conf.h
@@ -124,7 +124,7 @@ class UserOpWrapper final {
 
  public:
   void InputGradBind(const user_op::OpArg& input, const UserOpInputGradGetFn& grad_fn);
-  void BindGradTensorWithOpInput(const std::string logical_grad_blob_name,
+  void BindGradTensorWithOpInput(const std::string& logical_grad_blob_name,
                                  const std::string& input_arg_name, int32_t index) const;
   bool NeedGenGradTensor4OpInput(const std::string& input_arg_name, int32_t index) const;
 

--- a/oneflow/user/ops/normalization_op.cpp
+++ b/oneflow/user/ops/normalization_op.cpp
@@ -320,7 +320,7 @@ REGISTER_USER_OP_GRAD("normalization")
 
       ctx->FwOp().InputGradBind(user_op::OpArg("x", 0),
                                 [&ctx, &is_training, &is_fp16, &grad_op_name, &dx_f2h_cast_op_name,
-                                 &dy_mul_inv_var_op_name]() {
+                                 &dy_mul_inv_var_op_name]() -> const std::string& {
                                   if (is_training) {
                                     return ctx->GetOp(grad_op_name).output("dx", 0);
                                   } else {
@@ -332,12 +332,14 @@ REGISTER_USER_OP_GRAD("normalization")
                                   }
                                 });
 
-      ctx->FwOp().InputGradBind(user_op::OpArg("gamma", 0), [&ctx, &gamma_identity_op_name]() {
-        return ctx->GetOp(gamma_identity_op_name).output("out", 0);
-      });
-      ctx->FwOp().InputGradBind(user_op::OpArg("beta", 0), [&ctx, &beta_identity_op_name]() {
-        return ctx->GetOp(beta_identity_op_name).output("out", 0);
-      });
+      ctx->FwOp().InputGradBind(user_op::OpArg("gamma", 0),
+                                [&ctx, &gamma_identity_op_name]() -> const std::string& {
+                                  return ctx->GetOp(gamma_identity_op_name).output("out", 0);
+                                });
+      ctx->FwOp().InputGradBind(user_op::OpArg("beta", 0),
+                                [&ctx, &beta_identity_op_name]() -> const std::string& {
+                                  return ctx->GetOp(beta_identity_op_name).output("out", 0);
+                                });
     });
 
 }  // namespace oneflow

--- a/oneflow/user/ops/relu_op.cpp
+++ b/oneflow/user/ops/relu_op.cpp
@@ -81,9 +81,10 @@ REGISTER_USER_OP_GRAD("relu").SetBackwardOpConfGenFn([](user_op::BackwardOpConfC
         .Output("dx")
         .Build();
   });
-  ctx->FwOp().InputGradBind(user_op::OpArg("in", 0), [&ctx, &relu_grad_op_name]() {
-    return ctx->GetOp(relu_grad_op_name).output("dx", 0);
-  });
+  ctx->FwOp().InputGradBind(user_op::OpArg("in", 0),
+                            [&ctx, &relu_grad_op_name]() -> const std::string& {
+                              return ctx->GetOp(relu_grad_op_name).output("dx", 0);
+                            });
 });
 
 }  // namespace

--- a/oneflow/user/ops/where_op.cpp
+++ b/oneflow/user/ops/where_op.cpp
@@ -97,12 +97,14 @@ REGISTER_USER_OP_GRAD("where").SetBackwardOpConfGenFn([](user_op::BackwardOpConf
         .Build();
   });
 
-  ctx->FwOp().InputGradBind(user_op::OpArg("x", 0), [&ctx, &x_grad_op_name]() {
-    return ctx->GetOp(x_grad_op_name).output("out", 0);
-  });
-  ctx->FwOp().InputGradBind(user_op::OpArg("y", 0), [&ctx, &y_grad_op_name]() {
-    return ctx->GetOp(y_grad_op_name).output("out", 0);
-  });
+  ctx->FwOp().InputGradBind(user_op::OpArg("x", 0),
+                            [&ctx, &x_grad_op_name]() -> const std::string& {
+                              return ctx->GetOp(x_grad_op_name).output("out", 0);
+                            });
+  ctx->FwOp().InputGradBind(user_op::OpArg("y", 0),
+                            [&ctx, &y_grad_op_name]() -> const std::string& {
+                              return ctx->GetOp(y_grad_op_name).output("out", 0);
+                            });
 });
 
 }  // namespace oneflow


### PR DESCRIPTION
We should explicitly specify the return type of these lambdas, to prevent some potential segmentation fault or unexpected behavior.

For your reference, check the code below, gcc5.4~gcc10.2 give `Segmentation fault`, clang10 gives wrong output, but gcc4.8.5 gives the seemingly right output. You can try it out [here](https://godbolt.org/).

```c++
#include <functional>
#include <string>
#include <iostream>

using FFF = std::function<const std::string&()>;

const std::string& call(const FFF& f) {
    return f();
}

std::string abc = "some string";

int main() {
    std::cout << call([]() {
            return abc;
            }) << std::endl;
}
```