### PR TITLE
Add implementation of InstanceNorm2D op 

### DIFF
--- a/oneflow/python/test/ops/test_instance_norm_2d_op.py
+++ b/oneflow/python/test/ops/test_instance_norm_2d_op.py
@@ -1,0 +1,134 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import oneflow as flow
+import oneflow.typing as tp
+
+from collections import OrderedDict
+import numpy as np
+import os
+from test_util import GenArgList
+import unittest
+
+
+def _compare_instance_norm_2d_with_np(
+    input_shape, device_type, machine_ids, device_counts, eps, affine
+):
+    assert device_type in ["cpu", "gpu"]
+    assert len(input_shape) == 4
+
+    flow.clear_default_session()
+
+    if device_type == "cpu":
+        flow.config.cpu_device_num(device_counts)
+    else:
+        flow.config.gpu_device_num(device_counts)
+
+    func_config = flow.FunctionConfig()
+    func_config.default_placement_scope(flow.scope.placement(device_type, machine_ids))
+
+    input = np.random.random(size=input_shape).astype(np.float32)
+    gout = np.random.random(size=input_shape).astype(np.float32)
+
+    # compute instance normalization in numpy
+    gamma = np.ones((1, input_shape[1], 1, 1), dtype=np.float32)
+    mean_np = np.mean(input, axis=(2, 3), keepdims=True)
+    in_sub_mean = input - mean_np
+    var_np = np.mean(np.square(in_sub_mean), axis=(2, 3), keepdims=True)
+    invar_np = 1.0 / np.sqrt(var_np + eps)
+    out_np = in_sub_mean * invar_np * gamma
+
+    def assert_prediction_grad(gin_of: tp.Numpy):
+        # compute the gradient of variance
+        gvar = gout * gamma * in_sub_mean * -0.5 * np.power(var_np + eps, -1.5)
+        gvar = np.sum(gvar, axis=(2, 3), keepdims=True)
+        # compute the gradient of mean
+        gmean = np.sum(gout * gamma, axis=(2, 3), keepdims=True)
+        gmean *= -invar_np
+        scale = 1.0 / (input_shape[2] * input_shape[3])
+        tmp = scale * np.sum(-2.0 * in_sub_mean, axis=(2, 3), keepdims=True) * gvar
+        gmean += tmp
+        # compute the gradient of input
+        gin_np = (
+            gout * gamma * invar_np + gvar * scale * 2.0 * in_sub_mean + gmean * scale
+        )
+
+        assert np.allclose(gin_of, gin_np, atol=1e-5)
+
+    @flow.global_function(type="train", function_config=func_config)
+    def instanceNormJob(
+        of_input: tp.Numpy.Placeholder(shape=input.shape),
+        multipler: tp.Numpy.Placeholder(shape=input.shape),
+    ) -> tp.Numpy:
+        with flow.scope.placement(device_type, "0:0"):
+            v = flow.get_variable(
+                shape=of_input.shape,
+                dtype=flow.float32,
+                initializer=flow.constant_initializer(0),
+                name="v",
+            )
+
+            x_var = of_input + v
+            # watch the gradient
+            flow.watch_diff(x_var, assert_prediction_grad)
+
+        out = flow.nn.InstanceNorm2d(x_var, eps=eps, affine=affine)
+
+        with flow.scope.placement(device_type, "0:0"):
+            flow.optimizer.SGD(
+                flow.optimizer.PiecewiseConstantScheduler([], [1e-3]), momentum=0
+            ).minimize(out * multipler)
+
+        return out
+
+    check = flow.train.CheckPoint()
+    check.init()
+
+    of_out = instanceNormJob(input, gout)
+
+    assert np.allclose(of_out, out_np, atol=1e-5)
+
+
+@flow.unittest.skip_unless_1n1d()
+class Testzeros1n1d(flow.unittest.TestCase):
+    def test_zeros_cpu(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["input_shape"] = [(4, 2, 32, 32)]
+        arg_dict["device_type"] = ["cpu", "gpu"]
+        arg_dict["machine_ids"] = ["0:0"]
+        arg_dict["device_counts"] = [1]
+        arg_dict["eps"] = [1e-3]
+        arg_dict["affine"] = [True, False]
+        for arg in GenArgList(arg_dict):
+            _compare_instance_norm_2d_with_np(*arg)
+
+
+@flow.unittest.skip_unless_1n2d()
+class Testzeros1n2d(flow.unittest.TestCase):
+    def test_zeros_cpu(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["input_shape"] = [(4, 2, 32, 32)]
+        arg_dict["device_type"] = ["cpu", "gpu"]
+        arg_dict["machine_ids"] = ["0:0-1"]
+        arg_dict["device_counts"] = [2]
+        arg_dict["eps"] = [1e-3]
+        arg_dict["affine"] = [True, False]
+        for arg in GenArgList(arg_dict):
+            _compare_instance_norm_2d_with_np(*arg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oneflow/python/test/ops/test_instance_norm_2d_op.py
+++ b/oneflow/python/test/ops/test_instance_norm_2d_op.py
@@ -103,8 +103,8 @@ def _compare_instance_norm_2d_with_np(
 
 
 @flow.unittest.skip_unless_1n1d()
-class Testzeros1n1d(flow.unittest.TestCase):
-    def test_zeros_cpu(test_case):
+class TestInstanceNorm1n1d(flow.unittest.TestCase):
+    def test_instance_norm(test_case):
         arg_dict = OrderedDict()
         arg_dict["input_shape"] = [(4, 2, 32, 32)]
         arg_dict["device_type"] = ["cpu", "gpu"]
@@ -117,8 +117,8 @@ class Testzeros1n1d(flow.unittest.TestCase):
 
 
 @flow.unittest.skip_unless_1n2d()
-class Testzeros1n2d(flow.unittest.TestCase):
-    def test_zeros_cpu(test_case):
+class TestInstanceNorm1n2d(flow.unittest.TestCase):
+    def test_instance_norm(test_case):
         arg_dict = OrderedDict()
         arg_dict["input_shape"] = [(4, 2, 32, 32)]
         arg_dict["device_type"] = ["cpu", "gpu"]


### PR DESCRIPTION
对齐 pytroch 的实现 [torch.nn.InstanceNorm2d](https://pytorch.org/docs/stable/generated/torch.nn.InstanceNorm2d.html)。

```pythno3
torch.nn.InstanceNorm2d(num_features: int, 
eps: float = 1e-05, 
momentum: float = 0.1, 
affine: bool = False, 
track_running_stats: bool = False)
```
不同的地方是没加 `track_running_stats` 和 `momentum` 参数，因为根据 [instance_norm](https://arxiv.org/pdf/1607.08022.pdf) 的论文，训练和测试阶段的行为是一致的，都是用的当前batch 的 mean 和 var。不像 batchnorm ，训练阶段用当前batch的 mean 和 var，测试阶段用 moving_mean 和 moving_var。

而 pytorch 提供了这两个参数是因为其 instance_norm C++代码实现是调用的 [batchnorm 的实现](https://github.com/pytorch/pytorch/blob/fa153184c8f70259337777a1fd1d803c7325f758/aten%2Fsrc%2FATen%2Fnative%2FNormalization.cpp#L524)，所以才与bn的参数保持了一致。而实际使用的时候，都是把 `affine` 设为 True。而且能调用bn是因为一个 (N,C,H,W) 的 instance_norm 等价于 (1, N*C, H, W) 的 batchnorm。


单测的求导实现参考了 mxnet 的 [bp 实现](https://github.com/apache/incubator-mxnet/blob/4a7282f104590023d846f505527fd0d490b65509/src%2Foperator%2Finstance_norm-inl.h#L112)

