### PR TITLE
Add CudnnConvAlgoCache

### DIFF
--- a/oneflow/core/device/cudnn_conv_util.h
+++ b/oneflow/core/device/cudnn_conv_util.h
@@ -198,6 +198,32 @@ struct hash<oneflow::CudnnConvParams> final {
 
 }  // namespace std
 
+namespace oneflow {
+
+class CudnnConvAlgoCache final {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudnnConvAlgoCache);
+  CudnnConvAlgoCache() = default;
+  ~CudnnConvAlgoCache() = default;
+
+  template<typename perf_t>
+  using Store = HashMap<CudnnConvParams, std::vector<std::pair<size_t, perf_t>>>;
+
+  template<typename perf_t>
+  perf_t Remember(const CudnnConvParams& params,
+                  const std::function<perf_t(const CudnnConvParams& param)>& InferFn);
+
+ private:
+  Store<cudnnConvolutionFwdAlgoPerf_t> fwd_algo_store_;
+  std::mutex fwd_algo_store_mutex_;
+  Store<cudnnConvolutionBwdDataAlgoPerf_t> bwd_data_algo_store_;
+  std::mutex bwd_data_algo_store_mutex_;
+  Store<cudnnConvolutionBwdFilterAlgoPerf_t> bwd_filter_algo_store_;
+  std::mutex bwd_filter_algo_cache_mutex_;
+};
+
+}  // namespace oneflow
+
 #endif  // WITH_CUDA
 
 #endif  // ONEFLOW_CORE_DEVICE_CUDNN_CONV_UTIL_H_

--- a/oneflow/core/device/cudnn_conv_util.h
+++ b/oneflow/core/device/cudnn_conv_util.h
@@ -207,7 +207,9 @@ class CudnnConvAlgoCache final {
   ~CudnnConvAlgoCache() = default;
 
   template<typename perf_t>
-  using Store = HashMap<CudnnConvParams, std::vector<std::pair<size_t, perf_t>>>;
+  using WorkspaceSizeAndPerfT = std::pair<size_t, perf_t>;
+  template<typename perf_t>
+  using Store = HashMap<CudnnConvParams, std::list<WorkspaceSizeAndPerfT<perf_t>>>;
 
   template<typename perf_t>
   perf_t Remember(const CudnnConvParams& params,

--- a/oneflow/core/job/env_global_objects_scope.cpp
+++ b/oneflow/core/job/env_global_objects_scope.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include "oneflow/core/vm/virtual_machine_scope.h"
 #include "oneflow/core/job/job_build_and_infer_ctx_mgr.h"
 #include "oneflow/core/job/eager_nccl_comm_manager.h"
+#include "oneflow/core/device/cudnn_conv_util.h"
 
 namespace oneflow {
 
@@ -91,12 +92,14 @@ Maybe<void> EnvGlobalObjectsScope::Init(const EnvProto& env_proto) {
   Global<EagerJobBuildAndInferCtxMgr>::New();
 #ifdef WITH_CUDA
   Global<EagerNcclCommMgr>::New();
+  Global<CudnnConvAlgoCache>::New();
 #endif
   return Maybe<void>::Ok();
 }
 
 EnvGlobalObjectsScope::~EnvGlobalObjectsScope() {
 #ifdef WITH_CUDA
+  Global<CudnnConvAlgoCache>::Delete();
   Global<EagerNcclCommMgr>::Delete();
 #endif
   Global<EagerJobBuildAndInferCtxMgr>::Delete();


### PR DESCRIPTION
目前cuDNN conv 算法缓存存在一下两个问题

1. 使用 ThreadLocalCachedCall 作为缓存，多卡之间以及编译期和运行时之间的算法推导不能有效利用缓存
2. 当使用试跑推导算法是，在运行时推导算法可能会受到其他stream(比如 nccl 或者 decode)的影响，从而推导出错误的算法

额外加上一层全局缓存，可以一定程度上缓解 1 和 2 的影响(多机情况下2仍不能避免)。

因为编译期推导算法时使用的workspace size是cudnn buffer size，运行时用的是编译期推导出来的 workspace size，所以缓存的key抹掉了workspace size 信息，并且依据 " 更大的workspace size 推导出来的最优算法适用于更小的 workspace " 检索缓存。

TODO：
多机情况下问题 2 的解决，这里一个备选方案是在runtime启动时遍历plan并“预热” CudnnConvAlgoCache，或者大家讨论有没有更好的解决办法。