### PR TITLE
[bugfix] GRPC: control server CompletionQueue shutdown.

### DIFF
--- a/oneflow/core/control/ctrl_server.cpp
+++ b/oneflow/core/control/ctrl_server.cpp
@@ -31,10 +31,10 @@ int ExtractPortFromAddr(const std::string& addr) {
 }  // namespace
 
 CtrlServer::~CtrlServer() {
+  // NOTE(chengcheng): This enqueues a special event (with a null tag) that causes
+  // the completion queue to be shut down on the polling thread.
   grpc::Alarm alarm(cq_.get(), gpr_now(GPR_CLOCK_MONOTONIC), nullptr);
   loop_thread_.join();
-  grpc_server_->Shutdown();
-  cq_->Shutdown();
 }
 
 CtrlServer::CtrlServer() : is_first_connect_(true), this_machine_addr_("") {
@@ -60,14 +60,29 @@ void CtrlServer::HandleRpcs() {
 
   void* tag = nullptr;
   bool ok = false;
-  while (true) {
-    CHECK(cq_->Next(&tag, &ok));
-    CHECK(ok);
+  bool is_shutdown = false;
+  // NOTE(chengcheng): The final end is cq_->Next() get false (cq_ items is empty).
+  while (cq_->Next(&tag, &ok)) {
+    if (!ok) {
+      // NOTE(chengcheng): when call grpc_server_->Shutdown() and cq_->Shutdown(),
+      // there will trigger some cancel on each RPC. so cq_->Next() can get these tag
+      // with ok = false. so just continue.
+      CHECK(is_shutdown);
+      continue;
+    }
     auto call = static_cast<CtrlCallIf*>(tag);
     if (call) {
       call->Process();
     } else {
-      break;
+      // NOTE(chengcheng): A null `call` indicates that this is the shutdown alarm.
+      CHECK(!is_shutdown);
+      is_shutdown = true;
+      grpc_server_->Shutdown();
+      cq_->Shutdown();
+
+      // NOTE(chengcheng): You CANNOT use code 'break;' in this block because that
+      //   there may still be items in the cq_.
+      // break;
     }
   }
 }

--- a/oneflow/core/control/ctrl_test.cpp
+++ b/oneflow/core/control/ctrl_test.cpp
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/job/machine_context.h"
+#include "oneflow/core/job/env.pb.h"
+#include "oneflow/core/control/ctrl_client.h"
+#include "oneflow/core/control/ctrl_server.h"
+#include "oneflow/core/job/resource_desc.h"
+#include "oneflow/core/job/global_for.h"
+
+namespace oneflow {
+
+namespace {
+
+EnvProto GetEnvProto() {
+  EnvProto ret;
+  auto* machine0 = ret.add_machine();
+  machine0->set_id(0);
+  machine0->set_addr("127.0.0.1");
+  ret.set_ctrl_port(46323);
+  return ret;
+}
+
+Resource GetResource() {
+  Resource ret;
+  ret.set_machine_num(1);
+  ret.set_gpu_device_num(0);
+  ret.set_cpu_device_num(1);
+  ret.set_comm_net_worker_num(1);
+  return ret;
+}
+
+}  // namespace
+
+TEST(CtrlServer, new_delete) {
+  EnvProto env_proto = GetEnvProto();
+  Global<EnvDesc>::New(env_proto);
+  Global<CtrlServer>::New();
+  Global<CtrlClient>::New();
+  int64_t this_mchn_id =
+      Global<EnvDesc>::Get()->GetMachineId(Global<CtrlServer>::Get()->this_machine_addr());
+  Global<MachineCtx>::New(this_mchn_id);
+  Global<ResourceDesc, ForEnv>::New(GetResource());
+  Global<ResourceDesc, ForSession>::New(GetResource());
+
+  // maybe do some
+  // OF_BARRIER_ALL();
+
+  Global<ResourceDesc, ForSession>::Delete();
+  Global<ResourceDesc, ForEnv>::Delete();
+  Global<MachineCtx>::Delete();
+  Global<CtrlClient>::Delete();
+  Global<CtrlServer>::Delete();
+  Global<EnvDesc>::Delete();
+}
+
+}  // namespace oneflow


### PR DESCRIPTION

修复了 `oneflow/core/control/ctrl_server.cpp` 里的对ServerCompletionQueue处理的BUG。

增加了Ctrl Test。

blocking this PR: https://github.com/Oneflow-Inc/oneflow/pull/3549