### PR TITLE
force non void function to have return statement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ if(WIN32)
   #set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS} /DEBUG:FASTLINK")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /D_ITERATOR_DEBUG_LEVEL=0")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-sign-compare -Wno-unused-function -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-sign-compare -Wno-unused-function -fPIC -Werror=return-type")
 endif()
 
 if (THIRD_PARTY)


### PR DESCRIPTION
add  `-Werror=return-type` compile option to force non void function to have return statement, otherwise will raise compile error.

refer to：[How to enforce error when function has no return in gcc?](https://stackoverflow.com/questions/42760220/how-to-enforce-error-when-function-has-no-return-in-gcc)