### PR TITLE
Add OF_CUDA_CHECK/OF_CUDNN_CHECK/OF_CUBLAS_CHECK/OF_CURAND_CHECK

### DIFF
--- a/oneflow/core/common/blas.h
+++ b/oneflow/core/common/blas.h
@@ -60,15 +60,15 @@ OF_PP_FOR_EACH_TUPLE(CBLAS_TEMPLATE, BLAS_NAME_SEQ);
 #define CUBLAS_TEMPLATE(name)                                                                   \
   template<typename T, typename... Args>                                                        \
   typename std::enable_if<std::is_same<T, float>::value>::type cublas_##name(Args&&... args) {  \
-    CudaCheck(cublasS##name(std::forward<Args>(args)...));                                      \
+    OF_CUBLAS_CHECK(cublasS##name(std::forward<Args>(args)...));                                \
   }                                                                                             \
   template<typename T, typename... Args>                                                        \
   typename std::enable_if<std::is_same<T, double>::value>::type cublas_##name(Args&&... args) { \
-    CudaCheck(cublasD##name(std::forward<Args>(args)...));                                      \
+    OF_CUBLAS_CHECK(cublasD##name(std::forward<Args>(args)...));                                \
   }                                                                                             \
   template<typename T, typename... Args>                                                        \
   typename std::enable_if<std::is_same<T, half>::value>::type cublas_##name(Args&&... args) {   \
-    CudaCheck(cublasH##name(std::forward<Args>(args)...));                                      \
+    OF_CUBLAS_CHECK(cublasH##name(std::forward<Args>(args)...));                                \
   }
 
 OF_PP_FOR_EACH_TUPLE(CUBLAS_TEMPLATE, BLAS_NAME_SEQ);

--- a/oneflow/core/device/cuda_device_context.h
+++ b/oneflow/core/device/cuda_device_context.h
@@ -44,7 +44,7 @@ class CudaDeviceCtx : public DeviceCtx {
   }
   const cudnnHandle_t& cudnn_handle() const override { return *(cuda_handler_->cudnn_handle()); }
 
-  void SyncDevice() override { CudaCheck(cudaStreamSynchronize(cuda_stream())); }
+  void SyncDevice() override { OF_CUDA_CHECK(cudaStreamSynchronize(cuda_stream())); }
 
   void AddCallBack(std::function<void()> callback) const override {
     cuda_handler_->AddCallBack(callback);

--- a/oneflow/core/device/cuda_stream_handle.cpp
+++ b/oneflow/core/device/cuda_stream_handle.cpp
@@ -33,8 +33,8 @@ const cudaStream_t* CudaStreamHandle::cuda_stream() {
 const cublasHandle_t* CudaStreamHandle::cublas_pmh_handle() {
   if (!cublas_pmh_handle_) {
     cublas_pmh_handle_.reset(new cublasHandle_t);
-    CudaCheck(cublasCreate(cublas_pmh_handle_.get()));
-    CudaCheck(cublasSetStream(*cublas_pmh_handle_, *cuda_stream()));
+    OF_CUBLAS_CHECK(cublasCreate(cublas_pmh_handle_.get()));
+    OF_CUBLAS_CHECK(cublasSetStream(*cublas_pmh_handle_, *cuda_stream()));
   }
   return cublas_pmh_handle_.get();
 }
@@ -42,9 +42,9 @@ const cublasHandle_t* CudaStreamHandle::cublas_pmh_handle() {
 const cublasHandle_t* CudaStreamHandle::cublas_pmd_handle() {
   if (!cublas_pmd_handle_) {
     cublas_pmd_handle_.reset(new cublasHandle_t);
-    CudaCheck(cublasCreate(cublas_pmd_handle_.get()));
-    CudaCheck(cublasSetStream(*cublas_pmd_handle_, *cuda_stream()));
-    CudaCheck(cublasSetPointerMode(*cublas_pmd_handle_, CUBLAS_POINTER_MODE_DEVICE));
+    OF_CUBLAS_CHECK(cublasCreate(cublas_pmd_handle_.get()));
+    OF_CUBLAS_CHECK(cublasSetStream(*cublas_pmd_handle_, *cuda_stream()));
+    OF_CUBLAS_CHECK(cublasSetPointerMode(*cublas_pmd_handle_, CUBLAS_POINTER_MODE_DEVICE));
   }
   return cublas_pmd_handle_.get();
 }
@@ -52,9 +52,9 @@ const cublasHandle_t* CudaStreamHandle::cublas_pmd_handle() {
 const cublasHandle_t* CudaStreamHandle::cublas_tensor_op_math_handle() {
   if (!cublas_tensor_op_math_handle_) {
     cublas_tensor_op_math_handle_.reset(new cublasHandle_t);
-    CudaCheck(cublasCreate(cublas_tensor_op_math_handle_.get()));
-    CudaCheck(cublasSetStream(*cublas_tensor_op_math_handle_, *cuda_stream()));
-    CudaCheck(cublasSetMathMode(*cublas_tensor_op_math_handle_, CUBLAS_TENSOR_OP_MATH));
+    OF_CUBLAS_CHECK(cublasCreate(cublas_tensor_op_math_handle_.get()));
+    OF_CUBLAS_CHECK(cublasSetStream(*cublas_tensor_op_math_handle_, *cuda_stream()));
+    OF_CUBLAS_CHECK(cublasSetMathMode(*cublas_tensor_op_math_handle_, CUBLAS_TENSOR_OP_MATH));
   }
   return cublas_tensor_op_math_handle_.get();
 }
@@ -86,8 +86,8 @@ void CudaStreamHandle::AddCallBack(std::function<void()> callback) {
 
 CudaStreamHandle::~CudaStreamHandle() {
   if (cudnn_handle_) { OF_CUDNN_CHECK(cudnnDestroy(*cudnn_handle_)); }
-  if (cublas_pmh_handle_) { CudaCheck(cublasDestroy(*cublas_pmh_handle_)); }
-  if (cublas_pmd_handle_) { CudaCheck(cublasDestroy(*cublas_pmd_handle_)); }
+  if (cublas_pmh_handle_) { OF_CUBLAS_CHECK(cublasDestroy(*cublas_pmh_handle_)); }
+  if (cublas_pmd_handle_) { OF_CUBLAS_CHECK(cublasDestroy(*cublas_pmd_handle_)); }
   if (cuda_stream_) { OF_CUDA_CHECK(cudaStreamDestroy(*cuda_stream_)); }
 }
 

--- a/oneflow/core/device/cuda_stream_handle.cpp
+++ b/oneflow/core/device/cuda_stream_handle.cpp
@@ -66,12 +66,12 @@ const cudnnHandle_t* CudaStreamHandle::cudnn_handle() {
       OF_CUDA_CHECK(cudaGetLastError());
     }
     cudnn_handle_.reset(new cudnnHandle_t);
-    CudaCheck(cudnnCreate(cudnn_handle_.get()));
+    OF_CUDNN_CHECK(cudnnCreate(cudnn_handle_.get()));
     if (IsCuda9OnTuringDevice()) {
       OF_CUDA_CHECK(cudaDeviceSynchronize());
       cudaGetLastError();
     }
-    CudaCheck(cudnnSetStream(*cudnn_handle_, *cuda_stream()));
+    OF_CUDNN_CHECK(cudnnSetStream(*cudnn_handle_, *cuda_stream()));
   }
   return cudnn_handle_.get();
 }
@@ -85,7 +85,7 @@ void CudaStreamHandle::AddCallBack(std::function<void()> callback) {
 }
 
 CudaStreamHandle::~CudaStreamHandle() {
-  if (cudnn_handle_) { CudaCheck(cudnnDestroy(*cudnn_handle_)); }
+  if (cudnn_handle_) { OF_CUDNN_CHECK(cudnnDestroy(*cudnn_handle_)); }
   if (cublas_pmh_handle_) { CudaCheck(cublasDestroy(*cublas_pmh_handle_)); }
   if (cublas_pmd_handle_) { CudaCheck(cublasDestroy(*cublas_pmd_handle_)); }
   if (cuda_stream_) { OF_CUDA_CHECK(cudaStreamDestroy(*cuda_stream_)); }

--- a/oneflow/core/device/cuda_util.cpp
+++ b/oneflow/core/device/cuda_util.cpp
@@ -21,8 +21,6 @@ namespace oneflow {
 
 #ifdef WITH_CUDA
 
-namespace {
-
 const char* CublasGetErrorString(cublasStatus_t error) {
   switch (error) {
     case CUBLAS_STATUS_SUCCESS: return "CUBLAS_STATUS_SUCCESS";
@@ -61,8 +59,6 @@ const char* CurandGetErrorString(curandStatus_t error) {
   }
   return "Unknown curand status";
 }
-
-}  // namespace
 
 void InitGlobalCudaDeviceProp() {
   CHECK(Global<cudaDeviceProp>::Get() == nullptr) << "initialized Global<cudaDeviceProp> twice";

--- a/oneflow/core/device/cuda_util.cpp
+++ b/oneflow/core/device/cuda_util.cpp
@@ -143,7 +143,7 @@ void ParseCpuMask(const std::string& cpu_mask, cpu_set_t* cpu_set) {
 
 std::string CudaDeviceGetCpuMask(int32_t dev_id) {
   std::vector<char> pci_bus_id_buf(sizeof("0000:00:00.0"));
-  CudaCheck(cudaDeviceGetPCIBusId(pci_bus_id_buf.data(), static_cast<int>(pci_bus_id_buf.size()),
+  OF_CUDA_CHECK(cudaDeviceGetPCIBusId(pci_bus_id_buf.data(), static_cast<int>(pci_bus_id_buf.size()),
                                   dev_id));
   for (int32_t i = 0; i < pci_bus_id_buf.size(); ++i) {
     pci_bus_id_buf[i] = std::tolower(pci_bus_id_buf[i]);
@@ -178,7 +178,7 @@ void NumaAwareCudaMallocHost(int32_t dev, void** ptr, size_t size) {
   cpu_set_t saved_cpu_set;
   CHECK_EQ(sched_getaffinity(0, sizeof(cpu_set_t), &saved_cpu_set), 0);
   CHECK_EQ(sched_setaffinity(0, sizeof(cpu_set_t), &new_cpu_set), 0);
-  CudaCheck(cudaMallocHost(ptr, size));
+  OF_CUDA_CHECK(cudaMallocHost(ptr, size));
   CHECK_EQ(sched_setaffinity(0, sizeof(cpu_set_t), &saved_cpu_set), 0);
 #else
   UNIMPLEMENTED();
@@ -194,13 +194,13 @@ cudaDataType_t GetCudaDataType(DataType val) {
 }
 
 CudaCurrentDeviceGuard::CudaCurrentDeviceGuard(int32_t dev_id) {
-  CudaCheck(cudaGetDevice(&saved_dev_id_));
-  CudaCheck(cudaSetDevice(dev_id));
+  OF_CUDA_CHECK(cudaGetDevice(&saved_dev_id_));
+  OF_CUDA_CHECK(cudaSetDevice(dev_id));
 }
 
-CudaCurrentDeviceGuard::CudaCurrentDeviceGuard() { CudaCheck(cudaGetDevice(&saved_dev_id_)); }
+CudaCurrentDeviceGuard::CudaCurrentDeviceGuard() { OF_CUDA_CHECK(cudaGetDevice(&saved_dev_id_)); }
 
-CudaCurrentDeviceGuard::~CudaCurrentDeviceGuard() { CudaCheck(cudaSetDevice(saved_dev_id_)); }
+CudaCurrentDeviceGuard::~CudaCurrentDeviceGuard() { OF_CUDA_CHECK(cudaSetDevice(saved_dev_id_)); }
 
 #endif  // WITH_CUDA
 

--- a/oneflow/core/device/cuda_util.cpp
+++ b/oneflow/core/device/cuda_util.cpp
@@ -143,8 +143,8 @@ void ParseCpuMask(const std::string& cpu_mask, cpu_set_t* cpu_set) {
 
 std::string CudaDeviceGetCpuMask(int32_t dev_id) {
   std::vector<char> pci_bus_id_buf(sizeof("0000:00:00.0"));
-  OF_CUDA_CHECK(cudaDeviceGetPCIBusId(pci_bus_id_buf.data(), static_cast<int>(pci_bus_id_buf.size()),
-                                  dev_id));
+  OF_CUDA_CHECK(cudaDeviceGetPCIBusId(pci_bus_id_buf.data(),
+                                      static_cast<int>(pci_bus_id_buf.size()), dev_id));
   for (int32_t i = 0; i < pci_bus_id_buf.size(); ++i) {
     pci_bus_id_buf[i] = std::tolower(pci_bus_id_buf[i]);
   }

--- a/oneflow/core/device/cuda_util.h
+++ b/oneflow/core/device/cuda_util.h
@@ -31,6 +31,33 @@ limitations under the License.
 
 namespace oneflow {
 
+const char* CublasGetErrorString(cublasStatus_t error);
+
+const char* CurandGetErrorString(curandStatus_t error);
+
+#define OF_CUDA_CHECK(condition)                                                               \
+  for (cudaError_t _of_cuda_check_status = (condition); _of_cuda_check_status != cudaSuccess;) \
+  LOG(FATAL) << "Check failed: " #condition " : " << cudaGetErrorString(_of_cuda_check_status) \
+             << " (" << _of_cuda_check_status << ") "
+
+#define OF_CUDNN_CHECK(condition)                                                                \
+  for (cudnnStatus_t _of_cudnn_check_status = (condition);                                       \
+       _of_cudnn_check_status != CUDNN_STATUS_SUCCESS;)                                          \
+  LOG(FATAL) << "Check failed: " #condition " : " << cudnnGetErrorString(_of_cudnn_check_status) \
+             << " (" << _of_cudnn_check_status << ") "
+
+#define OF_CUBLAS_CHECK(condition)                                                                 \
+  for (cublasStatus_t _of_cublas_check_status = (condition);                                       \
+       _of_cublas_check_status != CUBLAS_STATUS_SUCCESS;)                                          \
+  LOG(FATAL) << "Check failed: " #condition " : " << CublasGetErrorString(_of_cublas_check_status) \
+             << " (" << _of_cublas_check_status << ") "
+
+#define OF_CURAND_CHECK(condition)                                                                 \
+  for (curandStatus_t _of_curand_check_status = (condition);                                       \
+       _of_curand_check_status != CURAND_STATUS_SUCCESS;)                                          \
+  LOG(FATAL) << "Check failed: " #condition " : " << CurandGetErrorString(_of_curand_check_status) \
+             << " (" << _of_curand_check_status << ") "
+
 template<typename T>
 void CudaCheck(T error);
 

--- a/oneflow/core/device/cuda_util.h
+++ b/oneflow/core/device/cuda_util.h
@@ -58,6 +58,11 @@ const char* CurandGetErrorString(curandStatus_t error);
   LOG(FATAL) << "Check failed: " #condition " : " << CurandGetErrorString(_of_curand_check_status) \
              << " (" << _of_curand_check_status << ") "
 
+#define OF_NCCL_CHECK(condition)                                                                \
+  for (ncclResult_t _of_nccl_check_status = (condition); _of_nccl_check_status != ncclSuccess;) \
+  LOG(FATAL) << "Check failed: " #condition " : " << ncclGetErrorString(_of_nccl_check_status)  \
+             << " (" << _of_nccl_check_status << ") "
+
 template<typename T>
 void CudaCheck(T error);
 

--- a/oneflow/core/device/cudnn_conv_util.cpp
+++ b/oneflow/core/device/cudnn_conv_util.cpp
@@ -60,7 +60,7 @@ void SetAlgo4Perf(const CudnnConvArgs& args, CudnnConvResource* res, perf_t* alg
   } else {
     algo_perf->mathType = CUDNN_DEFAULT_MATH;
   }
-  CudaCheck(GetCudnnConvWorkspaceSize(args, res, algo_perf->algo, &(algo_perf->memory)));
+  OF_CUDNN_CHECK(GetCudnnConvWorkspaceSize(args, res, algo_perf->algo, &(algo_perf->memory)));
   algo_perf->status = CUDNN_STATUS_SUCCESS;
 }
 
@@ -132,62 +132,62 @@ perf_t GetBestAlgorithm(const CudnnConvArgs& args, CudnnConvResource* res,
 
 }  // namespace
 
-CudnnConvDesc::~CudnnConvDesc() { CudaCheck(cudnnDestroyConvolutionDescriptor(val_)); }
+CudnnConvDesc::~CudnnConvDesc() { OF_CUDNN_CHECK(cudnnDestroyConvolutionDescriptor(val_)); }
 
 CudnnConvDesc::CudnnConvDesc(const DataType& data_type, const ShapeView& in_blob_shape,
                              const PbMessage& conv_conf) {
   int32_t opkernel_dim = in_blob_shape.NumAxes() - 2;
-  CudaCheck(cudnnCreateConvolutionDescriptor(&val_));
+  OF_CUDNN_CHECK(cudnnCreateConvolutionDescriptor(&val_));
   std::vector<int32_t> pad_large_side;
   GetConvOutAndPad(in_blob_shape, conv_conf, nullptr, nullptr, &pad_large_side);
   const PbRf<int32_t>& strides = GetPbRfFromPbMessage<int32_t>(conv_conf, "strides");
   const PbRf<int32_t>& dilation_rate = GetPbRfFromPbMessage<int32_t>(conv_conf, "dilation_rate");
   if (opkernel_dim == 2) {
-    CudaCheck(cudnnSetConvolution2dDescriptor(val_, pad_large_side[0], pad_large_side[1],
-                                              strides.Get(0), strides.Get(1), dilation_rate.Get(0),
-                                              dilation_rate.Get(1), CUDNN_CROSS_CORRELATION,
-                                              GetCudnnDataType(data_type)));
+    OF_CUDNN_CHECK(
+        cudnnSetConvolution2dDescriptor(val_, pad_large_side[0], pad_large_side[1], strides.Get(0),
+                                        strides.Get(1), dilation_rate.Get(0), dilation_rate.Get(1),
+                                        CUDNN_CROSS_CORRELATION, GetCudnnDataType(data_type)));
   } else if (opkernel_dim == 1) {
-    CudaCheck(cudnnSetConvolution2dDescriptor(val_, pad_large_side[0], 0, strides.Get(0), 1,
-                                              dilation_rate.Get(0), 1, CUDNN_CROSS_CORRELATION,
-                                              GetCudnnDataType(data_type)));
+    OF_CUDNN_CHECK(cudnnSetConvolution2dDescriptor(val_, pad_large_side[0], 0, strides.Get(0), 1,
+                                                   dilation_rate.Get(0), 1, CUDNN_CROSS_CORRELATION,
+                                                   GetCudnnDataType(data_type)));
   } else {
-    CudaCheck(cudnnSetConvolutionNdDescriptor(
+    OF_CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(
         val_, opkernel_dim, pad_large_side.data(), strides.data(), dilation_rate.data(),
         CUDNN_CROSS_CORRELATION, GetCudnnDataType(data_type)));
   }
   const int32_t groups = GetValFromPbMessage<int32_t>(conv_conf, "groups");
-  if (groups != 1) { CudaCheck(cudnnSetConvolutionGroupCount(val_, groups)); }
+  if (groups != 1) { OF_CUDNN_CHECK(cudnnSetConvolutionGroupCount(val_, groups)); }
   if (GetCudnnDataType(data_type) == CUDNN_DATA_HALF) {
-    CudaCheck(cudnnSetConvolutionMathType(val_, CUDNN_TENSOR_OP_MATH));
+    OF_CUDNN_CHECK(cudnnSetConvolutionMathType(val_, CUDNN_TENSOR_OP_MATH));
   }
 }
 
 CudnnConvDesc::CudnnConvDesc(const DataType& data_type, const ShapeView& in_blob_shape,
                              const user_op::UserOpConfWrapper& conv_conf) {
   int32_t opkernel_dim = in_blob_shape.NumAxes() - 2;
-  CudaCheck(cudnnCreateConvolutionDescriptor(&val_));
+  OF_CUDNN_CHECK(cudnnCreateConvolutionDescriptor(&val_));
   const auto& padding_before = conv_conf.attr<std::vector<int32_t>>("padding_before");
   const auto& strides = conv_conf.attr<std::vector<int32_t>>("strides");
   const auto& dilation_rate = conv_conf.attr<std::vector<int32_t>>("dilation_rate");
   if (opkernel_dim == 2) {
-    CudaCheck(cudnnSetConvolution2dDescriptor(val_, padding_before.at(0), padding_before.at(1),
-                                              strides.at(0), strides.at(1), dilation_rate.at(0),
-                                              dilation_rate.at(1), CUDNN_CROSS_CORRELATION,
-                                              GetCudnnDataType(data_type)));
+    OF_CUDNN_CHECK(cudnnSetConvolution2dDescriptor(
+        val_, padding_before.at(0), padding_before.at(1), strides.at(0), strides.at(1),
+        dilation_rate.at(0), dilation_rate.at(1), CUDNN_CROSS_CORRELATION,
+        GetCudnnDataType(data_type)));
   } else if (opkernel_dim == 1) {
-    CudaCheck(cudnnSetConvolution2dDescriptor(val_, padding_before.at(0), 0, strides.at(0), 1,
-                                              dilation_rate.at(0), 1, CUDNN_CROSS_CORRELATION,
-                                              GetCudnnDataType(data_type)));
+    OF_CUDNN_CHECK(cudnnSetConvolution2dDescriptor(val_, padding_before.at(0), 0, strides.at(0), 1,
+                                                   dilation_rate.at(0), 1, CUDNN_CROSS_CORRELATION,
+                                                   GetCudnnDataType(data_type)));
   } else {
-    CudaCheck(cudnnSetConvolutionNdDescriptor(
+    OF_CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(
         val_, opkernel_dim, padding_before.data(), strides.data(), dilation_rate.data(),
         CUDNN_CROSS_CORRELATION, GetCudnnDataType(data_type)));
   }
   const int32_t groups = conv_conf.attr<int32_t>("groups");
-  if (groups != 1) { CudaCheck(cudnnSetConvolutionGroupCount(val_, groups)); }
+  if (groups != 1) { OF_CUDNN_CHECK(cudnnSetConvolutionGroupCount(val_, groups)); }
   if (GetCudnnDataType(data_type) == CUDNN_DATA_HALF) {
-    CudaCheck(cudnnSetConvolutionMathType(val_, CUDNN_TENSOR_OP_MATH));
+    OF_CUDNN_CHECK(cudnnSetConvolutionMathType(val_, CUDNN_TENSOR_OP_MATH));
   }
 }
 
@@ -204,24 +204,24 @@ CudnnConvArgs::CudnnConvArgs(const PbMessage& conv_conf, DataType x_data_type,
       heuristic(heuristic_search),
       deterministic(use_deterministic_algo_only) {
   std::memset(&params, 0, sizeof(CudnnConvParams));
-  CudaCheck(cudnnGetTensorNdDescriptor(xdesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                       &params.x_data_type, &params.x_ndim, params.x_dims,
-                                       params.x_strides));
-  CudaCheck(cudnnGetTensorNdDescriptor(ydesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                       &params.y_data_type, &params.y_ndim, params.y_dims,
-                                       params.y_strides));
-  CudaCheck(cudnnGetFilterNdDescriptor(wdesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                       &params.w_data_type, &params.w_format, &params.w_ndim,
-                                       params.w_dims));
+  OF_CUDNN_CHECK(cudnnGetTensorNdDescriptor(xdesc.Get(), CudnnConvParams::kTensorMaxDims,
+                                            &params.x_data_type, &params.x_ndim, params.x_dims,
+                                            params.x_strides));
+  OF_CUDNN_CHECK(cudnnGetTensorNdDescriptor(ydesc.Get(), CudnnConvParams::kTensorMaxDims,
+                                            &params.y_data_type, &params.y_ndim, params.y_dims,
+                                            params.y_strides));
+  OF_CUDNN_CHECK(cudnnGetFilterNdDescriptor(wdesc.Get(), CudnnConvParams::kTensorMaxDims,
+                                            &params.w_data_type, &params.w_format, &params.w_ndim,
+                                            params.w_dims));
   cudnnConvolutionMode_t mode;
   int conv_dim_size = 0;
-  CudaCheck(cudnnGetConvolutionNdDescriptor(cdesc.Get(), CudnnConvParams::kConvMaxDims,
-                                            &conv_dim_size, params.padding, params.stride,
-                                            params.dilation, &mode, &params.data_type));
+  OF_CUDNN_CHECK(cudnnGetConvolutionNdDescriptor(cdesc.Get(), CudnnConvParams::kConvMaxDims,
+                                                 &conv_dim_size, params.padding, params.stride,
+                                                 params.dilation, &mode, &params.data_type));
   CHECK_EQ(params.x_data_type, params.w_data_type);
   CHECK_EQ(params.x_ndim, params.w_ndim);
   CHECK_EQ(conv_dim_size + 2, params.x_ndim);
-  CudaCheck(cudnnGetConvolutionGroupCount(cdesc.Get(), &params.groups));
+  OF_CUDNN_CHECK(cudnnGetConvolutionGroupCount(cdesc.Get(), &params.groups));
   params.max_ws_size = max_workspace_size;
 }
 
@@ -238,24 +238,24 @@ CudnnConvArgs::CudnnConvArgs(const user_op::UserOpConfWrapper& conv_conf, DataTy
       heuristic(heuristic_search),
       deterministic(use_deterministic_algo_only) {
   std::memset(&params, 0, sizeof(CudnnConvParams));
-  CudaCheck(cudnnGetTensorNdDescriptor(xdesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                       &params.x_data_type, &params.x_ndim, params.x_dims,
-                                       params.x_strides));
-  CudaCheck(cudnnGetTensorNdDescriptor(ydesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                       &params.y_data_type, &params.y_ndim, params.y_dims,
-                                       params.y_strides));
-  CudaCheck(cudnnGetFilterNdDescriptor(wdesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                       &params.w_data_type, &params.w_format, &params.w_ndim,
-                                       params.w_dims));
+  OF_CUDNN_CHECK(cudnnGetTensorNdDescriptor(xdesc.Get(), CudnnConvParams::kTensorMaxDims,
+                                            &params.x_data_type, &params.x_ndim, params.x_dims,
+                                            params.x_strides));
+  OF_CUDNN_CHECK(cudnnGetTensorNdDescriptor(ydesc.Get(), CudnnConvParams::kTensorMaxDims,
+                                            &params.y_data_type, &params.y_ndim, params.y_dims,
+                                            params.y_strides));
+  OF_CUDNN_CHECK(cudnnGetFilterNdDescriptor(wdesc.Get(), CudnnConvParams::kTensorMaxDims,
+                                            &params.w_data_type, &params.w_format, &params.w_ndim,
+                                            params.w_dims));
   cudnnConvolutionMode_t mode;
   int conv_dim_size = 0;
-  CudaCheck(cudnnGetConvolutionNdDescriptor(cdesc.Get(), CudnnConvParams::kConvMaxDims,
-                                            &conv_dim_size, params.padding, params.stride,
-                                            params.dilation, &mode, &params.data_type));
+  OF_CUDNN_CHECK(cudnnGetConvolutionNdDescriptor(cdesc.Get(), CudnnConvParams::kConvMaxDims,
+                                                 &conv_dim_size, params.padding, params.stride,
+                                                 params.dilation, &mode, &params.data_type));
   CHECK_EQ(params.x_data_type, params.w_data_type);
   CHECK_EQ(params.x_ndim, params.w_ndim);
   CHECK_EQ(conv_dim_size + 2, params.x_ndim);
-  CudaCheck(cudnnGetConvolutionGroupCount(cdesc.Get(), &params.groups));
+  OF_CUDNN_CHECK(cudnnGetConvolutionGroupCount(cdesc.Get(), &params.groups));
   params.max_ws_size = max_workspace_size;
 }
 
@@ -268,7 +268,7 @@ ManagedCudnnConvResource::ManagedCudnnConvResource(const CudnnConvArgs& args)
 }
 
 ManagedCudnnConvResource::~ManagedCudnnConvResource() {
-  if (handle_ != nullptr) { CudaCheck(cudnnDestroy(handle_)); }
+  if (handle_ != nullptr) { OF_CUDNN_CHECK(cudnnDestroy(handle_)); }
   if (x_dptr_ != nullptr) { OF_CUDA_CHECK(cudaFree(x_dptr_)); }
   if (w_dptr_ != nullptr) { OF_CUDA_CHECK(cudaFree(w_dptr_)); }
   if (y_dptr_ != nullptr) { OF_CUDA_CHECK(cudaFree(y_dptr_)); }
@@ -276,7 +276,7 @@ ManagedCudnnConvResource::~ManagedCudnnConvResource() {
 }
 
 cudnnHandle_t ManagedCudnnConvResource::cudnn_handle() {
-  if (handle_ == nullptr) { CudaCheck(cudnnCreate(&handle_)); }
+  if (handle_ == nullptr) { OF_CUDNN_CHECK(cudnnCreate(&handle_)); }
   return handle_;
 }
 
@@ -349,7 +349,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionFwdAlgoPerf_t> {
 
   static int GetAlgoMaxCount(CudnnConvResource* res) {
     int max_algo_cnt = 0;
-    CudaCheck(cudnnGetConvolutionForwardAlgorithmMaxCount(res->cudnn_handle(), &max_algo_cnt));
+    OF_CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithmMaxCount(res->cudnn_handle(), &max_algo_cnt));
     return max_algo_cnt;
   }
 
@@ -357,7 +357,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionFwdAlgoPerf_t> {
                               std::vector<perf_t>* perf_vec) {
     int found_algo_cnt = 0;
     perf_vec->resize(GetAlgoMaxCount(res));
-    CudaCheck(cudnnGetConvolutionForwardAlgorithm_v7(
+    OF_CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm_v7(
         res->cudnn_handle(), args.xdesc.Get(), args.wdesc.Get(), args.cdesc.Get(), args.ydesc.Get(),
         perf_vec->size(), &found_algo_cnt, perf_vec->data()));
     // vector::resize does not affect the first found_algo_cnt elements.
@@ -368,7 +368,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionFwdAlgoPerf_t> {
                                std::vector<perf_t>* perf_vec) {
     int found_algo_cnt = 0;
     perf_vec->resize(GetAlgoMaxCount(res));
-    CudaCheck(cudnnFindConvolutionForwardAlgorithmEx(
+    OF_CUDNN_CHECK(cudnnFindConvolutionForwardAlgorithmEx(
         res->cudnn_handle(), args.xdesc.Get(), res->x_const_dptr(), args.wdesc.Get(),
         res->w_const_dptr(), args.cdesc.Get(), args.ydesc.Get(), res->y_mut_dptr(),
         perf_vec->size(), &found_algo_cnt, perf_vec->data(), res->ws_dptr(),
@@ -384,7 +384,8 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdDataAlgoPerf_t> {
 
   static int GetAlgoMaxCount(CudnnConvResource* res) {
     int max_algo_cnt = 0;
-    CudaCheck(cudnnGetConvolutionBackwardDataAlgorithmMaxCount(res->cudnn_handle(), &max_algo_cnt));
+    OF_CUDNN_CHECK(
+        cudnnGetConvolutionBackwardDataAlgorithmMaxCount(res->cudnn_handle(), &max_algo_cnt));
     return max_algo_cnt;
   }
 
@@ -392,7 +393,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdDataAlgoPerf_t> {
                               std::vector<perf_t>* perf_vec) {
     int found_algo_cnt = 0;
     perf_vec->resize(GetAlgoMaxCount(res));
-    CudaCheck(cudnnGetConvolutionBackwardDataAlgorithm_v7(
+    OF_CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm_v7(
         res->cudnn_handle(), args.wdesc.Get(), args.ydesc.Get(), args.cdesc.Get(), args.xdesc.Get(),
         perf_vec->size(), &found_algo_cnt, perf_vec->data()));
     // vector::resize does not affect the first found_algo_cnt elements.
@@ -403,7 +404,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdDataAlgoPerf_t> {
                                std::vector<perf_t>* perf_vec) {
     int found_algo_cnt = 0;
     perf_vec->resize(GetAlgoMaxCount(res));
-    CudaCheck(cudnnFindConvolutionBackwardDataAlgorithmEx(
+    OF_CUDNN_CHECK(cudnnFindConvolutionBackwardDataAlgorithmEx(
         res->cudnn_handle(), args.wdesc.Get(), res->w_const_dptr(), args.ydesc.Get(),
         res->y_const_dptr(), args.cdesc.Get(), args.xdesc.Get(), res->x_mut_dptr(),
         perf_vec->size(), &found_algo_cnt, perf_vec->data(), res->ws_dptr(),
@@ -419,7 +420,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdFilterAlgoPerf_t> {
 
   static int GetAlgoMaxCount(CudnnConvResource* res) {
     int max_algo_cnt = 0;
-    CudaCheck(
+    OF_CUDNN_CHECK(
         cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(res->cudnn_handle(), &max_algo_cnt));
     return max_algo_cnt;
   }
@@ -428,7 +429,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdFilterAlgoPerf_t> {
                               std::vector<perf_t>* perf_vec) {
     int found_algo_cnt = 0;
     perf_vec->resize(GetAlgoMaxCount(res));
-    CudaCheck(cudnnGetConvolutionBackwardFilterAlgorithm_v7(
+    OF_CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm_v7(
         res->cudnn_handle(), args.xdesc.Get(), args.ydesc.Get(), args.cdesc.Get(), args.wdesc.Get(),
         perf_vec->size(), &found_algo_cnt, perf_vec->data()));
     // vector::resize does not affect the first found_algo_cnt elements.
@@ -439,7 +440,7 @@ struct CudnnConvAlgorithmSearch<cudnnConvolutionBwdFilterAlgoPerf_t> {
                                std::vector<perf_t>* perf_vec) {
     int found_algo_cnt = 0;
     perf_vec->resize(GetAlgoMaxCount(res));
-    CudaCheck(cudnnFindConvolutionBackwardFilterAlgorithmEx(
+    OF_CUDNN_CHECK(cudnnFindConvolutionBackwardFilterAlgorithmEx(
         res->cudnn_handle(), args.xdesc.Get(), res->x_const_dptr(), args.ydesc.Get(),
         res->y_const_dptr(), args.cdesc.Get(), args.wdesc.Get(), res->w_mut_dptr(),
         perf_vec->size(), &found_algo_cnt, perf_vec->data(), res->ws_dptr(),

--- a/oneflow/core/device/cudnn_conv_util.cpp
+++ b/oneflow/core/device/cudnn_conv_util.cpp
@@ -269,10 +269,10 @@ ManagedCudnnConvResource::ManagedCudnnConvResource(const CudnnConvArgs& args)
 
 ManagedCudnnConvResource::~ManagedCudnnConvResource() {
   if (handle_ != nullptr) { CudaCheck(cudnnDestroy(handle_)); }
-  if (x_dptr_ != nullptr) { CudaCheck(cudaFree(x_dptr_)); }
-  if (w_dptr_ != nullptr) { CudaCheck(cudaFree(w_dptr_)); }
-  if (y_dptr_ != nullptr) { CudaCheck(cudaFree(y_dptr_)); }
-  if (ws_dptr_ != nullptr) { CudaCheck(cudaFree(ws_dptr_)); }
+  if (x_dptr_ != nullptr) { OF_CUDA_CHECK(cudaFree(x_dptr_)); }
+  if (w_dptr_ != nullptr) { OF_CUDA_CHECK(cudaFree(w_dptr_)); }
+  if (y_dptr_ != nullptr) { OF_CUDA_CHECK(cudaFree(y_dptr_)); }
+  if (ws_dptr_ != nullptr) { OF_CUDA_CHECK(cudaFree(ws_dptr_)); }
 }
 
 cudnnHandle_t ManagedCudnnConvResource::cudnn_handle() {
@@ -281,17 +281,17 @@ cudnnHandle_t ManagedCudnnConvResource::cudnn_handle() {
 }
 
 void* ManagedCudnnConvResource::x_mut_dptr() {
-  if (x_dptr_ == nullptr) { CudaCheck(cudaMalloc(&x_dptr_, x_byte_size_)); }
+  if (x_dptr_ == nullptr) { OF_CUDA_CHECK(cudaMalloc(&x_dptr_, x_byte_size_)); }
   return x_dptr_;
 }
 
 void* ManagedCudnnConvResource::w_mut_dptr() {
-  if (w_dptr_ == nullptr) { CudaCheck(cudaMalloc(&w_dptr_, w_byte_size_)); }
+  if (w_dptr_ == nullptr) { OF_CUDA_CHECK(cudaMalloc(&w_dptr_, w_byte_size_)); }
   return w_dptr_;
 }
 
 void* ManagedCudnnConvResource::y_mut_dptr() {
-  if (y_dptr_ == nullptr) { CudaCheck(cudaMalloc(&y_dptr_, y_byte_size_)); }
+  if (y_dptr_ == nullptr) { OF_CUDA_CHECK(cudaMalloc(&y_dptr_, y_byte_size_)); }
   return y_dptr_;
 }
 
@@ -308,7 +308,7 @@ const void* ManagedCudnnConvResource::y_const_dptr() const {
 }
 
 void* ManagedCudnnConvResource::ws_dptr() {
-  if (ws_dptr_ == nullptr) { CudaCheck(cudaMalloc(&ws_dptr_, ws_byte_size_)); }
+  if (ws_dptr_ == nullptr) { OF_CUDA_CHECK(cudaMalloc(&ws_dptr_, ws_byte_size_)); }
   return ws_dptr_;
 }
 

--- a/oneflow/core/device/cudnn_util.cpp
+++ b/oneflow/core/device/cudnn_util.cpp
@@ -28,20 +28,20 @@ cudnnDataType_t GetCudnnDataType(DataType val) {
   UNIMPLEMENTED();
 }
 
-CudnnTensorDesc::CudnnTensorDesc() { CudaCheck(cudnnCreateTensorDescriptor(&val_)); }
-CudnnTensorDesc::~CudnnTensorDesc() { CudaCheck(cudnnDestroyTensorDescriptor(val_)); }
+CudnnTensorDesc::CudnnTensorDesc() { OF_CUDNN_CHECK(cudnnCreateTensorDescriptor(&val_)); }
+CudnnTensorDesc::~CudnnTensorDesc() { OF_CUDNN_CHECK(cudnnDestroyTensorDescriptor(val_)); }
 CudnnTensorDesc::CudnnTensorDesc(cudnnTensorFormat_t format, DataType data_type, int n, int c,
                                  int h, int w) {
-  CudaCheck(cudnnCreateTensorDescriptor(&val_));
-  CudaCheck(cudnnSetTensor4dDescriptor(val_, format, GetCudnnDataType(data_type), n, c, h, w));
+  OF_CUDNN_CHECK(cudnnCreateTensorDescriptor(&val_));
+  OF_CUDNN_CHECK(cudnnSetTensor4dDescriptor(val_, format, GetCudnnDataType(data_type), n, c, h, w));
 }
 CudnnTensorDesc::CudnnTensorDesc(DataType data_type, int dims, const int* dim, const int* stride) {
-  CudaCheck(cudnnCreateTensorDescriptor(&val_));
-  CudaCheck(cudnnSetTensorNdDescriptor(val_, GetCudnnDataType(data_type), dims, dim, stride));
+  OF_CUDNN_CHECK(cudnnCreateTensorDescriptor(&val_));
+  OF_CUDNN_CHECK(cudnnSetTensorNdDescriptor(val_, GetCudnnDataType(data_type), dims, dim, stride));
 }
 CudnnTensorDesc::CudnnTensorDesc(DataType data_type, const ShapeView& shape,
                                  const std::string& data_format) {
-  CudaCheck(cudnnCreateTensorDescriptor(&val_));
+  OF_CUDNN_CHECK(cudnnCreateTensorDescriptor(&val_));
   cudnnTensorFormat_t cudnn_data_format;
   if (data_format == "channels_first") {
     cudnn_data_format = CUDNN_TENSOR_NCHW;
@@ -58,8 +58,8 @@ CudnnTensorDesc::CudnnTensorDesc(DataType data_type, const ShapeView& shape,
     int kernel_h = data_format == "channels_first" ? static_cast<int>(shape.At(2))
                                                    : static_cast<int>(shape.At(1));
     int kernel_w = 1;
-    CudaCheck(cudnnSetTensor4dDescriptor(val_, cudnn_data_format, GetCudnnDataType(data_type),
-                                         data_num, channels, kernel_h, kernel_w));
+    OF_CUDNN_CHECK(cudnnSetTensor4dDescriptor(val_, cudnn_data_format, GetCudnnDataType(data_type),
+                                              data_num, channels, kernel_h, kernel_w));
   } else if (shape.NumAxes() == 4) {
     int data_num = static_cast<int>(shape.At(0));
     int channels = data_format == "channels_first" ? static_cast<int>(shape.At(1))
@@ -68,8 +68,8 @@ CudnnTensorDesc::CudnnTensorDesc(DataType data_type, const ShapeView& shape,
                                                    : static_cast<int>(shape.At(1));
     int kernel_w = data_format == "channels_first" ? static_cast<int>(shape.At(3))
                                                    : static_cast<int>(shape.At(2));
-    CudaCheck(cudnnSetTensor4dDescriptor(val_, cudnn_data_format, GetCudnnDataType(data_type),
-                                         data_num, channels, kernel_h, kernel_w));
+    OF_CUDNN_CHECK(cudnnSetTensor4dDescriptor(val_, cudnn_data_format, GetCudnnDataType(data_type),
+                                              data_num, channels, kernel_h, kernel_w));
   } else {
     std::vector<int> tensor_dim({shape.ptr(), shape.ptr() + shape.NumAxes()});
     std::vector<int> stride_of_tensor(shape.NumAxes(), 1);
@@ -77,16 +77,16 @@ CudnnTensorDesc::CudnnTensorDesc(DataType data_type, const ShapeView& shape,
       stride_of_tensor[i] = stride_of_tensor[i + 1] * shape.At(i + 1);
     }
 
-    CudaCheck(cudnnSetTensorNdDescriptor(val_, GetCudnnDataType(data_type), shape.NumAxes(),
-                                         tensor_dim.data(), stride_of_tensor.data()));
+    OF_CUDNN_CHECK(cudnnSetTensorNdDescriptor(val_, GetCudnnDataType(data_type), shape.NumAxes(),
+                                              tensor_dim.data(), stride_of_tensor.data()));
   }
 }
 
-CudnnFilterDesc::~CudnnFilterDesc() { CudaCheck(cudnnDestroyFilterDescriptor(val_)); }
+CudnnFilterDesc::~CudnnFilterDesc() { OF_CUDNN_CHECK(cudnnDestroyFilterDescriptor(val_)); }
 
 CudnnFilterDesc::CudnnFilterDesc(DataType data_type, const ShapeView& shape,
                                  const std::string& data_format) {
-  CudaCheck(cudnnCreateFilterDescriptor(&val_));
+  OF_CUDNN_CHECK(cudnnCreateFilterDescriptor(&val_));
   cudnnTensorFormat_t cudnn_data_format;
   if (data_format == "channels_first") {
     cudnn_data_format = CUDNN_TENSOR_NCHW;
@@ -103,8 +103,8 @@ CudnnFilterDesc::CudnnFilterDesc(DataType data_type, const ShapeView& shape,
     int kernel_h = data_format == "channels_first" ? static_cast<int>(shape.At(2))
                                                    : static_cast<int>(shape.At(1));
     int kernel_w = 1;
-    CudaCheck(cudnnSetFilter4dDescriptor(val_, GetCudnnDataType(data_type), cudnn_data_format,
-                                         filters, c, kernel_h, kernel_w));
+    OF_CUDNN_CHECK(cudnnSetFilter4dDescriptor(val_, GetCudnnDataType(data_type), cudnn_data_format,
+                                              filters, c, kernel_h, kernel_w));
   } else if (shape.NumAxes() == 4) {
     int filters = static_cast<int>(shape.At(0));
     int kernel_h = data_format == "channels_first" ? static_cast<int>(shape.At(2))
@@ -113,22 +113,24 @@ CudnnFilterDesc::CudnnFilterDesc(DataType data_type, const ShapeView& shape,
                                                    : static_cast<int>(shape.At(2));
     int c = data_format == "channels_first" ? static_cast<int>(shape.At(1))
                                             : static_cast<int>(shape.At(3));
-    CudaCheck(cudnnSetFilter4dDescriptor(val_, GetCudnnDataType(data_type), cudnn_data_format,
-                                         filters, c, kernel_h, kernel_w));
+    OF_CUDNN_CHECK(cudnnSetFilter4dDescriptor(val_, GetCudnnDataType(data_type), cudnn_data_format,
+                                              filters, c, kernel_h, kernel_w));
   } else {
     std::vector<int> dims({shape.ptr(), shape.ptr() + shape.NumAxes()});
-    CudaCheck(cudnnSetFilterNdDescriptor(val_, GetCudnnDataType(data_type), cudnn_data_format,
-                                         dims.size(), dims.data()));
+    OF_CUDNN_CHECK(cudnnSetFilterNdDescriptor(val_, GetCudnnDataType(data_type), cudnn_data_format,
+                                              dims.size(), dims.data()));
   }
 }
 
 CudnnActivationDesc::CudnnActivationDesc(cudnnActivationMode_t mode,
                                          cudnnNanPropagation_t relu_nan_opt, double coef) {
-  CudaCheck(cudnnCreateActivationDescriptor(&val_));
-  CudaCheck(cudnnSetActivationDescriptor(val_, mode, relu_nan_opt, coef));
+  OF_CUDNN_CHECK(cudnnCreateActivationDescriptor(&val_));
+  OF_CUDNN_CHECK(cudnnSetActivationDescriptor(val_, mode, relu_nan_opt, coef));
 }
 
-CudnnActivationDesc::~CudnnActivationDesc() { CudaCheck(cudnnDestroyActivationDescriptor(val_)); }
+CudnnActivationDesc::~CudnnActivationDesc() {
+  OF_CUDNN_CHECK(cudnnDestroyActivationDescriptor(val_));
+}
 
 size_t GetCudnnDataTypeByteSize(cudnnDataType_t data_type) {
   size_t byte_size = 0;

--- a/oneflow/core/device/memory_copier.cpp
+++ b/oneflow/core/device/memory_copier.cpp
@@ -221,7 +221,7 @@ void CudaAsyncMemoryCopier::Copy1D(DeviceCtx* ctx, void* dst, const void* src, s
 void CudaAsyncMemoryCopier::Copy2D(DeviceCtx* ctx, void* dst, size_t dst_pitch, const void* src,
                                    size_t src_pitch, size_t width, size_t height) const {
   OF_CUDA_CHECK(cudaMemcpy2DAsync(dst, dst_pitch, src, src_pitch, width, height, cudaMemcpyDefault,
-                              ctx->cuda_stream()));
+                                  ctx->cuda_stream()));
 }
 
 void CudaAsyncMemoryCopier::Copy3D(DeviceCtx* ctx, void* dst, const void* src,

--- a/oneflow/core/device/memory_copier.cpp
+++ b/oneflow/core/device/memory_copier.cpp
@@ -215,12 +215,12 @@ void HostMemoryCopier::CopyND(DeviceCtx* ctx, void* dst, const void* src,
 #ifdef WITH_CUDA
 
 void CudaAsyncMemoryCopier::Copy1D(DeviceCtx* ctx, void* dst, const void* src, size_t count) const {
-  CudaCheck(cudaMemcpyAsync(dst, src, count, cudaMemcpyDefault, ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaMemcpyAsync(dst, src, count, cudaMemcpyDefault, ctx->cuda_stream()));
 }
 
 void CudaAsyncMemoryCopier::Copy2D(DeviceCtx* ctx, void* dst, size_t dst_pitch, const void* src,
                                    size_t src_pitch, size_t width, size_t height) const {
-  CudaCheck(cudaMemcpy2DAsync(dst, dst_pitch, src, src_pitch, width, height, cudaMemcpyDefault,
+  OF_CUDA_CHECK(cudaMemcpy2DAsync(dst, dst_pitch, src, src_pitch, width, height, cudaMemcpyDefault,
                               ctx->cuda_stream()));
 }
 
@@ -235,7 +235,7 @@ void CudaAsyncMemoryCopier::Copy3D(DeviceCtx* ctx, void* dst, const void* src,
       make_cudaPitchedPtr(dst, desc.dst_shape.At(2), desc.dst_shape.At(2), desc.dst_shape.At(1));
   params.extent = make_cudaExtent(desc.extent.At(2), desc.extent.At(1), desc.extent.At(0));
   params.kind = cudaMemcpyDefault;
-  CudaCheck(cudaMemcpy3DAsync(&params, ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaMemcpy3DAsync(&params, ctx->cuda_stream()));
 }
 
 void CudaAsyncMemoryCopier::CopyND(DeviceCtx* ctx, void* dst, const void* src,

--- a/oneflow/core/eager/blob_instruction_type.cpp
+++ b/oneflow/core/eager/blob_instruction_type.cpp
@@ -56,7 +56,7 @@ class CudaHostRegisterBlobInstructionType final : public vm::InstructionType {
     size_t size = blob->AlignedByteSizeOfBlobBody();
     cudaError_t cuda_error = cudaHostRegister(dptr, size, cudaHostRegisterDefault);
     if (cuda_error == cudaErrorHostMemoryAlreadyRegistered) { return; }
-    CudaCheck(cuda_error);
+    OF_CUDA_CHECK(cuda_error);
   }
 };
 COMMAND(vm::RegisterInstructionType<CudaHostRegisterBlobInstructionType>("CudaHostRegisterBlob"));
@@ -80,7 +80,7 @@ class CudaHostUnregisterBlobInstructionType final : public vm::InstructionType {
     CHECK_NOTNULL(dptr);
     cudaError_t cuda_error = cudaHostUnregister(dptr);
     if (cuda_error == cudaErrorHostMemoryNotRegistered) { return; }
-    CudaCheck(cuda_error);
+    OF_CUDA_CHECK(cuda_error);
   }
 };
 COMMAND(

--- a/oneflow/core/job/collective_boxing_executor.cpp
+++ b/oneflow/core/job/collective_boxing_executor.cpp
@@ -464,7 +464,7 @@ void NcclCollectiveBoxingExecutorBackend::Init(const CollectiveBoxingPlan& colle
       auto& device_ctx = device_id2device_ctx_.at(device_id);
       OF_CUDA_CHECK(cudaSetDevice(device_id));
       OF_CUDA_CHECK(cudaStreamCreateWithPriority(&device_ctx->stream, cudaStreamNonBlocking,
-                                             cuda_stream_greatest_priority));
+                                                 cuda_stream_greatest_priority));
       OF_CUDA_CHECK(cudaMalloc(&device_ctx->fusion_buffer, fusion_threshold_));
     }
   }

--- a/oneflow/core/job/collective_boxing_executor.cpp
+++ b/oneflow/core/job/collective_boxing_executor.cpp
@@ -132,7 +132,7 @@ class NcclCollectiveBoxingExecutorBackend : public CollectiveBoxingExecutorBacke
 NcclCollectiveBoxingExecutorBackend::NcclCollectiveBoxingExecutorBackend()
     : collective_boxing_conf_(Global<ResourceDesc, ForSession>::Get()->collective_boxing_conf()),
       shutdown_(false) {
-  CudaCheck(cudaGetDeviceCount(&num_devices_));
+  OF_CUDA_CHECK(cudaGetDeviceCount(&num_devices_));
   callback_executor_pool_.reset(new ThreadPool(num_devices_));
   CHECK_GT(collective_boxing_conf_.nccl_num_streams(), 0);
   num_streams_ = collective_boxing_conf_.nccl_num_streams();
@@ -150,20 +150,20 @@ NcclCollectiveBoxingExecutorBackend::NcclCollectiveBoxingExecutorBackend()
       }
       if (local_event_list.empty() && shutdown_) { break; }
       for (auto it = local_event_list.begin(); it != local_event_list.end();) {
-        CudaCheck(cudaSetDevice(it->device_id));
+        OF_CUDA_CHECK(cudaSetDevice(it->device_id));
         cudaError_t err = cudaEventQuery(it->cuda_event);
         if (err == cudaErrorNotReady) {
           ++it;
           continue;
         } else if (err == cudaSuccess) {
-          CudaCheck(cudaEventDestroy(it->cuda_event));
+          OF_CUDA_CHECK(cudaEventDestroy(it->cuda_event));
           auto callback_ptr =
               std::make_shared<std::function<void(Maybe<void>)>>(std::move(it->callback));
           callback_executor_pool_->AddWork(
               [callback_ptr]() { (*callback_ptr)(Maybe<void>::Ok()); });
           local_event_list.erase(it++);
         } else {
-          CudaCheck(err);
+          OF_CUDA_CHECK(err);
           UNIMPLEMENTED();
         }
       }
@@ -182,16 +182,16 @@ NcclCollectiveBoxingExecutorBackend::~NcclCollectiveBoxingExecutorBackend() {
   CudaCurrentDeviceGuard guard;
   for (auto& device_id2device_ctx : stream_id2device_id2device_ctx_) {
     for (auto& device_id7device_ctx : device_id2device_ctx) {
-      CudaCheck(cudaSetDevice(device_id7device_ctx.first));
-      CudaCheck(cudaStreamSynchronize(device_id7device_ctx.second->stream));
-      CudaCheck(cudaStreamDestroy(device_id7device_ctx.second->stream));
-      CudaCheck(cudaFree(device_id7device_ctx.second->fusion_buffer));
+      OF_CUDA_CHECK(cudaSetDevice(device_id7device_ctx.first));
+      OF_CUDA_CHECK(cudaStreamSynchronize(device_id7device_ctx.second->stream));
+      OF_CUDA_CHECK(cudaStreamDestroy(device_id7device_ctx.second->stream));
+      OF_CUDA_CHECK(cudaFree(device_id7device_ctx.second->fusion_buffer));
     }
   }
   for (auto& device_set7stream_id2device_id2comm : device_set2stream_id2device_id2comm_) {
     for (auto& device_id2comm : device_set7stream_id2device_id2comm.second) {
       for (auto& device_id7comm : device_id2comm) {
-        CudaCheck(cudaSetDevice(device_id7comm.first));
+        OF_CUDA_CHECK(cudaSetDevice(device_id7comm.first));
         NcclCheck(ncclCommDestroy(device_id7comm.second));
       }
     }
@@ -309,7 +309,7 @@ void NcclCollectiveBoxingExecutorBackend::ExecuteGroup(
       offset += aligned_size;
     }
     for (auto& device_id7copy_in_params : device_id2copy_in_params) {
-      CudaCheck(cudaSetDevice(device_id7copy_in_params.first));
+      OF_CUDA_CHECK(cudaSetDevice(device_id7copy_in_params.first));
       BatchMemcpyKernelUtil<DeviceType::kGPU>::Copy(
           device_id2device_ctx.at(device_id7copy_in_params.first).get(),
           device_id7copy_in_params.second);
@@ -319,7 +319,7 @@ void NcclCollectiveBoxingExecutorBackend::ExecuteGroup(
     CHECK_EQ(offset % size_of_data_type, 0);
     const int64_t elem_cnt = offset / size_of_data_type;
     for (auto& device_id7comm : device_id2comm) {
-      CudaCheck(cudaSetDevice(device_id7comm.first));
+      OF_CUDA_CHECK(cudaSetDevice(device_id7comm.first));
       auto& device_ctx = device_id2device_ctx.at(device_id7comm.first);
       NcclCheck(ncclAllReduce(device_ctx->fusion_buffer, device_ctx->fusion_buffer, elem_cnt,
                               GetNcclDataType(group.front()->op_desc().data_type()),
@@ -328,7 +328,7 @@ void NcclCollectiveBoxingExecutorBackend::ExecuteGroup(
     }
     NcclCheck(ncclGroupEnd());
     for (auto& device_id7copy_out_params : device_id2copy_out_params) {
-      CudaCheck(cudaSetDevice(device_id7copy_out_params.first));
+      OF_CUDA_CHECK(cudaSetDevice(device_id7copy_out_params.first));
       BatchMemcpyKernelUtil<DeviceType::kGPU>::Copy(
           device_id2device_ctx.at(device_id7copy_out_params.first).get(),
           device_id7copy_out_params.second);
@@ -344,7 +344,7 @@ void NcclCollectiveBoxingExecutorBackend::ExecuteGroup(
         const RuntimeRequestInfo& request_info = rank7request_info.second;
         const DeviceDesc& device_desc = request_desc->device_set().device().Get(rank);
         const int64_t device_id = device_desc.device_id();
-        CudaCheck(cudaSetDevice(device_id));
+        OF_CUDA_CHECK(cudaSetDevice(device_id));
         ncclComm_t comm = device_id2comm.at(device_id);
         auto& device_ctx = device_id2device_ctx.at(device_id);
         ncclDataType_t nccl_data_type = GetNcclDataType(op_desc.data_type());
@@ -383,10 +383,10 @@ void NcclCollectiveBoxingExecutorBackend::ExecuteGroup(
   }
   for (auto& device_id7callbacks : device_id2callbacks) {
     const int64_t device_id = device_id7callbacks.first;
-    CudaCheck(cudaSetDevice(device_id));
+    OF_CUDA_CHECK(cudaSetDevice(device_id));
     cudaEvent_t event;
-    CudaCheck(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
-    CudaCheck(cudaEventRecord(event, device_id2device_ctx.at(device_id)->stream));
+    OF_CUDA_CHECK(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+    OF_CUDA_CHECK(cudaEventRecord(event, device_id2device_ctx.at(device_id)->stream));
     {
       std::unique_lock<std::mutex> event_list_lock(event_list_mutex_);
       event_list_.emplace_back(Event{device_id, event, [=](const Maybe<void>& status) {
@@ -444,7 +444,7 @@ void NcclCollectiveBoxingExecutorBackend::Init(const CollectiveBoxingPlan& colle
         NcclCheck(ncclGroupStart());
         for (const int64_t rank : local_ranks) {
           const int64_t device_id = device_set.device(rank).device_id();
-          CudaCheck(cudaSetDevice(device_id));
+          OF_CUDA_CHECK(cudaSetDevice(device_id));
           NcclCheck(ncclCommInitRank(&device_id2comm.at(device_id), device_set.device_size(),
                                      nccl_unique_id, rank));
         }
@@ -453,7 +453,7 @@ void NcclCollectiveBoxingExecutorBackend::Init(const CollectiveBoxingPlan& colle
     }
   }
   int cuda_stream_greatest_priority;
-  CudaCheck(cudaDeviceGetStreamPriorityRange(nullptr, &cuda_stream_greatest_priority));
+  OF_CUDA_CHECK(cudaDeviceGetStreamPriorityRange(nullptr, &cuda_stream_greatest_priority));
   stream_id2device_id2device_ctx_.resize(num_streams_);
   for (int64_t stream_id = 0; stream_id < num_streams_; ++stream_id) {
     auto& device_id2device_ctx_ = stream_id2device_id2device_ctx_.at(stream_id);
@@ -462,10 +462,10 @@ void NcclCollectiveBoxingExecutorBackend::Init(const CollectiveBoxingPlan& colle
     }
     for (const int64_t device_id : local_device_ids) {
       auto& device_ctx = device_id2device_ctx_.at(device_id);
-      CudaCheck(cudaSetDevice(device_id));
-      CudaCheck(cudaStreamCreateWithPriority(&device_ctx->stream, cudaStreamNonBlocking,
+      OF_CUDA_CHECK(cudaSetDevice(device_id));
+      OF_CUDA_CHECK(cudaStreamCreateWithPriority(&device_ctx->stream, cudaStreamNonBlocking,
                                              cuda_stream_greatest_priority));
-      CudaCheck(cudaMalloc(&device_ctx->fusion_buffer, fusion_threshold_));
+      OF_CUDA_CHECK(cudaMalloc(&device_ctx->fusion_buffer, fusion_threshold_));
     }
   }
 }

--- a/oneflow/core/job/eager_nccl_comm_manager.cpp
+++ b/oneflow/core/job/eager_nccl_comm_manager.cpp
@@ -37,7 +37,7 @@ std::string GetNcclUniqueIdRpcKey(const std::vector<std::pair<int64_t, int64_t>>
 EagerNcclCommMgr::~EagerNcclCommMgr() {
   for (auto& device_set7device_id2comm : device_set2device_id2comm_) {
     for (auto& device_id7comm : device_set7device_id2comm.second) {
-      NcclCheck(ncclCommDestroy(device_id7comm.second));
+      OF_NCCL_CHECK(ncclCommDestroy(device_id7comm.second));
     }
   }
 }
@@ -68,7 +68,7 @@ ncclComm_t EagerNcclCommMgr::GetCommForDevice(
   ncclUniqueId nccl_unique_id{};
   std::string nccl_unique_id_rpc_key = GetNcclUniqueIdRpcKey(device_vec);
   if (rank == 0) {
-    NcclCheck(ncclGetUniqueId(&nccl_unique_id));
+    OF_NCCL_CHECK(ncclGetUniqueId(&nccl_unique_id));
     Global<CtrlClient>::Get()->PushKV(nccl_unique_id_rpc_key,
                                       std::string(nccl_unique_id.internal, NCCL_UNIQUE_ID_BYTES));
   } else {
@@ -78,7 +78,7 @@ ncclComm_t EagerNcclCommMgr::GetCommForDevice(
         });
   }
   ncclComm_t comm;
-  NcclCheck(ncclCommInitRank(&comm, device_vec.size(), nccl_unique_id, rank));
+  OF_NCCL_CHECK(ncclCommInitRank(&comm, device_vec.size(), nccl_unique_id, rank));
   {
     std::lock_guard<std::mutex> lock(mutex_);
     device_set2device_id2comm_[device_set][dev] = comm;

--- a/oneflow/core/job/eager_nccl_comm_manager.cpp
+++ b/oneflow/core/job/eager_nccl_comm_manager.cpp
@@ -45,7 +45,7 @@ EagerNcclCommMgr::~EagerNcclCommMgr() {
 ncclComm_t EagerNcclCommMgr::GetCommForDevice(
     const std::set<std::pair<int64_t, int64_t>>& device_set) {
   int dev;
-  CudaCheck(cudaGetDevice(&dev));
+  OF_CUDA_CHECK(cudaGetDevice(&dev));
   {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = device_set2device_id2comm_.find(device_set);

--- a/oneflow/core/kernel/arg_where_kernel_util.cu
+++ b/oneflow/core/kernel/arg_where_kernel_util.cu
@@ -81,12 +81,13 @@ struct ArgWhereKernelUtil<DeviceType::kGPU, T, I, NDims> {
     CHECK_LE(tmp_bytes, tmp_max_bytes);
 
     if (NDims == 1) {
-      CudaCheck(SelectTrue<T, I, I*>(ctx->cuda_stream(), in_shape.elem_cnt(), tmp, tmp_bytes,
-                                     in_ptr, out_ptr, out_size_ptr));
+      OF_CUDA_CHECK((SelectTrue<T, I, I*>(ctx->cuda_stream(), in_shape.elem_cnt(), tmp, tmp_bytes,
+                                          in_ptr, out_ptr, out_size_ptr)));
     } else {
       StrideIterator<I, NDims> out_iter(out_ptr, in_shape.elem_cnt());
-      CudaCheck(SelectTrue<T, I, StrideIterator<I, NDims>>(
-          ctx->cuda_stream(), in_shape.elem_cnt(), tmp, tmp_bytes, in_ptr, out_iter, out_size_ptr));
+      OF_CUDA_CHECK(
+          (SelectTrue<T, I, StrideIterator<I, NDims>>(ctx->cuda_stream(), in_shape.elem_cnt(), tmp,
+                                                      tmp_bytes, in_ptr, out_iter, out_size_ptr)));
 
       fixed_vector<I, NDims> dims(NDims);
       std::transform(in_shape.ptr(), in_shape.ptr() + in_shape.NumAxes(), dims.begin(),
@@ -102,11 +103,12 @@ struct ArgWhereKernelUtil<DeviceType::kGPU, T, I, NDims> {
     cudaStream_t stream = ctx ? ctx->cuda_stream() : 0;
     size_t tmp_bytes = 0;
     if (NDims == 1) {
-      CudaCheck(SelectTrue<T, I, I*>(stream, n, nullptr, tmp_bytes, nullptr, nullptr, nullptr));
+      OF_CUDA_CHECK(
+          (SelectTrue<T, I, I*>(stream, n, nullptr, tmp_bytes, nullptr, nullptr, nullptr)));
     } else {
       StrideIterator<I, NDims> out_iter(nullptr, n);
-      CudaCheck(SelectTrue<T, I, StrideIterator<I, NDims>>(stream, n, nullptr, tmp_bytes, nullptr,
-                                                           out_iter, nullptr));
+      OF_CUDA_CHECK((SelectTrue<T, I, StrideIterator<I, NDims>>(stream, n, nullptr, tmp_bytes,
+                                                                nullptr, out_iter, nullptr)));
     }
     return tmp_bytes;
   }

--- a/oneflow/core/kernel/batch_memcpy_kernel_util.cu
+++ b/oneflow/core/kernel/batch_memcpy_kernel_util.cu
@@ -54,7 +54,7 @@ void BatchMemcpyKernelUtil<DeviceType::kGPU>::Copy(DeviceCtx* ctx,
                                                    const std::vector<MemcpyParam>& params) {
   if (params.size() == 1) {
     OF_CUDA_CHECK(cudaMemcpyAsync(params.front().dst, params.front().src, params.front().count,
-                              cudaMemcpyDefault, ctx->cuda_stream()));
+                                  cudaMemcpyDefault, ctx->cuda_stream()));
   } else {
     int block_size = 0;
     int num_blocks = 0;

--- a/oneflow/core/kernel/batch_memcpy_kernel_util.cu
+++ b/oneflow/core/kernel/batch_memcpy_kernel_util.cu
@@ -58,8 +58,7 @@ void BatchMemcpyKernelUtil<DeviceType::kGPU>::Copy(DeviceCtx* ctx,
   } else {
     int block_size = 0;
     int num_blocks = 0;
-    OF_CUDA_CHECK(cudaMemcpyAsync(params.front().dst, params.front().src, params.front().count,
-                                  (cudaOccupancyMaxPotentialBlockSize(&num_blocks, &block_size, GpuCopy));
+    OF_CUDA_CHECK(cudaOccupancyMaxPotentialBlockSize(&num_blocks, &block_size, GpuCopy));
     BatchMemcpyParam batch_memcpy_param{};
     batch_memcpy_param.batch_size = 0;
     for (const MemcpyParam& param : params) {
@@ -73,9 +72,8 @@ void BatchMemcpyKernelUtil<DeviceType::kGPU>::Copy(DeviceCtx* ctx,
           batch_memcpy_param.batch_size = 0;
         }
       } else {
-        OF_CUDA_CHECK(cudaMemcpyAsync(params.front().dst, params.front().src, params.front().count,
-                                      (cudaMemcpyAsync(param.dst, param.src, param.count, cudaMemcpyDefault,
-                                  ctx->cuda_stream()));
+        OF_CUDA_CHECK(cudaMemcpyAsync(param.dst, param.src, param.count, cudaMemcpyDefault,
+                                      ctx->cuda_stream()));
       }
     }
     if (batch_memcpy_param.batch_size != 0) {

--- a/oneflow/core/kernel/batch_memcpy_kernel_util.cu
+++ b/oneflow/core/kernel/batch_memcpy_kernel_util.cu
@@ -53,12 +53,13 @@ template<>
 void BatchMemcpyKernelUtil<DeviceType::kGPU>::Copy(DeviceCtx* ctx,
                                                    const std::vector<MemcpyParam>& params) {
   if (params.size() == 1) {
-    CudaCheck(cudaMemcpyAsync(params.front().dst, params.front().src, params.front().count,
+    OF_CUDA_CHECK(cudaMemcpyAsync(params.front().dst, params.front().src, params.front().count,
                               cudaMemcpyDefault, ctx->cuda_stream()));
   } else {
     int block_size = 0;
     int num_blocks = 0;
-    CudaCheck(cudaOccupancyMaxPotentialBlockSize(&num_blocks, &block_size, GpuCopy));
+    OF_CUDA_CHECK(cudaMemcpyAsync(params.front().dst, params.front().src, params.front().count,
+                                  (cudaOccupancyMaxPotentialBlockSize(&num_blocks, &block_size, GpuCopy));
     BatchMemcpyParam batch_memcpy_param{};
     batch_memcpy_param.batch_size = 0;
     for (const MemcpyParam& param : params) {
@@ -72,7 +73,8 @@ void BatchMemcpyKernelUtil<DeviceType::kGPU>::Copy(DeviceCtx* ctx,
           batch_memcpy_param.batch_size = 0;
         }
       } else {
-        CudaCheck(cudaMemcpyAsync(param.dst, param.src, param.count, cudaMemcpyDefault,
+        OF_CUDA_CHECK(cudaMemcpyAsync(params.front().dst, params.front().src, params.front().count,
+                                      (cudaMemcpyAsync(param.dst, param.src, param.count, cudaMemcpyDefault,
                                   ctx->cuda_stream()));
       }
     }

--- a/oneflow/core/kernel/kernel_util.cpp
+++ b/oneflow/core/kernel/kernel_util.cpp
@@ -286,7 +286,7 @@ void SyncAutoMemcpy(DeviceCtx* ctx, void* dst, const void* src, size_t sz,
   AutoMemcpy(ctx, dst, src, sz, dst_mem_case, src_mem_case);
   if (src_mem_case.has_device_cuda_mem() || dst_mem_case.has_device_cuda_mem()) {
 #ifdef WITH_CUDA
-    CudaCheck(cudaStreamSynchronize(ctx->cuda_stream()));
+    OF_CUDA_CHECK(cudaStreamSynchronize(ctx->cuda_stream()));
 #else
     UNIMPLEMENTED();
 #endif  // WITH_CUDA

--- a/oneflow/core/kernel/kernel_util.cu
+++ b/oneflow/core/kernel/kernel_util.cu
@@ -379,12 +379,12 @@ size_t GetTmpSizeForReduceSum(DataType data_type, int64_t sum_elem_num) {
 
 KU_IF_METHOD Max(DeviceCtx* ctx, const int64_t n, const T* x, T* max_ptr, T* temp_storage,
                  size_t temp_storage_bytes) {
-  CudaCheck(
+  OF_CUDA_CHECK(
       cub::DeviceReduce::Max(temp_storage, temp_storage_bytes, x, max_ptr, n, ctx->cuda_stream()));
 }
 KU_IF_METHOD Sum(DeviceCtx* ctx, const int64_t n, const T* x, T* sum_ptr, T* temp_storage,
                  size_t temp_storage_bytes) {
-  CudaCheck(
+  OF_CUDA_CHECK(
       cub::DeviceReduce::Sum(temp_storage, temp_storage_bytes, x, sum_ptr, n, ctx->cuda_stream()));
 }
 KU_IF_METHOD CopyColsRegion(DeviceCtx* ctx, const int64_t row_num, const int64_t col_num,

--- a/oneflow/core/kernel/model_io_v2_kernel.cpp
+++ b/oneflow/core/kernel/model_io_v2_kernel.cpp
@@ -92,9 +92,9 @@ void SyncCopyToHost<DeviceType::kCPU>(DeviceCtx* ctx, const void* src, void* dst
 #ifdef WITH_CUDA
 template<>
 void SyncCopyToHost<DeviceType::kGPU>(DeviceCtx* ctx, const void* src, void* dst, size_t size) {
-  CudaCheck(cudaStreamSynchronize(ctx->cuda_stream()));
-  CudaCheck(cudaMemcpyAsync(dst, src, size, cudaMemcpyDeviceToHost, ctx->cuda_stream()));
-  CudaCheck(cudaStreamSynchronize(ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaStreamSynchronize(ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaMemcpyAsync(dst, src, size, cudaMemcpyDeviceToHost, ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaStreamSynchronize(ctx->cuda_stream()));
 }
 #endif
 
@@ -109,9 +109,9 @@ void SyncCopyToDevice<DeviceType::kCPU>(DeviceCtx* ctx, const void* src, void* d
 #ifdef WITH_CUDA
 template<>
 void SyncCopyToDevice<DeviceType::kGPU>(DeviceCtx* ctx, const void* src, void* dst, size_t size) {
-  CudaCheck(cudaStreamSynchronize(ctx->cuda_stream()));
-  CudaCheck(cudaMemcpyAsync(dst, src, size, cudaMemcpyHostToDevice, ctx->cuda_stream()));
-  CudaCheck(cudaStreamSynchronize(ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaStreamSynchronize(ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaMemcpyAsync(dst, src, size, cudaMemcpyHostToDevice, ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaStreamSynchronize(ctx->cuda_stream()));
 }
 #endif
 

--- a/oneflow/core/kernel/new_kernel_util.cpp
+++ b/oneflow/core/kernel/new_kernel_util.cpp
@@ -37,13 +37,13 @@ void WithHostBlobAndStreamSynchronizeEnv(DeviceCtx* ctx, Blob* blob,
                                          std::function<void(Blob*)> Callback) {
 #ifdef WITH_CUDA
   char* host_raw_dptr = nullptr;
-  CudaCheck(cudaMallocHost(&host_raw_dptr, blob->AlignedTotalByteSize()));
+  OF_CUDA_CHECK(cudaMallocHost(&host_raw_dptr, blob->AlignedTotalByteSize()));
   Blob host_blob(MemoryCase(), &blob->blob_desc(), host_raw_dptr);
   Callback(&host_blob);
   Memcpy<DeviceType::kGPU>(ctx, blob->mut_dptr(), host_blob.dptr(), blob->ByteSizeOfBlobBody(),
                            cudaMemcpyHostToDevice);
-  CudaCheck(cudaStreamSynchronize(ctx->cuda_stream()));
-  CudaCheck(cudaFreeHost(host_raw_dptr));
+  OF_CUDA_CHECK(cudaStreamSynchronize(ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaFreeHost(host_raw_dptr));
 #else
   UNIMPLEMENTED();
 #endif

--- a/oneflow/core/kernel/new_kernel_util.cu
+++ b/oneflow/core/kernel/new_kernel_util.cu
@@ -22,12 +22,12 @@ template<>
 void Memcpy<DeviceType::kGPU>(DeviceCtx* ctx, void* dst, const void* src, size_t sz,
                               cudaMemcpyKind kind) {
   if (dst == src) { return; }
-  CudaCheck(cudaMemcpyAsync(dst, src, sz, kind, ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaMemcpyAsync(dst, src, sz, kind, ctx->cuda_stream()));
 }
 
 template<>
 void Memset<DeviceType::kGPU>(DeviceCtx* ctx, void* dst, const char value, size_t sz) {
-  CudaCheck(cudaMemsetAsync(dst, value, sz, ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaMemsetAsync(dst, value, sz, ctx->cuda_stream()));
 }
 
 }  // namespace oneflow

--- a/oneflow/core/kernel/random_generator.cu
+++ b/oneflow/core/kernel/random_generator.cu
@@ -24,25 +24,25 @@ void RngUniformGpu(const curandGenerator_t& gen, int64_t n, T* ret);
 
 template<>
 void RngUniformGpu<float>(const curandGenerator_t& gen, int64_t n, float* ret) {
-  CudaCheck(curandGenerateUniform(gen, ret, n));
+  OF_CURAND_CHECK(curandGenerateUniform(gen, ret, n));
 }
 
 template<>
 void RngUniformGpu<double>(const curandGenerator_t& gen, int64_t n, double* ret) {
-  CudaCheck(curandGenerateUniformDouble(gen, ret, n));
+  OF_CURAND_CHECK(curandGenerateUniformDouble(gen, ret, n));
 }
 
 }  // namespace
 
 RandomGenerator<DeviceType::kGPU>::RandomGenerator(int64_t seed, DeviceCtx* device_ctx) {
   CHECK_NOTNULL(device_ctx);
-  CudaCheck(curandCreateGenerator(&curand_generator_, CURAND_RNG_PSEUDO_DEFAULT));
-  CudaCheck(curandSetPseudoRandomGeneratorSeed(curand_generator_, seed));
-  CudaCheck(curandSetStream(curand_generator_, device_ctx->cuda_stream()));
+  OF_CURAND_CHECK(curandCreateGenerator(&curand_generator_, CURAND_RNG_PSEUDO_DEFAULT));
+  OF_CURAND_CHECK(curandSetPseudoRandomGeneratorSeed(curand_generator_, seed));
+  OF_CURAND_CHECK(curandSetStream(curand_generator_, device_ctx->cuda_stream()));
 }
 
 RandomGenerator<DeviceType::kGPU>::~RandomGenerator() {
-  CudaCheck(curandDestroyGenerator(curand_generator_));
+  OF_CURAND_CHECK(curandDestroyGenerator(curand_generator_));
 }
 
 template<typename T>

--- a/oneflow/core/kernel/sync_dynamic_resize_kernel.cpp
+++ b/oneflow/core/kernel/sync_dynamic_resize_kernel.cpp
@@ -32,8 +32,8 @@ namespace {
 class CudaHostMem {
  public:
   OF_DISALLOW_COPY_AND_MOVE(CudaHostMem);
-  CudaHostMem(const size_t size) { CudaCheck(cudaMallocHost(&ptr_, size)); }
-  ~CudaHostMem() { CudaCheck(cudaFreeHost(ptr_)); }
+  CudaHostMem(const size_t size) { OF_CUDA_CHECK(cudaMallocHost(&ptr_, size)); }
+  ~CudaHostMem() { OF_CUDA_CHECK(cudaFreeHost(ptr_)); }
   void* Ptr() const { return ptr_; }
 
  private:
@@ -87,7 +87,7 @@ class SyncDynamicResizeGPUKernel final : public KernelIf<DeviceType::kGPU> {
       queue_.push(cuda_host_mem_ptr);
     };
     if (conf.eager()) {
-      CudaCheck(cudaStreamSynchronize(ctx.device_ctx->cuda_stream()));
+      OF_CUDA_CHECK(cudaStreamSynchronize(ctx.device_ctx->cuda_stream()));
       UpdateShape();
     } else {
       ctx.device_ctx->AddCallBack(UpdateShape);

--- a/oneflow/core/kernel/unique_kernel_util.cu
+++ b/oneflow/core/kernel/unique_kernel_util.cu
@@ -116,8 +116,8 @@ int64_t GetTempBufferSize(int64_t n) {
 template<typename KEY, typename IDX>
 int64_t GetCubSortTempStorageSize(int64_t n) {
   size_t cub_sort_temp_store_size = 0;
-  CudaCheck(cub::DeviceRadixSort::SortPairs<KEY, IDX>(nullptr, cub_sort_temp_store_size, nullptr,
-                                                      nullptr, nullptr, nullptr, n));
+  OF_CUDA_CHECK((cub::DeviceRadixSort::SortPairs<KEY, IDX>(nullptr, cub_sort_temp_store_size,
+                                                           nullptr, nullptr, nullptr, nullptr, n)));
   CHECK_GE(cub_sort_temp_store_size, 0);
   CHECK_LT(cub_sort_temp_store_size, GetMaxVal<int64_t>());
   return GetCudaAlignedSize(static_cast<int64_t>(cub_sort_temp_store_size));
@@ -128,9 +128,9 @@ int64_t GetCubScanTempStorageSize(int64_t n) {
   size_t cub_scan_temp_store_size = 0;
   NotEqualToPreviousAdjacentIterator<IDX, KEY> unique_counting_iter(nullptr, 0);
   PermutationIterator<IDX, IDX*, IDX*> remapping_iter(nullptr, nullptr);
-  CudaCheck(cub::DeviceScan::InclusiveSum<NotEqualToPreviousAdjacentIterator<IDX, KEY>,
-                                          PermutationIterator<IDX, IDX*, IDX*>>(
-      nullptr, cub_scan_temp_store_size, unique_counting_iter, remapping_iter, n));
+  OF_CUDA_CHECK((cub::DeviceScan::InclusiveSum<NotEqualToPreviousAdjacentIterator<IDX, KEY>,
+                                               PermutationIterator<IDX, IDX*, IDX*>>(
+      nullptr, cub_scan_temp_store_size, unique_counting_iter, remapping_iter, n)));
   CHECK_GE(cub_scan_temp_store_size, 0);
   CHECK_LT(cub_scan_temp_store_size, GetMaxVal<int64_t>());
   return GetCudaAlignedSize(static_cast<int64_t>(cub_scan_temp_store_size));
@@ -139,8 +139,8 @@ int64_t GetCubScanTempStorageSize(int64_t n) {
 template<typename KEY, typename IDX>
 int64_t GetCubRleTempStorageSize(int64_t n) {
   size_t cub_rle_temp_store_size = 0;
-  CudaCheck(cub::DeviceRunLengthEncode::Encode<KEY*, KEY*, IDX*, int64_t*>(
-      nullptr, cub_rle_temp_store_size, nullptr, nullptr, nullptr, nullptr, n));
+  OF_CUDA_CHECK((cub::DeviceRunLengthEncode::Encode<KEY*, KEY*, IDX*, int64_t*>(
+      nullptr, cub_rle_temp_store_size, nullptr, nullptr, nullptr, nullptr, n)));
   CHECK_GE(cub_rle_temp_store_size, 0);
   CHECK_LT(cub_rle_temp_store_size, GetMaxVal<int64_t>());
   return GetCudaAlignedSize(static_cast<int64_t>(cub_rle_temp_store_size));
@@ -222,18 +222,18 @@ void UniqueKernelUtil<DeviceType::kGPU, KEY, IDX>::UniqueWithCounts(
   CHECK_LE(rt_workspace_size, workspace_size_in_bytes);
   IotaKernel<IDX><<<BlocksNum4ThreadsNum(n), kCudaThreadsNumPerBlock, 0, ctx->cuda_stream()>>>(
       n, cub_sort_values_in_ptr);
-  CudaCheck(cub::DeviceRadixSort::SortPairs<KEY, IDX>(
+  OF_CUDA_CHECK((cub::DeviceRadixSort::SortPairs<KEY, IDX>(
       cub_temp_storage.ptr, cub_temp_storage.size_in_bytes, in, cub_sort_keys_out.ptr,
-      cub_sort_values_in_ptr, cub_sort_values_out.ptr, n, 0, sizeof(KEY) * 8, ctx->cuda_stream()));
-  CudaCheck(cub::DeviceRunLengthEncode::Encode<KEY*, KEY*, IDX*, IDX*>(
+      cub_sort_values_in_ptr, cub_sort_values_out.ptr, n, 0, sizeof(KEY) * 8, ctx->cuda_stream())));
+  OF_CUDA_CHECK((cub::DeviceRunLengthEncode::Encode<KEY*, KEY*, IDX*, IDX*>(
       cub_temp_storage.ptr, cub_temp_storage.size_in_bytes, cub_sort_keys_out.ptr, unique_out,
-      count, num_unique, n, ctx->cuda_stream()));
+      count, num_unique, n, ctx->cuda_stream())));
   NotEqualToPreviousAdjacentIterator<IDX, KEY> unique_counting_iter(cub_sort_keys_out.ptr, 0);
   PermutationIterator<IDX, IDX*, IDX*> remapping_iter(idx_out, cub_sort_values_out.ptr);
-  CudaCheck(cub::DeviceScan::InclusiveSum<NotEqualToPreviousAdjacentIterator<IDX, KEY>,
-                                          PermutationIterator<IDX, IDX*, IDX*>>(
+  OF_CUDA_CHECK((cub::DeviceScan::InclusiveSum<NotEqualToPreviousAdjacentIterator<IDX, KEY>,
+                                               PermutationIterator<IDX, IDX*, IDX*>>(
       cub_temp_storage.ptr, cub_temp_storage.size_in_bytes, unique_counting_iter, remapping_iter, n,
-      ctx->cuda_stream()));
+      ctx->cuda_stream())));
 }
 
 template<typename KEY, typename IDX>

--- a/oneflow/core/kernel/util/cuda_blas_interface.cu
+++ b/oneflow/core/kernel/util/cuda_blas_interface.cu
@@ -75,7 +75,7 @@ void HGemmWithFloat(DeviceCtx* ctx, const enum CBLAS_ORDER order, enum CBLAS_TRA
       PrepareToCallCublasGemm(trans_a, trans_b, m, n, k);
 
   cudaDataType_t data_type = GetCudaDataType(DataType::kFloat16);
-  CudaCheck(cublasSgemmEx(ctx->cublas_tensor_op_math_handle(), cublas_trans_b, cublas_trans_a, n, m,
+  OF_CUBLAS_CHECK(cublasSgemmEx(ctx->cublas_tensor_op_math_handle(), cublas_trans_b, cublas_trans_a, n, m,
                           k, alpha, b, data_type, ldb, a, data_type, lda, beta, c, data_type, ldc));
 }
 

--- a/oneflow/core/kernel/util/cuda_blas_interface.cu
+++ b/oneflow/core/kernel/util/cuda_blas_interface.cu
@@ -75,8 +75,9 @@ void HGemmWithFloat(DeviceCtx* ctx, const enum CBLAS_ORDER order, enum CBLAS_TRA
       PrepareToCallCublasGemm(trans_a, trans_b, m, n, k);
 
   cudaDataType_t data_type = GetCudaDataType(DataType::kFloat16);
-  OF_CUBLAS_CHECK(cublasSgemmEx(ctx->cublas_tensor_op_math_handle(), cublas_trans_b, cublas_trans_a, n, m,
-                          k, alpha, b, data_type, ldb, a, data_type, lda, beta, c, data_type, ldc));
+  OF_CUBLAS_CHECK(cublasSgemmEx(ctx->cublas_tensor_op_math_handle(), cublas_trans_b, cublas_trans_a,
+                                n, m, k, alpha, b, data_type, ldb, a, data_type, lda, beta, c,
+                                data_type, ldc));
 }
 
 std::tuple<int, int, int> CalcMNKForGemm(enum CBLAS_TRANSPOSE trans_a, const Blob* a,

--- a/oneflow/core/memory/memory_allocator.cpp
+++ b/oneflow/core/memory/memory_allocator.cpp
@@ -32,7 +32,7 @@ void* MemoryAllocatorImpl::Allocate(MemoryCase mem_case, size_t size) {
       if (Global<ResourceDesc, ForSession>::Get()->enable_numa_aware_cuda_malloc_host()) {
         NumaAwareCudaMallocHost(mem_case.host_mem().cuda_pinned_mem().device_id(), &ptr, size);
       } else {
-        CudaCheck(cudaMallocHost(&ptr, size));
+        OF_CUDA_CHECK(cudaMallocHost(&ptr, size));
       }
 #else
       UNIMPLEMENTED();
@@ -44,7 +44,7 @@ void* MemoryAllocatorImpl::Allocate(MemoryCase mem_case, size_t size) {
   } else if (mem_case.has_device_cuda_mem()) {
 #ifdef WITH_CUDA
     CudaCurrentDeviceGuard guard(mem_case.device_cuda_mem().device_id());
-    CudaCheck(cudaMalloc(&ptr, size));
+    OF_CUDA_CHECK(cudaMalloc(&ptr, size));
 #else
     UNIMPLEMENTED();
 #endif
@@ -58,7 +58,7 @@ void MemoryAllocatorImpl::Deallocate(void* ptr, MemoryCase mem_case) {
   if (mem_case.has_host_mem()) {
     if (mem_case.host_mem().has_cuda_pinned_mem()) {
 #ifdef WITH_CUDA
-      CudaCheck(cudaFreeHost(ptr));
+      OF_CUDA_CHECK(cudaFreeHost(ptr));
 #else
       UNIMPLEMENTED();
 #endif
@@ -68,7 +68,7 @@ void MemoryAllocatorImpl::Deallocate(void* ptr, MemoryCase mem_case) {
   } else if (mem_case.has_device_cuda_mem()) {
 #ifdef WITH_CUDA
     CudaCurrentDeviceGuard guard(mem_case.device_cuda_mem().device_id());
-    CudaCheck(cudaFree(ptr));
+    OF_CUDA_CHECK(cudaFree(ptr));
 #else
     UNIMPLEMENTED();
 #endif
@@ -97,7 +97,7 @@ char* MemoryAllocator::Allocate(MemoryCase mem_case, std::size_t size) {
   } else if (mem_case.has_device_cuda_mem()) {
 #ifdef WITH_CUDA
     CudaCurrentDeviceGuard guard(mem_case.device_cuda_mem().device_id());
-    CudaCheck(cudaMemset(dptr, memset_val, size));
+    OF_CUDA_CHECK(cudaMemset(dptr, memset_val, size));
 #else
     UNIMPLEMENTED();
 #endif

--- a/oneflow/core/thread/gpu_thread.cpp
+++ b/oneflow/core/thread/gpu_thread.cpp
@@ -23,19 +23,19 @@ namespace oneflow {
 GpuThread::GpuThread(int64_t thrd_id, int64_t dev_id) {
   set_thrd_id(thrd_id);
   mut_actor_thread() = std::thread([this, dev_id]() {
-    CudaCheck(cudaSetDevice(dev_id));
+    OF_CUDA_CHECK(cudaSetDevice(dev_id));
     ThreadCtx ctx;
     ctx.g_cuda_stream.reset(new CudaStreamHandle(&cb_event_chan_));
     ctx.cb_event_chan = &cb_event_chan_;
     PollMsgChannel(ctx);
   });
   cb_event_poller_ = std::thread([this, dev_id]() {
-    CudaCheck(cudaSetDevice(dev_id));
+    OF_CUDA_CHECK(cudaSetDevice(dev_id));
     CudaCBEvent cb_event;
     while (cb_event_chan_.Receive(&cb_event) == kChannelStatusSuccess) {
-      CudaCheck(cudaEventSynchronize(cb_event.event));
+      OF_CUDA_CHECK(cudaEventSynchronize(cb_event.event));
       cb_event.callback();
-      CudaCheck(cudaEventDestroy(cb_event.event));
+      OF_CUDA_CHECK(cudaEventDestroy(cb_event.event));
     }
   });
 }

--- a/oneflow/core/vm/cuda_allocator.cpp
+++ b/oneflow/core/vm/cuda_allocator.cpp
@@ -52,7 +52,7 @@ CudaAllocator::~CudaAllocator() {
     return;
   }
   cudaSetDevice(device_id_);
-  for (auto& pair : mem_ptr2block_) { CudaCheck(cudaFree(pair.first)); }
+  for (auto& pair : mem_ptr2block_) { OF_CUDA_CHECK(cudaFree(pair.first)); }
 }
 
 void CudaAllocator::InsertPiece2Bin(Piece* piece) {
@@ -164,7 +164,7 @@ bool CudaAllocator::AllocateBlockToExtendTotalMem(size_t aligned_size) {
   cudaSetDevice(device_id_);
   size_t free_bytes = -1;
   size_t total_bytes = -1;
-  CudaCheck(cudaMemGetInfo(&free_bytes, &total_bytes));
+  OF_CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
   const size_t remain_bytes = 50 * 1048576;
   const size_t available_bytes = free_bytes - remain_bytes;  // remain at least 50MiB memory
 
@@ -247,7 +247,7 @@ bool CudaAllocator::DeallocateFreeBlockForGarbageCollection() {
       CHECK_EQ(block.size, piece_size_sum);
 
       mem_ptr2block_.erase(it);
-      CudaCheck(cudaFree(ptr));
+      OF_CUDA_CHECK(cudaFree(ptr));
     }
   }
 

--- a/oneflow/core/vm/cuda_copy_d2h_device_context.h
+++ b/oneflow/core/vm/cuda_copy_d2h_device_context.h
@@ -48,7 +48,7 @@ class CudaCopyD2HDeviceCtx : public DeviceCtx {
   }
   const cudnnHandle_t& cudnn_handle() const override { return *(cuda_handler_->cudnn_handle()); }
 
-  void SyncDevice() override { CudaCheck(cudaStreamSynchronize(cuda_stream())); }
+  void SyncDevice() override { OF_CUDA_CHECK(cudaStreamSynchronize(cuda_stream())); }
 
   void AddCallBack(std::function<void()> callback) const override {
     callback_msg_list_->EmplaceBack(ObjectMsgPtr<CallbackMsg>::New(callback));

--- a/oneflow/core/vm/cuda_copy_d2h_stream_type.cpp
+++ b/oneflow/core/vm/cuda_copy_d2h_stream_type.cpp
@@ -49,7 +49,7 @@ void CudaCopyD2HStreamType::Compute(Instruction* instruction) const {
     const auto& instr_type_id = instruction->mut_instr_msg()->instr_type_id();
     CHECK_EQ(instr_type_id.stream_type_id().interpret_type(), InterpretType::kCompute);
     instr_type_id.instruction_type().Compute(instruction);
-    CudaCheck(cudaGetLastError());
+    OF_CUDA_CHECK(cudaGetLastError());
   }
   stream->mut_callback_list()->MoveTo(instruction->mut_callback_list());
   char* data_ptr = instruction->mut_status_buffer()->mut_buffer()->mut_data();

--- a/oneflow/core/vm/cuda_copy_h2d_stream_type.cpp
+++ b/oneflow/core/vm/cuda_copy_h2d_stream_type.cpp
@@ -49,7 +49,7 @@ void CudaCopyH2DStreamType::Compute(Instruction* instruction) const {
     const auto& instr_type_id = instruction->mut_instr_msg()->instr_type_id();
     CHECK_EQ(instr_type_id.stream_type_id().interpret_type(), InterpretType::kCompute);
     instr_type_id.instruction_type().Compute(instruction);
-    CudaCheck(cudaGetLastError());
+    OF_CUDA_CHECK(cudaGetLastError());
   }
   stream->mut_callback_list()->MoveTo(instruction->mut_callback_list());
   char* data_ptr = instruction->mut_status_buffer()->mut_buffer()->mut_data();

--- a/oneflow/core/vm/cuda_host_allocator.cpp
+++ b/oneflow/core/vm/cuda_host_allocator.cpp
@@ -22,11 +22,11 @@ namespace oneflow {
 namespace vm {
 
 void CudaHostAllocator::Allocate(char** mem_ptr, std::size_t size) {
-  CudaCheck(cudaMallocHost(mem_ptr, size));
+  OF_CUDA_CHECK(cudaMallocHost(mem_ptr, size));
 }
 
 void CudaHostAllocator::Deallocate(char* mem_ptr, std::size_t size) {
-  CudaCheck(cudaFreeHost(mem_ptr));
+  OF_CUDA_CHECK(cudaFreeHost(mem_ptr));
 }
 
 }  // namespace vm

--- a/oneflow/core/vm/cuda_instruction_status_querier.cpp
+++ b/oneflow/core/vm/cuda_instruction_status_querier.cpp
@@ -28,8 +28,8 @@ bool CudaInstrStatusQuerier::event_completed() const {
 
 void CudaInstrStatusQuerier::SetLaunched(DeviceCtx* device_ctx) {
   cudaSetDevice(device_id_);
-  CudaCheck(cudaEventCreateWithFlags(&event_, cudaEventBlockingSync | cudaEventDisableTiming));
-  CudaCheck(cudaEventRecord(event_, device_ctx->cuda_stream()));
+  OF_CUDA_CHECK(cudaEventCreateWithFlags(&event_, cudaEventBlockingSync | cudaEventDisableTiming));
+  OF_CUDA_CHECK(cudaEventRecord(event_, device_ctx->cuda_stream()));
   launched_ = true;
 }
 

--- a/oneflow/core/vm/cuda_stream_handle_device_context.h
+++ b/oneflow/core/vm/cuda_stream_handle_device_context.h
@@ -52,7 +52,7 @@ class CudaStreamHandleDeviceCtx : public DeviceCtx {
   }
   const cudnnHandle_t& cudnn_handle() const override { return *(cuda_handler_->cudnn_handle()); }
 
-  void SyncDevice() override { CudaCheck(cudaStreamSynchronize(cuda_stream())); }
+  void SyncDevice() override { OF_CUDA_CHECK(cudaStreamSynchronize(cuda_stream())); }
 
   void AddCallBack(std::function<void()> callback) const override {
     callback_msg_list_->EmplaceBack(ObjectMsgPtr<CallbackMsg>::New(callback));

--- a/oneflow/core/vm/cuda_stream_type.cpp
+++ b/oneflow/core/vm/cuda_stream_type.cpp
@@ -55,7 +55,7 @@ void CudaStreamType::Compute(Instruction* instruction) const {
     const auto& instr_type_id = instruction->mut_instr_msg()->instr_type_id();
     CHECK_EQ(instr_type_id.stream_type_id().interpret_type(), InterpretType::kCompute);
     instr_type_id.instruction_type().Compute(instruction);
-    CudaCheck(cudaGetLastError());
+    OF_CUDA_CHECK(cudaGetLastError());
   }
   stream->mut_callback_list()->MoveTo(instruction->mut_callback_list());
   char* data_ptr = instruction->mut_status_buffer()->mut_buffer()->mut_data();

--- a/oneflow/core/vm/device_helper_stream_type.cpp
+++ b/oneflow/core/vm/device_helper_stream_type.cpp
@@ -66,7 +66,7 @@ class CudaMallocInstructionType final : public InstructionType {
     }
     const auto& stream = instruction->stream();
     cudaSetDevice(stream.device_id());
-    CudaCheck(cudaMalloc(&dptr, buffer_type->size()));
+    OF_CUDA_CHECK(cudaMalloc(&dptr, buffer_type->size()));
     buffer_value->reset_data(dptr);
   }
 };
@@ -99,7 +99,7 @@ class CudaFreeInstructionType final : public InstructionType {
     }
     const auto& stream = instruction->stream();
     cudaSetDevice(stream.device_id());
-    CudaCheck(cudaFree(value_rw_mutexed_object->Mut<MemBufferObjectValue>()->mut_data()));
+    OF_CUDA_CHECK(cudaFree(value_rw_mutexed_object->Mut<MemBufferObjectValue>()->mut_data()));
     value_rw_mutexed_object->reset_object();
   }
 };

--- a/oneflow/core/vm/host_stream_type.cpp
+++ b/oneflow/core/vm/host_stream_type.cpp
@@ -66,7 +66,7 @@ class CudaMallocHostInstructionType final : public InstructionType {
       buffer_type = CHECK_JUST(instruction->mut_operand_type(operand)->Get<MemBufferObjectType>());
       buffer_value = instruction->mut_operand_value(operand)->Init<MemBufferObjectValue>();
     }
-    CudaCheck(cudaMallocHost(&dptr, buffer_type->size()));
+    OF_CUDA_CHECK(cudaMallocHost(&dptr, buffer_type->size()));
     buffer_value->reset_data(dptr);
   }
 };
@@ -142,7 +142,7 @@ class CudaFreeHostInstructionType final : public InstructionType {
       const auto& operand = view->mem_buffer();
       value_rw_mutexed_object = instruction->mut_operand_value(operand);
     }
-    CudaCheck(cudaFreeHost(value_rw_mutexed_object->Mut<MemBufferObjectValue>()->mut_data()));
+    OF_CUDA_CHECK(cudaFreeHost(value_rw_mutexed_object->Mut<MemBufferObjectValue>()->mut_data()));
     value_rw_mutexed_object->reset_object();
   }
 };

--- a/oneflow/user/kernels/argmax_kernel.cu
+++ b/oneflow/user/kernels/argmax_kernel.cu
@@ -78,7 +78,7 @@ size_t InferTempStorageForArgMax(int32_t num_row, int32_t num_col) {
           /* d_in */ nullptr, /* d_out */ nullptr, /* num_segments */ num_row,
           /* d_begin_offsets */ segment_offset_iter, /* d_end_offsets */ segment_offset_iter + 1,
           /* stream */ 0);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 
   return temp_storage_bytes;
 }
@@ -105,7 +105,7 @@ void ArgMax(const T* in_ptr, int32_t num_row, int32_t num_col, void* temp_storag
       /* d_begin_offsets */ segment_offset_iter,
       /* d_end_offsets */ segment_offset_iter + 1,
       /* stream */ stream);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 }
 
 template<typename T>

--- a/oneflow/user/kernels/conv_cudnn_kernels.cpp
+++ b/oneflow/user/kernels/conv_cudnn_kernels.cpp
@@ -171,7 +171,7 @@ class ConvGpuKernel final : public user_op::OpKernel {
     const CudnnConvArgs& args = args_and_algo.args;
     const cudnnConvolutionFwdAlgoPerf_t& algo_perf = args_and_algo.algo_perf;
 
-    CudaCheck(cudnnConvolutionForward(
+    OF_CUDNN_CHECK(cudnnConvolutionForward(
         ctx->device_ctx()->cudnn_handle(), CudnnSPOnePtr<T>(), args.xdesc.Get(), in->dptr(),
         args.wdesc.Get(), weight->dptr(), args.cdesc.Get(), algo_perf.algo, buf->mut_dptr(),
         args.params.max_ws_size, CudnnSPZeroPtr<T>(), args.ydesc.Get(), out->mut_dptr()));
@@ -180,9 +180,9 @@ class ConvGpuKernel final : public user_op::OpKernel {
     if (bias != nullptr) {
       ConvCudnnOpKernelState* conv_state = dynamic_cast<ConvCudnnOpKernelState*>(state);
       CHECK_NOTNULL(conv_state);
-      CudaCheck(cudnnAddTensor(ctx->device_ctx()->cudnn_handle(), CudnnSPOnePtr<T>(),
-                               conv_state->bias_desc->Get(), bias->dptr<T>(), CudnnSPOnePtr<T>(),
-                               args.ydesc.Get(), out->mut_dptr<T>()));
+      OF_CUDNN_CHECK(cudnnAddTensor(ctx->device_ctx()->cudnn_handle(), CudnnSPOnePtr<T>(),
+                                    conv_state->bias_desc->Get(), bias->dptr<T>(),
+                                    CudnnSPOnePtr<T>(), args.ydesc.Get(), out->mut_dptr<T>()));
     }
   }
 };
@@ -238,7 +238,7 @@ class ConvDataGradGpuKernel final : public user_op::OpKernel {
     const CudnnConvArgs& args = args_and_algo.args;
     const cudnnConvolutionBwdDataAlgoPerf_t& algo_perf = args_and_algo.algo_perf;
 
-    CudaCheck(cudnnConvolutionBackwardData(
+    OF_CUDNN_CHECK(cudnnConvolutionBackwardData(
         ctx->device_ctx()->cudnn_handle(), CudnnSPOnePtr<T>(), args.wdesc.Get(), filter->dptr(),
         args.ydesc.Get(), dy->dptr(), args.cdesc.Get(), algo_perf.algo, buf->mut_dptr(),
         args.params.max_ws_size, CudnnSPZeroPtr<T>(), args.xdesc.Get(), dx->mut_dptr()));
@@ -290,7 +290,7 @@ class ConvFilterGradGpuKernel final : public user_op::OpKernel {
     const CudnnConvArgs& args = args_and_algo.args;
     const cudnnConvolutionBwdFilterAlgoPerf_t& algo_perf = args_and_algo.algo_perf;
 
-    CudaCheck(cudnnConvolutionBackwardFilter(
+    OF_CUDNN_CHECK(cudnnConvolutionBackwardFilter(
         ctx->device_ctx()->cudnn_handle(), CudnnSPOnePtr<T>(), args.xdesc.Get(), x->dptr(),
         args.ydesc.Get(), dy->dptr(), args.cdesc.Get(), algo_perf.algo, buf->mut_dptr(),
         args.params.max_ws_size, CudnnSPZeroPtr<T>(), args.wdesc.Get(), filter_diff->mut_dptr()));
@@ -365,7 +365,7 @@ class ConvBiasGradGpuKernel final : public user_op::OpKernel {
     dy_desc.reset(new CudnnTensorDesc(dy->data_type(), dy->shape(), data_format));
     auto* bias_grad_state = dynamic_cast<ConvBiasGradState*>(state);
     CHECK_NOTNULL(bias_grad_state);
-    CudaCheck(cudnnConvolutionBackwardBias(
+    OF_CUDNN_CHECK(cudnnConvolutionBackwardBias(
         ctx->device_ctx()->cudnn_handle(), CudnnSPOnePtr<T>(), dy_desc->Get(), dy->dptr<T>(),
         CudnnSPZeroPtr<T>(), bias_grad_state->bias_diff_desc->Get(), bias_diff->mut_dptr<T>()));
   }

--- a/oneflow/user/kernels/deconv_cudnn_kernel.cpp
+++ b/oneflow/user/kernels/deconv_cudnn_kernel.cpp
@@ -121,7 +121,7 @@ class DeConvGpuKernel final : public user_op::OpKernel {
     const CudnnConvArgs& args = args_and_algo.args;
     const cudnnConvolutionBwdDataAlgoPerf_t& algo_perf = args_and_algo.algo_perf;
 
-    CudaCheck(cudnnConvolutionBackwardData(
+    OF_CUDNN_CHECK(cudnnConvolutionBackwardData(
         ctx->device_ctx()->cudnn_handle(), CudnnSPOnePtr<T>(), args.wdesc.Get(), weight->dptr(),
         args.ydesc.Get(), in->dptr(), args.cdesc.Get(), algo_perf.algo, buf->mut_dptr(),
         args.params.max_ws_size, CudnnSPZeroPtr<T>(), args.xdesc.Get(), out->mut_dptr()));

--- a/oneflow/user/kernels/eager_nccl_kernels.cu
+++ b/oneflow/user/kernels/eager_nccl_kernels.cu
@@ -41,9 +41,9 @@ class EagerNcclAllReduceKernel final : public user_op::OpKernel {
                                         parallel_desc.DeviceIdForParallelId(parallel_id)));
     }
     ncclComm_t comm = CHECK_NOTNULL(Global<EagerNcclCommMgr>::Get())->GetCommForDevice(device_set);
-    NcclCheck(ncclAllReduce(in->dptr(), out->mut_dptr(), in->shape().elem_cnt(),
-                            GetNcclDataType(in->data_type()), ncclSum, comm,
-                            ctx->device_ctx()->cuda_stream()));
+    OF_NCCL_CHECK(ncclAllReduce(in->dptr(), out->mut_dptr(), in->shape().elem_cnt(),
+                                GetNcclDataType(in->data_type()), ncclSum, comm,
+                                ctx->device_ctx()->cuda_stream()));
   };
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };

--- a/oneflow/user/kernels/layer_norm_gpu_kernel.cpp
+++ b/oneflow/user/kernels/layer_norm_gpu_kernel.cpp
@@ -88,7 +88,7 @@ class LayerNormGpuKernel final : public user_op::OpKernel {
     NewKernelUtil<DeviceType::kGPU>::Fill(ctx->device_ctx(), mean->shape().elem_cnt(),
                                           static_cast<BNParamT>(0),
                                           reinterpret_cast<BNParamT*>(cudnn_bn_bias_zeros_dptr));
-    CudaCheck(cudnnBatchNormalizationForwardTraining(
+    OF_CUDNN_CHECK(cudnnBatchNormalizationForwardTraining(
         ctx->device_ctx()->cudnn_handle(), bn_ctx.mode(), CudnnSPOnePtr<T>(), CudnnSPZeroPtr<T>(),
         bn_ctx.data_tensor_desc(), x->dptr<T>(), bn_ctx.data_tensor_desc(),
         normalized->mut_dptr<T>(), bn_ctx.param_tensor_desc(),
@@ -160,7 +160,7 @@ class LayerNormGradGpuKernel final : public user_op::OpKernel {
     const double epsilon = ctx->Attr<double>("epsilon");
     CHECK_GE(epsilon, CUDNN_BN_MIN_EPSILON);
     LayerNormCudnnBnCtx bn_ctx(x->shape(), mean->shape(), x->data_type());
-    CudaCheck(cudnnBatchNormalizationBackward(
+    OF_CUDNN_CHECK(cudnnBatchNormalizationBackward(
         ctx->device_ctx()->cudnn_handle(), bn_ctx.mode(), CudnnSPOnePtr<T>(), CudnnSPZeroPtr<T>(),
         CudnnSPOnePtr<T>(), CudnnSPZeroPtr<T>(), bn_ctx.data_tensor_desc(), x->dptr<T>(),
         bn_ctx.data_tensor_desc(), dy->dptr<T>(), bn_ctx.data_tensor_desc(), dx->mut_dptr<T>(),

--- a/oneflow/user/kernels/normalization_kernel.cpp
+++ b/oneflow/user/kernels/normalization_kernel.cpp
@@ -261,7 +261,7 @@ class NormalizationTrainKernel final : public user_op::OpKernel {
           inv_variance->mut_dptr()));
     }
 #else
-    CudaCheck(cudnnBatchNormalizationForwardTraining(
+    OF_CUDNN_CHECK(cudnnBatchNormalizationForwardTraining(
         ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT, CudnnSPOnePtr<T>(),
         CudnnSPZeroPtr<T>(), desc_helper.xy_desc(), x->dptr(), desc_helper.xy_desc(), y->mut_dptr(),
         desc_helper.param_desc(), gamma->dptr(), beta->dptr(), 1.0 - momentum,
@@ -337,7 +337,7 @@ class NormalizationGradUserKernel final : public user_op::OpKernel {
           epsilon, mean->dptr(), inv_variance->dptr()));
     }
 #else
-    CudaCheck(cudnnBatchNormalizationBackward(
+    OF_CUDNN_CHECK(cudnnBatchNormalizationBackward(
         ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT, CudnnSPOnePtr<T>(),
         CudnnSPZeroPtr<T>(), CudnnSPOnePtr<T>(), CudnnSPZeroPtr<T>(), desc_helper.xy_desc(),
         x->dptr(), desc_helper.xy_desc(), dy->dptr(), desc_helper.xy_desc(), dx->mut_dptr(),

--- a/oneflow/user/kernels/normalization_kernel.cpp
+++ b/oneflow/user/kernels/normalization_kernel.cpp
@@ -48,12 +48,13 @@ void InferXYCudnnTensorDesc(const ShapeView& xy_shape, const DataType& data_type
   int32_t n, c, h, w;
   cudnnTensorFormat_t format;
   InferDimSizeAndDataFormat(xy_shape, axis, &n, &c, &h, &w, &format);
-  CudaCheck(cudnnSetTensor4dDescriptor(xy_desc, format, GetCudnnDataType(data_type), n, c, h, w));
+  OF_CUDNN_CHECK(
+      cudnnSetTensor4dDescriptor(xy_desc, format, GetCudnnDataType(data_type), n, c, h, w));
 }
 
 void InferParamCudnnTensorDesc(const cudnnTensorDescriptor_t xy_desc, cudnnBatchNormMode_t mode,
                                cudnnTensorDescriptor_t param_desc) {
-  CudaCheck(cudnnDeriveBNTensorDescriptor(param_desc, xy_desc, mode));
+  OF_CUDNN_CHECK(cudnnDeriveBNTensorDescriptor(param_desc, xy_desc, mode));
 }
 
 class CudnnTensorDescHelper final {
@@ -61,18 +62,18 @@ class CudnnTensorDescHelper final {
   OF_DISALLOW_COPY_AND_MOVE(CudnnTensorDescHelper);
   CudnnTensorDescHelper(const ShapeView& xy_shape, const DataType& data_type, const int32_t axis,
                         cudnnBatchNormMode_t mode) {
-    CudaCheck(cudnnCreateTensorDescriptor(&xy_desc_));
+    OF_CUDNN_CHECK(cudnnCreateTensorDescriptor(&xy_desc_));
     InferXYCudnnTensorDesc(xy_shape, data_type, axis, xy_desc_);
-    CudaCheck(cudnnCreateTensorDescriptor(&param_desc_));
+    OF_CUDNN_CHECK(cudnnCreateTensorDescriptor(&param_desc_));
     InferParamCudnnTensorDesc(xy_desc_, mode, param_desc_);
     int n, c, h, w, n_stride, c_stride, h_stride, w_stride;
-    CudaCheck(cudnnGetTensor4dDescriptor(param_desc_, &param_data_type_, &n, &c, &h, &w, &n_stride,
-                                         &c_stride, &h_stride, &w_stride));
+    OF_CUDNN_CHECK(cudnnGetTensor4dDescriptor(param_desc_, &param_data_type_, &n, &c, &h, &w,
+                                              &n_stride, &c_stride, &h_stride, &w_stride));
     param_size_ = c;
   }
   ~CudnnTensorDescHelper() {
-    CudaCheck(cudnnDestroyTensorDescriptor(param_desc_));
-    CudaCheck(cudnnDestroyTensorDescriptor(xy_desc_));
+    OF_CUDNN_CHECK(cudnnDestroyTensorDescriptor(param_desc_));
+    OF_CUDNN_CHECK(cudnnDestroyTensorDescriptor(xy_desc_));
   }
 
   cudnnTensorDescriptor_t xy_desc() const { return xy_desc_; }
@@ -98,11 +99,11 @@ size_t InferTrainWorkspaceSize(const ShapeView& x_shape, const DataType data_typ
                                           CUDNN_BATCHNORM_SPATIAL_PERSISTENT);
   size_t size_in_bytes;
   cudnnHandle_t handle;
-  CudaCheck(cudnnCreate(&handle));
-  CudaCheck(cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize(
+  OF_CUDNN_CHECK(cudnnCreate(&handle));
+  OF_CUDNN_CHECK(cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize(
       handle, CUDNN_BATCHNORM_SPATIAL_PERSISTENT, CUDNN_BATCHNORM_OPS_BN, desc_helper.xy_desc(),
       nullptr, desc_helper.xy_desc(), desc_helper.param_desc(), nullptr, &size_in_bytes));
-  CudaCheck(cudnnDestroy(handle));
+  OF_CUDNN_CHECK(cudnnDestroy(handle));
   return std::max(size_in_bytes, static_cast<size_t>(1));
 #else
   return 1;
@@ -122,12 +123,12 @@ size_t InferGradWorkspaceSize(const ShapeView& x_shape, const DataType data_type
                                           CUDNN_BATCHNORM_SPATIAL_PERSISTENT);
   size_t size_in_bytes;
   cudnnHandle_t handle;
-  CudaCheck(cudnnCreate(&handle));
-  CudaCheck(cudnnGetBatchNormalizationBackwardExWorkspaceSize(
+  OF_CUDNN_CHECK(cudnnCreate(&handle));
+  OF_CUDNN_CHECK(cudnnGetBatchNormalizationBackwardExWorkspaceSize(
       handle, CUDNN_BATCHNORM_SPATIAL_PERSISTENT, CUDNN_BATCHNORM_OPS_BN, desc_helper.xy_desc(),
       nullptr, desc_helper.xy_desc(), nullptr, desc_helper.xy_desc(), desc_helper.param_desc(),
       nullptr, &size_in_bytes));
-  CudaCheck(cudnnDestroy(handle));
+  OF_CUDNN_CHECK(cudnnDestroy(handle));
   return std::max(size_in_bytes, static_cast<size_t>(1));
 #else
   return 1;
@@ -171,7 +172,7 @@ class NormalizationInferenceKernel final : public user_op::OpKernel {
     desc_helper.CheckParamTensor(moving_mean);
     desc_helper.CheckParamTensor(moving_variance);
 
-    CudaCheck(cudnnBatchNormalizationForwardInference(
+    OF_CUDNN_CHECK(cudnnBatchNormalizationForwardInference(
         ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL, CudnnSPOnePtr<T>(),
         CudnnSPZeroPtr<T>(), desc_helper.xy_desc(), x->dptr(), desc_helper.xy_desc(), y->mut_dptr(),
         desc_helper.param_desc(), gamma->dptr(), beta->dptr(), moving_mean->dptr(),
@@ -233,17 +234,17 @@ class NormalizationTrainKernel final : public user_op::OpKernel {
 
 #if defined(BN_ENABLE_EX_API)
     size_t workspace_size;
-    CudaCheck(cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize(
+    OF_CUDNN_CHECK(cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize(
         ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT,
         CUDNN_BATCHNORM_OPS_BN, desc_helper.xy_desc(), nullptr, desc_helper.xy_desc(),
         desc_helper.param_desc(), nullptr, &workspace_size));
     size_t reserve_space_size;
-    CudaCheck(cudnnGetBatchNormalizationTrainingExReserveSpaceSize(
+    OF_CUDNN_CHECK(cudnnGetBatchNormalizationTrainingExReserveSpaceSize(
         ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT,
         CUDNN_BATCHNORM_OPS_BN, nullptr, desc_helper.xy_desc(), &reserve_space_size));
     auto* workspace = ctx->Tensor4ArgNameAndIndex("tmp_buffer", 0);
     if (reserve_space_size == 0 && workspace_size <= workspace->shape().elem_cnt()) {
-      CudaCheck(cudnnBatchNormalizationForwardTrainingEx(
+      OF_CUDNN_CHECK(cudnnBatchNormalizationForwardTrainingEx(
           ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT,
           CUDNN_BATCHNORM_OPS_BN, CudnnSPOnePtr<T>(), CudnnSPZeroPtr<T>(), desc_helper.xy_desc(),
           x->dptr(), nullptr, nullptr, desc_helper.xy_desc(), y->mut_dptr(),
@@ -252,7 +253,7 @@ class NormalizationTrainKernel final : public user_op::OpKernel {
           inv_variance->mut_dptr(), nullptr, workspace->mut_dptr(), workspace->shape().elem_cnt(),
           nullptr, 0));
     } else {
-      CudaCheck(cudnnBatchNormalizationForwardTraining(
+      OF_CUDNN_CHECK(cudnnBatchNormalizationForwardTraining(
           ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT, CudnnSPOnePtr<T>(),
           CudnnSPZeroPtr<T>(), desc_helper.xy_desc(), x->dptr(), desc_helper.xy_desc(),
           y->mut_dptr(), desc_helper.param_desc(), gamma->dptr(), beta->dptr(), 1.0 - momentum,
@@ -309,17 +310,17 @@ class NormalizationGradUserKernel final : public user_op::OpKernel {
 
 #if defined(BN_ENABLE_EX_API)
     size_t workspace_size;
-    CudaCheck(cudnnGetBatchNormalizationBackwardExWorkspaceSize(
+    OF_CUDNN_CHECK(cudnnGetBatchNormalizationBackwardExWorkspaceSize(
         ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT,
         CUDNN_BATCHNORM_OPS_BN, desc_helper.xy_desc(), nullptr, desc_helper.xy_desc(), nullptr,
         desc_helper.xy_desc(), desc_helper.param_desc(), nullptr, &workspace_size));
     size_t reserve_space_size;
-    CudaCheck(cudnnGetBatchNormalizationTrainingExReserveSpaceSize(
+    OF_CUDNN_CHECK(cudnnGetBatchNormalizationTrainingExReserveSpaceSize(
         ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT,
         CUDNN_BATCHNORM_OPS_BN, nullptr, desc_helper.xy_desc(), &reserve_space_size));
     auto* workspace = ctx->Tensor4ArgNameAndIndex("tmp_buffer", 0);
     if (reserve_space_size == 0 && workspace_size <= workspace->shape().elem_cnt()) {
-      CudaCheck(cudnnBatchNormalizationBackwardEx(
+      OF_CUDNN_CHECK(cudnnBatchNormalizationBackwardEx(
           ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT,
           CUDNN_BATCHNORM_OPS_BN, CudnnSPOnePtr<T>(), CudnnSPZeroPtr<T>(), CudnnSPOnePtr<T>(),
           CudnnSPZeroPtr<T>(), desc_helper.xy_desc(), x->dptr(), nullptr, nullptr,
@@ -328,7 +329,7 @@ class NormalizationGradUserKernel final : public user_op::OpKernel {
           beta_diff->mut_dptr(), epsilon, mean->dptr(), inv_variance->dptr(), nullptr,
           workspace->mut_dptr(), workspace->shape().elem_cnt(), nullptr, 0));
     } else {
-      CudaCheck(cudnnBatchNormalizationBackward(
+      OF_CUDNN_CHECK(cudnnBatchNormalizationBackward(
           ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT, CudnnSPOnePtr<T>(),
           CudnnSPZeroPtr<T>(), CudnnSPOnePtr<T>(), CudnnSPZeroPtr<T>(), desc_helper.xy_desc(),
           x->dptr(), desc_helper.xy_desc(), dy->dptr(), desc_helper.xy_desc(), dx->mut_dptr(),

--- a/oneflow/user/kernels/pool_gpu_kernel.cpp
+++ b/oneflow/user/kernels/pool_gpu_kernel.cpp
@@ -28,12 +28,12 @@ class CudnnPoolDesc final {
   OF_DISALLOW_COPY_AND_MOVE(CudnnPoolDesc);
   CudnnPoolDesc(cudnnPoolingMode_t pooling_mode, int dims, const int* window, const int* padding,
                 const int* stride) {
-    CudaCheck(cudnnCreatePoolingDescriptor(&val_));
-    CudaCheck(cudnnSetPoolingNdDescriptor(val_, pooling_mode, CUDNN_NOT_PROPAGATE_NAN, dims, window,
-                                          padding, stride));
+    OF_CUDNN_CHECK(cudnnCreatePoolingDescriptor(&val_));
+    OF_CUDNN_CHECK(cudnnSetPoolingNdDescriptor(val_, pooling_mode, CUDNN_NOT_PROPAGATE_NAN, dims,
+                                               window, padding, stride));
   }
 
-  ~CudnnPoolDesc() { CudaCheck(cudnnDestroyPoolingDescriptor(val_)); }
+  ~CudnnPoolDesc() { OF_CUDNN_CHECK(cudnnDestroyPoolingDescriptor(val_)); }
 
   const cudnnPoolingDescriptor_t& Get() const { return val_; }
 
@@ -145,7 +145,7 @@ struct PoolGpuKernelUtil {
     GPUPoolOpKernelState* gpu_pool_op_kernel_state = dynamic_cast<GPUPoolOpKernelState*>(state);
     gpu_pool_op_kernel_state->ResetIfDynamic(ctx);
     CHECK(gpu_pool_op_kernel_state != nullptr);
-    CudaCheck(cudnnPoolingForward(
+    OF_CUDNN_CHECK(cudnnPoolingForward(
         ctx->device_ctx()->cudnn_handle(), gpu_pool_op_kernel_state->cudnn_pooling_desc(),
         CudnnSPOnePtr<T>(), gpu_pool_op_kernel_state->cudnn_x_tensor_desc(), x->dptr(),
         CudnnSPZeroPtr<T>(), gpu_pool_op_kernel_state->cudnn_y_tensor_desc(), y->mut_dptr()));
@@ -159,7 +159,7 @@ struct PoolGpuKernelUtil {
     GPUPoolOpKernelState* gpu_pool_op_kernel_state = dynamic_cast<GPUPoolOpKernelState*>(state);
     gpu_pool_op_kernel_state->ResetIfDynamic(ctx);
     CHECK(gpu_pool_op_kernel_state != nullptr);
-    CudaCheck(cudnnPoolingBackward(
+    OF_CUDNN_CHECK(cudnnPoolingBackward(
         ctx->device_ctx()->cudnn_handle(), gpu_pool_op_kernel_state->cudnn_pooling_desc(),
         CudnnSPOnePtr<T>(), gpu_pool_op_kernel_state->cudnn_y_tensor_desc(), y->dptr(),
         gpu_pool_op_kernel_state->cudnn_y_tensor_desc(), dy->dptr(),

--- a/oneflow/user/kernels/radix_sort.cuh
+++ b/oneflow/user/kernels/radix_sort.cuh
@@ -60,7 +60,7 @@ size_t InferTempStorageForSortPairsAscending(int32_t num_row, int32_t num_col) {
       /* begin_bit */ 0,
       /* end_bit */ sizeof(KeyType) * 8,
       /* stream */ 0);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 
   return temp_storage_bytes;
 }
@@ -90,7 +90,7 @@ size_t InferTempStorageForSortPairsDescending(int32_t num_row, int32_t num_col) 
           /* begin_bit */ 0,
           /* end_bit */ sizeof(KeyType) * 8,
           /* stream */ 0);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 
   return temp_storage_bytes;
 }
@@ -117,7 +117,7 @@ size_t InferTempStorageForSortKeysAscending(int32_t num_row, int32_t num_col) {
       /* begin_bit */ 0,
       /* end_bit */ sizeof(KeyType) * 8,
       /* stream */ 0);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 
   return temp_storage_bytes;
 }
@@ -144,7 +144,7 @@ size_t InferTempStorageForSortKeysDescending(int32_t num_row, int32_t num_col) {
       /* begin_bit */ 0,
       /* end_bit */ sizeof(KeyType) * 8,
       /* stream */ 0);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 
   return temp_storage_bytes;
 }
@@ -179,7 +179,7 @@ void SortPairsAscending(const KeyType* keys_ptr, const ValueType* values_ptr, in
       /* begin_bit */ 0,
       /* end_bit */ sizeof(KeyType) * 8,
       /* stream */ stream);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 }
 
 template<typename KeyType, typename ValueType>
@@ -212,7 +212,7 @@ void SortPairsDescending(const KeyType* keys_ptr, const ValueType* values_ptr, i
       /* begin_bit */ 0,
       /* end_bit */ sizeof(KeyType) * 8,
       /* stream */ stream);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 }
 
 template<typename KeyType>
@@ -242,7 +242,7 @@ void SortKeysAscending(const KeyType* keys_ptr, int32_t num_row, int32_t num_col
       /* begin_bit */ 0,
       /* end_bit */ sizeof(KeyType) * 8,
       /* stream */ stream);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 }
 
 template<typename KeyType>
@@ -272,7 +272,7 @@ void SortKeysDescending(const KeyType* keys_ptr, int32_t num_row, int32_t num_co
       /* begin_bit */ 0,
       /* end_bit */ sizeof(KeyType) * 8,
       /* stream */ stream);
-  CudaCheck(err);
+  OF_CUDA_CHECK(err);
 }
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/random_mask_generator.cu
+++ b/oneflow/user/kernels/random_mask_generator.cu
@@ -77,15 +77,15 @@ __global__ void GenerateGpu(curandState* state, const int64_t n, const float rat
 
 RandomMaskGenerator<DeviceType::kGPU>::RandomMaskGenerator(int64_t seed) {
   cudaDeviceProp prop;
-  CudaCheck(cudaGetDeviceProperties(&prop, 0));
+  OF_CUDA_CHECK(cudaGetDeviceProperties(&prop, 0));
   block_num_ = prop.multiProcessorCount;
   thread_num_ = GetThreadNum(prop);
-  CudaCheck(cudaMalloc(&curand_states_, block_num_ * thread_num_ * sizeof(curandState)));
+  OF_CUDA_CHECK(cudaMalloc(&curand_states_, block_num_ * thread_num_ * sizeof(curandState)));
   SetupKernel<<<block_num_, thread_num_>>>(seed, curand_states_);
 }
 
 RandomMaskGenerator<DeviceType::kGPU>::~RandomMaskGenerator() {
-  CudaCheck(cudaFree(curand_states_));
+  OF_CUDA_CHECK(cudaFree(curand_states_));
 }
 
 void RandomMaskGenerator<DeviceType::kGPU>::Generate(DeviceCtx* device_ctx, const int64_t n,


### PR DESCRIPTION
CudaCheck:

```
F0808 14:02:36.887184 29334 cuda_util.cpp:88] Check failed: error == cudaSuccess (2 vs. 0) out of memory
*** Check failure stack trace: ***
    @     0x7feeceb683ad  google::LogMessage::Fail()
    @     0x7feeceb6c56c  google::LogMessage::SendToLog()
    @     0x7feeceb67ed3  google::LogMessage::Flush()
    @     0x7feeceb6cfbe  google::LogMessageFatal::~LogMessageFatal()
    @     0x7feecd9fde50  oneflow::CudaCheck<>()
    @     0x7feecdf98436  oneflow::(anonymous namespace)::ConvGpuKernel<>::Compute()
    @     0x7feecdd3ba09  oneflow::UserKernel::ForwardDataContent()
    @     0x7feecdccb50c  oneflow::Kernel::Forward()
    @     0x7feecdcca9e7  oneflow::Kernel::Launch()
    @     0x7feecd99ab18  oneflow::Actor::AsyncLaunchKernel()
    @     0x7feecd9ae93c  oneflow::NormalForwardCompActor::Act()
    @     0x7feecd99c07e  oneflow::Actor::TryLogActEvent()
    @     0x7feecd99ec36  oneflow::Actor::ActUntilFail()
    @     0x7feecd99ed25  oneflow::Actor::HandlerNormal()
    @     0x7feecde9f051  oneflow::Thread::PollMsgChannel()
    @     0x7feecde9cee8  _ZNSt6thread5_ImplISt12_Bind_simpleIFZN7oneflow9GpuThreadC1EllEUlvE_vEEE6_M_runEv
    @     0x7feef2b84421  execute_native_thread_routine_compat
    @     0x7feefac36304  start_thread
    @     0x7feefa975d1d  __clone
    @              (nil)  (unknown)
Fatal Python error: Aborted
```

OF_CUDA_CHECK:

```
F0808 14:04:04.819490 32547 conv_cudnn_kernels.cpp:164] Check failed: cudaMalloc(&ptr, 1024LL * 1024LL * 1024LL * 32LL ) : out of memory (2) 
*** Check failure stack trace: ***
    @     0x7f66eb96887d  google::LogMessage::Fail()
    @     0x7f66eb96ca3c  google::LogMessage::SendToLog()
    @     0x7f66eb9683a3  google::LogMessage::Flush()
    @     0x7f66eb96d48e  google::LogMessageFatal::~LogMessageFatal()
    @     0x7f66ead98c22  oneflow::(anonymous namespace)::ConvGpuKernel<>::Compute()
    @     0x7f66eab3ba09  oneflow::UserKernel::ForwardDataContent()
    @     0x7f66eaacb50c  oneflow::Kernel::Forward()
    @     0x7f66eaaca9e7  oneflow::Kernel::Launch()
    @     0x7f66ea79ab18  oneflow::Actor::AsyncLaunchKernel()
    @     0x7f66ea7ae93c  oneflow::NormalForwardCompActor::Act()
    @     0x7f66ea79c07e  oneflow::Actor::TryLogActEvent()
    @     0x7f66ea79ec36  oneflow::Actor::ActUntilFail()
    @     0x7f66ea79ed25  oneflow::Actor::HandlerNormal()
    @     0x7f66eac9f051  oneflow::Thread::PollMsgChannel()
    @     0x7f66eac9cee8  _ZNSt6thread5_ImplISt12_Bind_simpleIFZN7oneflow9GpuThreadC1EllEUlvE_vEEE6_M_runEv
    @     0x7f670f984421  execute_native_thread_routine_compat
    @     0x7f6717a36304  start_thread
    @     0x7f6717775d1d  __clone
    @              (nil)  (unknown)
Fatal Python error: Aborted
```

CudaCheck:

```
F0808 13:49:52.191977 13059 cuda_util.cpp:93] Check failed: error : CUDNN_STATUS_BAD_PARAM 
*** Check failure stack trace: ***
    @     0x7ff06e3d3a8d  google::LogMessage::Fail()
    @     0x7ff06e3d7c4c  google::LogMessage::SendToLog()
    @     0x7ff06e3d35b3  google::LogMessage::Flush()
    @     0x7ff06e3d869e  google::LogMessageFatal::~LogMessageFatal()
    @     0x7ff06d269c84  oneflow::CudaCheck<>()
    @     0x7ff06d803e98  oneflow::(anonymous namespace)::ConvGpuKernel<>::Compute()
    @     0x7ff06d5a7689  oneflow::UserKernel::ForwardDataContent()
    @     0x7ff06d53718c  oneflow::Kernel::Forward()
    @     0x7ff06d536667  oneflow::Kernel::Launch()
    @     0x7ff06d206998  oneflow::Actor::AsyncLaunchKernel()
    @     0x7ff06d21a7bc  oneflow::NormalForwardCompActor::Act()
    @     0x7ff06d207efe  oneflow::Actor::TryLogActEvent()
    @     0x7ff06d20aab6  oneflow::Actor::ActUntilFail()
    @     0x7ff06d20aba5  oneflow::Actor::HandlerNormal()
    @     0x7ff06d70acd1  oneflow::Thread::PollMsgChannel()
    @     0x7ff06d708b68  _ZNSt6thread5_ImplISt12_Bind_simpleIFZN7oneflow9GpuThreadC1EllEUlvE_vEEE6_M_runEv
    @     0x7ff0923ef421  execute_native_thread_routine_compat
    @     0x7ff09a4a1304  start_thread
    @     0x7ff09a1e0d1d  __clone
    @              (nil)  (unknown)
Fatal Python error: Aborted
```

OF_CUDNN_CHECK:

```
F0808 14:00:59.760102 26053 conv_cudnn_kernels.cpp:181] Check failed: cudnnConvolutionForward( ctx->device_ctx()->cudnn_handle(), CudnnSPOnePtr<T>(), args.xdesc.Get(), in->dptr(), nullptr, weight->dptr(), args.cdesc.Get(), algo_perf.algo, buf->mut_dptr(), args.params.max_ws_size, CudnnSPZeroPtr<T>(), args.ydesc.Get(), out->mut_dptr()) : CUDNN_STATUS_BAD_PARAM (3) 
*** Check failure stack trace: ***
    @     0x7f68efa5824d  google::LogMessage::Fail()
    @     0x7f68efa5c40c  google::LogMessage::SendToLog()
    @     0x7f68efa57d73  google::LogMessage::Flush()
    @     0x7f68efa5ce5e  google::LogMessageFatal::~LogMessageFatal()
    @     0x7f68eee88727  oneflow::(anonymous namespace)::ConvGpuKernel<>::Compute()
    @     0x7f68eec2ba09  oneflow::UserKernel::ForwardDataContent()
    @     0x7f68eebbb50c  oneflow::Kernel::Forward()
    @     0x7f68eebba9e7  oneflow::Kernel::Launch()
    @     0x7f68ee88ab18  oneflow::Actor::AsyncLaunchKernel()
    @     0x7f68ee89e93c  oneflow::NormalForwardCompActor::Act()
    @     0x7f68ee88c07e  oneflow::Actor::TryLogActEvent()
    @     0x7f68ee88ec36  oneflow::Actor::ActUntilFail()
    @     0x7f68ee88ed25  oneflow::Actor::HandlerNormal()
    @     0x7f68eed8f051  oneflow::Thread::PollMsgChannel()
    @     0x7f68eed8cee8  _ZNSt6thread5_ImplISt12_Bind_simpleIFZN7oneflow9GpuThreadC1EllEUlvE_vEEE6_M_runEv
    @     0x7f6913a74421  execute_native_thread_routine_compat
    @     0x7f691bb26304  start_thread
    @     0x7f691b865d1d  __clone
    @              (nil)  (unknown)
Fatal Python error: Aborted
```