### PR TITLE
Comment release global for now to avoid random crash in python

### DIFF
--- a/oneflow/python/oneflow_internal_helper.h
+++ b/oneflow/python/oneflow_internal_helper.h
@@ -106,7 +106,7 @@ Maybe<void> DestroyEnv() {
   if (Global<EnvGlobalObjectsScope>::Get() == nullptr) { return Maybe<void>::Ok(); }
   CHECK_OR_RETURN(Global<MachineCtx>::Get()->IsThisMachineMaster());
   ClusterInstruction::MasterSendHalt();
-  Global<EnvGlobalObjectsScope>::Delete();
+  // Global<EnvGlobalObjectsScope>::Delete();
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
之前解决的全局变量没有完全释放的问题，会经常出现奇怪的错误，处于系统可靠性考虑先把释放操作注释掉，等梳理好生命周期后再添加。 #3628 