### PR TITLE
Fix eager memory leak and re-enable new checkpoint

### DIFF
--- a/oneflow/core/job/job_set.proto
+++ b/oneflow/core/job/job_set.proto
@@ -11,7 +11,7 @@ message IOConf {
   optional bool save_downloaded_file_to_local_fs = 3 [default = false];
   optional uint64 persistence_buf_byte = 4;
   optional bool enable_model_io_v2 = 5 [default = false];
-  optional bool enable_legacy_model_io = 6 [default = true];
+  optional bool enable_legacy_model_io = 6 [default = false];
 }
 
 message ProfilerConf {

--- a/oneflow/core/vm/virtual_machine.cpp
+++ b/oneflow/core/vm/virtual_machine.cpp
@@ -90,6 +90,9 @@ void VirtualMachine::MakeInstructions(TmpPendingInstrMsgList* instr_msg_list,
                                       /*out*/ NewInstructionList* new_instruction_list) {
   auto IsStreamInParallelDesc = [](const ParallelDesc* parallel_desc, const Stream& stream) {
     if (parallel_desc == nullptr) { return true; }
+    if (stream.stream_type().SharingVirtualMachineThread()) {
+      return parallel_desc->ContainingMachineId(stream.machine_id());
+    }
     return parallel_desc->Containing(stream.machine_id(), stream.device_id());
   };
   OBJECT_MSG_LIST_FOR_EACH_PTR(instr_msg_list, instr_msg) {

--- a/oneflow/python/test/ops/test_checkpoint.py
+++ b/oneflow/python/test/ops/test_checkpoint.py
@@ -333,7 +333,6 @@ def _TestAssignmentBetweenMemory(test_case, dtype):
     test_case.assertTrue(np.allclose(flow_res, np_res))
 
 
-@unittest.skip("new checkpoint is disabled temporarily")
 class TestCheckpoint(flow.unittest.TestCase):
     @flow.unittest.skip_unless_1n4d()
     @unittest.skipIf(


### PR DESCRIPTION
`IsStreamInParallelDesc` 里没有特殊处理 ControlStreamType，一部分 DeleteObject 指令被错误忽略了，导致 object 的引用计数不正确，引起内存泄漏

修复之后，在原先重复调用 save 会 OOM 的代码里测试，不再出现内存泄漏的情况。现在每张卡上由 checkpoint 引起的显存占用只有 32M，是流式 save/load/init 时的一个 slice 的大小