### PR TITLE
Optimize conv performance

### DIFF
--- a/oneflow/core/device/cudnn_conv_util.h
+++ b/oneflow/core/device/cudnn_conv_util.h
@@ -35,10 +35,10 @@ class CudnnConvDesc final {
   CudnnConvDesc() = delete;
   ~CudnnConvDesc();
 
-  CudnnConvDesc(const DataType& data_type, const ShapeView& in_blob_shape,
-                const PbMessage& conv_conf);
-  CudnnConvDesc(const DataType& data_type, const ShapeView& in_blob_shape,
-                const user_op::UserOpConfWrapper& conv_conf);
+  CudnnConvDesc(const DataType compute_type, const DataType data_type,
+                const ShapeView& in_blob_shape, const PbMessage& conv_conf);
+  CudnnConvDesc(const DataType compute_type, const DataType data_type,
+                const ShapeView& in_blob_shape, const user_op::UserOpConfWrapper& conv_conf);
 
   const cudnnConvolutionDescriptor_t& Get() const { return val_; }
 

--- a/oneflow/core/job/job_conf.proto
+++ b/oneflow/core/job/job_conf.proto
@@ -101,7 +101,7 @@ message JobConfigProto {
   optional bool prune_parallel_cast_ops = 509 [default = true];
   optional bool prune_cast_to_static_shape_ops = 510 [default = true];
 
-  optional bool cudnn_conv_enable_pseudo_half = 600 [default = false];
+  optional bool cudnn_conv_enable_pseudo_half = 600 [default = true];
   optional bool enable_float_compute_for_half_gemm = 601 [default = true];
   optional bool enable_auto_mixed_precision = 602 [default = false];
   


### PR DESCRIPTION
优化Conv FP16 性能
* 将pseudo_half而不是true_half作为默认值
* 根据输入输出的dtype决定是否启用`CUDNN_TENSOR_OP_MATH`，而不是根据compute_type

在2080ti上测试resnet50，单卡batch_size为64，吞吐率如下


  | 优化前 | 优化后
-- | -- | --
FP32+NCHW | 284 | 280
FP16+NCHW | 443 | 505
FP16+NHWC | 336 | 615
