### PR TITLE
add python api require_resource

### DIFF
--- a/oneflow/core/job/improver.cpp
+++ b/oneflow/core/job/improver.cpp
@@ -568,13 +568,16 @@ Maybe<void> Improver::CheckAllZoneNotOOM(
       const uint64_t calc =
           CalcMemoryConsumed(regst_descs, PathDurations4RegstDescId, PathIIScales4RegstDescId, ii);
       const uint64_t available = AvailableMemSize(machine_id, mem_zone_id);
+      const auto* id_mgr = Global<IDMgr>::Get();
+      const char* device_tag = JUST(DeviceTag4DeviceType(
+          id_mgr->IsGpuMemZone(mem_zone_id) ? DeviceType::kGPU : DeviceType::kCPU));
       if (calc >= available) {
-        const auto* id_mgr = Global<IDMgr>::Get();
-        const char* device_tag = JUST(DeviceTag4DeviceType(
-            id_mgr->IsGpuMemZone(mem_zone_id) ? DeviceType::kGPU : DeviceType::kCPU));
         return Error::MemoryZoneOutOfMemoryError(machine_id, mem_zone_id, calc, available,
                                                  device_tag)
                << "OOM detected at compile time. ";
+      } else {
+        Global<ResourceDesc, ForSession>::Get()->SetRequiredMemoryZoneInfo(machine_id, mem_zone_id,
+                                                                           calc, device_tag);
       }
     }
   }

--- a/oneflow/core/job/resource.proto
+++ b/oneflow/core/job/resource.proto
@@ -19,6 +19,13 @@ message CollectiveBoxingConf {
   optional bool nccl_fusion_all_reduce_use_buffer = 108 [default = true];
 }
 
+message RequiredMemoryZoneInfo {
+  required int32 machine_id = 1;
+  required int32 mem_zone_id = 2;
+  required string device_tag = 3;
+  required uint64 required = 4;
+}
+
 message Resource {
   optional int32 machine_num = 1 [default = 0];
   optional int32 gpu_device_num = 4 [default = 0];
@@ -37,4 +44,5 @@ message Resource {
   optional int64 thread_local_cache_max_size = 17 [default = 67108864]; // 64M
   optional bool enable_debug_mode = 18 [default = false];
   optional CollectiveBoxingConf collective_boxing_conf = 19;
+  repeated RequiredMemoryZoneInfo required_memory_zone_info = 20;
 }

--- a/oneflow/core/job/resource_desc.cpp
+++ b/oneflow/core/job/resource_desc.cpp
@@ -50,4 +50,15 @@ CollectiveBoxingConf ResourceDesc::collective_boxing_conf() const {
   }
 }
 
+void ResourceDesc::SetRequiredMemoryZoneInfo(int64_t machine_id, int64_t mem_zone_id, uint64_t calc,
+                                             const std::string& device_tag) {
+  if (calc > 0) {
+    auto* required_memory_zone_info = resource_.add_required_memory_zone_info();
+    required_memory_zone_info->set_machine_id(machine_id);
+    required_memory_zone_info->set_mem_zone_id(mem_zone_id);
+    required_memory_zone_info->set_device_tag(device_tag);
+    required_memory_zone_info->set_required(calc);
+  }
+}
+
 }  // namespace oneflow

--- a/oneflow/core/job/resource_desc.h
+++ b/oneflow/core/job/resource_desc.h
@@ -56,6 +56,8 @@ class ResourceDesc final {
 
   void SetMachineNum(int32_t val) { resource_.set_machine_num(val); }
   void SetCpuDeviceNum(int32_t val) { resource_.set_cpu_device_num(val); }
+  void SetRequiredMemoryZoneInfo(int64_t machine_id, int64_t mem_zone_id, uint64_t calc,
+                                 const std::string& device_tag);
   const Resource& resource() const { return resource_; }
 
  private:

--- a/oneflow/python/framework/env_util.py
+++ b/oneflow/python/framework/env_util.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 
 import socket
 from contextlib import closing
+from functools import reduce
 
 import oneflow.core.job.env_pb2 as env_pb
 import oneflow.python.framework.c_api_util as c_api_util
@@ -213,6 +214,27 @@ def api_logbuflevel(val: int) -> None:
 def logbuflevel(val):
     assert type(val) is int
     default_env_proto.cpp_logging_conf.logbuflevel = val
+
+
+@oneflow_export("require_resource")
+def api_get_require_resource():
+    return enable_if.unique([get_require_resource])()
+
+
+@enable_if.condition(hob.in_normal_mode & hob.session_initialized)
+def get_require_resource():
+    resource = c_api_util.CurrentResource()
+    required_memory_zone_info_list = []
+    required_memory_zone_info_detail = {}
+    for item in resource.required_memory_zone_info:
+        required_memory_zone_info_detail["machine_id"] = item.machine_id
+        required_memory_zone_info_detail["mem_zone_id"] = item.mem_zone_id
+        required_memory_zone_info_detail["device_tag"] = item.device_tag
+        required_memory_zone_info_detail["required"] = item.required
+        required_memory_zone_info_list.append(required_memory_zone_info_detail)
+    return reduce(
+        lambda x, y: x if y in x else x + [y], [[],] + required_memory_zone_info_list
+    )
 
 
 @enable_if.condition(hob.in_normal_mode & hob.env_initialized)

--- a/oneflow/python/test/ops/test_require_memory.py
+++ b/oneflow/python/test/ops/test_require_memory.py
@@ -1,0 +1,56 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+from collections import OrderedDict
+
+import numpy as np
+import oneflow as flow
+import tensorflow as tf
+from test_util import GenArgList
+
+func_config = flow.FunctionConfig()
+func_config.default_data_type(flow.float)
+
+
+def compare_with_tensorflow(test_case, device_type, value, shape, rtol=1e-5, atol=1e-5):
+    assert device_type in ["gpu", "cpu"]
+    flow.clear_default_session()
+
+    @flow.global_function(function_config=func_config)
+    def ConstantJob():
+        with flow.scope.placement(device_type, "0:0"):
+            x = flow.constant(value, dtype=flow.float, shape=shape)
+            y = flow.math.relu(x)
+            z = flow.math.relu(y)
+            return x
+
+    numpy0 = ConstantJob().get().numpy()
+    of_out = ConstantJob().get()
+    test_case.assertTrue(np.allclose(of_out.numpy(), numpy0, rtol=rtol, atol=atol))
+    tf_out = tf.constant(value, dtype=float, shape=shape)
+    test_case.assertTrue(
+        np.allclose(of_out.numpy(), tf_out.numpy(), rtol=rtol, atol=atol)
+    )
+
+
+def test_constant(test_case):
+    arg_dict = OrderedDict()
+    arg_dict["device_type"] = ["gpu", "cpu"]
+    arg_dict["value"] = [6, 6.66]
+    arg_dict["shape"] = [(2, 3), (3, 3, 3)]
+    for arg in GenArgList(arg_dict):
+        compare_with_tensorflow(test_case, *arg)
+        print(flow.require_resource())


### PR DESCRIPTION
- 添加require_resource接口，可以查询编译之后这里的内存需求
- 在oneflow/python/test/ops/目录下，运行python3 1node_test.py test_require_memory.py，输出：
```
[{'machine_id': 0, 'mem_zone_id': 1, 'device_tag': 'cpu', 'required': 72704}]
[{'machine_id': 0, 'mem_zone_id': 1, 'device_tag': 'cpu', 'required': 72704}]
[{'machine_id': 0, 'mem_zone_id': 1, 'device_tag': 'cpu', 'required': 72704}]
[{'machine_id': 0, 'mem_zone_id': 1, 'device_tag': 'cpu', 'required': 72704}]
[{'machine_id': 0, 'mem_zone_id': 1, 'device_tag': 'cpu', 'required': 72704}]
[{'machine_id': 0, 'mem_zone_id': 1, 'device_tag': 'cpu', 'required': 72704}]
[{'machine_id': 0, 'mem_zone_id': 1, 'device_tag': 'cpu', 'required': 72704}]
[{'machine_id': 0, 'mem_zone_id': 1, 'device_tag': 'cpu', 'required': 72704}]
```