### PR TITLE
support reflecting cfg message

### DIFF
--- a/cmake/cfg.cmake
+++ b/cmake/cfg.cmake
@@ -15,6 +15,7 @@ include_directories(${CFG_INCLUDE_DIR})
 
 function(GENERATE_CFG_AND_PYBIND11_CPP SRCS HDRS PYBIND_SRCS ROOT_DIR)
   list(APPEND ALL_CFG_CONVERT_PROTO
+      oneflow/core/common/cfg_reflection_test.proto
       oneflow/core/common/data_type.proto
       oneflow/core/common/device_type.proto
   )

--- a/oneflow/core/common/cfg_reflection_test.cpp
+++ b/oneflow/core/common/cfg_reflection_test.cpp
@@ -1,0 +1,255 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/common/cfg_reflection_test.cfg.h"
+#include "oneflow/core/common/cfg_reflection_test.pb.h"
+#include "oneflow/core/common/util.h"
+#include "oneflow/core/common/protobuf.h"
+
+namespace oneflow {
+namespace test {
+
+TEST(CfgReflection, HasField_required_not_set) {
+  {
+    ReflectionTestFoo foo;
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "required_int32"),
+              cfg_foo.HasField4FieldName("required_int32"));
+  }
+  {
+    ReflectionTestBar bar;
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "required_foo"), cfg_bar.HasField4FieldName("required_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_required_set) {
+  {
+    ReflectionTestFoo foo;
+    foo.set_required_int32(0);
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "required_int32"),
+              cfg_foo.HasField4FieldName("required_int32"));
+  }
+  {
+    ReflectionTestBar bar;
+    bar.mutable_required_foo();
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "required_foo"), cfg_bar.HasField4FieldName("required_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_optional_not_set) {
+  {
+    ReflectionTestFoo foo;
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "optional_string"),
+              cfg_foo.HasField4FieldName("optional_string"));
+  }
+  {
+    ReflectionTestBar bar;
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "optional_foo"), cfg_bar.HasField4FieldName("optional_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_optional_set) {
+  {
+    ReflectionTestFoo foo;
+    foo.set_optional_string("");
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "optional_string"),
+              cfg_foo.HasField4FieldName("optional_string"));
+  }
+  {
+    ReflectionTestBar bar;
+    bar.mutable_optional_foo();
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "optional_foo"), cfg_bar.HasField4FieldName("optional_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_repeated_not_set) {
+  {
+    ReflectionTestFoo foo;
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "repeated_int32"),
+              cfg_foo.HasField4FieldName("repeated_int32"));
+  }
+  {
+    ReflectionTestBar bar;
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "repeated_foo"), cfg_bar.HasField4FieldName("repeated_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_repeated_set) {
+  {
+    ReflectionTestFoo foo;
+    foo.add_repeated_int32(0);
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "repeated_int32"),
+              cfg_foo.HasField4FieldName("repeated_int32"));
+  }
+  {
+    ReflectionTestBar bar;
+    bar.add_repeated_foo();
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "repeated_foo"), cfg_bar.HasField4FieldName("repeated_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_map_not_set) {
+  {
+    ReflectionTestFoo foo;
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "map_int32"), cfg_foo.HasField4FieldName("map_int32"));
+  }
+  {
+    ReflectionTestBar bar;
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "map_foo"), cfg_bar.HasField4FieldName("map_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_map_set) {
+  {
+    ReflectionTestFoo foo;
+    (*foo.mutable_map_int32())[0] = 0;
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "map_int32"), cfg_foo.HasField4FieldName("map_int32"));
+  }
+  {
+    ReflectionTestBar bar;
+    (*bar.mutable_map_foo())[0] = ReflectionTestFoo();
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "map_foo"), cfg_bar.HasField4FieldName("map_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_oneof_not_set) {
+  {
+    ReflectionTestFoo foo;
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "oneof_int32"), cfg_foo.HasField4FieldName("oneof_int32"));
+  }
+  {
+    ReflectionTestBar bar;
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "oneof_foo"), cfg_bar.HasField4FieldName("oneof_foo"));
+  }
+}
+
+TEST(CfgReflection, HasField_oneof_set) {
+  {
+    ReflectionTestFoo foo;
+    foo.set_oneof_int32(0);
+    cfg::ReflectionTestFoo cfg_foo(foo);
+    ASSERT_EQ(HasFieldInPbMessage(foo, "oneof_int32"), cfg_foo.HasField4FieldName("oneof_int32"));
+  }
+  {
+    ReflectionTestBar bar;
+    bar.mutable_oneof_foo();
+    cfg::ReflectionTestBar cfg_bar(bar);
+    ASSERT_EQ(HasFieldInPbMessage(bar, "oneof_foo"), cfg_bar.HasField4FieldName("oneof_foo"));
+  }
+}
+
+TEST(CfgReflection, FieldPtr) {
+  {
+    cfg::ReflectionTestFoo cfg_foo;
+    cfg_foo.set_required_int32(0);
+    ASSERT_EQ(&cfg_foo.required_int32(), cfg_foo.FieldPtr4FieldName<int32_t>("required_int32"));
+    cfg_foo.set_optional_string("");
+    ASSERT_EQ(&cfg_foo.optional_string(),
+              cfg_foo.FieldPtr4FieldName<std::string>("optional_string"));
+    cfg_foo.add_repeated_int32(0);
+    using RepeatedField = cfg::_RepeatedField_<int32_t>;
+    ASSERT_EQ(dynamic_cast<const RepeatedField*>(&cfg_foo.repeated_int32()),
+              cfg_foo.FieldPtr4FieldName<RepeatedField>("repeated_int32"));
+    (*cfg_foo.mutable_map_int32())[0] = 0;
+    using MapField = cfg::_MapField_<int32_t, int32_t>;
+    ASSERT_EQ(dynamic_cast<const MapField*>(&cfg_foo.map_int32()),
+              cfg_foo.FieldPtr4FieldName<MapField>("map_int32"));
+    cfg_foo.set_oneof_int32(0);
+    ASSERT_EQ(&cfg_foo.oneof_int32(), cfg_foo.FieldPtr4FieldName<int32_t>("oneof_int32"));
+  }
+  {
+    cfg::ReflectionTestBar cfg_bar;
+    cfg_bar.mutable_required_foo();
+    ASSERT_EQ(&cfg_bar.required_foo(),
+              cfg_bar.FieldPtr4FieldName<cfg::ReflectionTestFoo>("required_foo"));
+    cfg_bar.mutable_optional_foo();
+    ASSERT_EQ(&cfg_bar.optional_foo(),
+              cfg_bar.FieldPtr4FieldName<cfg::ReflectionTestFoo>("optional_foo"));
+    cfg_bar.add_repeated_foo();
+    using RepeatedField = cfg::_RepeatedField_<cfg::ReflectionTestFoo>;
+    ASSERT_EQ(dynamic_cast<const RepeatedField*>(&cfg_bar.repeated_foo()),
+              cfg_bar.FieldPtr4FieldName<RepeatedField>("repeated_foo"));
+    (*cfg_bar.mutable_map_foo())[0] = cfg::ReflectionTestFoo();
+    using MapField = cfg::_MapField_<int32_t, cfg::ReflectionTestFoo>;
+    ASSERT_EQ(dynamic_cast<const MapField*>(&cfg_bar.map_foo()),
+              cfg_bar.FieldPtr4FieldName<MapField>("map_foo"));
+    cfg_bar.mutable_oneof_foo();
+    ASSERT_EQ(&cfg_bar.oneof_foo(),
+              cfg_bar.FieldPtr4FieldName<cfg::ReflectionTestFoo>("oneof_foo"));
+  }
+}
+
+TEST(CfgReflection, MutableFieldPtr) {
+  {
+    cfg::ReflectionTestFoo cfg_foo;
+    cfg_foo.set_required_int32(0);
+    ASSERT_EQ(cfg_foo.mutable_required_int32(),
+              cfg_foo.MutableFieldPtr4FieldName<int32_t>("required_int32"));
+    cfg_foo.set_optional_string("");
+    ASSERT_EQ(cfg_foo.mutable_optional_string(),
+              cfg_foo.MutableFieldPtr4FieldName<std::string>("optional_string"));
+    cfg_foo.add_repeated_int32(0);
+    using RepeatedField = cfg::_RepeatedField_<int32_t>;
+    ASSERT_EQ(dynamic_cast<RepeatedField*>(cfg_foo.mutable_repeated_int32()),
+              cfg_foo.MutableFieldPtr4FieldName<RepeatedField>("repeated_int32"));
+    (*cfg_foo.mutable_map_int32())[0] = 0;
+    using MapField = cfg::_MapField_<int32_t, int32_t>;
+    ASSERT_EQ(dynamic_cast<MapField*>(cfg_foo.mutable_map_int32()),
+              cfg_foo.MutableFieldPtr4FieldName<MapField>("map_int32"));
+    cfg_foo.set_oneof_int32(0);
+    ASSERT_EQ(cfg_foo.mutable_oneof_int32(),
+              cfg_foo.MutableFieldPtr4FieldName<int32_t>("oneof_int32"));
+  }
+  {
+    cfg::ReflectionTestBar cfg_bar;
+    cfg_bar.mutable_required_foo();
+    ASSERT_EQ(cfg_bar.mutable_required_foo(),
+              cfg_bar.MutableFieldPtr4FieldName<cfg::ReflectionTestFoo>("required_foo"));
+    cfg_bar.mutable_optional_foo();
+    ASSERT_EQ(cfg_bar.mutable_optional_foo(),
+              cfg_bar.MutableFieldPtr4FieldName<cfg::ReflectionTestFoo>("optional_foo"));
+    cfg_bar.add_repeated_foo();
+    using RepeatedField = cfg::_RepeatedField_<cfg::ReflectionTestFoo>;
+    ASSERT_EQ(dynamic_cast<RepeatedField*>(cfg_bar.mutable_repeated_foo()),
+              cfg_bar.MutableFieldPtr4FieldName<RepeatedField>("repeated_foo"));
+    (*cfg_bar.mutable_map_foo())[0] = cfg::ReflectionTestFoo();
+    using MapField = cfg::_MapField_<int32_t, cfg::ReflectionTestFoo>;
+    ASSERT_EQ(dynamic_cast<MapField*>(cfg_bar.mutable_map_foo()),
+              cfg_bar.MutableFieldPtr4FieldName<MapField>("map_foo"));
+    cfg_bar.mutable_oneof_foo();
+    ASSERT_EQ(cfg_bar.mutable_oneof_foo(),
+              cfg_bar.MutableFieldPtr4FieldName<cfg::ReflectionTestFoo>("oneof_foo"));
+  }
+}
+
+}  // namespace test
+}  // namespace oneflow

--- a/oneflow/core/common/cfg_reflection_test.proto
+++ b/oneflow/core/common/cfg_reflection_test.proto
@@ -10,6 +10,7 @@ message ReflectionTestFoo {
   map<int32, int32> map_int32 = 4;
   oneof type {
     int32 oneof_int32 = 5;
+    int32 another_oneof_int32 = 6;
   }
 }
 
@@ -21,5 +22,6 @@ message ReflectionTestBar {
   map<int32, ReflectionTestFoo> map_foo = 4;
   oneof type {
     ReflectionTestFoo oneof_foo = 5;
+    ReflectionTestFoo another_oneof_foo = 6;
   }
 }

--- a/oneflow/core/common/cfg_reflection_test.proto
+++ b/oneflow/core/common/cfg_reflection_test.proto
@@ -1,0 +1,25 @@
+syntax = "proto2";
+
+package oneflow;
+
+message ReflectionTestFoo {
+  required int32 required_int32 = 1;
+  optional string optional_string = 2 [default = "undefined"];
+
+  repeated int32 repeated_int32 = 3;
+  map<int32, int32> map_int32 = 4;
+  oneof type {
+    int32 oneof_int32 = 5;
+  }
+}
+
+message ReflectionTestBar {
+  required ReflectionTestFoo required_foo = 1;
+  optional ReflectionTestFoo optional_foo = 2;
+
+  repeated ReflectionTestFoo repeated_foo = 3;
+  map<int32, ReflectionTestFoo> map_foo = 4;
+  oneof type {
+    ReflectionTestFoo oneof_foo = 5;
+  }
+}

--- a/oneflow/core/common/protobuf.cpp
+++ b/oneflow/core/common/protobuf.cpp
@@ -74,12 +74,6 @@ bool HasFieldInPbMessage(const PbMessage& msg, const std::string& field_name) {
   return fd != nullptr;
 }
 
-const PbFd* GetPbFdFromPbMessage(const PbMessage& msg, const std::string& field_name) {
-  PROTOBUF_GET_FIELDDESC(msg, field_name);
-  CHECK_NOTNULL(fd);
-  return fd;
-}
-
 #define DEFINE_GET_VAL_FROM_PBMESSAGE(cpp_type, pb_type_name)                                   \
   template<>                                                                                    \
   cpp_type GetValFromPbMessage<cpp_type>(const PbMessage& msg, const std::string& field_name) { \
@@ -89,11 +83,6 @@ const PbFd* GetPbFdFromPbMessage(const PbMessage& msg, const std::string& field_
 
 OF_PP_FOR_EACH_TUPLE(DEFINE_GET_VAL_FROM_PBMESSAGE,
                      PROTOBUF_BASIC_DATA_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(const PbMessage&, Message))
-
-int32_t GetEnumFromPbMessage(const PbMessage& msg, const std::string& field_name) {
-  PROTOBUF_REFLECTION(msg, field_name);
-  return r->GetEnumValue(msg, fd);
-}
 
 #define DEFINE_SET_VAL_IN_PBMESSAGE(cpp_type, pb_type_name)                                    \
   template<>                                                                                   \

--- a/oneflow/core/common/protobuf.h
+++ b/oneflow/core/common/protobuf.h
@@ -76,13 +76,8 @@ bool TxtString2PbMessage(const std::string& proto_str, PbMessage* proto);
 bool HasFieldInPbMessage(const PbMessage&, const std::string& field_name);
 
 // Get From PbMessage
-
-const PbFd* GetPbFdFromPbMessage(const PbMessage&, const std::string& field_name);
-
 template<typename T>
 T GetValFromPbMessage(const PbMessage&, const std::string& field_name);
-
-int32_t GetEnumFromPbMessage(const PbMessage&, const std::string& field_name);
 
 template<typename T>
 const PbRf<T>& GetPbRfFromPbMessage(const PbMessage& msg, const std::string& field_name) {

--- a/oneflow/core/kernel/kernel.h
+++ b/oneflow/core/kernel/kernel.h
@@ -131,25 +131,6 @@ class Kernel {
   void CheckSameDim0ValidNum(const PbRpf<std::string>& bns,
                              const std::function<Blob*(const std::string&)>& BnInOp2Blob) const;
 
-#define DEFINE_GET_VAL_FROM_CUSTOMIZED_CONF(conf_type)                                   \
-  template<typename T>                                                                   \
-  T GetValFromCustomized##conf_type(const std::string& field_name) const {               \
-    const PbMessage& customized_conf = GetCustomized##conf_type();                       \
-    return GetValFromPbMessage<T>(customized_conf, field_name);                          \
-  }                                                                                      \
-  template<typename T>                                                                   \
-  const PbRf<T>& GetPbRfFromCustomized##conf_type(const std::string& field_name) const { \
-    return GetPbRfFromPbMessage<T>(GetCustomized##conf_type(), field_name);              \
-  }                                                                                      \
-  int32_t GetEnumFromCustomized##conf_type(const std::string& field_name) const {        \
-    return GetEnumFromPbMessage(GetCustomized##conf_type(), field_name);                 \
-  }
-
-  DEFINE_GET_VAL_FROM_CUSTOMIZED_CONF(OpConf);
-  DEFINE_GET_VAL_FROM_CUSTOMIZED_CONF(KernelConf);
-
-#undef DEFINE_GET_VAL_FROM_CUSTOMIZED_CONF
-
  private:
   const JobDesc* job_desc_;
   RuntimeBlobShapeInferHelper* shape_infer_helper_;

--- a/oneflow/user/kernels/image_preprocess_kernels.cu
+++ b/oneflow/user/kernels/image_preprocess_kernels.cu
@@ -105,7 +105,7 @@ __global__ void CropMirrorNormalizeGpuImpl(int32_t elem_cnt, const uint8_t* in_d
     float mean_val;
     float inv_std_val;
     const int32_t c = in_idx[3];
-    // When the compiler can’t resolve array indices to constants it will put private arrays into
+    // When the compiler can't resolve array indices to constants it will put private arrays into
     // GPU local memory. Using local memory is slower than keeping array elements directly in
     // registers.
     if (c == 0) {

--- a/tools/cfg/include/oneflow/cfg/message.h
+++ b/tools/cfg/include/oneflow/cfg/message.h
@@ -13,6 +13,24 @@ class Message {
   Message() = default;
   virtual ~Message() = default;
 
+  // Returns nullptr if field not exists or T is field type.
+  template<typename T>
+  const T* FieldPtr4FieldName(const std::string& field_name) const {
+    return FieldPtr4FieldNumber<T>(FieldNumber4FieldName(field_name));
+  }
+
+  // Returns nullptr if field not exists or T is field type.
+  template<typename T>
+  T* MutableFieldPtr4FieldName(const std::string& field_name) {
+    return MutableFieldPtr4FieldNumber<T>(FieldNumber4FieldName(field_name));
+  }
+
+  // Returns true if field_name defined.
+  // This is nothing related to has_xxx().
+  bool HasField4FieldName(const std::string& field_name) const {
+    return HasField4FieldNumber(FieldNumber4FieldName(field_name));
+  }
+
   template<typename T>
   const T* FieldPtr4FieldNumber(int field_number) const {
     const auto& type_index = TypeIndex4FieldNumber(field_number);
@@ -24,11 +42,6 @@ class Message {
   }
 
   template<typename T>
-  const T* FieldPtr4FieldName(const std::string& field_name) const {
-    return FieldPtr4FieldNumber<T>(FieldNumber4FieldName(field_name));
-  }
-
-  template<typename T>
   T* MutableFieldPtr4FieldNumber(int field_number) {
     const auto& type_index = TypeIndex4FieldNumber(field_number);
     if (type_index != typeid(T)) { return nullptr; }
@@ -36,15 +49,6 @@ class Message {
     if (void_ptr == nullptr) { return nullptr; }
     T* __attribute__((__may_alias__)) ptr = reinterpret_cast<T*>(void_ptr);
     return ptr;
-  }
-
-  template<typename T>
-  T* MutableFieldPtr4FieldName(const std::string& field_name) {
-    return MutableFieldPtr4FieldNumber<T>(FieldNumber4FieldName(field_name));
-  }
-
-  bool HasField4FieldName(const std::string& field_name) const {
-    return HasField4FieldNumber(FieldNumber4FieldName(field_name));
   }
 
   virtual int FieldNumber4FieldName(const std::string& field_name) const = 0;

--- a/tools/cfg/include/oneflow/cfg/message.h
+++ b/tools/cfg/include/oneflow/cfg/message.h
@@ -1,0 +1,62 @@
+#ifndef ONEFLOW_CFG_CFG_MESSAGE_H_
+#define ONEFLOW_CFG_CFG_MESSAGE_H_
+
+#include <typeinfo>
+#include <typeindex>
+
+namespace oneflow {
+namespace cfg {
+
+
+class Message {
+ public:
+  Message() = default;
+  virtual ~Message() = default;
+
+  template<typename T>
+  const T* FieldPtr4FieldNumber(int field_number) const {
+    const auto& type_index = TypeIndex4FieldNumber(field_number);
+    if (type_index != typeid(T)) { return nullptr; }
+    const void* void_ptr = FieldPtr4FieldNumber(field_number);
+    if (void_ptr == nullptr) { return nullptr; }
+    const T* __attribute__((__may_alias__)) ptr = reinterpret_cast<const T*>(void_ptr);
+    return ptr;
+  }
+
+  template<typename T>
+  const T* FieldPtr4FieldName(const std::string& field_name) const {
+    return FieldPtr4FieldNumber<T>(FieldNumber4FieldName(field_name));
+  }
+
+  template<typename T>
+  T* MutableFieldPtr4FieldNumber(int field_number) {
+    const auto& type_index = TypeIndex4FieldNumber(field_number);
+    if (type_index != typeid(T)) { return nullptr; }
+    void* void_ptr = MutableFieldPtr4FieldNumber(field_number);
+    if (void_ptr == nullptr) { return nullptr; }
+    T* __attribute__((__may_alias__)) ptr = reinterpret_cast<T*>(void_ptr);
+    return ptr;
+  }
+
+  template<typename T>
+  T* MutableFieldPtr4FieldName(const std::string& field_name) {
+    return MutableFieldPtr4FieldNumber<T>(FieldNumber4FieldName(field_name));
+  }
+
+  bool HasField4FieldName(const std::string& field_name) const {
+    return HasField4FieldNumber(FieldNumber4FieldName(field_name));
+  }
+
+  virtual int FieldNumber4FieldName(const std::string& field_name) const = 0;
+  virtual bool HasField4FieldNumber(int field_number) const = 0; 
+  virtual const std::type_index& TypeIndex4FieldNumber(int field_number) const = 0;
+  virtual const void* FieldPtr4FieldNumber(int field_number) const = 0;
+  virtual void* MutableFieldPtr4FieldNumber(int field_number) { return nullptr; }
+
+  struct UndefinedField {};
+};
+
+}
+}
+
+#endif  // ONEFLOW_CFG_CFG_MESSAGE_H_

--- a/tools/cfg/util/proto_reflect_util.py
+++ b/tools/cfg/util/proto_reflect_util.py
@@ -94,7 +94,7 @@ class ProtoReflectionUtil:
     def oneof_type_field_enum_value_name(self, field):
         return "k" + self._underline_name_to_camel(field.name)
 
-    def oneof_type_field_enum_value_number(self, field):
+    def field_number(self, field):
         return field.number
 
     def field_oneof_name(self, field):

--- a/tools/cfg/util/proto_reflect_util.py
+++ b/tools/cfg/util/proto_reflect_util.py
@@ -173,10 +173,16 @@ class ProtoReflectionUtil:
         return field.message_type.fields_by_name["value"]
 
     def field_map_pair_type_name(self, field):
-        return f"{self.field_map_key_type_name(field)}, {self.field_map_value_type_name(field)}"
+        return "%s, %s" % (
+            self.field_map_key_type_name(field),
+            self.field_map_value_type_name(field),
+        )
 
     def field_map_pair_type_name_with_cfg_namespace(self, field):
-        return f"{self.field_map_key_type_name(field)}, {self.field_map_value_type_name_with_cfg_namespace(field)}"
+        return "%s, %s" % (
+            self.field_map_key_type_name(field),
+            self.field_map_value_type_name_with_cfg_namespace(field),
+        )
 
     def field_is_message_type(self, field):
         return field.message_type is not None
@@ -209,7 +215,10 @@ class ProtoReflectionUtil:
         return _ToValidVarName("_%s_RepeatedField_%s_" % (module_prefix, type_name))
 
     def field_map_pair_type_name_with_underline(self, field):
-        return f"{self.field_map_key_type_name(field)}_{self.field_map_value_type_name(field)}"
+        return "%s_%s" % (
+            self.field_map_key_type_name(field),
+            self.field_map_value_type_name(field),
+        )
 
     def field_map_container_name(self, field):
         module_prefix = self.module_header_macro_lock(field.containing_type.file)


### PR DESCRIPTION
原本没必要给cfg添加反射功能，我们最终也不怎么会用到它们。但是，system op部分大量用到反射，而且它们在近期并不能被迁移成user op。cfg的反射功能基本对齐protobuf的，使得我们能不落下节奏地重构代码，而不需要依赖system op的迁移。
