### PR TITLE
import tensorflow in RunTensorFlowOp

### DIFF
--- a/oneflow/python/test/ops/test_util.py
+++ b/oneflow/python/test/ops/test_util.py
@@ -22,7 +22,6 @@ import numpy as np
 import oneflow as flow
 import oneflow.typing as oft
 
-import tensorflow as tf
 import test_global_storage
 
 
@@ -88,7 +87,8 @@ def RunOneflowOp(device_type, flow_op, x, flow_args):
 
 
 def RunTensorFlowOp(tf_op, x, tf_args):
-    # TensorFlow
+    import tensorflow as tf
+
     with tf.GradientTape(persistent=True) as tape:
         x = tf.Variable(x)
         y = tf_op(x, *tf_args)


### PR DESCRIPTION
`import tensorflow` 放到 RunTensorFlowOp 里面，方便不依赖 tf 的单元测试可以在无 tf 的环境下单独运行。