### PR TITLE
merge chain without area id

### DIFF
--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -101,11 +101,9 @@ void TraverseConnectedSubGraphMergeInThisChain(TaskNode* this_node, const int64_
     CHECK_EQ(cur_node->chain_id(), -1);
     cur_node->set_chain_id(this_chain_id);
 
-    cur_node->ForEachNodeOnInOutEdge([&](TaskNode* next_node) {
-      // NOTE(chengcheng): use area_id to not merge optimizer ops with fw/bw ops
+    cur_node->ForEachNodeOnInOutDataEdge([&](TaskNode* next_node) {
       if (visited_nodes.find(next_node) == visited_nodes.end() && CanBeMergedInChain(next_node)
-          && this_node->GlobalWorkStreamId() == next_node->GlobalWorkStreamId()
-          && this_node->area_id() == next_node->area_id()) {
+          && this_node->GlobalWorkStreamId() == next_node->GlobalWorkStreamId()) {
         if (next_node->chain_id() == -1) {
           queued_nodes.push(next_node);
           visited_nodes.insert(next_node);


### PR DESCRIPTION
area id最后的作用就是让Optimizer子图跟Fw/Bw不要合并到一个Chain中。

修改Chain合并的算法，使得多卡的Optimizer可以通过NCCL、Variable、Tick等特殊node隔开，不跟Fw/Bw合并。

area id概念后续可以从系统中移除。

测试：

15机器：  resnet50 2卡 batch size/ gpu = 64

分支/策略 | 内存 | 吞吐率
-- | -- | --
without area id | 6187M | 588img/s
master | 6185M | 583img/s


