### PR TITLE
fix missing symbol when load so

### DIFF
--- a/cmake/oneflow.cmake
+++ b/cmake/oneflow.cmake
@@ -240,6 +240,7 @@ RELATIVE_SWIG_GENERATE_CPP(SWIG_SRCS SWIG_HDRS
                           ${of_all_rel_swigs})
 
 pybind11_add_module(oneflow_internal ${PYBIND11_SRCS} ${of_pybind_obj_cc} ${SWIG_SRCS} ${SWIG_HDRS} ${of_main_cc} ${PYBIND_REGISTRY_CC})
+set_property(TARGET oneflow_internal PROPERTY CXX_VISIBILITY_PRESET "default")
 add_dependencies(oneflow_internal of_cfgobj)
 set_target_properties(oneflow_internal PROPERTIES PREFIX "_")
 set_target_properties(oneflow_internal PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/python_scripts/oneflow")


### PR DESCRIPTION
创建user op编译成so文件，然后加载时出现如下错误：
```
Check failed: handle     LoadLibrary ERROR! Cannot load library file: final_relu.so the Error is: ./final_relu.so: undefined symbol: _ZN7oneflow7user_op17UserOpRegistryMgr3GetEv
```
使用ldd -r final_relu.so可以看到里面有很多undefine symbol，原因是这些symbol是oneflow_internal.so的local符号，通过如下命令看对应符号的类型`t`是小写的，表示是so外部不可见的符号。
```
$ nm _oneflow_internal.cpython-37m-x86_64-linux-gnu.so | grep _ZN7oneflow7user_op17UserOpRegistryMgr3GetEv
0000000004bc577e t _ZN7oneflow7user_op17UserOpRegistryMgr3GetEv 
```
原因是当前编译oneflow_internal.so使用的pybind11_add_module，默认把gcc的visibility改成了hidden，参考：https://pybind11.readthedocs.io/en/stable/compiling.html#pybind11-add-module

需要恢复visibility。恢复后符号表正常、已经可以正常加载SO。

这里break掉没有发现的原因是因为没有编译+加载so的测试用例，导致比较难定位到可能的问题。后面会和另外一个pr一起提交一个python compile util，用来编译user op。