### PR TITLE
make float/double as aliases of float32/float64

### DIFF
--- a/oneflow/python/framework/dtype.py
+++ b/oneflow/python/framework/dtype.py
@@ -29,29 +29,27 @@ class char(dtype):
     oneflow_proto_dtype = data_type_pb2.kChar
 
 
-@oneflow_export("float")
-class float(dtype):
-    oneflow_proto_dtype = data_type_pb2.kFloat
-
-
 @oneflow_export("float16")
 class float16(dtype):
     oneflow_proto_dtype = data_type_pb2.kFloat16
 
 
+@oneflow_export("float")
 @oneflow_export("float32")
 class float32(dtype):
     oneflow_proto_dtype = data_type_pb2.kFloat
 
 
+float = float32
+
+
+@oneflow_export("double")
 @oneflow_export("float64")
 class float64(dtype):
     oneflow_proto_dtype = data_type_pb2.kDouble
 
 
-@oneflow_export("double")
-class double(dtype):
-    oneflow_proto_dtype = data_type_pb2.kDouble
+double = float64
 
 
 @oneflow_export("int8")

--- a/oneflow/python/ops/pad.py
+++ b/oneflow/python/ops/pad.py
@@ -91,7 +91,6 @@ def pad(
     else:
         raise ValueError("paddings must be a tuple or a list.")
     if x.dtype in [
-        dtype_util.float,
         dtype_util.float32,
         dtype_util.float16,
         dtype_util.float64,

--- a/tools/generate_oneflow_api.py
+++ b/tools/generate_oneflow_api.py
@@ -96,7 +96,7 @@ def collect_exports():
     api_name2module = {}
     for api_name, symbol, module in exported_symbols():
         assert (
-            api_name not in exports
+            api_name not in exports or exports[api_name] == symbol
         ), "exported twice: {}, previous exported: {} in {}, current: {} in {}".format(
             api_name,
             exports[api_name],

--- a/tools/generate_oneflow_api.py
+++ b/tools/generate_oneflow_api.py
@@ -95,8 +95,11 @@ def collect_exports():
     exports = {}
     api_name2module = {}
     for api_name, symbol, module in exported_symbols():
+        has_another_symbol_exported = (
+            api_name in exports and exports[api_name] != symbol
+        )
         assert (
-            api_name not in exports or exports[api_name] == symbol
+            not has_another_symbol_exported
         ), "exported twice: {}, previous exported: {} in {}, current: {} in {}".format(
             api_name,
             exports[api_name],


### PR DESCRIPTION
float/double 应该只是 float32/float64 的别名，但现在却被实现为独立的另一种类型，这会不小心写出 bug 或者引起令人困惑的现象，例如一些 initializer 只处理了 float 没有处理 float32