### PR TITLE
Reduce the number of tests

### DIFF
--- a/oneflow/python/test/ops/test_boxing_v2.py
+++ b/oneflow/python/test/ops/test_boxing_v2.py
@@ -53,8 +53,8 @@ def test_split_to_split(test_case):
     arg_dict = OrderedDict()
     arg_dict["src_device_type"] = ["cpu", "gpu"]
     arg_dict["dst_device_type"] = ["cpu", "gpu"]
-    arg_dict["src_device_num"] = [1, 2, 3]
-    arg_dict["dst_device_num"] = [1, 2, 3]
+    arg_dict["src_device_num"] = [1, 2]
+    arg_dict["dst_device_num"] = [1, 2]
     arg_dict["src_axis"] = [0, 1]
     arg_dict["dst_axis"] = [0, 1]
     for arg in GenArgList(arg_dict):
@@ -92,8 +92,8 @@ def test_split_to_broadcast(test_case):
     arg_dict = OrderedDict()
     arg_dict["src_device_type"] = ["cpu", "gpu"]
     arg_dict["dst_device_type"] = ["cpu", "gpu"]
-    arg_dict["src_device_num"] = [1, 2, 3]
-    arg_dict["dst_device_num"] = [1, 2, 3]
+    arg_dict["src_device_num"] = [1, 2]
+    arg_dict["dst_device_num"] = [1, 2]
     arg_dict["src_axis"] = [0, 1]
     for arg in GenArgList(arg_dict):
         _test_split_to_broadcast(test_case, *arg)
@@ -130,8 +130,8 @@ def test_broadcast_to_split(test_case):
     arg_dict = OrderedDict()
     arg_dict["src_device_type"] = ["cpu", "gpu"]
     arg_dict["dst_device_type"] = ["cpu", "gpu"]
-    arg_dict["src_device_num"] = [1, 2, 3]
-    arg_dict["dst_device_num"] = [1, 2, 3]
+    arg_dict["src_device_num"] = [1, 2]
+    arg_dict["dst_device_num"] = [1, 2]
     arg_dict["dst_axis"] = [0, 1]
     for arg in GenArgList(arg_dict):
         _test_broadcast_to_split(test_case, *arg)
@@ -170,7 +170,7 @@ def test_partial_sum_to_split(test_case):
     arg_dict["src_device_type"] = ["cpu", "gpu"]
     arg_dict["dst_device_type"] = ["cpu", "gpu"]
     arg_dict["src_device_num"] = [2, 3]
-    arg_dict["dst_device_num"] = [1, 2, 3]
+    arg_dict["dst_device_num"] = [1, 2]
     arg_dict["dst_axis"] = [0, 1]
     for arg in GenArgList(arg_dict):
         _test_partial_sum_to_split(test_case, *arg)
@@ -204,7 +204,7 @@ def test_partial_sum_to_broadcast(test_case):
     arg_dict["src_device_type"] = ["cpu", "gpu"]
     arg_dict["dst_device_type"] = ["cpu", "gpu"]
     arg_dict["src_device_num"] = [2, 3]
-    arg_dict["dst_device_num"] = [1, 2, 3]
+    arg_dict["dst_device_num"] = [1, 2]
     for arg in GenArgList(arg_dict):
         _test_partial_sum_to_broadcast(test_case, *arg)
 
@@ -235,8 +235,8 @@ def test_broadcast_to_broadcast(test_case):
     arg_dict = OrderedDict()
     arg_dict["src_device_type"] = ["cpu", "gpu"]
     arg_dict["dst_device_type"] = ["cpu", "gpu"]
-    arg_dict["src_device_num"] = [1, 2, 3]
-    arg_dict["dst_device_num"] = [1, 2, 3]
+    arg_dict["src_device_num"] = [1, 2]
+    arg_dict["dst_device_num"] = [1, 2]
 
     for arg in GenArgList(arg_dict):
         _test_broadcast_to_broadcast(test_case, *arg)
@@ -278,7 +278,7 @@ def test_multi_lbi(test_case):
     arg_dict = OrderedDict()
     arg_dict["src_device_type"] = ["cpu", "gpu"]
     arg_dict["dst_device_type"] = ["cpu", "gpu"]
-    arg_dict["src_device_num"] = [1, 2, 3]
-    arg_dict["dst_device_num"] = [1, 2, 3]
+    arg_dict["src_device_num"] = [1, 2]
+    arg_dict["dst_device_num"] = [1, 2]
     for arg in GenArgList(arg_dict):
         _test_multi_lbi(test_case, *arg)

--- a/oneflow/python/test/ops/test_broadcast_logical_ops.py
+++ b/oneflow/python/test/ops/test_broadcast_logical_ops.py
@@ -136,10 +136,10 @@ def test_broadcast_logical(test_case):
         func_greater_than,
         func_greater_equal,
         func_less_than,
-        func_less_than,
+        func_less_equal,
     ]
     arg_dict["a_shape"] = [(64, 64), (64, 64, 64)]
-    arg_dict["b_shape"] = [(1, 64), (64, 1), (64, 1, 64), (1, 64, 1)]
+    arg_dict["b_shape"] = [(1, 64), (1, 64, 1)]
     arg_dict["data_type"] = [flow.int8, flow.int32, flow.int64, flow.float, flow.double]
     arg_dict["device_type"] = ["cpu", "gpu"]
 
@@ -149,19 +149,3 @@ def test_broadcast_logical(test_case):
         if len(arg[2]) < len(arg[3]):
             continue
         GenerateTest(*arg)
-
-
-def test_xy_mod_x1(test_case):
-    GenerateTest(test_case, func_less_than, (64, 64), (64, 1), flow.int8)
-
-
-def test_xy_mod_1y(test_case):
-    GenerateTest(test_case, func_greater_than, (64, 64), (1, 64))
-
-
-def test_xyz_mod_x1z(test_case):
-    GenerateTest(test_case, func_equal, (64, 64, 64), (64, 1, 64))
-
-
-def test_xyz_mod_1y1(test_case):
-    GenerateTest(test_case, func_not_equal, (64, 64, 64), (1, 64, 1))

--- a/oneflow/python/test/ops/test_nn_conv2d_padding_dynamic.py
+++ b/oneflow/python/test/ops/test_nn_conv2d_padding_dynamic.py
@@ -163,7 +163,7 @@ def compare_with_tensorflow(
 def test_padding_valid(test_case):
     arg_dict = OrderedDict()
     arg_dict["device_type"] = ["gpu"]
-    arg_dict["x_shape"] = [(10, 3, 10, 10), (10, 3, 11, 11)]
+    arg_dict["x_shape"] = [(10, 3, 10, 10)]
     arg_dict["filters"] = [64]
     arg_dict["kernel_size"] = [3, 2]
     arg_dict["groups"] = [1]
@@ -178,7 +178,7 @@ def test_padding_valid(test_case):
 def test_padding_same(test_case):
     arg_dict = OrderedDict()
     arg_dict["device_type"] = ["gpu"]
-    arg_dict["x_shape"] = [(10, 3, 10, 10), (10, 3, 11, 11)]
+    arg_dict["x_shape"] = [(10, 3, 11, 11)]
     arg_dict["filters"] = [64]
     arg_dict["kernel_size"] = [3, 2]
     arg_dict["groups"] = [1]
@@ -193,7 +193,7 @@ def test_padding_same(test_case):
 def test_pad_list1(test_case):
     arg_dict = OrderedDict()
     arg_dict["device_type"] = ["gpu"]
-    arg_dict["x_shape"] = [(10, 3, 10, 10), (10, 3, 11, 11)]
+    arg_dict["x_shape"] = [(10, 3, 10, 10)]
     arg_dict["filters"] = [64]
     arg_dict["kernel_size"] = [3, 2]
     arg_dict["groups"] = [1]
@@ -208,7 +208,7 @@ def test_pad_list1(test_case):
 def test_pad_list2(test_case):
     arg_dict = OrderedDict()
     arg_dict["device_type"] = ["gpu"]
-    arg_dict["x_shape"] = [(10, 3, 10, 10), (10, 3, 11, 11)]
+    arg_dict["x_shape"] = [(10, 3, 11, 11)]
     arg_dict["filters"] = [64]
     arg_dict["kernel_size"] = [3, 2]
     arg_dict["groups"] = [1]
@@ -223,7 +223,7 @@ def test_pad_list2(test_case):
 def test_pad_list3(test_case):
     arg_dict = OrderedDict()
     arg_dict["device_type"] = ["gpu"]
-    arg_dict["x_shape"] = [(10, 3, 10, 10), (10, 3, 11, 11)]
+    arg_dict["x_shape"] = [(10, 3, 10, 10)]
     arg_dict["filters"] = [64]
     arg_dict["kernel_size"] = [3, 2]
     arg_dict["groups"] = [1]
@@ -238,7 +238,7 @@ def test_pad_list3(test_case):
 def test_pad_list4(test_case):
     arg_dict = OrderedDict()
     arg_dict["device_type"] = ["gpu"]
-    arg_dict["x_shape"] = [(10, 3, 10, 10), (10, 3, 11, 11)]
+    arg_dict["x_shape"] = [(10, 3, 11, 11)]
     arg_dict["filters"] = [64]
     arg_dict["kernel_size"] = [3, 2]
     arg_dict["groups"] = [1]

--- a/oneflow/python/test/ops/test_pool.py
+++ b/oneflow/python/test/ops/test_pool.py
@@ -29,20 +29,6 @@ for gpu in gpus:
 
 pool_confs = [
     {
-        "x_shape": (1, 1, 6, 6),
-        "ksize": 1,
-        "strides": 1,
-        "padding": "VALID",
-        "data_format": "NCHW",
-    },
-    {
-        "x_shape": (1, 3, 7, 7),
-        "ksize": 3,
-        "strides": 2,
-        "padding": "SAME",
-        "data_format": "NCHW",
-    },
-    {
         "x_shape": (1, 7, 7, 3),
         "ksize": 3,
         "strides": 2,
@@ -69,27 +55,6 @@ pool_confs = [
         "strides": 1,
         "padding": "VALID",
         "data_format": "NCHW",
-    },
-    {
-        "x_shape": (1, 1, 9, 9),
-        "ksize": 2,
-        "strides": 2,
-        "padding": "VALID",
-        "data_format": "NCHW",
-    },
-    {
-        "x_shape": (1, 9, 9, 1),
-        "ksize": 2,
-        "strides": 2,
-        "padding": "VALID",
-        "data_format": "NHWC",
-    },
-    {
-        "x_shape": (1, 1, 9, 9, 9),
-        "ksize": 2,
-        "strides": 2,
-        "padding": "VALID",
-        "data_format": "NCDHW",
     },
     {
         "x_shape": (1, 7, 5, 5, 5),

--- a/oneflow/python/test/ops/test_pool_padding.py
+++ b/oneflow/python/test/ops/test_pool_padding.py
@@ -29,32 +29,11 @@ for gpu in gpus:
 
 pool_confs = [
     {
-        "x_shape": (1, 1, 10, 10),
-        "ksize": 2,
-        "strides": 1,
-        "padding": "SAME",
-        "data_format": "NCHW",
-    },
-    {
-        "x_shape": (1, 3, 7, 7),
-        "ksize": 3,
-        "strides": 2,
-        "padding": "SAME",
-        "data_format": "NCHW",
-    },
-    {
         "x_shape": (1, 7, 7, 3),
         "ksize": 3,
         "strides": 2,
         "padding": "SAME",
         "data_format": "NHWC",
-    },
-    {
-        "x_shape": (1, 5, 6, 6),
-        "ksize": 3,
-        "strides": 2,
-        "padding": "SAME",
-        "data_format": "NCHW",
     },
     {
         "x_shape": (1, 7, 5, 5),
@@ -78,13 +57,6 @@ pool_confs = [
         "data_format": "NCHW",
     },
     {
-        "x_shape": (1, 10, 10, 1),
-        "ksize": 3,
-        "strides": 2,
-        "padding": "SAME",
-        "data_format": "NHWC",
-    },
-    {
         "x_shape": (1, 1, 10, 10, 10),
         "ksize": 2,
         "strides": 2,
@@ -104,13 +76,6 @@ pool_confs = [
         "strides": 2,
         "padding": "VALID",
         "data_format": "NDHWC",
-    },
-    {
-        "x_shape": (1, 3, 3, 3, 3),
-        "ksize": 2,
-        "strides": 1,
-        "padding": "SAME",
-        "data_format": "NCDHW",
     },
 ]
 


### PR DESCRIPTION
### 优化测试用例，减少测试时间
> 14号机器上进行单个测试，得出优化前后的时间
- test_boxing_v2.py：从635.978s到298.713s
- test_broadcast_logical_ops.py：从 635.978s到312.483s
- test_nn_conv2d_padding_dynamic.py：14号有人在使用导致OOM
- test_pool.py：从180.752s到94.723s
- test_pool_padding.py：从177.403s到104.746s