### PR TITLE
Remove useless code in cudnn conv util

### DIFF
--- a/oneflow/core/device/cudnn_conv_util.cpp
+++ b/oneflow/core/device/cudnn_conv_util.cpp
@@ -135,35 +135,6 @@ perf_t GetBestAlgorithm(const CudnnConvArgs& args, CudnnConvResource* res,
 CudnnConvDesc::~CudnnConvDesc() { OF_CUDNN_CHECK(cudnnDestroyConvolutionDescriptor(val_)); }
 
 CudnnConvDesc::CudnnConvDesc(const DataType compute_type, const DataType data_type,
-                             const ShapeView& in_blob_shape, const PbMessage& conv_conf) {
-  int32_t opkernel_dim = in_blob_shape.NumAxes() - 2;
-  OF_CUDNN_CHECK(cudnnCreateConvolutionDescriptor(&val_));
-  std::vector<int32_t> pad_large_side;
-  GetConvOutAndPad(in_blob_shape, conv_conf, nullptr, nullptr, &pad_large_side);
-  const PbRf<int32_t>& strides = GetPbRfFromPbMessage<int32_t>(conv_conf, "strides");
-  const PbRf<int32_t>& dilation_rate = GetPbRfFromPbMessage<int32_t>(conv_conf, "dilation_rate");
-  if (opkernel_dim == 2) {
-    OF_CUDNN_CHECK(
-        cudnnSetConvolution2dDescriptor(val_, pad_large_side[0], pad_large_side[1], strides.Get(0),
-                                        strides.Get(1), dilation_rate.Get(0), dilation_rate.Get(1),
-                                        CUDNN_CROSS_CORRELATION, GetCudnnDataType(compute_type)));
-  } else if (opkernel_dim == 1) {
-    OF_CUDNN_CHECK(cudnnSetConvolution2dDescriptor(val_, pad_large_side[0], 0, strides.Get(0), 1,
-                                                   dilation_rate.Get(0), 1, CUDNN_CROSS_CORRELATION,
-                                                   GetCudnnDataType(compute_type)));
-  } else {
-    OF_CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(
-        val_, opkernel_dim, pad_large_side.data(), strides.data(), dilation_rate.data(),
-        CUDNN_CROSS_CORRELATION, GetCudnnDataType(compute_type)));
-  }
-  const int32_t groups = GetValFromPbMessage<int32_t>(conv_conf, "groups");
-  if (groups != 1) { OF_CUDNN_CHECK(cudnnSetConvolutionGroupCount(val_, groups)); }
-  if (GetCudnnDataType(data_type) == CUDNN_DATA_HALF) {
-    OF_CUDNN_CHECK(cudnnSetConvolutionMathType(val_, CUDNN_TENSOR_OP_MATH));
-  }
-}
-
-CudnnConvDesc::CudnnConvDesc(const DataType compute_type, const DataType data_type,
                              const ShapeView& in_blob_shape,
                              const user_op::UserOpConfWrapper& conv_conf) {
   int32_t opkernel_dim = in_blob_shape.NumAxes() - 2;
@@ -190,40 +161,6 @@ CudnnConvDesc::CudnnConvDesc(const DataType compute_type, const DataType data_ty
   if (GetCudnnDataType(data_type) == CUDNN_DATA_HALF) {
     OF_CUDNN_CHECK(cudnnSetConvolutionMathType(val_, CUDNN_TENSOR_OP_MATH));
   }
-}
-
-CudnnConvArgs::CudnnConvArgs(const PbMessage& conv_conf, DataType x_data_type,
-                             const ShapeView& x_shape, DataType w_data_type,
-                             const ShapeView& w_shape, DataType y_data_type,
-                             const ShapeView& y_shape, const std::string& data_format,
-                             size_t max_workspace_size, bool heuristic_search,
-                             bool use_deterministic_algo_only, bool enable_pseudo_half)
-    : xdesc(x_data_type, x_shape, data_format),
-      ydesc(y_data_type, y_shape, data_format),
-      wdesc(w_data_type, w_shape, data_format),
-      cdesc(GetConvDescDataType(x_data_type, enable_pseudo_half), x_data_type, x_shape, conv_conf),
-      heuristic(heuristic_search),
-      deterministic(use_deterministic_algo_only) {
-  std::memset(&params, 0, sizeof(CudnnConvParams));
-  OF_CUDNN_CHECK(cudnnGetTensorNdDescriptor(xdesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                            &params.x_data_type, &params.x_ndim, params.x_dims,
-                                            params.x_strides));
-  OF_CUDNN_CHECK(cudnnGetTensorNdDescriptor(ydesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                            &params.y_data_type, &params.y_ndim, params.y_dims,
-                                            params.y_strides));
-  OF_CUDNN_CHECK(cudnnGetFilterNdDescriptor(wdesc.Get(), CudnnConvParams::kTensorMaxDims,
-                                            &params.w_data_type, &params.w_format, &params.w_ndim,
-                                            params.w_dims));
-  cudnnConvolutionMode_t mode;
-  int conv_dim_size = 0;
-  OF_CUDNN_CHECK(cudnnGetConvolutionNdDescriptor(cdesc.Get(), CudnnConvParams::kConvMaxDims,
-                                                 &conv_dim_size, params.padding, params.stride,
-                                                 params.dilation, &mode, &params.data_type));
-  CHECK_EQ(params.x_data_type, params.w_data_type);
-  CHECK_EQ(params.x_ndim, params.w_ndim);
-  CHECK_EQ(conv_dim_size + 2, params.x_ndim);
-  OF_CUDNN_CHECK(cudnnGetConvolutionGroupCount(cdesc.Get(), &params.groups));
-  params.max_ws_size = max_workspace_size;
 }
 
 CudnnConvArgs::CudnnConvArgs(const user_op::UserOpConfWrapper& conv_conf, DataType x_data_type,

--- a/oneflow/core/device/cudnn_conv_util.h
+++ b/oneflow/core/device/cudnn_conv_util.h
@@ -36,8 +36,6 @@ class CudnnConvDesc final {
   ~CudnnConvDesc();
 
   CudnnConvDesc(const DataType compute_type, const DataType data_type,
-                const ShapeView& in_blob_shape, const PbMessage& conv_conf);
-  CudnnConvDesc(const DataType compute_type, const DataType data_type,
                 const ShapeView& in_blob_shape, const user_op::UserOpConfWrapper& conv_conf);
 
   const cudnnConvolutionDescriptor_t& Get() const { return val_; }
@@ -80,11 +78,6 @@ struct CudnnConvArgs final {
   bool deterministic;
 
   OF_DISALLOW_COPY_AND_MOVE(CudnnConvArgs);
-  CudnnConvArgs(const PbMessage& conv_conf, DataType x_data_type, const ShapeView& x_shape,
-                DataType w_data_type, const ShapeView& w_shape, DataType y_data_type,
-                const ShapeView& y_shape, const std::string& data_format, size_t max_workspace_size,
-                bool heuristic_search, bool use_deterministic_algo_only, bool enable_pseudo_half);
-
   CudnnConvArgs(const user_op::UserOpConfWrapper& conv_conf, DataType x_data_type,
                 const ShapeView& x_shape, DataType w_data_type, const ShapeView& w_shape,
                 DataType y_data_type, const ShapeView& y_shape, const std::string& data_format,


### PR DESCRIPTION
删除 CudnnConvArgs 和 CudnnConvDesc 接受 PbMessage 参数的构造函数，它们随着老的 conv op 代码的删除已经没处使用了。