### PR TITLE
Add flatten/squeeze/expand_dims to auto mixed precision clear list and use reshape instead of reshape_like to do reshape grad computation

### DIFF
--- a/oneflow/core/job_rewriter/auto_mixed_precision_lists.cpp
+++ b/oneflow/core/job_rewriter/auto_mixed_precision_lists.cpp
@@ -44,7 +44,7 @@ const AMPList& AutoMixedPrecisionLists::ClearList() {
   static AMPList clear_list = {
       "gather",    "max_pool_1d",      "max_pool_2d", "max_pool_3d", "reshape",      "relu",
       "transpose", "random_mask_like", "concat",      "pad",         "same_padding", "tril",
-      "slice",     "fused_scale_tril", "identity"};
+      "slice",     "fused_scale_tril", "identity",    "flatten",     "squeeze",      "expand_dims"};
 
   return clear_list;
 }


### PR DESCRIPTION
- [x] add flatten/squeeze/expand_dims to auto mixed precision clear list 
- [x] use reshape to compute grad for itself rather than reshape_like when input is a static tensor