### PR TITLE
Add OpRegistry::SetAreaId

### DIFF
--- a/oneflow/core/framework/user_op_registry.cpp
+++ b/oneflow/core/framework/user_op_registry.cpp
@@ -87,6 +87,12 @@ OpRegistry& OpRegistry::SetOutputBufferNum(int32_t num) {
   return *this;
 }
 
+OpRegistry& OpRegistry::SetAreaId(int64_t area_id) {
+  CHECK_NE(area_id, AreaType::kInvalidArea);
+  result_.area_id = area_id;
+  return *this;
+}
+
 OpRegistry& OpRegistry::Attr(const std::string& name, UserOpAttrType type) {
   CHECK(InsertIfNotExists(name, &unique_names_));
   UserOpDef::AttrDef attr_def;

--- a/oneflow/core/framework/user_op_registry.h
+++ b/oneflow/core/framework/user_op_registry.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "oneflow/core/framework/user_op_attr.pb.h"
 #include "oneflow/core/framework/user_op_conf.pb.h"
 #include "oneflow/core/operator/op_attribute.pb.h"
+#include "oneflow/core/job/task.pb.h"
 
 namespace oneflow {
 
@@ -47,7 +48,8 @@ using GetOutputArgModifier =
 using OutputArgModifyFn = std::function<void(GetOutputArgModifier, const UserOpConfWrapper&)>;
 
 struct OpRegistryResult {
-  OpRegistryResult() : cpu_only_supported(false), same_output_regst_num(-1) {}
+  OpRegistryResult()
+      : cpu_only_supported(false), same_output_regst_num(-1), area_id(AreaType::kInvalidArea) {}
   ~OpRegistryResult() = default;
 
   std::string op_type_name;
@@ -62,6 +64,7 @@ struct OpRegistryResult {
   // performance other than op definition
   InputArgModifyFn input_arg_modify_fn;
   OutputArgModifyFn output_arg_modify_fn;
+  int64_t area_id;
 };
 
 class OpRegistry final {
@@ -84,6 +87,7 @@ class OpRegistry final {
 
   OpRegistry& SupportCpuOnly();
   OpRegistry& SetOutputBufferNum(int32_t num);
+  OpRegistry& SetAreaId(int64_t area_id);
 
   OpRegistry& Attr(const std::string& name, UserOpAttrType type);
   template<typename T>


### PR DESCRIPTION
允许 user op 注册的时候指定 area_id，而不用通过继承 LogicalNode 来实现。
短期内用于支持将 optimizer 迁移到 user op 框架，长期目的可以逐渐削弱 LogicalGraph 的功能，直到取消。