### PR TITLE
Optimize softmax cuda kernel

### DIFF
--- a/oneflow/python/ops/nn_ops.py
+++ b/oneflow/python/ops/nn_ops.py
@@ -1664,12 +1664,12 @@ def _softmax_need_transpose(x, axis):
     assert dim_num >= 2
     if axis < 0:
         axis += dim_num
-    assert axis >= 1
+    assert axis >= 0
     assert axis < dim_num
 
     need_transpose = False
-    permute = [i for i in range(dim_num)]
-    if axis > 0 and axis != dim_num - 1:
+    permute = list(range(dim_num))
+    if axis != dim_num - 1:
         need_transpose = True
         permute[axis] = permute[-1]
         permute[-1] = axis

--- a/oneflow/python/test/ops/test_softmax.py
+++ b/oneflow/python/test/ops/test_softmax.py
@@ -45,9 +45,11 @@ def compare_with_tensorflow(device_type, x_shape, data_type, axis):
                 "x",
                 shape=x_shape,
                 dtype=dtype,
-                initializer=flow.random_uniform_initializer(minval=-0.1, maxval=0.1),
+                initializer=flow.random_uniform_initializer(minval=-1.0, maxval=1.0),
                 trainable=True,
             )
+            x1 = x
+            x = flow.identity(x)
             if data_type == "float16":
                 loss = flow.cast(
                     flow.nn.softmax(flow.cast(x, dtype=flow.float16), axis=axis),
@@ -55,14 +57,17 @@ def compare_with_tensorflow(device_type, x_shape, data_type, axis):
                 )
             else:
                 loss = flow.nn.softmax(x, axis=axis)
-            flow.optimizer.SGD(
-                flow.optimizer.PiecewiseConstantScheduler([], [1e-4]), momentum=0
-            ).minimize(loss)
 
             flow.watch(x, test_global_storage.Setter("x"))
             flow.watch_diff(x, test_global_storage.Setter("x_diff"))
             flow.watch(loss, test_global_storage.Setter("loss"))
             flow.watch_diff(loss, test_global_storage.Setter("loss_diff"))
+
+            total_loss = loss * x1
+
+            flow.optimizer.SGD(
+                flow.optimizer.PiecewiseConstantScheduler([], [1e-4]), momentum=0
+            ).minimize(total_loss)
 
             return loss
 
@@ -92,7 +97,7 @@ def compare_with_tensorflow(device_type, x_shape, data_type, axis):
 
 @flow.unittest.skip_unless_1n1d()
 class TestSoftmax(flow.unittest.TestCase):
-    def test_softmax(test_case):
+    def test_softmax_shape(test_case):
         if flow.eager_execution_enabled():
             print("\nSkip under erger mode!")
             return
@@ -100,19 +105,37 @@ class TestSoftmax(flow.unittest.TestCase):
         arg_dict["device_type"] = ["gpu", "cpu"]
         arg_dict["x_shape"] = [
             (10, 10, 20, 30),
+            (10, 20, 13),
             (10, 20, 30),
             (10, 20),
+            (10, 60),
+            (32, 12, 128),
             (10, 960),
+            (12, 2001),
             (10, 4096),
             (10, 8092),
             (256, 1001),
+            (100, 65536),
+            (10, 65535),
         ]
         arg_dict["data_type"] = ["float32", "double", "float16"]
-        arg_dict["axis"] = [-1, 1, 2, 3]
+        arg_dict["axis"] = [-1]
         for arg in GenArgList(arg_dict):
             if arg[0] == "cpu" and arg[2] == "float16":
                 continue
-            if arg[3] >= len(arg[1]):
+            compare_with_tensorflow(*arg)
+
+    def test_softmax_axis(test_case):
+        if flow.eager_execution_enabled():
+            print("\nSkip under erger mode!")
+            return
+        arg_dict = OrderedDict()
+        arg_dict["device_type"] = ["gpu", "cpu"]
+        arg_dict["x_shape"] = [(10, 20, 30, 40)]
+        arg_dict["data_type"] = ["float32", "double", "float16"]
+        arg_dict["axis"] = [-4, -3, -2, -1, 0, 1, 2, 3]
+        for arg in GenArgList(arg_dict):
+            if arg[0] == "cpu" and arg[2] == "float16":
                 continue
             compare_with_tensorflow(*arg)
 

--- a/oneflow/user/kernels/softmax_kernel.cu
+++ b/oneflow/user/kernels/softmax_kernel.cu
@@ -17,215 +17,813 @@ limitations under the License.
 #include "oneflow/core/kernel/new_kernel_util.h"
 #include "oneflow/user/kernels/softmax_kernel_util.h"
 #include <cub/cub.cuh>
+#include <math_constants.h>
 
 namespace oneflow {
 
 namespace {
 
-constexpr int64_t kSoftmaxGpuBlockSize = 128;
+constexpr int kWarpSize = 32;
 
 template<typename T>
-struct SoftmaxUtil {
-  using ComputeType = T;
-  __device__ static ComputeType ToComputeType(T v) { return v; }
-  __device__ static T FromComputeType(ComputeType v) { return v; }
+struct SumOp {
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const { return a + b; }
+};
+
+template<typename T>
+struct MaxOp {
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const { return max(a, b); }
+};
+
+template<template<typename> typename ReductionOp, typename T>
+__inline__ __device__ T WarpAllReduce(T val) {
+  for (int mask = kWarpSize / 2; mask > 0; mask /= 2) {
+    val = ReductionOp<T>()(val, __shfl_xor_sync(0xffffffff, val, mask));
+  }
+  return val;
+}
+
+template<template<typename> typename ReductionOp, typename T, int block_size>
+__inline__ __device__ T BlockAllReduce(T val) {
+  typedef cub::BlockReduce<T, block_size> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  __shared__ T result_broadcast;
+  T result = BlockReduce(temp_storage).Reduce(val, ReductionOp<T>());
+  if (threadIdx.x == 0) { result_broadcast = result; }
+  __syncthreads();
+  return result_broadcast;
+}
+
+template<typename T>
+__device__ T Inf();
+
+template<>
+__device__ float Inf<float>() {
+  return CUDART_INF_F;
+}
+
+template<>
+__device__ double Inf<double>() {
+  return CUDART_INF;
+}
+
+int GetNumBlocks(int64_t block_size, int64_t max_blocks, int64_t waves) {
+  int dev;
+  OF_CUDA_CHECK(cudaGetDevice(&dev));
+  int sm_count;
+  OF_CUDA_CHECK(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, dev));
+  int tpm;
+  OF_CUDA_CHECK(cudaDeviceGetAttribute(&tpm, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
+  return std::max<int>(1, std::min<int64_t>(max_blocks, sm_count * tpm / block_size * waves));
+}
+
+template<typename T>
+struct GetComputeType {
+  using type = T;
 };
 
 template<>
-struct SoftmaxUtil<half> {
-  using ComputeType = float;
-  __device__ static ComputeType ToComputeType(half v) { return __half2float(v); }
-  __device__ static half FromComputeType(ComputeType v) { return __float2half(v); }
+struct GetComputeType<half> {
+  using type = float;
 };
 
-__device__ double Exp(double x) { return exp(x); }
-
-__device__ float Exp(float x) { return expf(x); }
-
-template<typename T>
-int GetForwardDynamicSharedMemorySize(const int num_classes) {
-  return num_classes * sizeof(typename SoftmaxUtil<T>::ComputeType);
-}
+template<typename T, int N>
+struct GetPackType;
 
 template<typename T>
-int GetBackwardDynamicSharedMemorySize(const int num_classes) {
-  return 2 * num_classes * sizeof(typename SoftmaxUtil<T>::ComputeType);
-}
+struct GetPackType<T, 1> {
+  using type = T;
+};
 
-int GetSoftmaxBlockSize() { return kSoftmaxGpuBlockSize; }
+template<>
+struct GetPackType<half, 2> {
+  using type = half2;
+};
 
-int GetSoftmaxNumBlocks(const int num_instances) {
-  return std::min(static_cast<int>(num_instances), kCudaMaxBlocksNum);
-}
+template<typename T, int N>
+using PackType = typename GetPackType<T, N>::type;
 
-template<typename T>
-int GetMinNumClasses() {
-  return 32;
-}
+template<typename T, int N>
+union Pack {
+  static_assert(sizeof(PackType<T, N>) == sizeof(T) * N, "");
+  __device__ Pack() {
+    // do nothing
+  }
+  PackType<T, N> storage;
+  T elem[N];
+};
 
-template<typename T>
-__global__ void SoftmaxGpuForwardImpl(const int num_instances, const int num_classes, const T* in,
-                                      T* prob) {
-  using SU = SoftmaxUtil<T>;
-  using ComputeType = typename SU::ComputeType;
-  extern __shared__ __align__(sizeof(ComputeType)) unsigned char fw_shared_buf[];
-  auto* compute_buf = reinterpret_cast<ComputeType*>(fw_shared_buf);
-  __shared__ ComputeType row_reduce_result;
-  typedef cub::BlockReduce<ComputeType, kSoftmaxGpuBlockSize> BlockReduce;
-  __shared__ typename BlockReduce::TempStorage cub_reduce_tmp_storage;
-  const int tid = threadIdx.x;
-  for (int row = blockIdx.x; row < num_instances; row += gridDim.x) {
-    const int row_offset = row * num_classes;
-    const T* in_row = in + row_offset;
-    T* prob_row = prob + row_offset;
-    ComputeType thread_max = GetMinVal<ComputeType>();
-    for (int col = tid; col < num_classes; col += kSoftmaxGpuBlockSize) {
-      const ComputeType x = SU::ToComputeType(in_row[col]);
-      compute_buf[col] = x;
-      thread_max = max(thread_max, x);
+template<typename SRC, typename DST, int N>
+struct MultiFetch {
+  __device__ void operator()(DST* dst, const SRC* src) const {
+    Pack<SRC, N> pack;
+    pack.storage = *reinterpret_cast<const PackType<SRC, N>*>(src);
+#pragma unroll
+    for (int i = 0; i < N; ++i) { dst[i] = static_cast<DST>(pack.elem[i]); }
+  }
+};
+
+template<typename SRC, typename DST, int N>
+struct MultiStore {
+  __device__ void operator()(DST* dst, const SRC* src) const {
+    Pack<DST, N> pack;
+#pragma unroll
+    for (int i = 0; i < N; ++i) { pack.elem[i] = static_cast<DST>(src[i]); }
+    *reinterpret_cast<PackType<DST, N>*>(dst) = pack.storage;
+  }
+};
+
+template<typename T, int pack_size, int cols_per_thread, bool padding>
+__global__ void SoftmaxWarpImpl(const int64_t rows, const int64_t cols, const T* x, T* y) {
+  static_assert(cols_per_thread % pack_size == 0, "");
+  constexpr int pack_per_thread = cols_per_thread / pack_size;
+  assert(cols <= cols_per_thread * kWarpSize);
+  using ComputeType = typename GetComputeType<T>::type;
+  ComputeType buf[cols_per_thread];
+  const int global_warp_id = blockIdx.x * blockDim.y + threadIdx.y;
+  const int num_global_warp = gridDim.x * blockDim.y;
+  const int lane_id = threadIdx.x;
+  for (int64_t row = global_warp_id; row < rows; row += num_global_warp) {
+    const int64_t row_offset = row * cols;
+    const T* row_x = x + row_offset;
+    T* row_y = y + row_offset;
+    ComputeType thread_max = -Inf<ComputeType>();
+#pragma unroll
+    for (int i = 0; i < pack_per_thread; ++i) {
+      const int col = (i * kWarpSize + lane_id) * pack_size;
+      if (!padding || col < cols) {
+        MultiFetch<T, ComputeType, pack_size>()(buf + i * pack_size, row_x + col);
+#pragma unroll
+        for (int j = 0; j < pack_size; ++j) {
+          thread_max = max(thread_max, buf[i * pack_size + j]);
+        }
+      } else {
+#pragma unroll
+        for (int j = 0; j < pack_size; ++j) { buf[i * pack_size + j] = -Inf<ComputeType>(); }
+      }
     }
-    __syncthreads();
-    ComputeType block_max = BlockReduce(cub_reduce_tmp_storage).Reduce(thread_max, cub::Max());
-    if (tid == 0) { row_reduce_result = block_max; }
-    __syncthreads();
-    const ComputeType row_max_t = row_reduce_result;
+    const ComputeType warp_max = WarpAllReduce<MaxOp, ComputeType>(thread_max);
     ComputeType thread_sum = 0;
-    for (int col = tid; col < num_classes; col += kSoftmaxGpuBlockSize) {
-      const ComputeType exp_x = Exp(compute_buf[col] - row_max_t);
-      compute_buf[col] = exp_x;
+#pragma unroll
+    for (int i = 0; i < cols_per_thread; ++i) {
+      buf[i] = exp(buf[i] - warp_max);
+      thread_sum += buf[i];
+    }
+    const ComputeType warp_sum = WarpAllReduce<SumOp, ComputeType>(thread_sum);
+#pragma unroll
+    for (int i = 0; i < cols_per_thread; ++i) { buf[i] = buf[i] / warp_sum; }
+#pragma unroll
+    for (int i = 0; i < pack_per_thread; ++i) {
+      const int col = (i * kWarpSize + lane_id) * pack_size;
+      if (!padding || col < cols) {
+        MultiStore<ComputeType, T, pack_size>()(row_y + col, buf + i * pack_size);
+      }
+    }
+  }
+}
+
+template<typename T, int pack_size, int cols_per_thread, bool padding>
+void LaunchSoftmaxWarpImpl(cudaStream_t stream, const int64_t rows, const int64_t cols, const T* x,
+                           T* y) {
+  constexpr int block_size = 128;
+  constexpr int waves = 32;
+  static_assert(block_size % kWarpSize == 0, "");
+  constexpr int rows_per_block = block_size / kWarpSize;
+  dim3 block_dim(kWarpSize, rows_per_block);
+  const int64_t num_blocks = (rows + rows_per_block - 1) / rows_per_block;
+  const int grid_dim_x = GetNumBlocks(block_size, num_blocks, waves);
+  SoftmaxWarpImpl<T, pack_size, cols_per_thread, padding>
+      <<<grid_dim_x, block_dim, 0, stream>>>(rows, cols, x, y);
+}
+
+template<typename T, int pack_size, int cols_per_thread>
+void DispatchSoftmaxWarpImplPadding(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                                    const T* x, T* y) {
+  if (cols == cols_per_thread * kWarpSize) {
+    LaunchSoftmaxWarpImpl<T, pack_size, cols_per_thread, false>(stream, rows, cols, x, y);
+  } else {
+    LaunchSoftmaxWarpImpl<T, pack_size, cols_per_thread, true>(stream, rows, cols, x, y);
+  }
+}
+
+template<typename T, int pack_size>
+typename std::enable_if<pack_size == 1, void>::type DispatchSoftmaxWarpImplCols(cudaStream_t stream,
+                                                                                const int64_t rows,
+                                                                                const int64_t cols,
+                                                                                const T* x, T* y) {
+  if (cols <= 0) { UNIMPLEMENTED(); }
+#define DEFINE_ONE_ELIF(col)                                                     \
+  else if (cols <= (col)*kWarpSize) {                                            \
+    DispatchSoftmaxWarpImplPadding<T, pack_size, col>(stream, rows, cols, x, y); \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(3)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(5)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(7)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(9)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(11)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(13)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(15)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(17)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(19)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(21)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(23)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(25)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(27)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(29)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(31)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    UNIMPLEMENTED();
+  }
+}
+
+template<typename T, int pack_size>
+typename std::enable_if<pack_size == 2, void>::type DispatchSoftmaxWarpImplCols(cudaStream_t stream,
+                                                                                const int64_t rows,
+                                                                                const int64_t cols,
+                                                                                const T* x, T* y) {
+  if (cols <= 0) { UNIMPLEMENTED(); }
+#define DEFINE_ONE_ELIF(col)                                                     \
+  else if (cols <= (col)*kWarpSize) {                                            \
+    DispatchSoftmaxWarpImplPadding<T, pack_size, col>(stream, rows, cols, x, y); \
+  }
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    UNIMPLEMENTED();
+  }
+}
+
+template<typename T>
+void DispatchSoftmaxWarpImplPackSize(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                                     const T* x, T* y) {
+  DispatchSoftmaxWarpImplCols<T, 1>(stream, rows, cols, x, y);
+}
+
+template<>
+void DispatchSoftmaxWarpImplPackSize<half>(cudaStream_t stream, const int64_t rows,
+                                           const int64_t cols, const half* x, half* y) {
+  if (cols % 2 == 0 && cols > kWarpSize) {
+    DispatchSoftmaxWarpImplCols<half, 2>(stream, rows, cols, x, y);
+  } else {
+    DispatchSoftmaxWarpImplCols<half, 1>(stream, rows, cols, x, y);
+  }
+}
+
+template<typename T>
+void DispatchSoftmaxWarpImpl(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                             const T* x, T* y) {
+  DispatchSoftmaxWarpImplPackSize<T>(stream, rows, cols, x, y);
+}
+
+template<typename T, int pack_size, int block_size>
+__global__ void SoftmaxBlockSMemImpl(const int64_t rows, const int64_t cols, const T* x, T* y) {
+  using ComputeType = typename GetComputeType<T>::type;
+  extern __shared__ __align__(sizeof(ComputeType)) unsigned char shared_buf[];
+  auto* buf = reinterpret_cast<ComputeType*>(shared_buf);
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = cols / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int64_t row_offset = row * cols;
+    const T* row_x = x + row_offset;
+    T* row_y = y + row_offset;
+    ComputeType thread_max = -Inf<ComputeType>();
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      MultiFetch<T, ComputeType, pack_size>()(pack, row_x + pack_id * pack_size);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) {
+        buf[num_packs * j + pack_id] = pack[j];
+        thread_max = max(thread_max, pack[j]);
+      }
+    }
+    const ComputeType row_max = BlockAllReduce<MaxOp, ComputeType, block_size>(thread_max);
+    ComputeType thread_sum = 0;
+    for (int col = tid; col < cols; col += block_size) {
+      const ComputeType exp_x = exp(buf[col] - row_max);
+      buf[col] = exp_x;
       thread_sum += exp_x;
     }
-    __syncthreads();
-    ComputeType block_sum = BlockReduce(cub_reduce_tmp_storage).Reduce(thread_sum, cub::Sum());
-    if (tid == 0) { row_reduce_result = static_cast<ComputeType>(1.0) / block_sum; }
-    __syncthreads();
-    const ComputeType inv_row_sum = row_reduce_result;
-    for (int col = tid; col < num_classes; col += kSoftmaxGpuBlockSize) {
-      prob_row[col] = SU::FromComputeType(compute_buf[col] * inv_row_sum);
+    const ComputeType row_sum = BlockAllReduce<SumOp, ComputeType, block_size>(thread_sum);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) {
+        pack[j] = buf[num_packs * j + pack_id] / row_sum;
+        thread_max = max(thread_max, pack[j]);
+      }
+      MultiStore<ComputeType, T, pack_size>()(row_y + pack_id * pack_size, pack);
     }
   }
 }
 
-template<typename T>
-void SoftmaxForwardGpu(DeviceCtx* ctx, const int num_instances, const int num_classes, const T* in,
-                       T* prob) {
-  SoftmaxGpuForwardImpl<<<GetSoftmaxNumBlocks(num_instances), GetSoftmaxBlockSize(),
-                          GetForwardDynamicSharedMemorySize<T>(num_classes), ctx->cuda_stream()>>>(
-      num_instances, num_classes, in, prob);
+template<typename T, int pack_size, int block_size>
+void LaunchSoftmaxBlockSMemImpl(cudaStream_t stream, int smem, const int64_t rows,
+                                const int64_t cols, const T* x, T* y) {
+  constexpr int waves = 32;
+  const int grid_dim_x = GetNumBlocks(block_size, rows, waves);
+  SoftmaxBlockSMemImpl<T, pack_size, block_size>
+      <<<grid_dim_x, block_size, smem, stream>>>(rows, cols, x, y);
 }
 
-template<>
-void SoftmaxForwardGpu<float16>(DeviceCtx* ctx, const int num_instances, const int num_classes,
-                                const float16* in, float16* prob) {
-  SoftmaxForwardGpu<half>(ctx, num_instances, num_classes, reinterpret_cast<const half*>(in),
-                          reinterpret_cast<half*>(prob));
-}
-
-template<typename T>
-int GetForwardFusedKernelMaxActiveBlocks(const int num_classes) {
-  int max_active_blocks;
+template<typename T, int pack_size>
+bool TryDispatchSoftmaxBlockSMemImplBlockSize(cudaStream_t stream, const int64_t rows,
+                                              const int64_t cols, const T* x, T* y) {
+  constexpr int block_size_conf_1 = 128;
+  constexpr int block_size_conf_2 = 256;
+  const size_t smem = cols * sizeof(typename GetComputeType<T>::type);
+  int max_active_blocks_conf_1;
+  int max_active_blocks_conf_2;
   OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-      &max_active_blocks, SoftmaxGpuForwardImpl<T>, GetSoftmaxBlockSize(),
-      GetForwardDynamicSharedMemorySize<T>(num_classes)));
-  return max_active_blocks;
-}
-
-template<>
-int GetForwardFusedKernelMaxActiveBlocks<float16>(const int num_classes) {
-  int max_active_blocks;
+      &max_active_blocks_conf_1, SoftmaxBlockSMemImpl<T, pack_size, block_size_conf_1>,
+      block_size_conf_1, smem));
+  if (max_active_blocks_conf_1 <= 0) { return false; }
   OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-      &max_active_blocks, SoftmaxGpuForwardImpl<half>, GetSoftmaxBlockSize(),
-      GetForwardDynamicSharedMemorySize<half>(num_classes)));
-  return max_active_blocks;
-}
-
-template<typename T>
-bool IsForwardFusedKernelSupported(const int num_classes) {
-  if (num_classes >= GetMinNumClasses<T>()
-      && GetForwardFusedKernelMaxActiveBlocks<T>(num_classes) > 0) {
-    return true;
+      &max_active_blocks_conf_2, SoftmaxBlockSMemImpl<T, pack_size, block_size_conf_2>,
+      block_size_conf_2, smem));
+  if (max_active_blocks_conf_2 == max_active_blocks_conf_1) {
+    LaunchSoftmaxBlockSMemImpl<T, pack_size, block_size_conf_2>(stream, smem, rows, cols, x, y);
   } else {
-    return false;
+    LaunchSoftmaxBlockSMemImpl<T, pack_size, block_size_conf_1>(stream, smem, rows, cols, x, y);
+  }
+  return true;
+}
+
+template<typename T>
+bool TryDispatchSoftmaxBlockSMemImplPackSize(cudaStream_t stream, const int64_t rows,
+                                             const int64_t cols, const T* x, T* y) {
+  return TryDispatchSoftmaxBlockSMemImplBlockSize<T, 1>(stream, rows, cols, x, y);
+}
+
+template<>
+bool TryDispatchSoftmaxBlockSMemImplPackSize<half>(cudaStream_t stream, const int64_t rows,
+                                                   const int64_t cols, const half* x, half* y) {
+  if (cols % 2 == 0) {
+    return TryDispatchSoftmaxBlockSMemImplBlockSize<half, 2>(stream, rows, cols, x, y);
+  } else {
+    return TryDispatchSoftmaxBlockSMemImplBlockSize<half, 1>(stream, rows, cols, x, y);
   }
 }
 
 template<typename T>
-__global__ void SoftmaxGpuBackwardImpl(const int num_instances, const int num_classes, const T* dy,
-                                       const T* prob, T* dx) {
-  using SU = SoftmaxUtil<T>;
-  using ComputeType = typename SU::ComputeType;
-  extern __shared__ __align__(sizeof(ComputeType)) unsigned char bw_shared_buf[];
-  auto* dy_buf = reinterpret_cast<ComputeType*>(bw_shared_buf);
-  auto* prob_buf =
-      reinterpret_cast<ComputeType*>(bw_shared_buf + num_classes * sizeof(ComputeType));
-  __shared__ ComputeType row_reduce_result;
-  typedef cub::BlockReduce<ComputeType, kSoftmaxGpuBlockSize> BlockReduce;
-  __shared__ typename BlockReduce::TempStorage cub_reduce_tmp_storage;
+bool TryDispatchSoftmaxBlockSMemImpl(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                                     const T* x, T* y) {
+  return TryDispatchSoftmaxBlockSMemImplPackSize<T>(stream, rows, cols, x, y);
+}
+
+template<typename T, int pack_size, int block_size>
+__global__ void SoftmaxBlockUncachedImpl(const int64_t rows, const int64_t cols, const T* x, T* y) {
+  using ComputeType = typename GetComputeType<T>::type;
   const int tid = threadIdx.x;
-  for (int row = blockIdx.x; row < num_instances; row += gridDim.x) {
-    const int row_offset = row * num_classes;
-    const T* dy_row = dy + row_offset;
-    const T* prob_row = prob + row_offset;
-    T* dx_row = dx + row_offset;
-    ComputeType thread_sum = 0;
-    for (int col = tid; col < num_classes; col += kSoftmaxGpuBlockSize) {
-      const ComputeType dy_col = SU::ToComputeType(dy_row[col]);
-      dy_buf[col] = dy_col;
-      const ComputeType prob_col = SU::ToComputeType(prob_row[col]);
-      prob_buf[col] = prob_col;
-      thread_sum += (dy_col * prob_col);
+  assert(cols % pack_size == 0);
+  const int num_packs = cols / pack_size;
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int64_t row_offset = row * cols;
+    const T* row_x = x + row_offset;
+    T* row_y = y + row_offset;
+    ComputeType thread_max = -Inf<ComputeType>();
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      MultiFetch<T, ComputeType, pack_size>()(pack, row_x + pack_id * pack_size);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) { thread_max = max(thread_max, pack[j]); }
     }
-    __syncthreads();
-    ComputeType block_sum = BlockReduce(cub_reduce_tmp_storage).Reduce(thread_sum, cub::Sum());
-    if (tid == 0) { row_reduce_result = block_sum; }
-    __syncthreads();
-    const ComputeType row_sum_t = row_reduce_result;
-    for (int col = tid; col < num_classes; col += kSoftmaxGpuBlockSize) {
-      dx_row[col] = SU::FromComputeType((dy_buf[col] - row_sum_t) * prob_buf[col]);
+    const ComputeType row_max = BlockAllReduce<MaxOp, ComputeType, block_size>(thread_max);
+    ComputeType thread_sum = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      MultiFetch<T, ComputeType, pack_size>()(pack, row_x + pack_id * pack_size);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) { thread_sum += exp(pack[j] - row_max); }
+    }
+    const ComputeType row_sum = BlockAllReduce<SumOp, ComputeType, block_size>(thread_sum);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      MultiFetch<T, ComputeType, pack_size>()(pack, row_x + pack_id * pack_size);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) { pack[j] = exp(pack[j] - row_max) / row_sum; }
+      MultiStore<ComputeType, T, pack_size>()(row_y + pack_id * pack_size, pack);
     }
   }
 }
 
+template<typename T, int pack_size>
+void LaunchSoftmaxBlockUncachedImpl(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                                    const T* x, T* y) {
+  constexpr int block_size = 1024;
+  constexpr int waves = 32;
+  const int grid_dim_x = GetNumBlocks(block_size, rows, waves);
+  SoftmaxBlockUncachedImpl<T, pack_size, block_size>
+      <<<grid_dim_x, block_size, 0, stream>>>(rows, cols, x, y);
+}
+
 template<typename T>
-void SoftmaxBackwardGpu(DeviceCtx* ctx, const int num_instances, const int num_classes, const T* in,
-                        const T* prob, T* dx) {
-  SoftmaxGpuBackwardImpl<<<GetSoftmaxNumBlocks(num_instances), GetSoftmaxBlockSize(),
-                           GetBackwardDynamicSharedMemorySize<T>(num_classes),
-                           ctx->cuda_stream()>>>(num_instances, num_classes, in, prob, dx);
+void DispatchSoftmaxBlockUncachedImplPackSize(cudaStream_t stream, const int64_t rows,
+                                              const int64_t cols, const T* x, T* y) {
+  LaunchSoftmaxBlockUncachedImpl<T, 1>(stream, rows, cols, x, y);
 }
 
 template<>
-void SoftmaxBackwardGpu<float16>(DeviceCtx* ctx, const int num_instances, const int num_classes,
-                                 const float16* in, const float16* prob, float16* dx) {
-  SoftmaxBackwardGpu<half>(ctx, num_instances, num_classes, reinterpret_cast<const half*>(in),
-                           reinterpret_cast<const half*>(prob), reinterpret_cast<half*>(dx));
-}
-
-template<typename T>
-int GetBackwardFusedKernelMaxActiveBlocks(const int num_classes) {
-  int max_active_blocks;
-  OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-      &max_active_blocks, SoftmaxGpuBackwardImpl<T>, GetSoftmaxBlockSize(),
-      GetBackwardDynamicSharedMemorySize<T>(num_classes)));
-  return max_active_blocks;
-}
-
-template<>
-int GetBackwardFusedKernelMaxActiveBlocks<float16>(const int num_classes) {
-  int max_active_blocks;
-  OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-      &max_active_blocks, SoftmaxGpuBackwardImpl<half>, GetSoftmaxBlockSize(),
-      GetBackwardDynamicSharedMemorySize<half>(num_classes)));
-  return max_active_blocks;
-}
-
-template<typename T>
-bool IsBackwardFusedKernelSupported(const int num_classes) {
-  if (num_classes >= GetMinNumClasses<T>()
-      && GetBackwardFusedKernelMaxActiveBlocks<T>(num_classes) > 0) {
-    return true;
+void DispatchSoftmaxBlockUncachedImplPackSize<half>(cudaStream_t stream, const int64_t rows,
+                                                    const int64_t cols, const half* x, half* y) {
+  if (cols % 2 == 0) {
+    LaunchSoftmaxBlockUncachedImpl<half, 2>(stream, rows, cols, x, y);
   } else {
-    return false;
+    LaunchSoftmaxBlockUncachedImpl<half, 1>(stream, rows, cols, x, y);
+  }
+}
+
+template<typename T>
+void DispatchSoftmaxBlockUncachedImpl(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                                      const T* x, T* y) {
+  return DispatchSoftmaxBlockUncachedImplPackSize<T>(stream, rows, cols, x, y);
+}
+
+template<typename T>
+void DispatchSoftmax(cudaStream_t stream, const int64_t rows, const int64_t cols, const T* x,
+                     T* y) {
+  if (cols <= 1024) {
+    DispatchSoftmaxWarpImpl<T>(stream, rows, cols, x, y);
+  } else if (!TryDispatchSoftmaxBlockSMemImpl(stream, rows, cols, x, y)) {
+    DispatchSoftmaxBlockUncachedImpl(stream, rows, cols, x, y);
+  }
+}
+
+template<typename T, int pack_size, int cols_per_thread, bool padding>
+__global__ void SoftmaxGradWarpImpl(const int64_t rows, const int64_t cols, const T* y, const T* dy,
+                                    T* dx) {
+  static_assert(cols_per_thread % pack_size == 0, "");
+  constexpr int pack_per_thread = cols_per_thread / pack_size;
+  assert(cols <= cols_per_thread * kWarpSize);
+  using ComputeType = typename GetComputeType<T>::type;
+  ComputeType y_buf[cols_per_thread];
+  ComputeType dy_buf[cols_per_thread];
+  const int global_warp_id = blockIdx.x * blockDim.y + threadIdx.y;
+  const int num_global_warp = gridDim.x * blockDim.y;
+  const int lane_id = threadIdx.x;
+  for (int64_t row = global_warp_id; row < rows; row += num_global_warp) {
+    const int64_t row_offset = row * cols;
+    const T* row_y = y + row_offset;
+    const T* row_dy = dy + row_offset;
+    T* row_dx = dx + row_offset;
+    ComputeType thread_sum = 0;
+#pragma unroll
+    for (int i = 0; i < pack_per_thread; ++i) {
+      const int col = (i * kWarpSize + lane_id) * pack_size;
+      if (!padding || col < cols) {
+        MultiFetch<T, ComputeType, pack_size>()(y_buf + i * pack_size, row_y + col);
+        MultiFetch<T, ComputeType, pack_size>()(dy_buf + i * pack_size, row_dy + col);
+#pragma unroll
+        for (int j = 0; j < pack_size; ++j) {
+          thread_sum += y_buf[i * pack_size + j] * dy_buf[i * pack_size + j];
+        }
+      }
+    }
+    const ComputeType warp_sum = WarpAllReduce<SumOp, ComputeType>(thread_sum);
+#pragma unroll
+    for (int i = 0; i < pack_per_thread; ++i) {
+      const int col = (i * kWarpSize + lane_id) * pack_size;
+      if (!padding || col < cols) {
+        for (int j = 0; j < pack_size; ++j) {
+          dy_buf[i * pack_size + j] =
+              (dy_buf[i * pack_size + j] - warp_sum) * y_buf[i * pack_size + j];
+        }
+        MultiStore<ComputeType, T, pack_size>()(row_dx + col, dy_buf + i * pack_size);
+      }
+    }
+  }
+}
+
+template<typename T, int pack_size, int cols_per_thread, bool padding>
+void LaunchSoftmaxGradWarpImpl(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                               const T* y, const T* dy, T* dx) {
+  constexpr int block_size = 128;
+  constexpr int waves = 32;
+  static_assert(block_size % kWarpSize == 0, "");
+  constexpr int rows_per_block = block_size / kWarpSize;
+  dim3 block_dim(kWarpSize, rows_per_block);
+  const int64_t num_blocks = (rows + rows_per_block - 1) / rows_per_block;
+  const int grid_dim_x = GetNumBlocks(block_size, num_blocks, waves);
+  SoftmaxGradWarpImpl<T, pack_size, cols_per_thread, padding>
+      <<<grid_dim_x, block_dim, 0, stream>>>(rows, cols, y, dy, dx);
+}
+
+template<typename T, int pack_size, int cols_per_thread>
+void DispatchSoftmaxGradWarpImplPadding(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                                        const T* y, const T* dy, T* dx) {
+  if (cols == cols_per_thread * kWarpSize) {
+    LaunchSoftmaxGradWarpImpl<T, pack_size, cols_per_thread, false>(stream, rows, cols, y, dy, dx);
+  } else {
+    LaunchSoftmaxGradWarpImpl<T, pack_size, cols_per_thread, true>(stream, rows, cols, y, dy, dx);
+  }
+}
+
+template<typename T, int pack_size>
+typename std::enable_if<pack_size == 1, void>::type DispatchSoftmaxGradWarpImplCols(
+    cudaStream_t stream, const int64_t rows, const int64_t cols, const T* y, const T* dy, T* dx) {
+  if (cols <= 0) { UNIMPLEMENTED(); }
+#define DEFINE_ONE_ELIF(col)                                                              \
+  else if (cols <= (col)*kWarpSize) {                                                     \
+    DispatchSoftmaxGradWarpImplPadding<T, pack_size, col>(stream, rows, cols, y, dy, dx); \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(3)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(5)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(7)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(9)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(11)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(13)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(15)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(17)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(19)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(21)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(23)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(25)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(27)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(29)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(31)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    UNIMPLEMENTED();
+  }
+}
+
+template<typename T, int pack_size>
+typename std::enable_if<pack_size == 2, void>::type DispatchSoftmaxGradWarpImplCols(
+    cudaStream_t stream, const int64_t rows, const int64_t cols, const T* y, const T* dy, T* dx) {
+  if (cols <= 0) { UNIMPLEMENTED(); }
+#define DEFINE_ONE_ELIF(col)                                                              \
+  else if (cols <= (col)*kWarpSize) {                                                     \
+    DispatchSoftmaxGradWarpImplPadding<T, pack_size, col>(stream, rows, cols, y, dy, dx); \
+  }
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    UNIMPLEMENTED();
+  }
+}
+
+template<typename T>
+void DispatchSoftmaxGradWarpImplPackSize(cudaStream_t stream, const int64_t rows,
+                                         const int64_t cols, const T* y, const T* dy, T* dx) {
+  DispatchSoftmaxGradWarpImplCols<T, 1>(stream, rows, cols, y, dy, dx);
+}
+
+template<>
+void DispatchSoftmaxGradWarpImplPackSize<half>(cudaStream_t stream, const int64_t rows,
+                                               const int64_t cols, const half* y, const half* dy,
+                                               half* dx) {
+  if (cols % 2 == 0 && cols > kWarpSize) {
+    DispatchSoftmaxGradWarpImplCols<half, 2>(stream, rows, cols, y, dy, dx);
+  } else {
+    DispatchSoftmaxGradWarpImplCols<half, 1>(stream, rows, cols, y, dy, dx);
+  }
+}
+
+template<typename T>
+void DispatchSoftmaxGradWarpImpl(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                                 const T* y, const T* dy, T* dx) {
+  DispatchSoftmaxGradWarpImplPackSize<T>(stream, rows, cols, y, dy, dx);
+}
+
+template<typename T, int pack_size, int block_size>
+__global__ void SoftmaxGradBlockSMemImpl(const int64_t rows, const int64_t cols, const T* y,
+                                         const T* dy, T* dx) {
+  using ComputeType = typename GetComputeType<T>::type;
+  extern __shared__ __align__(sizeof(ComputeType)) unsigned char grad_shared_buf[];
+  auto* y_buf = reinterpret_cast<ComputeType*>(grad_shared_buf);
+  auto* dy_buf = y_buf + cols;
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = cols / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int64_t row_offset = row * cols;
+    const T* row_y = y + row_offset;
+    const T* row_dy = dy + row_offset;
+    T* row_dx = dx + row_offset;
+    ComputeType thread_sum = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType y_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      MultiFetch<T, ComputeType, pack_size>()(y_pack, row_y + pack_id * pack_size);
+      MultiFetch<T, ComputeType, pack_size>()(dy_pack, row_dy + pack_id * pack_size);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) {
+        y_buf[num_packs * j + pack_id] = y_pack[j];
+        dy_buf[num_packs * j + pack_id] = dy_pack[j];
+        thread_sum += y_pack[j] * dy_pack[j];
+      }
+    }
+    const ComputeType row_sum = BlockAllReduce<SumOp, ComputeType, block_size>(thread_sum);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) {
+        pack[j] = (dy_buf[num_packs * j + pack_id] - row_sum) * y_buf[num_packs * j + pack_id];
+      }
+      MultiStore<ComputeType, T, pack_size>()(row_dx + pack_id * pack_size, pack);
+    }
+  }
+}
+
+template<typename T, int pack_size, int block_size>
+void LaunchSoftmaxGradBlockSMemImpl(cudaStream_t stream, int smem, const int64_t rows,
+                                    const int64_t cols, const T* y, const T* dy, T* dx) {
+  constexpr int waves = 32;
+  const int grid_dim_x = GetNumBlocks(block_size, rows, waves);
+  SoftmaxGradBlockSMemImpl<T, pack_size, block_size>
+      <<<grid_dim_x, block_size, smem, stream>>>(rows, cols, y, dy, dx);
+}
+
+template<typename T, int pack_size>
+bool TryDispatchSoftmaxGradBlockSMemImplBlockSize(cudaStream_t stream, const int64_t rows,
+                                                  const int64_t cols, const T* y, const T* dy,
+                                                  T* dx) {
+  constexpr int block_size_conf_1 = 128;
+  constexpr int block_size_conf_2 = 256;
+  const size_t smem = cols * sizeof(typename GetComputeType<T>::type) * 2;
+  int max_active_blocks_conf_1;
+  int max_active_blocks_conf_2;
+  OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_active_blocks_conf_1, SoftmaxGradBlockSMemImpl<T, pack_size, block_size_conf_1>,
+      block_size_conf_1, smem));
+  if (max_active_blocks_conf_1 <= 0) { return false; }
+  OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_active_blocks_conf_2, SoftmaxGradBlockSMemImpl<T, pack_size, block_size_conf_2>,
+      block_size_conf_2, smem));
+  if (max_active_blocks_conf_2 == max_active_blocks_conf_1) {
+    LaunchSoftmaxGradBlockSMemImpl<T, pack_size, block_size_conf_2>(stream, smem, rows, cols, y, dy,
+                                                                    dx);
+  } else {
+    LaunchSoftmaxGradBlockSMemImpl<T, pack_size, block_size_conf_1>(stream, smem, rows, cols, y, dy,
+                                                                    dx);
+  }
+  return true;
+}
+
+template<typename T>
+bool TryDispatchSoftmaxGradBlockSMemImplPackSize(cudaStream_t stream, const int64_t rows,
+                                                 const int64_t cols, const T* y, const T* dy,
+                                                 T* dx) {
+  return TryDispatchSoftmaxGradBlockSMemImplBlockSize<T, 1>(stream, rows, cols, y, dy, dx);
+}
+
+template<>
+bool TryDispatchSoftmaxGradBlockSMemImplPackSize<half>(cudaStream_t stream, const int64_t rows,
+                                                       const int64_t cols, const half* y,
+                                                       const half* dy, half* dx) {
+  if (cols % 2 == 0) {
+    return TryDispatchSoftmaxGradBlockSMemImplBlockSize<half, 2>(stream, rows, cols, y, dy, dx);
+  } else {
+    return TryDispatchSoftmaxGradBlockSMemImplBlockSize<half, 1>(stream, rows, cols, y, dy, dx);
+  }
+}
+
+template<typename T>
+bool TryDispatchSoftmaxGradBlockSMemImpl(cudaStream_t stream, const int64_t rows,
+                                         const int64_t cols, const T* y, const T* dy, T* dx) {
+  return TryDispatchSoftmaxGradBlockSMemImplPackSize<T>(stream, rows, cols, y, dy, dx);
+}
+
+template<typename T, int pack_size, int block_size>
+__global__ void SoftmaxGradBlockUncachedImpl(const int64_t rows, const int64_t cols, const T* y,
+                                             const T* dy, T* dx) {
+  using ComputeType = typename GetComputeType<T>::type;
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = cols / pack_size;
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int64_t row_offset = row * cols;
+    const T* row_y = y + row_offset;
+    const T* row_dy = dy + row_offset;
+    T* row_dx = dx + row_offset;
+    ComputeType thread_sum = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType y_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      MultiFetch<T, ComputeType, pack_size>()(y_pack, row_y + pack_id * pack_size);
+      MultiFetch<T, ComputeType, pack_size>()(dy_pack, row_dy + pack_id * pack_size);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) { thread_sum += y_pack[j] * dy_pack[j]; }
+    }
+    const ComputeType row_sum = BlockAllReduce<SumOp, ComputeType, block_size>(thread_sum);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType y_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      MultiFetch<T, ComputeType, pack_size>()(y_pack, row_y + pack_id * pack_size);
+      MultiFetch<T, ComputeType, pack_size>()(dy_pack, row_dy + pack_id * pack_size);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j) { dy_pack[j] = (dy_pack[j] - row_sum) * y_pack[j]; }
+      MultiStore<ComputeType, T, pack_size>()(row_dx + pack_id * pack_size, dy_pack);
+    }
+  }
+}
+
+template<typename T, int pack_size>
+void LaunchSoftmaxGradBlockUncachedImpl(cudaStream_t stream, const int64_t rows, const int64_t cols,
+                                        const T* y, const T* dy, T* dx) {
+  constexpr int block_size = 1024;
+  constexpr int waves = 32;
+  const int grid_dim_x = GetNumBlocks(block_size, rows, waves);
+  SoftmaxGradBlockUncachedImpl<T, pack_size, block_size>
+      <<<grid_dim_x, block_size, 0, stream>>>(rows, cols, y, dy, dx);
+}
+
+template<typename T>
+void DispatchSoftmaxGradBlockUncachedImplPackSize(cudaStream_t stream, const int64_t rows,
+                                                  const int64_t cols, const T* y, const T* dy,
+                                                  T* dx) {
+  LaunchSoftmaxGradBlockUncachedImpl<T, 1>(stream, rows, cols, y, dy, dx);
+}
+
+template<>
+void DispatchSoftmaxGradBlockUncachedImplPackSize<half>(cudaStream_t stream, const int64_t rows,
+                                                        const int64_t cols, const half* y,
+                                                        const half* dy, half* dx) {
+  if (cols % 2 == 0) {
+    LaunchSoftmaxGradBlockUncachedImpl<half, 2>(stream, rows, cols, y, dy, dx);
+  } else {
+    LaunchSoftmaxGradBlockUncachedImpl<half, 1>(stream, rows, cols, y, dy, dx);
+  }
+}
+
+template<typename T>
+void DispatchSoftmaxGradBlockUncachedImpl(cudaStream_t stream, const int64_t rows,
+                                          const int64_t cols, const T* y, const T* dy, T* dx) {
+  return DispatchSoftmaxGradBlockUncachedImplPackSize<T>(stream, rows, cols, y, dy, dx);
+}
+
+template<typename T>
+void DispatchSoftmaxGrad(cudaStream_t stream, const int64_t rows, const int64_t cols, const T* y,
+                         const T* dy, T* dx) {
+  if (cols <= 1024) {
+    DispatchSoftmaxGradWarpImpl(stream, rows, cols, y, dy, dx);
+  } else if (!TryDispatchSoftmaxGradBlockSMemImpl<T>(stream, rows, cols, y, dy, dx)) {
+    DispatchSoftmaxGradBlockUncachedImpl<T>(stream, rows, cols, y, dy, dx);
   }
 }
 
@@ -240,35 +838,20 @@ class SoftmaxKernel final : public user_op::OpKernel {
     const user_op::Tensor* in = ctx->Tensor4ArgNameAndIndex("in", 0);
     user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
     const ShapeView& in_shape = in->shape();
-    const int64_t num_classes = in_shape.At(in_shape.NumAxes() - 1);
-    const int64_t num_instances = in_shape.Count(0, in_shape.NumAxes() - 1);
-    if (IsForwardFusedKernelSupported<T>(num_classes)) {
-      SoftmaxForwardGpu<T>(ctx->device_ctx(), num_instances, num_classes, in->dptr<T>(),
-                           out->mut_dptr<T>());
-    } else {
-      user_op::Tensor* tmp_buffer = ctx->Tensor4ArgNameAndIndex("tmp_buffer", 0);
-      SoftmaxKernelUtil<DeviceType::kGPU, T>::ComputeProb(
-          ctx->device_ctx(), num_instances, num_classes, in->dptr<T>(), out->mut_dptr<T>(),
-          tmp_buffer->mut_dptr(), tmp_buffer->shape().elem_cnt());
-    }
+    const int64_t cols = in_shape.At(in_shape.NumAxes() - 1);
+    const int64_t rows = in_shape.Count(0, in_shape.NumAxes() - 1);
+    DispatchSoftmax(ctx->device_ctx()->cuda_stream(), rows, cols, in->dptr<T>(),
+                    out->mut_dptr<T>());
   }
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-#define REGISTER_SOFTMAX_GPU_KERNEL(dtype)                                                       \
-  REGISTER_USER_KERNEL("softmax")                                                                \
-      .SetCreateFn<SoftmaxKernel<dtype>>()                                                       \
-      .SetIsMatchedHob((user_op::HobDeviceTag() == DeviceType::kGPU)                             \
-                       & (user_op::HobDataType("out", 0) == GetDataType<dtype>::value))          \
-      .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                                        \
-        const Shape* in_shape = ctx->Shape4ArgNameAndIndex("in", 0);                             \
-        const int64_t num_classes = in_shape->At(in_shape->NumAxes() - 1);                       \
-        const int64_t num_instances = in_shape->Count(0, in_shape->NumAxes() - 1);               \
-        return SoftmaxKernelUtil<DeviceType::kGPU, dtype>::GetComputeProbTempStorageSizeInBytes( \
-            num_instances, num_classes);                                                         \
-      });
+#define REGISTER_SOFTMAX_GPU_KERNEL(dtype)                                             \
+  REGISTER_USER_KERNEL("softmax").SetCreateFn<SoftmaxKernel<dtype>>().SetIsMatchedHob( \
+      (user_op::HobDeviceTag() == DeviceType::kGPU)                                    \
+      & (user_op::HobDataType("out", 0) == GetDataType<dtype>::value));
 
-REGISTER_SOFTMAX_GPU_KERNEL(float16)
+REGISTER_SOFTMAX_GPU_KERNEL(half)
 REGISTER_SOFTMAX_GPU_KERNEL(float)
 REGISTER_SOFTMAX_GPU_KERNEL(double)
 #undef REGISTER_SOFTMAX_GPU_KERNEL
@@ -284,36 +867,21 @@ class SoftmaxGradKernel final : public user_op::OpKernel {
     const user_op::Tensor* y = ctx->Tensor4ArgNameAndIndex("y", 0);
     const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
     user_op::Tensor* dx = ctx->Tensor4ArgNameAndIndex("dx", 0);
-
-    const int64_t num_classes = y->shape().At(y->shape().NumAxes() - 1);
-    const int64_t num_instances = y->shape().elem_cnt() / num_classes;
-    if (IsBackwardFusedKernelSupported<T>(num_classes)) {
-      SoftmaxBackwardGpu<T>(ctx->device_ctx(), num_instances, num_classes, dy->dptr<T>(),
-                            y->dptr<T>(), dx->mut_dptr<T>());
-    } else {
-      user_op::Tensor* tmp_buffer = ctx->Tensor4ArgNameAndIndex("tmp_buffer", 0);
-      SoftmaxKernelUtil<DeviceType::kGPU, T>::ComputeDiff(
-          ctx->device_ctx(), num_instances, num_classes, dy->dptr<T>(), y->dptr<T>(),
-          dx->mut_dptr<T>(), tmp_buffer->mut_dptr(), tmp_buffer->shape().elem_cnt());
-    }
+    const int64_t cols = y->shape().At(y->shape().NumAxes() - 1);
+    const int64_t rows = y->shape().elem_cnt() / cols;
+    DispatchSoftmaxGrad(ctx->device_ctx()->cuda_stream(), rows, cols, y->dptr<T>(), dy->dptr<T>(),
+                        dx->mut_dptr<T>());
   }
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-#define REGISTER_SOFTMAX_GRAD_KERNEL(dtype)                                                      \
-  REGISTER_USER_KERNEL("softmax_grad")                                                           \
-      .SetCreateFn<SoftmaxGradKernel<dtype>>()                                                   \
-      .SetIsMatchedHob((user_op::HobDeviceTag() == DeviceType::kGPU)                             \
-                       & (user_op::HobDataType("dx", 0) == GetDataType<dtype>::value))           \
-      .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                                        \
-        const Shape* dy_shape = ctx->Shape4ArgNameAndIndex("dy", 0);                             \
-        const int64_t num_classes = dy_shape->At(dy_shape->NumAxes() - 1);                       \
-        const int64_t num_instances = dy_shape->Count(0, dy_shape->NumAxes() - 1);               \
-        return SoftmaxKernelUtil<DeviceType::kGPU, dtype>::GetComputeProbTempStorageSizeInBytes( \
-            num_instances, num_classes);                                                         \
-      });
+#define REGISTER_SOFTMAX_GRAD_KERNEL(dtype)                          \
+  REGISTER_USER_KERNEL("softmax_grad")                               \
+      .SetCreateFn<SoftmaxGradKernel<dtype>>()                       \
+      .SetIsMatchedHob((user_op::HobDeviceTag() == DeviceType::kGPU) \
+                       & (user_op::HobDataType("dx", 0) == GetDataType<dtype>::value));
 
-REGISTER_SOFTMAX_GRAD_KERNEL(float16)
+REGISTER_SOFTMAX_GRAD_KERNEL(half)
 REGISTER_SOFTMAX_GRAD_KERNEL(float)
 REGISTER_SOFTMAX_GRAD_KERNEL(double)
 #undef REGISTER_SOFTMAX_GRAD_KERNEL


### PR DESCRIPTION
测试数据 rows = 49152 dtype = half

Softmax

cols | size(GB) | t warp(us) | t smem(us) | T uncached(us) | T cudnn(us) | bw warp | bw smem | bw uncached | bw cudnn
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
32 | 0.00585938 | 18 | 103 | 1230 | 406 | 325.5208 | 56.88714 | 4.76372 | 14.43196
64 | 0.01171875 | 22 | 103 | 1210 | 413 | 532.6705 | 113.7743 | 9.684917 | 28.3747
128 | 0.0234375 | 32 | 112 | 1210 | 427 | 732.4219 | 209.2634 | 19.36983 | 54.88876
256 | 0.046875 | 62 | 133 | 1240 | 454 | 756.0484 | 352.4436 | 37.80242 | 103.2489
512 | 0.09375 | 122 | 201 | 1260 | 506 | 768.4426 | 466.4179 | 74.40476 | 185.2767
1024 | 0.1875 | 244 | 269 | 1360 | 613 | 768.4426 | 697.026 | 137.8676 | 305.8728
2048 | 0.375 |   | 484 | 1660 | 828 |   | 774.7934 | 225.9036 | 452.8986
4096 | 0.75 |   | 964 | 2520 | 1350 |   | 778.0083 | 297.619 | 555.5556
8192 | 1.5 |   | 2230 | 2920 | 4210 |   | 672.6457 | 513.6986 | 356.2945
16384 | 3 |   |   | 4720 | 10690 |   |   | 635.5932 | 280.6361
32768 | 6 |   |   | 11950 | 20940 |   |   | 502.0921 | 286.533

SoftmaxGrad

cols | size(GB) | t warp(us) | t smem(us) | T uncached(us) | T cudnn(us) | bw warp | bw smem | bw uncached | bw cudnn
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
32 | 0.00878906 | 16 | 62 | 737 | 215 | 549.3164 | 141.7591 | 11.92546 | 40.87936
64 | 0.01757813 | 22 | 62 | 729 | 223 | 799.0057 | 283.5181 | 24.11265 | 78.82567
128 | 0.03515625 | 44 | 71 | 737 | 241 | 799.0057 | 495.1585 | 47.70183 | 145.8766
256 | 0.0703125 | 88 | 94 | 753 | 279 | 799.0057 | 748.0053 | 93.37649 | 252.0161
512 | 0.140625 | 176 | 177 | 784 | 309 | 799.0057 | 794.4915 | 179.3686 | 455.0971
1024 | 0.28125 | 353 | 355 | 832 | 422 | 796.7422 | 792.2535 | 338.0409 | 666.4692
2048 | 0.5625 |   | 709 | 965 | 776 |   | 793.3709 | 582.9016 | 724.8711
4096 | 1.125 |   | 1420 | 1610 | 1880 |   | 792.2535 | 698.7578 | 598.4043
8192 | 2.25 |   |   | 2870 | 4530 |   |   | 783.9721 | 496.6887
16384 | 4.5 |   |   | 7620 | 9280 |   |   | 590.5512 | 484.9138
32768 | 9 |   |   | 18500 | 18600 |   |   | 486.4865 | 483.871





