### PR TITLE
Refactor rmsprop `mean_square` and add unit tests for optimizers 

### DIFF
--- a/oneflow/core/job_rewriter/rmsprop_optm.cpp
+++ b/oneflow/core/job_rewriter/rmsprop_optm.cpp
@@ -34,15 +34,23 @@ void GenerateOptimizerOpConf(const VariableOp& op, const ParallelConf& parallel_
                              JobBuilder* job_builder, const LogicalBlobId& diff_lbi_of_var_out) {
   OperatorConf mean_square_var(GenerateAdamHelperVariableOpConf(op, "mean_square", 0.f));
   mean_square_var.set_scope_symbol_id(op.op_conf().scope_symbol_id());
-  job_builder->AddOps(parallel_conf, {mean_square_var});
 
   OperatorConf mdupdt_op;
   mdupdt_op.set_name(op.op_name() + "_optimizer");
   auto* mdupdt_op_conf = mdupdt_op.mutable_rmsprop_model_update_conf();
+  *(mdupdt_op_conf->mutable_user_conf()) =
+      GlobalJobDesc().job_conf().train_conf().model_update_conf();
   ConstructMdUpdtOpConf(op, diff_lbi_of_var_out, job_builder, mdupdt_op_conf);
   mdupdt_op_conf->set_mean_square(mean_square_var.name() + "/out");
   mdupdt_op.set_scope_symbol_id(op.op_conf().scope_symbol_id());
-  job_builder->AddOps(parallel_conf, {mdupdt_op});
+  if (GlobalJobDesc().job_conf().train_conf().model_update_conf().rmsprop_conf().centered()) {
+    OperatorConf mean_gradient_var(GenerateAdamHelperVariableOpConf(op, "mean_gradient", 0.f));
+    mean_gradient_var.set_scope_symbol_id(op.op_conf().scope_symbol_id());
+    mdupdt_op_conf->set_mean_gradient(mean_gradient_var.name() + "/out");
+    job_builder->AddOps(parallel_conf, {mean_square_var, mean_gradient_var, mdupdt_op});
+  } else {
+    job_builder->AddOps(parallel_conf, {mean_square_var, mdupdt_op});
+  }
 }
 
 }  // namespace

--- a/oneflow/core/job_rewriter/rmsprop_optm.cpp
+++ b/oneflow/core/job_rewriter/rmsprop_optm.cpp
@@ -19,21 +19,21 @@ namespace oneflow {
 
 namespace {
 
-OperatorConf GenerateAdamHelperVariableOpConf(const VariableOp& op, const std::string& name,
-                                              const float initial_value) {
+OperatorConf GenerateRmspropHelperVariableOpConf(const VariableOp& op, const std::string& name,
+                                                 const float initial_value) {
   OperatorConf helper_variable_op(op.op_conf());
   helper_variable_op.set_name(op.op_name() + "-" + name);
   helper_variable_op.mutable_variable_conf()->set_out("out");
   InitializerConf constant_initializer;
   constant_initializer.mutable_constant_conf()->set_value(initial_value);
   *(helper_variable_op.mutable_variable_conf()->mutable_initializer()) = constant_initializer;
+  helper_variable_op.set_scope_symbol_id(op.op_conf().scope_symbol_id());
   return helper_variable_op;
 }
 
 void GenerateOptimizerOpConf(const VariableOp& op, const ParallelConf& parallel_conf,
                              JobBuilder* job_builder, const LogicalBlobId& diff_lbi_of_var_out) {
-  OperatorConf mean_square_var(GenerateAdamHelperVariableOpConf(op, "mean_square", 0.f));
-  mean_square_var.set_scope_symbol_id(op.op_conf().scope_symbol_id());
+  OperatorConf mean_square_var(GenerateRmspropHelperVariableOpConf(op, "mean_square", 0.f));
 
   OperatorConf mdupdt_op;
   mdupdt_op.set_name(op.op_name() + "_optimizer");
@@ -44,8 +44,7 @@ void GenerateOptimizerOpConf(const VariableOp& op, const ParallelConf& parallel_
   mdupdt_op_conf->set_mean_square(mean_square_var.name() + "/out");
   mdupdt_op.set_scope_symbol_id(op.op_conf().scope_symbol_id());
   if (GlobalJobDesc().job_conf().train_conf().model_update_conf().rmsprop_conf().centered()) {
-    OperatorConf mean_gradient_var(GenerateAdamHelperVariableOpConf(op, "mean_gradient", 0.f));
-    mean_gradient_var.set_scope_symbol_id(op.op_conf().scope_symbol_id());
+    OperatorConf mean_gradient_var(GenerateRmspropHelperVariableOpConf(op, "mean_gradient", 0.f));
     mdupdt_op_conf->set_mean_gradient(mean_gradient_var.name() + "/out");
     job_builder->AddOps(parallel_conf, {mean_square_var, mean_gradient_var, mdupdt_op});
   } else {

--- a/oneflow/core/kernel/rmsprop_model_update_kernel.cpp
+++ b/oneflow/core/kernel/rmsprop_model_update_kernel.cpp
@@ -39,24 +39,36 @@ void RMSPropMdUpdateKernel<device_type, T>::UpdateModel(
   Blob* mean_square_blob = BnInOp2Blob("mean_square");
   const RMSPropModelUpdateConf& conf = GetRMSPropModelUpdateConf(this->op_conf());
 
+  Blob* mean_gradient_blob = nullptr;
+  if (conf.centered()) { mean_gradient_blob = BnInOp2Blob("mean_gradient"); }
+
   RMSPropMdUpdateKernelUtil<device_type, T>::UpdateModel(
       ctx, model_blob->shape().elem_cnt(), train_step, learning_rate,
-      static_cast<T>(conf.decay_rate()), static_cast<T>(conf.epsilon()), weight_decay,
-      model_diff_blob->dptr<T>(), model_blob->mut_dptr<T>(), mean_square_blob->mut_dptr<T>());
+      static_cast<T>(conf.decay_rate()), static_cast<T>(conf.epsilon()), conf.centered(),
+      weight_decay, model_diff_blob->dptr<T>(), model_blob->mut_dptr<T>(),
+      mean_square_blob->mut_dptr<T>(),
+      conf.centered() ? mean_gradient_blob->mut_dptr<T>() : nullptr);
 }
 
 template<typename T>
 class RMSPropMdUpdateKernelUtil<DeviceType::kCPU, T> final {
  public:
-  static void UpdateModel(DeviceCtx*, int64_t n, const int64_t* train_step,
-                          const float* learning_rate, T decay_rate, T epsilon, T weight_decay,
-                          const T* model_diff, T* model, T* mean_square) {
-    const T cur_decay_rate = *train_step == 0 ? 0 : decay_rate;
+  static void UpdateModel(DeviceCtx* ctx, int64_t n, const int64_t* train_step,
+                          const float* learning_rate, T decay_rate, T epsilon, bool centered,
+                          T weight_decay, const T* model_diff, T* model, T* mean_square,
+                          T* mean_gradient) {
+    T denom_t;
     for (int64_t i = 0; i < n; ++i) {
       T model_diff_val = model_diff[i];
       mean_square[i] =
-          (1 - cur_decay_rate) * model_diff_val * model_diff_val + cur_decay_rate * mean_square[i];
-      model[i] = model[i] - *learning_rate * model_diff_val / std::sqrt(mean_square[i] + epsilon);
+          (1 - decay_rate) * model_diff_val * model_diff_val + decay_rate * mean_square[i];
+      if (centered) {
+        mean_gradient[i] = (1 - decay_rate) * model_diff_val + decay_rate * mean_gradient[i];
+        denom_t = mean_square[i] - mean_gradient[i] * mean_gradient[i];
+      } else {
+        denom_t = mean_square[i];
+      }
+      model[i] = model[i] - *learning_rate * model_diff_val / std::sqrt(denom_t + epsilon);
     }
   }
 };

--- a/oneflow/core/kernel/rmsprop_model_update_kernel.cpp
+++ b/oneflow/core/kernel/rmsprop_model_update_kernel.cpp
@@ -57,18 +57,26 @@ class RMSPropMdUpdateKernelUtil<DeviceType::kCPU, T> final {
                           const float* learning_rate, T decay_rate, T epsilon, bool centered,
                           T weight_decay, const T* model_diff, T* model, T* mean_square,
                           T* mean_gradient) {
-    T denom_t;
-    for (int64_t i = 0; i < n; ++i) {
-      T model_diff_val = model_diff[i];
-      mean_square[i] =
-          (1 - decay_rate) * model_diff_val * model_diff_val + decay_rate * mean_square[i];
-      if (centered) {
-        mean_gradient[i] = (1 - decay_rate) * model_diff_val + decay_rate * mean_gradient[i];
-        denom_t = mean_square[i] - mean_gradient[i] * mean_gradient[i];
-      } else {
-        denom_t = mean_square[i];
+    if (centered) {
+      for (int64_t i = 0; i < n; ++i) {
+        T model_diff_val = model_diff[i];
+        T mean_square_val = mean_square[i];
+        mean_square_val =
+            (1 - decay_rate) * model_diff_val * model_diff_val + decay_rate * mean_square_val;
+        mean_square[i] = mean_square_val;
+        T mean_gradient_val = mean_gradient[i];
+        mean_gradient_val = (1 - decay_rate) * model_diff_val + decay_rate * mean_gradient_val;
+        mean_gradient[i] = mean_gradient_val;
+        T denom_t = mean_square_val - mean_gradient_val * mean_gradient_val;
+        model[i] = model[i] - *learning_rate * model_diff_val / std::sqrt(denom_t + epsilon);
       }
-      model[i] = model[i] - *learning_rate * model_diff_val / std::sqrt(denom_t + epsilon);
+    } else {
+      for (int64_t i = 0; i < n; ++i) {
+        T model_diff_val = model_diff[i];
+        mean_square[i] =
+            (1 - decay_rate) * model_diff_val * model_diff_val + decay_rate * mean_square[i];
+        model[i] = model[i] - *learning_rate * model_diff_val / std::sqrt(mean_square[i] + epsilon);
+      }
     }
   }
 };

--- a/oneflow/core/kernel/rmsprop_model_update_kernel.cu
+++ b/oneflow/core/kernel/rmsprop_model_update_kernel.cu
@@ -22,14 +22,20 @@ namespace {
 
 template<typename T>
 __global__ void UpdateModelGpu(int64_t n, const int64_t* train_step, const float* learning_rate,
-                               T decay_rate, T epsilon, T weight_decay, const T* model_diff,
-                               T* model, T* mean_square) {
-  const T cur_decay_rate = *train_step == 0 ? 0 : decay_rate;
+                               T decay_rate, T epsilon, bool centered, T weight_decay,
+                               const T* model_diff, T* model, T* mean_square, T* mean_gradient) {
   CUDA_1D_KERNEL_LOOP(i, n) {
     T model_diff_val = model_diff[i];
     mean_square[i] =
-        (1 - cur_decay_rate) * model_diff_val * model_diff_val + cur_decay_rate * mean_square[i];
-    model[i] = model[i] - *learning_rate * model_diff_val / std::sqrt(mean_square[i] + epsilon);
+        (1 - decay_rate) * model_diff_val * model_diff_val + decay_rate * mean_square[i];
+    T denom_t;
+    if (centered) {
+      mean_gradient[i] = (1 - decay_rate) * model_diff_val + decay_rate * mean_gradient[i];
+      denom_t = mean_square[i] - mean_gradient[i] * mean_gradient[i];
+    } else {
+      denom_t = mean_square[i];
+    }
+    model[i] = model[i] - *learning_rate * model_diff_val / std::sqrt(denom_t + epsilon);
   }
 }
 
@@ -39,11 +45,12 @@ template<typename T>
 class RMSPropMdUpdateKernelUtil<DeviceType::kGPU, T> final {
  public:
   static void UpdateModel(DeviceCtx* ctx, int64_t n, const int64_t* train_step,
-                          const float* learning_rate, T decay_rate, T epsilon, T weight_decay,
-                          const T* model_diff, T* model, T* mean_square) {
+                          const float* learning_rate, T decay_rate, T epsilon, bool centered,
+                          T weight_decay, const T* model_diff, T* model, T* mean_square,
+                          T* mean_gradient) {
     UpdateModelGpu<T><<<BlocksNum4ThreadsNum(n), kCudaThreadsNumPerBlock, 0, ctx->cuda_stream()>>>(
-        n, train_step, learning_rate, decay_rate, epsilon, weight_decay, model_diff, model,
-        mean_square);
+        n, train_step, learning_rate, decay_rate, epsilon, centered, weight_decay, model_diff,
+        model, mean_square, mean_gradient);
   }
 };
 

--- a/oneflow/core/kernel/rmsprop_model_update_kernel.cu
+++ b/oneflow/core/kernel/rmsprop_model_update_kernel.cu
@@ -21,21 +21,36 @@ namespace oneflow {
 namespace {
 
 template<typename T>
-__global__ void UpdateModelGpu(int64_t n, const int64_t* train_step, const float* learning_rate,
-                               T decay_rate, T epsilon, bool centered, T weight_decay,
-                               const T* model_diff, T* model, T* mean_square, T* mean_gradient) {
+__global__ void UpdateModelGpuCentered(int64_t n, const int64_t* train_step,
+                                       const float* learning_rate, T decay_rate, T epsilon,
+                                       T weight_decay, const T* model_diff, T* model,
+                                       T* mean_square, T* mean_gradient) {
   CUDA_1D_KERNEL_LOOP(i, n) {
     T model_diff_val = model_diff[i];
-    mean_square[i] =
-        (1 - decay_rate) * model_diff_val * model_diff_val + decay_rate * mean_square[i];
-    T denom_t;
-    if (centered) {
-      mean_gradient[i] = (1 - decay_rate) * model_diff_val + decay_rate * mean_gradient[i];
-      denom_t = mean_square[i] - mean_gradient[i] * mean_gradient[i];
-    } else {
-      denom_t = mean_square[i];
-    }
-    model[i] = model[i] - *learning_rate * model_diff_val / std::sqrt(denom_t + epsilon);
+    T mean_square_val = mean_square[i];
+    mean_square_val =
+        (1 - decay_rate) * model_diff_val * model_diff_val + decay_rate * mean_square_val;
+    mean_square[i] = mean_square_val;
+    T mean_gradient_val = mean_gradient[i];
+    mean_gradient_val = (1 - decay_rate) * model_diff_val + decay_rate * mean_gradient_val;
+    mean_gradient[i] = mean_gradient_val;
+    T denom_t = mean_square_val - mean_gradient_val * mean_gradient_val;
+    model[i] = model[i] - *learning_rate * model_diff_val * rsqrt(denom_t + epsilon);
+  }
+}
+
+template<typename T>
+__global__ void UpdateModelGpuNotCentered(int64_t n, const int64_t* train_step,
+                                          const float* learning_rate, T decay_rate, T epsilon,
+                                          T weight_decay, const T* model_diff, T* model,
+                                          T* mean_square, T* mean_gradient) {
+  CUDA_1D_KERNEL_LOOP(i, n) {
+    T model_diff_val = model_diff[i];
+    T mean_square_val = mean_square[i];
+    mean_square_val =
+        (1 - decay_rate) * model_diff_val * model_diff_val + decay_rate * mean_square_val;
+    mean_square[i] = mean_square_val;
+    model[i] = model[i] - *learning_rate * model_diff_val * rsqrt(mean_square_val + epsilon);
   }
 }
 
@@ -48,9 +63,17 @@ class RMSPropMdUpdateKernelUtil<DeviceType::kGPU, T> final {
                           const float* learning_rate, T decay_rate, T epsilon, bool centered,
                           T weight_decay, const T* model_diff, T* model, T* mean_square,
                           T* mean_gradient) {
-    UpdateModelGpu<T><<<BlocksNum4ThreadsNum(n), kCudaThreadsNumPerBlock, 0, ctx->cuda_stream()>>>(
-        n, train_step, learning_rate, decay_rate, epsilon, centered, weight_decay, model_diff,
-        model, mean_square, mean_gradient);
+    if (centered) {
+      UpdateModelGpuCentered<T>
+          <<<BlocksNum4ThreadsNum(n), kCudaThreadsNumPerBlock, 0, ctx->cuda_stream()>>>(
+              n, train_step, learning_rate, decay_rate, epsilon, weight_decay, model_diff, model,
+              mean_square, mean_gradient);
+    } else {
+      UpdateModelGpuNotCentered<T>
+          <<<BlocksNum4ThreadsNum(n), kCudaThreadsNumPerBlock, 0, ctx->cuda_stream()>>>(
+              n, train_step, learning_rate, decay_rate, epsilon, weight_decay, model_diff, model,
+              mean_square, mean_gradient);
+    }
   }
 };
 

--- a/oneflow/core/kernel/rmsprop_model_update_kernel.h
+++ b/oneflow/core/kernel/rmsprop_model_update_kernel.h
@@ -38,10 +38,17 @@ template<DeviceType device_type, typename T>
 class RMSPropMdUpdateKernelUtil final {
  public:
   // mean_square = (1 - decay_rate) * model_diff ^ 2 + decay_rate * mean_square
-  // model = model - learning_rate * model_diff / sqrt(mean_square + epsilon)
-  static void UpdateModel(DeviceCtx*, int64_t n, const int64_t* train_step,
-                          const float* learning_rate, T decay_rate, T epsilon, T weight_decay,
-                          const T* model_diff, T* model, T* mean_square);
+  // if (centered) {
+  //    mean_gradient = (1 - decay_rate) * model_diff + decay_rate * mean_gradient
+  //    denom_t = mean_square - mean_gradient ^ 2
+  // } else {
+  //    denom_t = mean_square
+  // }
+  // model = model - learning_rate * model_diff / sqrt(denom_t + epsilon)
+  static void UpdateModel(DeviceCtx* ctx, int64_t n, const int64_t* train_step,
+                          const float* learning_rate, T decay_rate, T epsilon, bool centered,
+                          T weight_decay, const T* model_diff, T* model, T* mean_square,
+                          T* mean_gradient);
 };
 
 DECLARE_MDUPDT_KERNEL_CREATOR(RMSProp);

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -207,6 +207,7 @@ message MomentumModelUpdateConf {
 message RMSPropModelUpdateConf {
   optional float decay_rate = 1 [default = 0.99];
   optional float epsilon = 2 [default = 1e-8];
+  optional bool centered = 3 [default = false];
 }
 
 message LARSModelUpdateConf {
@@ -375,10 +376,11 @@ message RMSPropModelUpdateOpConf {
   required NormalModelUpdateOpUserConf user_conf = 1;
   required string model_diff = 2;
   required string mean_square = 3;
-  required string model = 4;
-  required string train_step = 5;
-  required string learning_rate = 6;
-  optional float weight_decay = 7 [default = 0.0];
+  optional string mean_gradient = 4;
+  required string model = 5;
+  required string train_step = 6;
+  required string learning_rate = 7;
+  optional float weight_decay = 8 [default = 0.0];
 }
 
 message LARSModelUpdateOpConf {

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -374,6 +374,7 @@ message MomentumModelUpdateOpConf {
 message RMSPropModelUpdateOpConf {
   required NormalModelUpdateOpUserConf user_conf = 1;
   required string model_diff = 2;
+  required string mean_square = 3;
   required string model = 4;
   required string train_step = 5;
   required string learning_rate = 6;

--- a/oneflow/core/operator/rmsprop_model_update_op.cpp
+++ b/oneflow/core/operator/rmsprop_model_update_op.cpp
@@ -18,15 +18,21 @@ limitations under the License.
 namespace oneflow {
 
 void RMSPropModelUpdateOp::MdUpdtVirtualInitFromOpConf() {
+  const auto& rmsprop_conf = op_conf().rmsprop_model_update_conf().user_conf().rmsprop_conf();
   EnrollInputBn("mean_square", false)->set_is_mutable(true);
+  if (rmsprop_conf.centered()) { EnrollInputBn("mean_gradient", false)->set_is_mutable(true); }
 }
 
 Maybe<void> RMSPropModelUpdateOp::MdUpdtVirtualInferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx) const {
+  const auto& rmsprop_conf = op_conf().rmsprop_model_update_conf().user_conf().rmsprop_conf();
   const BlobDesc* model_blob_desc = GetBlobDesc4BnInOp("model");
   CHECK_EQ_OR_RETURN(model_blob_desc->data_type(), job_desc().DefaultDataType());
   CHECK_OR_RETURN(*GetBlobDesc4BnInOp("mean_square") == *model_blob_desc);
+  if (rmsprop_conf.centered()) {
+    CHECK_OR_RETURN(*GetBlobDesc4BnInOp("mean_gradient") == *model_blob_desc);
+  }
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/operator/rmsprop_model_update_op.cpp
+++ b/oneflow/core/operator/rmsprop_model_update_op.cpp
@@ -17,14 +17,16 @@ limitations under the License.
 
 namespace oneflow {
 
-void RMSPropModelUpdateOp::MdUpdtVirtualInitFromOpConf() { EnrollTmpBn("mean_square"); }
+void RMSPropModelUpdateOp::MdUpdtVirtualInitFromOpConf() {
+  EnrollInputBn("mean_square", false)->set_is_mutable(true);
+}
 
 Maybe<void> RMSPropModelUpdateOp::MdUpdtVirtualInferBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx) const {
   const BlobDesc* model_blob_desc = GetBlobDesc4BnInOp("model");
   CHECK_EQ_OR_RETURN(model_blob_desc->data_type(), job_desc().DefaultDataType());
-  *GetBlobDesc4BnInOp("mean_square") = *model_blob_desc;
+  CHECK_OR_RETURN(*GetBlobDesc4BnInOp("mean_square") == *model_blob_desc);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/python/ops/optimizer.py
+++ b/oneflow/python/ops/optimizer.py
@@ -1239,18 +1239,18 @@ class RMSProp(Optimizer):
     This algorithm uses mean squared gradient to adjust the learning rate. 
 
     The equation of parameters updating is: 
-    
-    .. math::
-
-        & S_t = \beta_1*S_{t-1} + (1-\beta_1)*grad \odot grad
-
+        .. math::
+            & S_t = \beta_1*S_{t-1} + (1-\beta_1)*grad \odot grad
+            & param_{new} = param_{old} - \frac{learning\_rate}{\sqrt{S_t+\epsilon}} \odot grad
         if centered:
-            & mg_t = mg * \beta_1 + (1 - \beta_1) * grad
-            & denom_t = S_t - mg_t * mg_t
+            .. math::
+                & mg_t = mg * \beta_1 + (1 - \beta_1) * grad
+                & denom_t = S_t - mg_t * mg_t
         else:
-            & denom_t = S_t
-
-        & param_{new} = param_{old} - \frac{learning\_rate}{\sqrt{denom_t+\epsilon}} \odot grad
+            .. math::
+                denom_t = S_t
+        .. math:: 
+            param_{new} = param_{old} - \frac{learning\_rate}{\sqrt{denom_t+\epsilon}} \odot grad
 
     Args:
         lr_scheduler (LrScheduler): The scheduler of learning rate.

--- a/oneflow/python/test/ops/test_optimizers.py
+++ b/oneflow/python/test/ops/test_optimizers.py
@@ -1,0 +1,93 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+from collections import OrderedDict
+
+import numpy as np
+import oneflow as flow
+import tensorflow as tf
+import test_global_storage
+from test_util import GenArgList
+
+gpus = tf.config.experimental.list_physical_devices("GPU")
+for gpu in gpus:
+    tf.config.experimental.set_memory_growth(gpu, True)
+
+
+def compare_with_tensorflow_rmsprop(
+    device_type, x_shape, centered, decay_rate, learning_rate, train_iters
+):
+    assert device_type in ["gpu", "cpu"]
+    flow.clear_default_session()
+    func_config = flow.FunctionConfig()
+    func_config.default_data_type(flow.float32)
+
+    @flow.global_function(type="train", function_config=func_config)
+    def testRmsprop() -> flow.typing.Numpy:
+        with flow.scope.placement(device_type, "0:0-0"):
+            x = flow.get_variable(
+                name="x",
+                shape=x_shape,
+                dtype=flow.float32,
+                initializer=flow.random_uniform_initializer(minval=0, maxval=100),
+                trainable=True,
+            )
+            loss = flow.math.reduce_mean(x)
+            flow.optimizer.RMSProp(
+                flow.optimizer.PiecewiseConstantScheduler([], [learning_rate]),
+                decay_rate=decay_rate,
+                epsilon=0,
+                centered=centered,
+            ).minimize(loss)
+            return x
+
+    checkpoint = flow.train.CheckPoint()
+    checkpoint.init()
+
+    init_value = None
+    for i in range(train_iters + 1):
+        x = testRmsprop()
+        if i == 0:
+            init_value = x
+
+    var = tf.Variable(init_value)
+    opt = tf.keras.optimizers.RMSprop(
+        learning_rate=learning_rate,
+        rho=decay_rate,
+        momentum=0.0,
+        epsilon=0,
+        centered=centered,
+    )
+
+    for i in range(train_iters):
+        with tf.GradientTape() as tape:
+            loss = tf.reduce_mean(var)
+        gradients = tape.gradient(loss, var)
+        opt.apply_gradients(zip([gradients], [var]))
+
+    assert np.allclose(x.flatten(), var.numpy().flatten(), rtol=1e-4, atol=1e-4,)
+
+
+def test_rmsprop(test_case):
+    arg_dict = OrderedDict()
+    arg_dict["device_type"] = ["cpu", "gpu"]
+    arg_dict["x_shape"] = [(10,)]
+    arg_dict["centered"] = [True, False]
+    arg_dict["decay_rate"] = [0.9]
+    arg_dict["learning_rate"] = [1]
+    arg_dict["train_iters"] = [10]
+    for arg in GenArgList(arg_dict):
+        compare_with_tensorflow_rmsprop(*arg)

--- a/oneflow/python/test/ops/test_optimizers.py
+++ b/oneflow/python/test/ops/test_optimizers.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 import test_global_storage
 from test_util import GenArgList
 
+
 gpus = tf.config.experimental.list_physical_devices("GPU")
 for gpu in gpus:
     tf.config.experimental.set_memory_growth(gpu, True)
@@ -213,6 +214,94 @@ def compare_with_numpy_adamw(
     assert np.allclose(x.flatten(), param.flatten(), rtol=1e-4, atol=1e-4,)
 
 
+def compare_with_numpy_lazy_adam(
+    device_type, x_shape, beta1, beta2, epsilon, learning_rate, train_iters,
+):
+    assert device_type in ["gpu", "cpu"]
+    flow.clear_default_session()
+    func_config = flow.FunctionConfig()
+    func_config.default_data_type(flow.float32)
+
+    @flow.global_function(type="train", function_config=func_config)
+    def testLazyAdam(
+        mask: flow.typing.Numpy.Placeholder(x_shape, dtype=flow.float32)
+    ) -> flow.typing.Numpy:
+        with flow.scope.placement(device_type, "0:0-0"):
+            x = flow.get_variable(
+                name="x",
+                shape=x_shape,
+                dtype=flow.float32,
+                initializer=flow.random_uniform_initializer(minval=0, maxval=100),
+                trainable=True,
+            )
+            loss = flow.math.reduce_mean(x * mask)
+
+            flow.optimizer.LazyAdam(
+                flow.optimizer.PiecewiseConstantScheduler([], [learning_rate]),
+                beta1=beta1,
+                beta2=beta2,
+                epsilon=epsilon,
+            ).minimize(loss)
+
+            return x
+
+    checkpoint = flow.train.CheckPoint()
+    checkpoint.init()
+
+    mask = np.random.randint(2, size=x_shape)
+    mask_float = mask.astype(np.float32)
+
+    init_value = None
+    for i in range(train_iters + 1):
+        x = testLazyAdam(mask_float)
+        if i == 0:
+            init_value = x
+
+    def lazy_adam_update_numpy(
+        param,
+        mask,
+        gradient,
+        iter,
+        m,
+        v,
+        lr=0.001,
+        beta1=0.9,
+        beta2=0.999,
+        epsilon=1e-7,
+    ):
+
+        lr_t = lr * np.sqrt(1 - beta2 ** (iter + 1)) / (1 - beta1 ** (iter + 1))
+
+        m_t = np.copy(m)
+        v_t = np.copy(v)
+
+        m_t_o = beta1 * m + (1 - beta1) * gradient
+        v_t_o = beta2 * v + (1 - beta2) * gradient * gradient
+
+        m_t[mask == 1] = m_t_o[mask == 1]
+        v_t[mask == 1] = v_t_o[mask == 1]
+
+        param_t = np.copy(param)
+
+        param_t_o = param - lr_t * m_t / (np.sqrt(v_t) + epsilon)
+
+        param_t[mask == 1] = param_t_o[mask == 1]
+
+        return param_t, m_t, v_t
+
+    param = init_value
+    gradient = np.ones(param.shape)
+    m = np.zeros(param.shape)
+    v = np.zeros(param.shape)
+
+    for i in range(train_iters):
+        param, m, v = lazy_adam_update_numpy(
+            param, mask, gradient, i, m, v, learning_rate, beta1, beta2, epsilon
+        )
+
+    assert np.allclose(x.flatten(), param.flatten(), rtol=1e-4, atol=1e-4,)
+
+
 def compare_with_tensorflow_sgd(
     device_type, x_shape, momentum, learning_rate, train_iters
 ):
@@ -284,6 +373,19 @@ def test_adam(test_case):
     arg_dict["train_iters"] = [10]
     for arg in GenArgList(arg_dict):
         compare_with_tensorflow_adam(*arg)
+
+
+def test_lazy_adam(test_case):
+    arg_dict = OrderedDict()
+    arg_dict["device_type"] = ["cpu", "gpu"]
+    arg_dict["x_shape"] = [(10,)]
+    arg_dict["beta1"] = [0.9]
+    arg_dict["beta2"] = [0.99]
+    arg_dict["epsilon"] = [1e-9]
+    arg_dict["learning_rate"] = [1]
+    arg_dict["train_iters"] = [10]
+    for arg in GenArgList(arg_dict):
+        compare_with_numpy_lazy_adam(*arg)
 
 
 def test_adamw(test_case):

--- a/oneflow/python/test/ops/test_optimizers.py
+++ b/oneflow/python/test/ops/test_optimizers.py
@@ -81,6 +81,61 @@ def compare_with_tensorflow_rmsprop(
     assert np.allclose(x.flatten(), var.numpy().flatten(), rtol=1e-4, atol=1e-4,)
 
 
+def compare_with_tensorflow_adam(
+    device_type, x_shape, beta1, beta2, epsilon, learning_rate, train_iters
+):
+    assert device_type in ["gpu", "cpu"]
+    flow.clear_default_session()
+    func_config = flow.FunctionConfig()
+    func_config.default_data_type(flow.float32)
+
+    @flow.global_function(type="train", function_config=flow.FunctionConfig())
+    def testAdam() -> flow.typing.Numpy:
+        with flow.scope.placement(device_type, "0:0-0"):
+            x = flow.get_variable(
+                name="x",
+                shape=x_shape,
+                dtype=flow.float32,
+                initializer=flow.random_uniform_initializer(minval=0, maxval=100),
+                trainable=True,
+            )
+            loss = flow.math.reduce_mean(x)
+            flow.optimizer.Adam(
+                flow.optimizer.PiecewiseConstantScheduler([], [learning_rate]),
+                beta1=beta1,
+                beta2=beta2,
+                epsilon=epsilon,
+                do_bias_correction=True,
+            ).minimize(loss)
+            return x
+
+    checkpoint = flow.train.CheckPoint()
+    checkpoint.init()
+
+    init_value = None
+    for i in range(train_iters + 1):
+        x = testAdam()
+        if i == 0:
+            init_value = x
+
+    var = tf.Variable(init_value)
+    opt = tf.keras.optimizers.Adam(
+        learning_rate=learning_rate,
+        beta_1=beta1,
+        beta_2=beta2,
+        epsilon=epsilon,
+        amsgrad=False,
+    )
+
+    for i in range(train_iters):
+        with tf.GradientTape() as tape:
+            loss = tf.reduce_mean(var)
+        gradients = tape.gradient(loss, var)
+        opt.apply_gradients(zip([gradients], [var]))
+
+    assert np.allclose(x.flatten(), var.numpy().flatten(), rtol=1e-4, atol=1e-4,)
+
+
 def test_rmsprop(test_case):
     arg_dict = OrderedDict()
     arg_dict["device_type"] = ["cpu", "gpu"]
@@ -91,3 +146,16 @@ def test_rmsprop(test_case):
     arg_dict["train_iters"] = [10]
     for arg in GenArgList(arg_dict):
         compare_with_tensorflow_rmsprop(*arg)
+
+
+def test_adam(test_case):
+    arg_dict = OrderedDict()
+    arg_dict["device_type"] = ["cpu", "gpu"]
+    arg_dict["x_shape"] = [(10,)]
+    arg_dict["beta1"] = [0.9]
+    arg_dict["beta2"] = [0.99]
+    arg_dict["epsilon"] = [1e-9]
+    arg_dict["learning_rate"] = [1]
+    arg_dict["train_iters"] = [10]
+    for arg in GenArgList(arg_dict):
+        compare_with_tensorflow_adam(*arg)


### PR DESCRIPTION
- [x] 把 rmsprop 优化器 op 的 `mean_square` 从  temp buffer 改为 variable op ；
- [x] 给优化器op添加单元测试：
  - [x] rmsprop
  - [x] adam
  - [x] sgd
  - [x] adamw
  - [x] lazy_adam
  - [x] lars 

tensorflow 2.0 并没有包含 lars，lazyadam和 adamw，所以采用 与 numpy 实现对比的形式。

给 optimizers 添加单测的方式是，对一个随机初始化的 variable 做 n（目前是10）次更新迭代 ，然后看与 tensorflow 或者 numpy 的实现是否结果相近（误差限制在 1e-4）。

