### PR TITLE
[Bug fix] Release global variables

### DIFF
--- a/oneflow/python/oneflow_internal_helper.h
+++ b/oneflow/python/oneflow_internal_helper.h
@@ -106,6 +106,7 @@ Maybe<void> DestroyEnv() {
   if (Global<EnvGlobalObjectsScope>::Get() == nullptr) { return Maybe<void>::Ok(); }
   CHECK_OR_RETURN(Global<MachineCtx>::Get()->IsThisMachineMaster());
   ClusterInstruction::MasterSendHalt();
+  Global<EnvGlobalObjectsScope>::Delete();
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
解决老版本CtrlServer在python端不会挂的问题，部分Global对象没有被释放。