### PR TITLE
Add AmpWhiteIdentityOp

### DIFF
--- a/oneflow/core/job_rewriter/auto_mixed_precision.cpp
+++ b/oneflow/core/job_rewriter/auto_mixed_precision.cpp
@@ -166,6 +166,9 @@ void InsertCastOpImpl(bool f2h, const OpGraph& op_graph, const HashSet<OpNode*>&
     const std::string& lbn = pair.first;
     OpNode* src_node = pair.second.front()->src_node();
 
+    const BlobDesc& blob_desc = src_node->LogicalBlobDesc4Lbi(GenLogicalBlobId(lbn));
+    if (blob_desc.data_type() != DataType::kFloat) { continue; }
+
     std::string cast_suffix = f2h ? "-cast_f2h" : "-cast_h2f";
     DataType cast_data_type = f2h ? DataType::kFloat16 : DataType::kFloat;
     auto cast_op = user_op::UserOpConfWrapperBuilder(ReplaceSlashToDash4Lbn(lbn) + cast_suffix)

--- a/oneflow/core/job_rewriter/auto_mixed_precision_lists.cpp
+++ b/oneflow/core/job_rewriter/auto_mixed_precision_lists.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 namespace oneflow {
 
 const AMPList& AutoMixedPrecisionLists::WhiteList() {
-  static AMPList white_list = {"matmul", "batch_matmul", "conv2d"};
+  static AMPList white_list = {"matmul", "batch_matmul", "conv2d", "amp_white_identity"};
   return white_list;
 }
 

--- a/oneflow/core/kernel/gather_kernel_util.cu
+++ b/oneflow/core/kernel/gather_kernel_util.cu
@@ -87,7 +87,6 @@ struct GatherKernelUtilImpl<DeviceType::kGPU, T, K> final {
   }
 };
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700 && CUDA_VERSION >= 10000
 template<typename K>
 struct GatherKernelUtilImpl<DeviceType::kGPU, float16, K> final {
   static void Forward(DeviceCtx* ctx, const K* indices, int64_t num_indices, const float16* in,
@@ -97,7 +96,6 @@ struct GatherKernelUtilImpl<DeviceType::kGPU, float16, K> final {
         reinterpret_cast<half*>(out), offset);
   }
 };
-#endif
 
 #define INITIATE_GATHER_KERNEL_UTIL_GPU_IMPL(in_type_pair, index_type_pair)              \
   template struct GatherKernelUtilImpl<DeviceType::kGPU, OF_PP_PAIR_FIRST(in_type_pair), \

--- a/oneflow/core/kernel/gather_kernel_util.h
+++ b/oneflow/core/kernel/gather_kernel_util.h
@@ -33,11 +33,7 @@ struct GatherKernelUtilImpl final {
                       const Shape& flat_in_shape, T* out, int64_t offset);
 };
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700 && CUDA_VERSION >= 10000
 #define GATHER_DATA_TYPE_SEQ ARITHMETIC_DATA_TYPE_SEQ FLOAT16_DATA_TYPE_SEQ
-#else
-#define GATHER_DATA_TYPE_SEQ ARITHMETIC_DATA_TYPE_SEQ
-#endif
 
 }  // namespace oneflow
 

--- a/oneflow/core/kernel/kernel_util.cu
+++ b/oneflow/core/kernel/kernel_util.cu
@@ -684,12 +684,14 @@ __device__ float gpu_atomic_add(float* address, float val) {
   return atomicAdd(address, val);
 }
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700 && CUDA_VERSION >= 10000
 template<>
 __device__ half gpu_atomic_add(half* address, half val) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700 && CUDA_VERSION >= 10000
   return atomicAdd(address, val);
-}
+#else
+  __trap();
 #endif
+}
 
 template<>
 __device__ double gpu_atomic_add(double* address, const double val) {

--- a/oneflow/core/kernel/unsorted_segment_sum_kernel_util.cu
+++ b/oneflow/core/kernel/unsorted_segment_sum_kernel_util.cu
@@ -85,7 +85,6 @@ struct UnsortedSegmentSumKernelUtil<DeviceType::kGPU, T, K> final {
   }
 };
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700 && CUDA_VERSION >= 10000
 template<typename K>
 struct UnsortedSegmentSumKernelUtil<DeviceType::kGPU, float16, K> final {
   static void UnsortedSegmentSum(DeviceCtx* ctx, const K* segment_ids, const float16* data,
@@ -97,7 +96,6 @@ struct UnsortedSegmentSumKernelUtil<DeviceType::kGPU, float16, K> final {
         outer_dim_size, inner_dim_size, segment_id_offset, reinterpret_cast<half*>(out));
   }
 };
-#endif
 
 #define INITIATE_UNSORTED_SEGMENT_SUM_KERNEL_UTIL_GPU(in_type_pair, index_type_pair)             \
   template struct UnsortedSegmentSumKernelUtil<DeviceType::kGPU, OF_PP_PAIR_FIRST(in_type_pair), \

--- a/oneflow/core/kernel/unsorted_segment_sum_kernel_util.h
+++ b/oneflow/core/kernel/unsorted_segment_sum_kernel_util.h
@@ -28,13 +28,8 @@ struct UnsortedSegmentSumKernelUtil final {
                                  int64_t segment_id_offset, T* out);
 };
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700 && CUDA_VERSION >= 10000
 #define UNSORTED_SEGMENT_SUM_DATA_TYPE_SEQ \
   FLOATING_DATA_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(int32_t, DataType::kInt32) FLOAT16_DATA_TYPE_SEQ
-#else
-#define UNSORTED_SEGMENT_SUM_DATA_TYPE_SEQ \
-  FLOATING_DATA_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(int32_t, DataType::kInt32)
-#endif
 
 }  // namespace oneflow
 

--- a/oneflow/python/ops/array_ops.py
+++ b/oneflow/python/ops/array_ops.py
@@ -928,3 +928,19 @@ def masked_fill(
         name = id_util.UniqueStr("MaskedFill_")
     value_like_x = flow.constant_like(like=x, value=value, name=name + "_ConstantLike")
     return flow.where(condition=mask, x=value_like_x, y=x, name=name + "_Where")
+
+
+@oneflow_export("amp_white_identity")
+def amp_white_identity(
+    x: remote_blob_util.BlobDef, name: Optional[str] = None
+) -> remote_blob_util.BlobDef:
+    if name is None:
+        name = id_util.UniqueStr("AmpWhiteIdentity_")
+    op = (
+        flow.user_op_builder(name)
+        .Op("amp_white_identity")
+        .Input("in", [x])
+        .Output("out")
+        .Build()
+    )
+    return op.InferAndTryRun().SoleOutputBlob()

--- a/oneflow/user/kernels/amp_white_identity_kernel.cpp
+++ b/oneflow/user/kernels/amp_white_identity_kernel.cpp
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/framework/framework.h"
+#include "oneflow/user/kernels/copy_data_content_kernel.h"
+
+namespace oneflow {
+
+#define REGISTER_AMP_WHITE_IDENTITY_KERNEL(device)                                              \
+  REGISTER_USER_KERNEL("amp_white_identity")                                                    \
+      .SetCreateFn<CopyDataContentKernel<device>>()                                             \
+      .SetIsMatchedHob(user_op::HobDeviceTag() == device)                                       \
+      .SetInplaceProposalFn([](const user_op::InferContext&,                                    \
+                               user_op::AddInplaceArgPair AddInplaceArgPairFn) -> Maybe<void> { \
+        OF_RETURN_IF_ERROR(AddInplaceArgPairFn("out", 0, "in", 0, false));                      \
+        return Maybe<void>::Ok();                                                               \
+      });
+
+REGISTER_AMP_WHITE_IDENTITY_KERNEL(DeviceType::kCPU)
+#ifdef WITH_CUDA
+REGISTER_AMP_WHITE_IDENTITY_KERNEL(DeviceType::kGPU)
+#endif
+
+}  // namespace oneflow

--- a/oneflow/user/ops/amp_white_identity_op.cpp
+++ b/oneflow/user/ops/amp_white_identity_op.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/framework/framework.h"
+
+namespace oneflow {
+
+namespace {
+
+REGISTER_USER_OP("amp_white_identity")
+    .Input("in")
+    .Output("out")
+    .SetTensorDescInferFn([](user_op::InferContext* ctx) {
+      const user_op::TensorDesc* in = ctx->TensorDesc4ArgNameAndIndex("in", 0);
+      user_op::TensorDesc* out = ctx->TensorDesc4ArgNameAndIndex("out", 0);
+      *out = *in;
+      return Maybe<void>::Ok();
+    })
+    .SetGetSbpFn([](user_op::SbpContext* ctx) {
+      const auto& in = ctx->LogicalTensorDesc4InputArgNameAndIndex("in", 0);
+      for (int i = 0; i < in.shape().NumAxes(); ++i) {
+        ctx->NewBuilder().Split(ctx->inputs(), i).Split(ctx->outputs(), i).Build();
+      }
+      ctx->NewBuilder().PartialSum(ctx->inputs()).PartialSum(ctx->outputs()).Build();
+      return Maybe<void>::Ok();
+    });
+
+REGISTER_USER_OP_GRAD("amp_white_identity")
+    .SetGenBackwardOpConfFn([](const user_op::UserOpWrapper& op, user_op::AddOpFn AddOp) {
+      if (op.NeedGenGradTensor4OpInput("in", 0)) {
+        user_op::UserOpConfWrapperBuilder builder(op.op_name() + "_grad");
+        user_op::UserOpConfWrapper grad_op =
+            builder.Op("amp_white_identity")
+                .Input("in", op.GetGradTensorWithOpOutput("out", 0))
+                .Output("out")
+                .Build();
+        op.BindGradTensorWithOpInput(grad_op.output("out", 0), "in", 0);
+        AddOp(grad_op);
+      }
+    });
+
+}  // namespace
+
+}  // namespace oneflow


### PR DESCRIPTION
根据目前的auto mixed precision机制，bert 网络中 embedding 的 gather 不会被 cast 成 fp16，而如果 gather 父节点是一个 while list 中的 op，gather 则可以 cast 为 fp16。bert embedding 的 gather 可以运行在 fp16，并且这种情况下性能会更好，提供一个临时的解决方案为引入一个amp_white_identity op，该 op 行为与 identity一致，但是在auto mixed precision的white list 中，用户可以通过其引入额外的white op。

* 添加amp_white_identity
* 修复Gather/UnsortedSegmentSum的kernel注册
* auto mixed precision仅为Float32的边插入cast

TODO: 能否从auto mixed precision机制角度解决这个问题