### PR TITLE
fix broadcast_to_compatible_with grad bug

### DIFF
--- a/oneflow/core/job_rewriter/broadcast_to_compatible_with_grad.cpp
+++ b/oneflow/core/job_rewriter/broadcast_to_compatible_with_grad.cpp
@@ -30,8 +30,9 @@ Maybe<void> GenBroadcastToCompatibleWithGradOpConf(
     const Shape& x_shape = LogicalBlobDesc4BnInOp("x").shape();
     const Shape& y_shape = LogicalBlobDesc4BnInOp("y").shape();
     Shape x_extend_shape = CreateLeftExtendedShape(ShapeView(x_shape), y_shape.NumAxes());
-    std::vector<int32_t> reduced_axes;
-    FOR_RANGE(int64_t, i, 0, y_shape.NumAxes()) {
+    std::vector<int32_t> reduced_axes(x_extend_shape.NumAxes() - x_shape.NumAxes());
+    std::iota(reduced_axes.begin(), reduced_axes.end(), 0);
+    FOR_RANGE(int64_t, i, reduced_axes.size(), y_shape.NumAxes()) {
       if (x_extend_shape.At(i) == 1 && y_shape.At(i) != 1) {
         reduced_axes.push_back(i);
       } else {

--- a/oneflow/python/test/ops/test_broadcast_to_compatible_with.py
+++ b/oneflow/python/test/ops/test_broadcast_to_compatible_with.py
@@ -168,6 +168,19 @@ def test_broadcast_to_compatible_with_grad(test_case):
     test_case.assertTrue(np.array_equal(exp_ret, ret))
 
 
+def test_broadcast_to_compatible_with_grad_case_2(test_case):
+    x = np.random.standard_normal((7, 1, 4)).astype(np.float32)
+    compatible_shape = [[1, 7, 5, 4]]
+
+    def compare_dy(dx_blob):
+        dx = np.ones([7, 5, 4], dtype=np.float32).sum(axis=1).reshape(x.shape)
+        test_case.assertTrue(np.array_equal(dx, dx_blob.numpy()))
+
+    ret = _of_broadcast_to_compatible_with_grad(x, compatible_shape, compare_dy)
+    exp_ret = np.broadcast_to(x, [1, 7, 5, 4])
+    test_case.assertTrue(np.array_equal(exp_ret, ret))
+
+
 def test_broadcast_to_compatible_with_no_broadcast(test_case):
     x = np.random.standard_normal((9, 9, 6)).astype(np.float32)
     x_static_shape = (10, 9, 6)


### PR DESCRIPTION
原来的写法没有考虑 y_shape[i] 本身就是 1 的情况，在从 [a, b] broadcast 到 [1, a, b] 的时候会报错