### PR TITLE
RtRegst/Regst GetBlobDesc/BlobByOrdinal

### DIFF
--- a/oneflow/core/register/register.cpp
+++ b/oneflow/core/register/register.cpp
@@ -36,14 +36,18 @@ Regst::~Regst() {
   if (comm_net_token_ != nullptr) { Global<CommNet>::Get()->UnRegisterMemory(comm_net_token_); }
 }
 
+Blob* Regst::GetBlobByOrdinal(int64_t ordinal) { return sorted_blob_vec_.at(ordinal).get(); }
+
 Blob* Regst::GetBlobByLbi(const LogicalBlobId& lbi) {
-  auto it = lbi2blob_.find(lbi);
-  if (it != lbi2blob_.end()) {
-    return it->second.get();
-  } else if (lbi.is_packed_id()) {
-    return packed_blob_.get();
+  const int64_t ordinal = regst_desc_->GetOrdinalForLbi(lbi);
+  if (ordinal >= 0) {
+    return sorted_blob_vec_.at(ordinal).get();
   } else {
-    return nullptr;
+    if (lbi.is_packed_id()) {
+      return packed_blob_.get();
+    } else {
+      return nullptr;
+    }
   }
 }
 
@@ -51,16 +55,22 @@ void Regst::set_regst_desc(const RtRegstDesc* regst_desc) {
   CHECK(regst_desc_ == nullptr);
   regst_desc_ = regst_desc;
   status_.regst_desc_id = regst_desc_->regst_desc_id();
+  sorted_blob_vec_.resize(regst_desc->lbi_num());
+}
+
+void Regst::SetBlobByOrdinal(int64_t ordinal, std::unique_ptr<Blob>&& blob) {
+  CHECK(!sorted_blob_vec_.at(ordinal));
+  sorted_blob_vec_.at(ordinal).swap(blob);
 }
 
 Blob* Regst::GetMutSoleBlob() {
   CHECK_EQ(GetBlobSize(), 1);
-  return lbi2blob_.begin()->second.get();
+  return sorted_blob_vec_.front().get();
 }
 
 const Blob* Regst::GetSoleBlob() const {
   CHECK_EQ(GetBlobSize(), 1);
-  return lbi2blob_.begin()->second.get();
+  return sorted_blob_vec_.front().get();
 }
 
 }  // namespace oneflow

--- a/oneflow/core/register/register.h
+++ b/oneflow/core/register/register.h
@@ -48,11 +48,11 @@ class Regst final {
   int64_t producer_actor_id() const { return regst_desc_->producer_actor_id(); }
   const std::vector<int64_t>& consumers_actor_id() const;
   const RtRegstDesc* regst_desc() const { return regst_desc_; }
+  Blob* GetBlobByOrdinal(int64_t ordinal);
   Blob* GetBlobByLbi(const LogicalBlobId& lbi);
   const Blob* GetSoleBlob() const;
   Blob* GetMutSoleBlob();
-  int64_t GetBlobSize() const { return lbi2blob_.size(); }
-  const HashMap<LogicalBlobId, std::unique_ptr<Blob>>& lbi2blob() const { return lbi2blob_; }
+  int64_t GetBlobSize() const { return sorted_blob_vec_.size(); }
   Blob* packed_blob() { return packed_blob_.get(); }
   bool IsMaxCol() const { return col_id() == max_col_id(); }
   void* comm_net_token() const { return comm_net_token_; }
@@ -68,12 +68,13 @@ class Regst final {
   Regst();
 
   void set_regst_desc(const RtRegstDesc* regst_desc);
+  void SetBlobByOrdinal(int64_t ordinal, std::unique_ptr<Blob>&& blob);
 
   void* comm_net_token_;
   RegstStatus status_;
   const RtRegstDesc* regst_desc_;
-  HashMap<LogicalBlobId, std::unique_ptr<Blob>> lbi2blob_;
   std::unique_ptr<Blob> packed_blob_;
+  std::vector<std::unique_ptr<Blob>> sorted_blob_vec_;
 };
 
 }  // namespace oneflow

--- a/oneflow/core/register/register_desc.cpp
+++ b/oneflow/core/register/register_desc.cpp
@@ -178,34 +178,6 @@ bool RegstDesc::HasSameBlobDescs(const RegstDesc* rhs) {
   return true;
 }
 
-int64_t RegstDesc::ByteOffsetInPackedBlobDescBody(const LogicalBlobId& lbi) const {
-  RegstDescProto regst_desc_proto;
-  ToProto(&regst_desc_proto);
-  RtRegstDesc rt_regst_desc(regst_desc_proto);
-  std::vector<LbiBlobDescPair> lbi_blob_desc_pairs;
-  for (const auto& pair : lbi2blob_desc_) {
-    LbiBlobDescPair lbi_blob_desc_pair;
-    *lbi_blob_desc_pair.mutable_lbi() = pair.first;
-    pair.second->ToProto(lbi_blob_desc_pair.mutable_blob_desc());
-    lbi_blob_desc_pairs.push_back(lbi_blob_desc_pair);
-  }
-  std::sort(lbi_blob_desc_pairs.begin(), lbi_blob_desc_pairs.end(), CompareLbiBlobDescPair);
-
-  bool found = false;
-  int64_t offset = 0;
-  rt_regst_desc.ForEachBlobDescOffsetInOnRegst(
-      lbi_blob_desc_pairs,
-      [&](const LbiBlobDescPair& lbi_blob_desc_pair, int64_t body_offset, int64_t header_offset) {
-        if (found) { return; }
-        if (lbi_blob_desc_pair.lbi() == lbi) {
-          offset = body_offset;
-          found = true;
-        }
-      });
-  CHECK(found);
-  return offset;
-}
-
 void InitCtrlRegstDesc(int64_t producer_task_id, RegstDescProto* ctrl_regst_proto) {
   CHECK_NOTNULL(ctrl_regst_proto);
   ctrl_regst_proto->set_regst_desc_id(Global<IDMgr>::Get()->NewRegstDescId());

--- a/oneflow/core/register/register_desc.h
+++ b/oneflow/core/register/register_desc.h
@@ -96,7 +96,6 @@ class RegstDesc final {
   void EraseZeroSizeBlob();
   void ToProto(RegstDescProto*) const;
   bool HasSameBlobDescs(const RegstDesc*);
-  int64_t ByteOffsetInPackedBlobDescBody(const LogicalBlobId& lbi) const;
 
  private:
   int64_t regst_desc_id_;

--- a/oneflow/core/register/register_manager.cpp
+++ b/oneflow/core/register/register_manager.cpp
@@ -147,32 +147,31 @@ void RegstMgr::NewBlobsInOneRegst(const std::vector<LbiBlobDescPair>& lbis, Regs
       cur_body_pointer = main_mem_ptr + packed_blob_desc->ByteSizeOfBlobHeader();
     }
   }
-  rt_regst_desc->ForEachBlobDescOffsetInOnRegst(
-      lbis, [&](const LbiBlobDescPair& lbi, int64_t body_offset, int64_t header_offset) {
-        const RtBlobDesc* blob_desc = rt_regst_desc->GetRtBlobDescFromLbi(lbi.lbi());
-        std::unique_ptr<Blob> blob_ptr;
-        if (cur_body_pointer == nullptr) {
-          CHECK(rt_regst_desc->is_body_disabled());
-          blob_ptr = std::move(std::make_unique<Blob>(regst->regst_desc()->mem_case(), blob_desc,
-                                                      cur_header_pointer + header_offset, nullptr));
-        } else {
-          CHECK(rt_regst_desc->is_body_disabled() == false);
-          blob_ptr = std::move(std::make_unique<Blob>(regst->regst_desc()->mem_case(), blob_desc,
-                                                      cur_header_pointer + header_offset,
-                                                      cur_body_pointer + body_offset));
-          InitNonPODTypeBlobIfNeed(Global<MemoryAllocator>::Get(), blob_ptr.get());
-        }
-        CHECK(regst->lbi2blob_.emplace(lbi.lbi(), std::move(blob_ptr)).second);
-        const int64_t regst_desc_id = rt_regst_desc->regst_desc_id();
-        const auto& parallel_ctx = regst_desc_id2parallel_ctx_.at(regst_desc_id);
-        if (parallel_ctx.has_parallel_id()) {
-          const int64_t parallel_id = parallel_ctx.parallel_id();
-          {
-            std::lock_guard<std::mutex> lock(mutex_);
-            lbi2parallel_id2blob_[lbi.lbi()][parallel_id] = regst->GetBlobByLbi(lbi.lbi());
-          }
-        }
-      });
+  rt_regst_desc->ForEachBlobDescOffsetInOnRegst([&](int64_t ordinal, const LogicalBlobId& lbi,
+                                                    const RtBlobDesc* blob_desc,
+                                                    int64_t body_offset, int64_t header_offset) {
+    std::unique_ptr<Blob> blob_ptr;
+    if (cur_body_pointer == nullptr) {
+      CHECK(rt_regst_desc->is_body_disabled());
+      blob_ptr.reset(new Blob(regst->regst_desc()->mem_case(), blob_desc,
+                              cur_header_pointer + header_offset, nullptr));
+    } else {
+      CHECK(rt_regst_desc->is_body_disabled() == false);
+      blob_ptr.reset(new Blob(regst->regst_desc()->mem_case(), blob_desc,
+                              cur_header_pointer + header_offset, cur_body_pointer + body_offset));
+      InitNonPODTypeBlobIfNeed(Global<MemoryAllocator>::Get(), blob_ptr.get());
+    }
+    regst->SetBlobByOrdinal(ordinal, std::move(blob_ptr));
+    const int64_t regst_desc_id = rt_regst_desc->regst_desc_id();
+    const auto& parallel_ctx = regst_desc_id2parallel_ctx_.at(regst_desc_id);
+    if (parallel_ctx.has_parallel_id()) {
+      const int64_t parallel_id = parallel_ctx.parallel_id();
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        lbi2parallel_id2blob_[lbi][parallel_id] = regst->GetBlobByOrdinal(ordinal);
+      }
+    }
+  });
 }
 
 const RtRegstDesc& RegstMgr::RegstDesc4RegstDescId(int64_t regst_desc_id) const {

--- a/oneflow/core/register/runtime_register_desc.cpp
+++ b/oneflow/core/register/runtime_register_desc.cpp
@@ -116,8 +116,8 @@ const Shape& RtRegstDesc::data_regst_time_shape() const {
 }
 
 void RtRegstDesc::ForEachBlobDescOffsetInOnRegst(
-    const std::function<void(int64_t, const LogicalBlobId&, const RtBlobDesc*, int64_t, int64_t)>&
-        Handler) const {
+    const std::function<void(int64_t ordinal, const LogicalBlobId& lbi, const RtBlobDesc* desc,
+                             int64_t body_offset, int64_t header_offset)>& Handler) const {
   int64_t cur_body_offset = 0;
   int64_t cur_header_offset = 0;
   for (int64_t i = 0; i < sorted_blob_desc_vec_.size(); ++i) {

--- a/oneflow/core/register/runtime_register_desc.cpp
+++ b/oneflow/core/register/runtime_register_desc.cpp
@@ -27,9 +27,16 @@ RtRegstDesc::RtRegstDesc(const RegstDescProto& proto) {
   regst_desc_type_ = proto.regst_desc_type();
   if (proto.regst_desc_type().has_data_regst_desc()) {
     const DataRegstDesc& data_regst_desc = proto.regst_desc_type().data_regst_desc();
-    for (const LbiBlobDescPair& pair : data_regst_desc.lbi2blob_desc()) {
-      auto blob_desc = std::make_unique<RtBlobDesc>(pair.blob_desc());
-      CHECK(lbi2blob_desc_.emplace(pair.lbi(), std::move(blob_desc)).second);
+    std::vector<LbiBlobDescPair> lbi_pairs(
+        {data_regst_desc.lbi2blob_desc().cbegin(), data_regst_desc.lbi2blob_desc().cend()});
+    std::sort(lbi_pairs.begin(), lbi_pairs.end(), &CompareLbiBlobDescPair);
+    sorted_blob_desc_vec_.reserve(lbi_pairs.size());
+    sorted_lbi_vec_.reserve(lbi_pairs.size());
+    for (int64_t i = 0; i < lbi_pairs.size(); ++i) {
+      const LbiBlobDescPair& pair = lbi_pairs.at(i);
+      sorted_blob_desc_vec_.push_back(std::make_unique<RtBlobDesc>(pair.blob_desc()));
+      sorted_lbi_vec_.push_back(pair.lbi());
+      lbi2blob_desc_ordinal_.emplace(pair.lbi(), i);
     }
     packed_blob_desc_.reset(new RtBlobDesc(data_regst_desc.packed_blob_desc()));
     CHECK(data_regst_desc.has_time_shape());
@@ -39,14 +46,31 @@ RtRegstDesc::RtRegstDesc(const RegstDescProto& proto) {
   }
 }
 
+int64_t RtRegstDesc::GetOrdinalForLbi(const LogicalBlobId& lbi) const {
+  auto it = lbi2blob_desc_ordinal_.find(lbi);
+  if (it != lbi2blob_desc_ordinal_.cend()) {
+    return it->second;
+  } else {
+    return -1;
+  }
+}
+
 const RtBlobDesc* RtRegstDesc::GetRtBlobDescFromLbi(const LogicalBlobId& lbi) const {
-  auto it = lbi2blob_desc_.find(lbi);
-  if (it == lbi2blob_desc_.end()) {
+  auto it = lbi2blob_desc_ordinal_.find(lbi);
+  if (it == lbi2blob_desc_ordinal_.end()) {
     CHECK(lbi.is_packed_id());
     return packed_blob_desc_.get();
   } else {
-    return it->second.get();
+    return GetRtBlobDescByOrdinal(it->second);
   }
+}
+
+const RtBlobDesc* RtRegstDesc::GetRtBlobDescByOrdinal(int64_t ordinal) const {
+  return sorted_blob_desc_vec_.at(ordinal).get();
+}
+
+const LogicalBlobId& RtRegstDesc::GetLbiByOrdinal(int64_t ordinal) const {
+  return sorted_lbi_vec_.at(ordinal);
 }
 
 size_t RtRegstDesc::TotalByteSize4AllRegst() const {
@@ -92,14 +116,14 @@ const Shape& RtRegstDesc::data_regst_time_shape() const {
 }
 
 void RtRegstDesc::ForEachBlobDescOffsetInOnRegst(
-    const std::vector<LbiBlobDescPair>& lbis,
-    const std::function<void(const LbiBlobDescPair&, int64_t body_offset, int64_t header_offset)>&
+    const std::function<void(int64_t, const LogicalBlobId&, const RtBlobDesc*, int64_t, int64_t)>&
         Handler) const {
   int64_t cur_body_offset = 0;
   int64_t cur_header_offset = 0;
-  for (const LbiBlobDescPair& lbi : lbis) {
-    Handler(lbi, cur_body_offset, cur_header_offset);
-    const RtBlobDesc* blob_desc = GetRtBlobDescFromLbi(lbi.lbi());
+  for (int64_t i = 0; i < sorted_blob_desc_vec_.size(); ++i) {
+    const RtBlobDesc* blob_desc = sorted_blob_desc_vec_.at(i).get();
+    const LogicalBlobId& lbi = sorted_lbi_vec_.at(i);
+    Handler(i, lbi, blob_desc, cur_body_offset, cur_header_offset);
     cur_body_offset += blob_desc->AlignedByteSizeOfBlobBody();
     cur_header_offset += blob_desc->ByteSizeOfBlobHeader();
   }

--- a/oneflow/core/register/runtime_register_desc.h
+++ b/oneflow/core/register/runtime_register_desc.h
@@ -37,7 +37,11 @@ class RtRegstDesc {
   const MemoryCase& mem_case() const { return mem_case_; }
   const RegstDescTypeProto& regst_desc_type() const { return regst_desc_type_; }
 
+  int64_t lbi_num() const { return sorted_lbi_vec_.size(); }
+  int64_t GetOrdinalForLbi(const LogicalBlobId& lbi) const;
   const RtBlobDesc* GetRtBlobDescFromLbi(const LogicalBlobId& lbi) const;
+  const RtBlobDesc* GetRtBlobDescByOrdinal(int64_t ordinal) const;
+  const LogicalBlobId& GetLbiByOrdinal(int64_t ordinal) const;
   const RtBlobDesc* packed_blob_desc() const { return packed_blob_desc_.get(); }
   size_t TotalByteSize4AllRegst() const;
   size_t TotalMainByteSize4AllRegst() const;
@@ -48,9 +52,8 @@ class RtRegstDesc {
   bool is_body_disabled() const { return packed_blob_desc_->is_body_disabled(); }
 
   void ForEachBlobDescOffsetInOnRegst(
-      const std::vector<LbiBlobDescPair>& lbis,
-      const std::function<void(const LbiBlobDescPair&, int64_t body_offset, int64_t header_offset)>&
-          Handler) const;
+      const std::function<void(int64_t ordinal, const LogicalBlobId& lbi, const RtBlobDesc* desc,
+                               int64_t body_offset, int64_t header_offset)>& Handler) const;
 
  private:
   int64_t regst_desc_id_;
@@ -59,9 +62,11 @@ class RtRegstDesc {
   int64_t register_num_;
   RegstDescTypeProto regst_desc_type_;
   MemoryCase mem_case_;
-  HashMap<LogicalBlobId, std::unique_ptr<RtBlobDesc>> lbi2blob_desc_;
+  HashMap<LogicalBlobId, int64_t> lbi2blob_desc_ordinal_;
   std::unique_ptr<RtBlobDesc> packed_blob_desc_;
   std::unique_ptr<Shape> data_regst_time_shape_;
+  std::vector<std::unique_ptr<RtBlobDesc>> sorted_blob_desc_vec_;
+  std::vector<LogicalBlobId> sorted_lbi_vec_;
 };
 
 }  // namespace oneflow


### PR DESCRIPTION
RtRegstDesc/Regst 支持以序号的方式访问 BlobDesc/Blob，序号由 regst 中 lbi 排序后确定。

后续工作：
因为BnInOp2Lbi的关系是静态的，所以可以在actor初始化的过程中绑定BnInOp2Ordinal，可以将原来的BnInOp2Lbi => GetBlobByLbi 优化为 BnInOp2Ordinal => GetBlobByOrdinal。更进一步可以在kernel init 的时候将 BnInOp和Ordinal绑定，后续kernel可以直接使用Ordinal而不是BnInOp访问Blob