### PR TITLE
stage context

### DIFF
--- a/oneflow/core/job/scope.proto
+++ b/oneflow/core/job/scope.proto
@@ -2,15 +2,17 @@ syntax = "proto2";
 package oneflow;
 
 import "oneflow/core/job/mirrored_parallel.proto";
+import "oneflow/core/job/stage_context.proto";
 
 message ScopeProto {
-  required int64 symbol_id = 10;
+  required int64 symbol_id = 1;
+  optional int64 parent_scope_symbol_id = 2;
+  required int64 session_id = 3;
   required int64 job_desc_symbol_id = 20;
   required int64 device_parallel_desc_symbol_id = 30;
   required int64 host_parallel_desc_symbol_id = 40; 
   optional bool enable_cpu_alternative_op = 41 [default = true];
   required OptMirroredParallel opt_mirrored_parallel_conf = 50;
   repeated string scope_op_name_prefixes = 60;
-  optional int64 parent_scope_symbol_id = 70;
-  required int64 session_id = 80;
+  optional StageContext stage_context = 70;
 }

--- a/oneflow/core/job/stage_context.proto
+++ b/oneflow/core/job/stage_context.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+package oneflow;
+
+// There are deep learning models that could be divided into sequantial consecutive stages.
+// Each stage is a set of ops
+message StageContext {
+  required int64 num_stages = 1;
+  required int64 stage_id = 2;
+}


### PR DESCRIPTION
SSP和repeated BSP的前后向之间都需要添加buffer op。buffer op的buffer size和当前所处的stage有关。
本PR仅为ScopeProto提供StageContext字段，具体使用在后续的pr里。
因为这个pr所提供的公共数据类型，可以让其他多个pr并行开展。