### PR TITLE
Sort cfg obj forward declare

### DIFF
--- a/tools/cfg/template_convert.py
+++ b/tools/cfg/template_convert.py
@@ -55,7 +55,10 @@ def convert_hpp(
         if os.path.dirname(dst_hpp_path):
             os.makedirs(os.path.dirname(dst_hpp_path))
 
-    if not os.path.exists(dst_hpp_path) or not filecmp.cmp(tmp_hpp_path, dst_hpp_path):
+    if not os.path.exists(dst_hpp_path) or not filecmp.cmp(
+        tmp_hpp_path, dst_hpp_path, shallow=False
+    ):
+        print("\033[34mRendering %s\033[0m" % (rel_dst_hpp_path))
         copyfile(tmp_hpp_path, dst_hpp_path)
 
 
@@ -74,7 +77,10 @@ def convert_cpp(
         if os.path.dirname(dst_cpp_path):
             os.makedirs(os.path.dirname(dst_cpp_path))
 
-    if not os.path.exists(dst_cpp_path) or not filecmp.cmp(tmp_cpp_path, dst_cpp_path):
+    if not os.path.exists(dst_cpp_path) or not filecmp.cmp(
+        tmp_cpp_path, dst_cpp_path, shallow=False
+    ):
+        print("\033[34mRendering %s\033[0m" % (rel_dst_cpp_path))
         copyfile(tmp_cpp_path, dst_cpp_path)
 
 
@@ -94,8 +100,9 @@ def convert_pybind(
             os.makedirs(os.path.dirname(dst_pybind_path))
 
     if not os.path.exists(dst_pybind_path) or not filecmp.cmp(
-        tmp_pybind_path, dst_pybind_path
+        tmp_pybind_path, dst_pybind_path, shallow=False
     ):
+        print("\033[34mRendering %s\033[0m" % (rel_dst_pybind_path))
         copyfile(tmp_pybind_path, dst_pybind_path)
 
 

--- a/tools/cfg/util/proto_reflect_util.py
+++ b/tools/cfg/util/proto_reflect_util.py
@@ -248,14 +248,17 @@ class ProtoReflectionUtil:
                     TryAddEnum(field.message_type.fields_by_name["value"])
                 else:
                     TryAddEnum(field)
+        namespaces = []
+        enums = []
         for enum in enum_defined_in_other_module:
             package = enum.file.package
             if package != "":
-                yield package.split("."), enum.full_name[len(package) + 1 :].replace(
-                    ".", "_"
-                )
+                namespaces.append(package.split("."))
+                enums.append(enum.full_name[len(package) + 1 :].replace(".", "_"))
             else:
-                yield [], enum.full_name.replace(".", "_")
+                namespaces.append([])
+                enums.append(enum.full_name.replace(".", "_"))
+        return sorted(zip(namespaces, enums))
 
     def other_file_declared_namespaces_and_class_name(self, module):
         cls_defined_in_this_module = set()
@@ -276,14 +279,17 @@ class ProtoReflectionUtil:
                     TryAddClass(field.message_type.fields_by_name["value"])
                 else:
                     TryAddClass(field)
+        namespaces = []
+        clss = []
         for cls in cls_defined_in_other_module:
             package = cls.file.package
             if package != "":
-                yield package.split("."), cls.full_name[len(package) + 1 :].replace(
-                    ".", "_"
-                )
+                namespaces.append(package.split("."))
+                clss.append(cls.full_name[len(package) + 1 :].replace(".", "_"))
             else:
-                yield [], cls.full_name.replace(".", "_")
+                namespaces.append([])
+                clss.append(enum.full_name.replace(".", "_"))
+        return sorted(zip(namespaces, clss))
 
     def field_message_type_name_with_cfg_namespace(self, field):
         package = field.message_type.file.package


### PR DESCRIPTION
在\*cfg.h中对前置声明的类排序，保证每次生成的\*cfg.h文件的一致性。