### PR TITLE
Add cuDNN implementation for bias_add

### DIFF
--- a/oneflow/user/kernels/bias_add_kernel.cu
+++ b/oneflow/user/kernels/bias_add_kernel.cu
@@ -16,6 +16,7 @@ limitations under the License.
 #include "oneflow/core/device/cuda_util.h"
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/user/kernels/bias_add_kernel.h"
+#include "oneflow/core/device/cudnn_util.h"
 
 namespace oneflow {
 
@@ -44,6 +45,27 @@ __global__ void InplaceBiasAddGpu(const Index elem_cnt, const Index bias_size,
   CUDA_1D_KERNEL_LOOP_T(Index, i, elem_cnt) { y[i] += bias[(i % block_size) / inner_size]; }
 }
 
+template<typename T, typename Index>
+typename std::enable_if<IsFloating<T>::value || std::is_same<T, float16>::value>::type
+InplaceBiasAdd(DeviceCtx* ctx, Index outer_size, Index bias_size, Index inner_size, const T* x,
+               const T* bias, T* y) {
+  CudnnTensorDesc c_desc(CUDNN_TENSOR_NCHW, GetDataType<T>::value, outer_size, bias_size,
+                         inner_size, 1);
+  CudnnTensorDesc a_desc(CUDNN_TENSOR_NCHW, GetDataType<T>::value, 1, bias_size, 1, 1);
+  OF_CUDNN_CHECK(cudnnAddTensor(ctx->cudnn_handle(), CudnnSPOnePtr<float>(), a_desc.Get(), bias,
+                                CudnnSPOnePtr<float>(), c_desc.Get(), y));
+}
+
+template<typename T, typename Index>
+typename std::enable_if<IsIntegral<T>::value>::type InplaceBiasAdd(DeviceCtx* ctx, Index outer_size,
+                                                                   Index bias_size,
+                                                                   Index inner_size, const T* x,
+                                                                   const T* bias, T* y) {
+  const Index elem_cnt = outer_size * bias_size * inner_size;
+  RUN_CUDA_KERNEL((InplaceBiasAddGpu<T, Index>), ctx, elem_cnt, elem_cnt, bias_size, inner_size,
+                  bias, y);
+}
+
 }  // namespace
 
 template<typename T, typename Index>
@@ -52,8 +74,7 @@ struct BiasAddCalculation<DeviceType::kGPU, T, Index> {
                      const T* x, const T* bias, T* y) {
     const Index elem_cnt = outer_size * bias_size * inner_size;
     if (x == y) {
-      RUN_CUDA_KERNEL((InplaceBiasAddGpu<T, Index>), ctx, elem_cnt, elem_cnt, bias_size, inner_size,
-                      bias, y);
+      InplaceBiasAdd<T, Index>(ctx, outer_size, bias_size, inner_size, x, bias, y);
     } else {
       RUN_CUDA_KERNEL((BiasAddGpu<T, Index>), ctx, elem_cnt, elem_cnt, bias_size, inner_size, x,
                       bias, y);
@@ -65,10 +86,14 @@ template<typename Index>
 struct BiasAddCalculation<DeviceType::kGPU, float16, Index> {
   static void Invoke(DeviceCtx* ctx, Index outer_size, Index bias_size, Index inner_size,
                      const float16* x, const float16* bias, float16* y) {
-    const Index elem_cnt = outer_size * bias_size * inner_size;
-    RUN_CUDA_KERNEL((BiasAddGpuHalf<Index>), ctx, elem_cnt, elem_cnt, bias_size, inner_size,
-                    reinterpret_cast<const half*>(x), reinterpret_cast<const half*>(bias),
-                    reinterpret_cast<half*>(y));
+    if (x == y) {
+      InplaceBiasAdd<float16, Index>(ctx, outer_size, bias_size, inner_size, x, bias, y);
+    } else {
+      const Index elem_cnt = outer_size * bias_size * inner_size;
+      RUN_CUDA_KERNEL((BiasAddGpuHalf<Index>), ctx, elem_cnt, elem_cnt, bias_size, inner_size,
+                      reinterpret_cast<const half*>(x), reinterpret_cast<const half*>(bias),
+                      reinterpret_cast<half*>(y));
+    }
   }
 };
 


### PR DESCRIPTION
Benchmarks of bert base on RTX 2080ti, batch size is 64.

Old + FP32

```
                    2.41%  1.28582s      7600  169.19us  1.9520us  816.07us  void oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::InplaceBiasAddGpu<float, int>(int, oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::InplaceBiasAddGpu<float, int>, oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::InplaceBiasAddGpu<float, int>, float const *, int*)

```

Old + FP16

```
                    4.84%  946.84ms      7300  129.70us  1.9840us  398.59us  void oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::BiasAddGpuHalf<int>(int, oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::BiasAddGpuHalf<int>, oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::BiasAddGpuHalf<int>, __half const *, __half const , int*)
                    0.47%  91.486ms       300  304.95us  1.8240us  847.07us  void oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::InplaceBiasAddGpu<float, int>(int, oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::InplaceBiasAddGpu<float, int>, oneflow::_GLOBAL__N__61_tmpxft_00004736_00000000_9_bias_add_kernel_compute_75_cpp1_ii_ba840438::InplaceBiasAddGpu<float, int>, float const *, int*)

```

New + FP32

```
                    2.04%  1.07918s      7600  142.00us  2.3360us  581.38us  void op_generic_tensor_kernel<int=2, float, float, float, int=256, cudnnGenericOp_t=0, cudnnNanPropagation_t=0, int=0>(cudnnTensorStruct, float*, cudnnTensorStruct, float const *, cudnnTensorStruct, float const *, float, float, float, float, reducedDivisorArray, int)

```

New + FP16

```
                    3.61%  672.64ms      7300  92.142us  2.2400us  290.21us  void op_generic_tensor_kernel<int=2, __half, float, __half, int=256, cudnnGenericOp_t=0, cudnnNanPropagation_t=0, int=0>(cudnnTensorStruct, __half*, cudnnTensorStruct, __half const *, cudnnTensorStruct, __half const *, float, float, float, float, reducedDivisorArray, int)
                    0.36%  68.010ms       300  226.70us  2.2400us  582.69us  void op_generic_tensor_kernel<int=2, float, float, float, int=256, cudnnGenericOp_t=0, cudnnNanPropagation_t=0, int=0>(cudnnTensorStruct, float*, cudnnTensorStruct, float const *, cudnnTensorStruct, float const *, float, float, float, float, reducedDivisorArray, int)

```
