### PR TITLE
Fix __hne in BinaryFuncFloorMod

### DIFF
--- a/oneflow/core/ndarray/binary_func.h
+++ b/oneflow/core/ndarray/binary_func.h
@@ -270,7 +270,7 @@ struct BinaryFuncFloorMod<half> final {
 #if __CUDA_ARCH__ >= 530
     const half trunc_mod = __float2half(fmodf(__half2float(x), __half2float(y)));
     return __hne(trunc_mod, GetZeroVal<half>())
-                   && __hne(__hlt(y, GetZeroVal<half>()), __hlt(trunc_mod, half(0)))
+                   && __hlt(y, GetZeroVal<half>()) != __hlt(trunc_mod, half(0))
                ? trunc_mod + y
                : trunc_mod;
 #else


### PR DESCRIPTION
`__hlt`返回值是bool类型，直接比较即可，不应使用`__hne`，同时编译8.0以上的arch时会出现确定将bool转成float16还是bfloat16导致的编译失败