### PR TITLE
initial fix

### DIFF
--- a/oneflow/core/kernel/arg_where_kernel.cpp
+++ b/oneflow/core/kernel/arg_where_kernel.cpp
@@ -31,7 +31,6 @@ class ArgWhereKernel : public KernelIf<DeviceType::kCPU> {
   void ForwardDataContent(const KernelCtx& ctx,
                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {
     const Blob* in = BnInOp2Blob("in");
-    if (in->shape().elem_cnt() == 0) { return; }
     Blob* out = BnInOp2Blob("out");
     Blob* out_size = BnInOp2Blob("out_size");
     Blob* tmp = BnInOp2Blob("tmp");


### PR DESCRIPTION
This is a fix about argwhere op, which would generate a weird memory bug in sync_dynamic_resize op when running maskrcnn inference.
I actually don't know much about it. Anyway, it works and could pass the op testcase and maskrcnn inference.