### PR TITLE
Use InferOutBlobDescIf in InferOpNodeLogicalBlobDesc to reduce compile time

### DIFF
--- a/oneflow/core/graph/boxing/slice_boxing_sub_task_graph_builder.cpp
+++ b/oneflow/core/graph/boxing/slice_boxing_sub_task_graph_builder.cpp
@@ -58,6 +58,12 @@ Maybe<SubTskGphBuilderStatus> SliceBoxingSubTskGphBuilder::Build(
     const ParallelDesc& dst_parallel_desc, const LogicalBlobId& lbi,
     const BlobDesc& logical_blob_desc, const SbpParallel& src_sbp_parallel,
     const SbpParallel& dst_sbp_parallel) const {
+  LOG(INFO) << "SliceBoxingSubTskGphBuilder, lbi: " << lbi.op_name() << "/" << lbi.blob_name()
+            << ", src_sbp_parallel: " << PbMessage2TxtString(src_sbp_parallel)
+            << ", dst_sbp_parallel: " << PbMessage2TxtString(dst_sbp_parallel)
+            << ", src_parallel_num: " << src_parallel_desc.parallel_num()
+            << ", dst_parallel_num: " << dst_parallel_desc.parallel_num()
+            << ", blob_desc shape: " << logical_blob_desc.shape().ToString();
   if (SubTskGphBuilderUtil::BlobHasDynamicShape(logical_blob_desc)) {
     return Error::BoxingNotSupportedError();
   }

--- a/oneflow/core/graph/exec_graph.cpp
+++ b/oneflow/core/graph/exec_graph.cpp
@@ -76,7 +76,6 @@ void ExecNode::InferBlobDescs(const ParallelContext* parallel_ctx) {
   }
   CHECK_JUST(op_->InferBlobDescsIf(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature,
                                    [this](OpContext* op_ctx) { op_ctx_.reset(op_ctx); }));
-  Global<OpGraph>::Get()->CheckBlobDescs(op_->op_name(), GetBlobDesc4BnInOp, parallel_ctx);
 }
 
 std::function<const BlobDesc&(const std::string&)> ExecNode::GetLogicalBlobDesc4BnInOpFunc() const {

--- a/oneflow/core/graph/op_graph.cpp
+++ b/oneflow/core/graph/op_graph.cpp
@@ -201,61 +201,6 @@ const Shape* OpNode::GetInputOutputFastestTimeShape() const {
   return in->elem_cnt() > out->elem_cnt() ? in : out;
 }
 
-void OpNode::ForEachSplitOrBroadcastBlobDesc(
-    const BlobDesc& blob_desc, const SbpParallel& sbp_parallel,
-    const std::function<void(const BlobDesc&)>& Handler) const {
-  if (sbp_parallel.has_split_parallel()) {
-    // split BlobDesc
-    int32_t axis = sbp_parallel.split_parallel().axis();
-    CHECK_GE(axis, 0);
-    CHECK_LT(axis, blob_desc.shape().NumAxes());
-    CHECK_GE(blob_desc.shape().At(axis), parallel_desc().parallel_num());
-    BalancedSplitter bs(blob_desc.shape().At(axis), parallel_desc().parallel_num());
-    BlobDesc sub_blob_desc(blob_desc);
-    FOR_RANGE(int64_t, axis_parallel_id, 0, parallel_desc().parallel_num()) {
-      sub_blob_desc.mut_shape().Set(axis, bs.At(axis_parallel_id).size());
-      Handler(sub_blob_desc);
-    }
-  } else {
-    CHECK(sbp_parallel.has_broadcast_parallel() || sbp_parallel.has_partial_sum_parallel());
-    // broadcast BlobDesc
-    FOR_RANGE(int64_t, axis_parallel_id, 0, parallel_desc().parallel_num()) { Handler(blob_desc); }
-  }
-}
-
-void OpNode::ConcatBlobDesc(const ParallelDesc& blob_parallel_desc,
-                            const std::vector<std::shared_ptr<BlobDesc>>& blob_descs,
-                            const SbpParallel& sbp_parallel,
-                            BlobDesc* concatenated_blob_desc) const {
-  CHECK_EQ(blob_descs.size(), blob_parallel_desc.parallel_num());
-  if (sbp_parallel.has_split_parallel()) {
-    int32_t axis = sbp_parallel.split_parallel().axis();
-    // concat BlobDesc
-    CHECK_GE(axis, 0);
-    CHECK_LT(axis, blob_descs.at(0)->shape().NumAxes());
-    int64_t logical_blob_axis_dim = 0;
-    for (const auto& blob_desc : blob_descs) {
-      logical_blob_axis_dim += blob_desc->shape().At(axis);
-    }
-    CHECK_GE(logical_blob_axis_dim, blob_parallel_desc.parallel_num());
-    BalancedSplitter bs(logical_blob_axis_dim, blob_parallel_desc.parallel_num());
-    std::vector<std::unique_ptr<BlobDesc>> same_blob_descs(blob_descs.size());
-    FOR_RANGE(int64_t, axis_parallel_id, 0, blob_parallel_desc.parallel_num()) {
-      CHECK_EQ(bs.At(axis_parallel_id).size(), blob_descs.at(axis_parallel_id)->shape().At(axis));
-      same_blob_descs.at(axis_parallel_id).reset(new BlobDesc(*blob_descs.at(axis_parallel_id)));
-      same_blob_descs.at(axis_parallel_id)->mut_shape().Set(axis, logical_blob_axis_dim);
-    }
-    FOR_RANGE(int64_t, i, 1, same_blob_descs.size()) {
-      CHECK(*same_blob_descs.at(i) == *same_blob_descs.at(0));
-    }
-    concatenated_blob_desc->CopyAllFrom(*same_blob_descs.at(0));
-  } else {
-    FOR_RANGE(int64_t, i, 1, blob_descs.size()) { CHECK(*blob_descs.at(i) == *blob_descs.at(0)); }
-    // select first BlobDesc
-    concatenated_blob_desc->CopyAllFrom(*blob_descs.at(0));
-  }
-}
-
 int64_t OpNode::GetAxisParallelNum(
     const std::function<void(bool*, int32_t*, int64_t*)>& GetAxisParallelInfo) const {
   bool is_split = false;
@@ -263,53 +208,6 @@ int64_t OpNode::GetAxisParallelNum(
   int64_t axis_parallel_num = 0;
   GetAxisParallelInfo(&is_split, &axis, &axis_parallel_num);
   return axis_parallel_num;
-}
-
-void OpNode::SplitLogicalInputBlobDesc() {
-  for (const std::string& bn : op().input_bns()) {
-    const LogicalBlobId& lbi = op().BnInOp2Lbi(bn);
-    const BlobDesc& logical_blob_desc = SrcNode4Ibn(bn).LogicalBlobDesc4Lbi(lbi);
-    CHECK_NE(logical_blob_desc.data_type(), DataType::kInvalidDataType);
-    const SbpParallel& sbp_parallel = SbpParallel4BnInOp(bn);
-    ForEachSplitOrBroadcastBlobDesc(
-        logical_blob_desc, sbp_parallel, [&](const BlobDesc& blob_desc) {
-          bn2parallel_id2blob_desc_[bn].emplace_back(new BlobDesc(blob_desc));
-          CHECK_NE(bn2parallel_id2blob_desc_[bn].back()->data_type(), DataType::kInvalidDataType);
-        });
-    CHECK_EQ(bn2parallel_id2blob_desc_.at(bn).size(), parallel_desc().parallel_num());
-  }
-}
-
-void OpNode::ConcatLogicalOutputBlobDesc() {
-  for (const std::string& obn : op().output_bns()) {
-    const ParallelDesc& blob_parallel_desc = BlobParallelDesc4Obn(obn);
-    const LogicalBlobId& lbi = op().BnInOp2Lbi(obn);
-    const SbpParallel& sbp_parallel = SbpParallel4BnInOp(obn);
-    std::vector<std::shared_ptr<BlobDesc>> paralleled_blob_descs;
-    for (const auto& blob_desc : bn2parallel_id2blob_desc_.at(obn)) {
-      if (blob_desc) { paralleled_blob_descs.push_back(blob_desc); }
-    }
-    ConcatBlobDesc(blob_parallel_desc, paralleled_blob_descs, sbp_parallel,
-                   MutLogicalBlobDesc4Lbi(lbi));
-  }
-}
-
-void OpNode::CheckBlobDescs(const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-                            const ParallelContext* parallel_ctx) const {
-  return;
-  int64_t parallel_id = parallel_ctx->parallel_id();
-  auto Check = [&](const std::string& bn) {
-    if (bn2parallel_id2blob_desc_.find(bn) == bn2parallel_id2blob_desc_.end()) { return; }
-    CHECK_EQ(parallel_ctx->parallel_num(), bn2parallel_id2blob_desc_.at(bn).size());
-    const BlobDesc& blob_desc_from_exec_graph = *GetBlobDesc4BnInOp(bn);
-    const BlobDesc& blob_desc_from_op_graph = *bn2parallel_id2blob_desc_.at(bn).at(parallel_id);
-    CHECK_EQ(blob_desc_from_exec_graph.shape(), blob_desc_from_op_graph.shape());
-    CHECK_EQ(blob_desc_from_exec_graph.data_type(), blob_desc_from_op_graph.data_type());
-  };
-  for (const std::string& bn : op().input_bns()) { Check(bn); }
-  for (const std::string& bn : op().output_bns()) { Check(bn); }
-  for (const std::string& bn : op().tmp_bns()) { Check(bn); }
-  for (const std::string& bn : op().const_buf_bns()) { Check(bn); }
 }
 
 const ParallelDesc& OpNode::BlobParallelDesc4Obn(const std::string& obn) const {
@@ -526,31 +424,26 @@ Maybe<void> OpGraph::InferOpNodeMirroredSignature(OpNode* op_node, bool is_mirro
 }
 
 Maybe<void> OpGraph::InferOpNodeLogicalBlobDesc(OpNode* op_node) const {
-  auto* bn2parallel_id2blob_desc = op_node->mut_bn2parallel_id2blob_desc();
-  op_node->SplitLogicalInputBlobDesc();
-  int64_t parallel_num = op_node->parallel_desc().parallel_num();
   const auto& input_bns = op_node->op().input_bns();
-  FOR_RANGE(int64_t, parallel_id, 0, parallel_num) {
-    auto BlobDesc4BnInOp = [&](const std::string& bn) -> BlobDesc* {
-      if (std::find(input_bns.begin(), input_bns.end(), bn) != input_bns.end()) {
-        CHECK(bn2parallel_id2blob_desc->find(bn) != bn2parallel_id2blob_desc->end());
-        CHECK_EQ(bn2parallel_id2blob_desc->at(bn).size(), parallel_num);
-      } else if (bn2parallel_id2blob_desc->find(bn) == bn2parallel_id2blob_desc->end()) {
-        (*bn2parallel_id2blob_desc)[bn].resize(parallel_num);
-      } else {
-        CHECK_EQ(bn2parallel_id2blob_desc->at(bn).size(), parallel_num);
-      }
-      auto* blob_desc = &bn2parallel_id2blob_desc->at(bn).at(parallel_id);
-      if (!*blob_desc) { blob_desc->reset(new BlobDesc(GlobalJobDesc().DefaultDataType())); }
-      return blob_desc->get();
-    };
-    ParallelContext parallel_ctx;
-    parallel_ctx.set_parallel_id(parallel_id);
-    parallel_ctx.set_parallel_num(parallel_num);
-    JUST(op_node->op().InferBlobDescsIf(BlobDesc4BnInOp, &parallel_ctx, &op_node->sbp_signature(),
-                                        [](OpContext*) {}));
-  }
-  op_node->ConcatLogicalOutputBlobDesc();
+  const auto& output_bns = op_node->op().output_bns();
+  auto BlobDesc4BnInOp = [&](const std::string& bn) -> BlobDesc* {
+    BlobDesc* logical_blob_desc = nullptr;
+    if (std::find(input_bns.begin(), input_bns.end(), bn) != input_bns.end()) {
+      const LogicalBlobId& lbi = op_node->op().BnInOp2Lbi(bn);
+      OpNode* producer = op_node->MutSrcNode4Ibn(bn);
+      logical_blob_desc = producer->MutLogicalBlobDesc4Lbi(lbi);
+    } else if (std::find(output_bns.begin(), output_bns.end(), bn) != output_bns.end()) {
+      const LogicalBlobId& lbi = op_node->op().BnInOp2Lbi(bn);
+      logical_blob_desc = op_node->MutLogicalBlobDesc4Lbi(lbi);
+    }
+    return logical_blob_desc;
+  };
+
+  ParallelContext parallel_ctx;
+  parallel_ctx.set_parallel_id(0);
+  parallel_ctx.set_parallel_num(1);
+  JUST(op_node->op().InferOutBlobDescsIf(BlobDesc4BnInOp, &parallel_ctx, &op_node->sbp_signature(),
+                                         [](OpContext*) {}));
   return Maybe<void>::Ok();
 }
 
@@ -662,13 +555,6 @@ bool OpGraph::IsBatchAxisBlob(const std::string& op_name, const LogicalBlobId& l
   const auto& op = *op_name2op_node_.at(GetOpNameKey(op_name, lbi));
   const auto& opt_int64 = *CHECK_JUST(op.BatchAxis4Lbi(GetLogicalBlobIdKey(op_name, lbi)));
   return opt_int64.has_value();
-}
-
-void OpGraph::CheckBlobDescs(const std::string& op_name,
-                             const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const {
-  if (op_name2op_node_.find(op_name) == op_name2op_node_.end()) { return; }
-  op_name2op_node_.at(op_name)->CheckBlobDescs(GetBlobDesc4BnInOp, parallel_ctx);
 }
 
 void OpGraph::ForEachChainFamily(

--- a/oneflow/core/graph/op_graph.cpp
+++ b/oneflow/core/graph/op_graph.cpp
@@ -441,7 +441,7 @@ Maybe<void> OpGraph::InferOpNodeLogicalBlobDesc(OpNode* op_node) const {
 
   ParallelContext parallel_ctx;
   parallel_ctx.set_parallel_id(0);
-  parallel_ctx.set_parallel_num(1);
+  parallel_ctx.set_parallel_num(op_node->parallel_desc().parallel_num());
   JUST(op_node->op().InferOutBlobDescsIf(BlobDesc4BnInOp, &parallel_ctx, &op_node->sbp_signature(),
                                          [](OpContext*) {}));
   return Maybe<void>::Ok();

--- a/oneflow/core/graph/op_graph.h
+++ b/oneflow/core/graph/op_graph.h
@@ -72,18 +72,9 @@ class OpNode final : public Node<OpNode, OpEdge> {
   BlobDesc* MutLogicalBlobDesc4Lbi(const LogicalBlobId& lbi);
   OpNode* MutSrcNode4Ibn(const std::string& bn_in_op) const;
   OpNode* MutSrcNode4InputLbi(const LogicalBlobId& lbi) const;
-  void ForEachSplitOrBroadcastBlobDesc(const BlobDesc& blob_desc, const SbpParallel& sbp_parallel,
-                                       const std::function<void(const BlobDesc&)>& Handler) const;
 
   int64_t GetAxisParallelNum(
       const std::function<void(bool*, int32_t*, int64_t*)>& GetAxisParallelInfo) const;
-  void ConcatBlobDesc(const ParallelDesc& blob_parallel_desc,
-                      const std::vector<std::shared_ptr<BlobDesc>>& blob_descs,
-                      const SbpParallel& sbp_parallel, BlobDesc* concatenated_blob_desc) const;
-  void SplitLogicalInputBlobDesc();
-  void ConcatLogicalOutputBlobDesc();
-  void CheckBlobDescs(const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-                      const ParallelContext* parallel_ctx) const;
   void InferBlobParallelDesc();
   void InitLbi2SourceNode();
   void InitInputBlobFastestTimeShape();
@@ -153,9 +144,6 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
   const SbpParallel& GetSbpParallel(const std::string& op_name, const LogicalBlobId& lbi) const;
   DataType GetBlobDataType(const LogicalBlobId& lbi) const;
   const BlobDesc& GetLogicalBlobDesc(const LogicalBlobId& lbi) const;
-  void CheckBlobDescs(const std::string& op_name,
-                      const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-                      const ParallelContext* parallel_ctx) const;
 
   // a set of nodes is called a chain family if they can divided into several connected chains
   void ForEachChainFamily(const std::function<void(const HashSet<OpNode*>&)>& Handler) const;

--- a/oneflow/core/operator/normal_model_update_op.h
+++ b/oneflow/core/operator/normal_model_update_op.h
@@ -28,6 +28,12 @@ class NormalModelUpdtOp : public Operator {
   void InitFromOpConf() override;
   Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                              const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature,
+                                std::function<void(OpContext*)> EnrollOpCtx) const override {
+    return Maybe<void>::Ok();
+  }
   virtual const PbMessage& GetCustomizedConf() const override;
 
  protected:

--- a/oneflow/python/test/ops/test_sparse_softmax_cross_entropy_ms.py
+++ b/oneflow/python/test/ops/test_sparse_softmax_cross_entropy_ms.py
@@ -54,6 +54,8 @@ def compare_with_tensorflow(
                 trainable=True,
             )
 
+        print("x shape", x.shape)
+        print("labels shape", labels.shape)
         with flow.scope.placement(device_type, "0:0-3"):
             lebels_distribute = flow.distribute.broadcast()
             logits_distribute = flow.distribute.split(len(x.shape) - 1)


### PR DESCRIPTION
把 `OpGraph::InferOpNodeLogicalBlobDesc` 中推导逻辑替换成真正的 logical infer (原来是 physical infer)。

替换前后 resnet-50 的 compile time 如下 (单位：秒)：
|  | 1n1c | 1n4c | 2n8c |
| - | - | - | - |
| master | 37.68388 | 86.304613 | 164.486297 |
| this pr | 26.213089 | 43.104999 | 70.065041 |

![image](https://user-images.githubusercontent.com/7133477/92074867-c5357800-ede9-11ea-947e-6aba8641d7c7.png)
