### PR TITLE
Fix gpu_atomic_max double overload use fmaxf

### DIFF
--- a/oneflow/core/kernel/kernel_util.cu
+++ b/oneflow/core/kernel/kernel_util.cu
@@ -724,7 +724,7 @@ __device__ double gpu_atomic_max(double* address, const double val) {
   do {
     assumed = old;
     old = atomicCAS(address_as_i, assumed,
-                    __double_as_longlong(fmaxf(val, __longlong_as_double(assumed))));
+                    __double_as_longlong(fmax(val, __longlong_as_double(assumed))));
   } while (assumed != old);
   return __longlong_as_double(old);
 }


### PR DESCRIPTION
gpu_atomic_max中使用了float版本的`fmaxf`而不是double版本的`fmax`，会导致精度损失