### PR TITLE
detect cxx11 abi availibility in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,13 +26,25 @@ endif()
 
 project(oneflow C CXX)
 
+set(oneflow_cmake_dir ${PROJECT_SOURCE_DIR}/cmake)
+
+# Modules
+list(APPEND CMAKE_MODULE_PATH ${oneflow_cmake_dir}/third_party)
+list(APPEND CMAKE_MODULE_PATH ${oneflow_cmake_dir})
+include(util)
+include(proto2cpp)
+include(swig)
+
 if (NOT DEFINED USE_CXX11_ABI)
-  if((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5))
-    set(USE_CXX11_ABI OFF)
-  else()
-    set(USE_CXX11_ABI ON)
+  check_cxx11_abi(CXX11_ABI_AVAILABLE)
+  set(USE_CXX11_ABI ${CXX11_ABI_AVAILABLE})
+elseif(USE_CXX11_ABI)
+  check_cxx11_abi(CXX11_ABI_AVAILABLE)
+  if (NOT CXX11_ABI_AVAILABLE)
+    message(FATAL_ERROR "cxx11 abi is not available for current compiler")
   endif()
 endif()
+message(STATUS "USE_CXX11_ABI: ${USE_CXX11_ABI}")
 
 if (WITH_XLA)
   add_definitions(-DWITH_XLA)
@@ -50,20 +62,11 @@ enable_testing()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(oneflow_cmake_dir ${PROJECT_SOURCE_DIR}/cmake)
-
 set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party"
   CACHE PATH "Where the third party headers and libs are put")
 
 set(THIRD_PARTY_SUBMODULE_DIR "${PROJECT_SOURCE_DIR}/build/third_party"
   CACHE PATH "Where the third party submodules are")
-
-# Modules
-list(APPEND CMAKE_MODULE_PATH ${oneflow_cmake_dir}/third_party)
-list(APPEND CMAKE_MODULE_PATH ${oneflow_cmake_dir})
-include(util)
-include(proto2cpp)
-include(swig)
 
 if(WIN32)
   set(CMAKE_BUILD_TYPE Debug)

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -107,9 +107,12 @@ endfunction()
 function(check_cxx11_abi OUTPUT_VAR)
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E echo "#include <string>\n void test(std::string){}\n int main(){}" OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/temp.cpp)
-  try_compile(_ ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/temp.cpp
+  try_compile(COMPILE_SUCCESS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/temp.cpp
     COMPILE_DEFINITIONS -D_GLIBCXX_USE_CXX11_ABI=1
     COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/temp)
+  if (NOT COMPILE_SUCCESS)
+    message(FATAL_ERROR "Detecting cxx11 availability failed. Please report to OneFlow developers.")
+  endif()
   execute_process(
     COMMAND nm ${CMAKE_CURRENT_BINARY_DIR}/temp
     COMMAND grep -q cxx11

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -103,3 +103,23 @@ function(use_mirror)
     endif()
   endif()
 endfunction()
+
+function(check_cxx11_abi OUTPUT_VAR)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E echo "#include <string>\n void test(std::string){}\n int main(){}" OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/temp.cpp)
+  try_compile(_ ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/temp.cpp
+    COMPILE_DEFINITIONS -D_GLIBCXX_USE_CXX11_ABI=1
+    COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/temp)
+  execute_process(
+    COMMAND nm ${CMAKE_CURRENT_BINARY_DIR}/temp
+    COMMAND grep -q cxx11
+    RESULT_VARIABLE RET_CODE)
+  if (RET_CODE EQUAL 0)
+    set(CXX11_ABI_AVAILABLE ON)
+  else()
+    set(CXX11_ABI_AVAILABLE OFF)
+  endif()
+  execute_process(
+    COMMAND rm ${CMAKE_CURRENT_BINARY_DIR}/temp ${CMAKE_CURRENT_BINARY_DIR}/temp.cpp)
+  set(${OUTPUT_VAR} ${CXX11_ABI_AVAILABLE} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
之前通过判断编译器版本来决定是不是使用 cxx11 abi 的方式并不可靠，例如 #3705 的原因就是在 centos 7 里，即使使用 gcc 7，也无法使用 cxx11 abi，https://stackoverflow.com/questions/47951367/d-glibcxx-use-cxx11-abi-1-ineffective-for-devtoolset-7-on-centos-7

这里通过编译一个包含 std::string 的 cpp 文件，并查看里面是否包含 cxx11 符号的方式来判断 cxx11 abi 是不是可用，在 ubuntu 18.04 + gcc 7.5，centos 7 + gcc 7.3 和 centos 7 + gcc 4.8 环境测试没问题