### PR TITLE
Split call_op_kernel instruction args into const_input/mutable_input/output 

### DIFF
--- a/oneflow/core/eager/opkernel_instruction.msg.h
+++ b/oneflow/core/eager/opkernel_instruction.msg.h
@@ -38,9 +38,13 @@ FLAT_MSG_VIEW_BEGIN(CallOpKernelInstrOperand);
   FLAT_MSG_VIEW_DEFINE_PATTERN(vm::MutOperand, opkernel);
   FLAT_MSG_VIEW_DEFINE_PATTERN(vm::SymbolOperand, op_node_signature);
 
-  FLAT_MSG_VIEW_DEFINE_PATTERN(vm::OperandSeparator, begin_ibn);
-  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::SymbolOperand, ibn);
-  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::ConstOperand, input_blob);
+  FLAT_MSG_VIEW_DEFINE_PATTERN(vm::OperandSeparator, begin_const_ibn);
+  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::SymbolOperand, const_ibn);
+  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::ConstOperand, const_input_blob);
+
+  FLAT_MSG_VIEW_DEFINE_PATTERN(vm::OperandSeparator, begin_mut_ibn);
+  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::SymbolOperand, mut_ibn);
+  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::MutOperand, mut_input_blob);
 
   FLAT_MSG_VIEW_DEFINE_PATTERN(vm::OperandSeparator, begin_obn);
   FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::SymbolOperand, obn);
@@ -57,9 +61,13 @@ FLAT_MSG_VIEW_BEGIN(StatelessCallOpKernelInstrOperand);
   FLAT_MSG_VIEW_DEFINE_PATTERN(vm::SymbolOperand, op_node_signature);
   FLAT_MSG_VIEW_DEFINE_PATTERN(vm::MutOperand, shared_opkernel);
 
-  FLAT_MSG_VIEW_DEFINE_PATTERN(vm::OperandSeparator, begin_ibn);
-  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::SymbolOperand, ibn);
-  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::ConstOperand, input_blob);
+  FLAT_MSG_VIEW_DEFINE_PATTERN(vm::OperandSeparator, begin_const_ibn);
+  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::SymbolOperand, const_ibn);
+  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::ConstOperand, const_input_blob);
+
+  FLAT_MSG_VIEW_DEFINE_PATTERN(vm::OperandSeparator, begin_mut_ibn);
+  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::SymbolOperand, mut_ibn);
+  FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::MutOperand, mut_input_blob);
 
   FLAT_MSG_VIEW_DEFINE_PATTERN(vm::OperandSeparator, begin_obn);
   FLAT_MSG_VIEW_DEFINE_REPEATED_PATTERN(vm::SymbolOperand, obn);

--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -112,16 +112,17 @@ std::shared_ptr<MemoryCase> MakeMemCase(const DeviceType device_type, const int6
 }
 
 template<typename T, typename CallbackT>
-Maybe<void> ForEachConstBnAndBlobObject(vm::Instruction* instruction, const T& args,
-                                        const CallbackT& Callback) {
-  CHECK_EQ_OR_RETURN(args.ibn_size(), args.input_blob_size());
-  FOR_RANGE(int, i, 0, args.ibn_size()) {
-    const auto* operand_ibn = instruction->operand_type(args.ibn(i));
+Maybe<void> ForEachConstInputBnAndBlobObject(vm::Instruction* instruction, const T& args,
+                                             const CallbackT& Callback) {
+  CHECK_EQ_OR_RETURN(args.const_ibn_size(), args.const_input_blob_size());
+  FOR_RANGE(int, i, 0, args.const_ibn_size()) {
+    const auto* operand_ibn = instruction->operand_type(args.const_ibn(i));
     CHECK_NOTNULL_OR_RETURN(operand_ibn);
     const std::string& bn_in_op = JUST(operand_ibn->template Get<vm::StringObject>())->str();
-    const auto* operand_input_blob = instruction->operand_type(args.input_blob(i));
+    const auto* operand_input_blob = instruction->operand_type(args.const_input_blob(i));
     CHECK_NOTNULL_OR_RETURN(operand_input_blob)
-        << "bn_in_op: " << bn_in_op << ", object_id: " << args.input_blob(i).logical_object_id();
+        << "bn_in_op: " << bn_in_op
+        << ", object_id: " << args.const_input_blob(i).logical_object_id();
     const auto& blob_object = *JUST(operand_input_blob->template Get<BlobObject>());
     JUST(Callback(bn_in_op, blob_object));
   }
@@ -129,8 +130,26 @@ Maybe<void> ForEachConstBnAndBlobObject(vm::Instruction* instruction, const T& a
 }
 
 template<typename T, typename CallbackT>
-Maybe<void> ForEachMutBnAndBlobObject(vm::Instruction* instruction, const T& args,
-                                      const CallbackT& Callback) {
+Maybe<void> ForEachMutInputBnAndBlobObject(vm::Instruction* instruction, const T& args,
+                                           const CallbackT& Callback) {
+  CHECK_EQ_OR_RETURN(args.mut_ibn_size(), args.mut_input_blob_size());
+  FOR_RANGE(int, i, 0, args.mut_ibn_size()) {
+    const auto* operand_ibn = instruction->operand_type(args.mut_ibn(i));
+    CHECK_NOTNULL_OR_RETURN(operand_ibn);
+    const std::string& bn_in_op = JUST(operand_ibn->template Get<vm::StringObject>())->str();
+    auto* operand_input_blob = instruction->mut_operand_type(args.mut_input_blob(i));
+    CHECK_NOTNULL_OR_RETURN(operand_input_blob)
+        << "bn_in_op: " << bn_in_op
+        << ", object_id: " << args.mut_input_blob(i).logical_object_id();
+    auto* blob_object = operand_input_blob->template Mut<BlobObject>();
+    JUST(Callback(bn_in_op, blob_object));
+  }
+  return Maybe<void>::Ok();
+}
+
+template<typename T, typename CallbackT>
+Maybe<void> ForEachOutputBnAndBlobObject(vm::Instruction* instruction, const T& args,
+                                         const CallbackT& Callback) {
   CHECK_EQ_OR_RETURN(args.obn_size(), args.output_blob_size());
   FOR_RANGE(int, i, 0, args.obn_size()) {
     const auto* operand_obn = instruction->operand_type(args.obn(i));
@@ -138,7 +157,7 @@ Maybe<void> ForEachMutBnAndBlobObject(vm::Instruction* instruction, const T& arg
     const std::string& bn_in_op = JUST(operand_obn->template Get<vm::StringObject>())->str();
     auto* operand_output_blob = instruction->mut_operand_type(args.output_blob(i));
     CHECK_NOTNULL_OR_RETURN(operand_output_blob) << "obn: " << bn_in_op;
-    auto* blob_object = operand_output_blob->template Mut<EagerBlobObject>();
+    auto* blob_object = operand_output_blob->template Mut<BlobObject>();
     JUST(Callback(bn_in_op, blob_object));
   }
   CHECK_EQ_OR_RETURN(args.mut2_obn_size(), args.mut2_output_blob_size());
@@ -148,7 +167,7 @@ Maybe<void> ForEachMutBnAndBlobObject(vm::Instruction* instruction, const T& arg
     const std::string& bn_in_op = JUST(operand_obn->template Get<vm::StringObject>())->str();
     auto* operand_output_blob = instruction->mut_operand_type(args.mut2_output_blob(i));
     CHECK_NOTNULL_OR_RETURN(operand_output_blob) << "obn: " << bn_in_op;
-    auto* blob_object = operand_output_blob->template Mut<EagerBlobObject>();
+    auto* blob_object = operand_output_blob->template Mut<BlobObject>();
     JUST(Callback(bn_in_op, blob_object));
   }
   return Maybe<void>::Ok();
@@ -160,9 +179,9 @@ Maybe<void> MakeBlobDesc4BnInOp(vm::Instruction* instruction, const T& args,
   const auto& obn2blob_desc = std::make_shared<HashMap<std::string, BlobDesc*>>();
   {
     HashSet<const BlobDesc*> out_blob_descs;
-    JUST(ForEachMutBnAndBlobObject(
+    JUST(ForEachOutputBnAndBlobObject(
         instruction, args,
-        [&](const std::string& bn_in_op, EagerBlobObject* blob_object) -> Maybe<void> {
+        [&](const std::string& bn_in_op, BlobObject* blob_object) -> Maybe<void> {
           auto* blob_desc = blob_object->mut_blob_desc();
           CHECK_OR_RETURN(out_blob_descs.insert(blob_desc).second);
           CHECK_OR_RETURN(obn2blob_desc->emplace(bn_in_op, blob_desc).second);
@@ -170,10 +189,15 @@ Maybe<void> MakeBlobDesc4BnInOp(vm::Instruction* instruction, const T& args,
         }));
   }
   const auto& ibn2blob_desc = std::make_shared<HashMap<std::string, const BlobDesc*>>();
-  JUST(ForEachConstBnAndBlobObject(
+  JUST(ForEachConstInputBnAndBlobObject(
       instruction, args,
       [&](const std::string& bn_in_op, const BlobObject& blob_object) -> Maybe<void> {
         CHECK_OR_RETURN(ibn2blob_desc->emplace(bn_in_op, &blob_object.blob_desc()).second);
+        return Maybe<void>::Ok();
+      }));
+  JUST(ForEachMutInputBnAndBlobObject(
+      instruction, args, [&](const std::string& bn_in_op, BlobObject* blob_object) -> Maybe<void> {
+        CHECK_OR_RETURN(ibn2blob_desc->emplace(bn_in_op, &blob_object->blob_desc()).second);
         return Maybe<void>::Ok();
       }));
   *BlobDesc4BnInOp = [obn2blob_desc, ibn2blob_desc](const std::string& bn_in_op) -> BlobDesc* {
@@ -190,20 +214,24 @@ template<typename T>
 Maybe<void> MakeBlob4BnInOp(
     vm::Instruction* instruction, const T& args,
     std::function<Blob*(const std::string&)>* Blob4BnInOp,
-    const std::function<bool(const std::string&, const EagerBlobObject&)>& FilterOutBlob) {
+    const std::function<bool(const std::string&, const BlobObject&)>& FilterOutBlob) {
   const auto& obn2blob = std::make_shared<HashMap<std::string, Blob*>>();
-  JUST(ForEachMutBnAndBlobObject(
-      instruction, args,
-      [&](const std::string& bn_in_op, EagerBlobObject* blob_object) -> Maybe<void> {
+  JUST(ForEachOutputBnAndBlobObject(
+      instruction, args, [&](const std::string& bn_in_op, BlobObject* blob_object) -> Maybe<void> {
         if (!FilterOutBlob(bn_in_op, *blob_object)) { return Maybe<void>::Ok(); }
         CHECK_OR_RETURN(obn2blob->emplace(bn_in_op, blob_object->mut_blob()).second);
         return Maybe<void>::Ok();
       }));
   const auto& ibn2blob = std::make_shared<HashMap<std::string, const Blob*>>();
-  JUST(ForEachConstBnAndBlobObject(
+  JUST(ForEachConstInputBnAndBlobObject(
       instruction, args,
       [&](const std::string& bn_in_op, const BlobObject& blob_object) -> Maybe<void> {
         CHECK_OR_RETURN(ibn2blob->emplace(bn_in_op, &blob_object.blob()).second);
+        return Maybe<void>::Ok();
+      }));
+  JUST(ForEachMutInputBnAndBlobObject(
+      instruction, args, [&](const std::string& bn_in_op, BlobObject* blob_object) -> Maybe<void> {
+        CHECK_OR_RETURN(ibn2blob->emplace(bn_in_op, blob_object->mut_blob()).second);
         return Maybe<void>::Ok();
       }));
   *Blob4BnInOp = [obn2blob, ibn2blob](const std::string& bn_in_op) -> Blob* {
@@ -220,7 +248,7 @@ template<typename T>
 Maybe<void> MakeBlob4BnInOp(vm::Instruction* instruction, const T& args,
                             std::function<Blob*(const std::string&)>* Blob4BnInOp) {
   return MakeBlob4BnInOp(instruction, args, Blob4BnInOp,
-                         [](const std::string&, const EagerBlobObject&) { return true; });
+                         [](const std::string&, const BlobObject&) { return true; });
 }
 
 template<typename T>
@@ -230,7 +258,8 @@ void InitOutputBlobObjects(vm::Instruction* instruction, const T& args,
     const auto& parallel_desc = instruction->parallel_desc();
     CHECK(static_cast<bool>(parallel_desc));
     if (rw_mutexed_object->has_object()) {
-      CHECK(rw_mutexed_object->Has<EagerBlobObject>());
+      // mutable input
+      CHECK(rw_mutexed_object->Has<BlobObject>());
     } else {
       rw_mutexed_object->Init<EagerBlobObject>(mem_case, data_type);
     }
@@ -260,21 +289,27 @@ Maybe<void> CheckBlobParallel(vm::Instruction* instruction, const T& args,
     return symbol_storage_ptr->GetPtr(symbol_id).get();
   };
 
-  JUST(ForEachMutBnAndBlobObject(
-      instruction, args,
-      [&](const std::string& bn_in_op, EagerBlobObject* blob_object) -> Maybe<void> {
+  JUST(ForEachOutputBnAndBlobObject(
+      instruction, args, [&](const std::string& bn_in_op, BlobObject* blob_object) -> Maybe<void> {
         const auto* parallel_desc = JUST(ParallelDesc4BnInOp(bn_in_op));
         if (parallel_desc == nullptr) { return Maybe<void>::Ok(); }
         JUST(blob_object->CheckMemCase(*parallel_desc, instruction->stream().machine_id()));
         return Maybe<void>::Ok();
       }));
 
-  JUST(ForEachConstBnAndBlobObject(
+  JUST(ForEachConstInputBnAndBlobObject(
       instruction, args,
       [&](const std::string& bn_in_op, const BlobObject& blob_object) -> Maybe<void> {
         const auto* parallel_desc = JUST(ParallelDesc4BnInOp(bn_in_op));
         if (parallel_desc == nullptr) { return Maybe<void>::Ok(); }
         JUST(blob_object.CheckMemCase(*parallel_desc, instruction->stream().machine_id()));
+        return Maybe<void>::Ok();
+      }));
+  JUST(ForEachMutInputBnAndBlobObject(
+      instruction, args, [&](const std::string& bn_in_op, BlobObject* blob_object) -> Maybe<void> {
+        const auto* parallel_desc = JUST(ParallelDesc4BnInOp(bn_in_op));
+        if (parallel_desc == nullptr) { return Maybe<void>::Ok(); }
+        JUST(blob_object->CheckMemCase(*parallel_desc, instruction->stream().machine_id()));
         return Maybe<void>::Ok();
       }));
   return Maybe<void>::Ok();
@@ -303,13 +338,13 @@ Maybe<void> OpKernelInfer(OpKernelObject* opkernel_obj, vm::Instruction* instruc
   JUST(opkernel_obj->ResetOpAndKernel(*op_node_signature, &parallel_ctx, BlobDesc4BnInOp,
                                       instruction->parallel_desc().get()));
   JUST(CheckBlobParallel(instruction, args, op_node_signature));
-  JUST(ForEachMutBnAndBlobObject(
-      instruction, args, [](const std::string& obn, EagerBlobObject* blob_object) -> Maybe<void> {
+  JUST(ForEachOutputBnAndBlobObject(
+      instruction, args, [](const std::string& obn, BlobObject* blob_object) -> Maybe<void> {
         return blob_object->TryInitBlob();
       }));
   std::function<Blob*(const std::string&)> Blob4BnInOp;
   Shape empty_shape{};
-  const auto& FilterOutBlob = [&](const std::string& bn_in_op, const EagerBlobObject& blob_object) {
+  const auto& FilterOutBlob = [&](const std::string& bn_in_op, const BlobObject& blob_object) {
     return !(bn_in_op == "tmp_buffer_0" && blob_object.blob_desc().shape() == empty_shape);
   };
   JUST(MakeBlob4BnInOp(instruction, args, &Blob4BnInOp, FilterOutBlob));
@@ -340,8 +375,8 @@ Maybe<void> OpKernelInfer(SystemOpKernelObject* opkernel_obj, vm::Instruction* i
   JUST(opkernel_obj->ResetKernel(*op_node_signature, &parallel_ctx, BlobDesc4BnInOp,
                                  instruction->parallel_desc().get()));
   JUST(CheckBlobParallel(instruction, args, op_node_signature));
-  JUST(ForEachMutBnAndBlobObject(
-      instruction, args, [](const std::string& obn, EagerBlobObject* blob_object) -> Maybe<void> {
+  JUST(ForEachOutputBnAndBlobObject(
+      instruction, args, [](const std::string& obn, BlobObject* blob_object) -> Maybe<void> {
         return blob_object->TryInitBlob();
       }));
   std::function<Blob*(const std::string&)> Blob4BnInOp;
@@ -354,8 +389,8 @@ template<typename T>
 Maybe<void> OpKernelCompute(OpKernelObject* opkernel_obj, vm::Instruction* instruction,
                             const T& args) {
   DeviceCtx* device_ctx = instruction->stream().device_ctx().get();
-  JUST(ForEachMutBnAndBlobObject(
-      instruction, args, [&](const std::string&, EagerBlobObject* blob_object) -> Maybe<void> {
+  JUST(ForEachOutputBnAndBlobObject(
+      instruction, args, [&](const std::string&, BlobObject* blob_object) -> Maybe<void> {
         blob_object->TryAllocateBlobBodyMemory(device_ctx);
         return Maybe<void>::Ok();
       }));
@@ -363,8 +398,7 @@ Maybe<void> OpKernelCompute(OpKernelObject* opkernel_obj, vm::Instruction* instr
   {
     std::function<Blob*(const std::string&)> Blob4BnInOp;
     Shape empty_shape{};
-    const auto& FilterOutBlob = [&](const std::string& bn_in_op,
-                                    const EagerBlobObject& blob_object) {
+    const auto& FilterOutBlob = [&](const std::string& bn_in_op, const BlobObject& blob_object) {
       return !(bn_in_op == "tmp_buffer_0" && blob_object.blob_desc().shape() == empty_shape);
     };
     JUST(MakeBlob4BnInOp(instruction, args, &Blob4BnInOp, FilterOutBlob));
@@ -379,8 +413,8 @@ Maybe<void> OpKernelCompute(OpKernelObject* opkernel_obj, vm::Instruction* instr
 Maybe<void> OpKernelCompute(SystemOpKernelObject* opkernel_obj, vm::Instruction* instruction,
                             const StatelessCallOpKernelInstrOperand& args) {
   DeviceCtx* device_ctx = instruction->stream().device_ctx().get();
-  JUST(ForEachMutBnAndBlobObject(
-      instruction, args, [&](const std::string&, EagerBlobObject* blob_object) -> Maybe<void> {
+  JUST(ForEachOutputBnAndBlobObject(
+      instruction, args, [&](const std::string&, BlobObject* blob_object) -> Maybe<void> {
         blob_object->TryAllocateBlobBodyMemory(device_ctx);
         return Maybe<void>::Ok();
       }));

--- a/oneflow/core/eager/opkernel_instruction_type_test.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type_test.cpp
@@ -168,6 +168,7 @@ TEST(OpkernelInstructionType, call_opkernel) {
                        ->add_symbol_operand(op_node_signature_id)
                        ->add_separator()
                        ->add_separator()
+                       ->add_separator()
                        ->add_symbol_operand(obn_id)
                        ->add_mut_operand(output_blob_id)
                        ->add_separator());
@@ -210,6 +211,7 @@ TEST(OpkernelInstructionType, consecutive_opkernel_calls) {
                          ->add_symbol_operand(op_node_signature_id)
                          ->add_separator()
                          ->add_separator()
+                         ->add_separator()
                          ->add_symbol_operand(out_id)
                          ->add_mut_operand(x)
                          ->add_separator());
@@ -239,6 +241,7 @@ TEST(OpkernelInstructionType, consecutive_opkernel_calls) {
                          ->add_separator()
                          ->add_symbol_operand(in_id)
                          ->add_const_operand(x)
+                         ->add_separator()
                          ->add_separator()
                          ->add_symbol_operand(out_id)
                          ->add_symbol_operand(tmp_buffer_id)
@@ -284,6 +287,7 @@ TEST(OpkernelInstructionType, stateless_call_opkernel) {
                        ->add_mut_operand(opkernel_id)
                        ->add_separator()
                        ->add_separator()
+                       ->add_separator()
                        ->add_symbol_operand(obn_id)
                        ->add_mut_operand(output_blob_id)
                        ->add_separator());
@@ -326,6 +330,7 @@ TEST(OpkernelInstructionType, consecutive_stateless_call_opkernel) {
                        ->add_mut_operand(opkernel_id)
                        ->add_separator()
                        ->add_separator()
+                       ->add_separator()
                        ->add_symbol_operand(out_id)
                        ->add_mut_operand(x)
                        ->add_separator());
@@ -355,6 +360,7 @@ TEST(OpkernelInstructionType, consecutive_stateless_call_opkernel) {
                        ->add_separator()
                        ->add_symbol_operand(in_id)
                        ->add_const_operand(x)
+                       ->add_separator()
                        ->add_separator()
                        ->add_symbol_operand(out_id)
                        ->add_symbol_operand(tmp_buffer_id)


### PR DESCRIPTION
把 call_op_kernel 的两条指令的操作数分成 const_input/mutable_input/output 而不是 input/output。顺便修了上一个 pr https://github.com/Oneflow-Inc/oneflow/pull/3485 遗漏的一些 EagerBlobObject->BlobObject