### PR TITLE
fix hardtanh CI precision error

### DIFF
--- a/oneflow/python/test/ops/test_elu.py
+++ b/oneflow/python/test/ops/test_elu.py
@@ -44,7 +44,7 @@ def _compare_elu_with_np(
     func_config = flow.FunctionConfig()
     func_config.default_placement_scope(flow.scope.placement(device_type, machine_ids))
     # global function needs float32 as type of argument and return value
-    if value_type == flow.float16:
+    if value_type[1] == flow.float16:
         func_config.default_data_type(flow.float32)
     else:
         func_config.default_data_type(value_type[1])

--- a/oneflow/python/test/ops/test_hardsigmoid.py
+++ b/oneflow/python/test/ops/test_hardsigmoid.py
@@ -48,7 +48,7 @@ def _compare_hardsigmoid_with_np(
     func_config = flow.FunctionConfig()
     func_config.default_placement_scope(flow.scope.placement(device_type, machine_ids))
     # global function needs float32 as type of argument and return value
-    if value_type == flow.float16:
+    if value_type[1] == flow.float16:
         func_config.default_data_type(flow.float32)
     else:
         func_config.default_data_type(value_type[1])

--- a/oneflow/python/test/ops/test_hardswish.py
+++ b/oneflow/python/test/ops/test_hardswish.py
@@ -45,7 +45,6 @@ def _compare_hardswish_with_np(
         input_1 += np.random.randn(*input_shape).astype(
             value_type[0]
         )  # add a randnom array, range from(0, 1)
-
     assert device_type in ["cpu", "gpu"]
 
     flow.clear_default_session()
@@ -57,7 +56,7 @@ def _compare_hardswish_with_np(
     func_config = flow.FunctionConfig()
     func_config.default_placement_scope(flow.scope.placement(device_type, machine_ids))
     # global function needs float32 as type of argument and return value
-    if value_type == flow.float16:
+    if value_type[1] == flow.float16:
         func_config.default_data_type(flow.float32)
     else:
         func_config.default_data_type(value_type[1])


### PR DESCRIPTION
修复激活函数系列算子在跑CI时，有一定几率不过的问题

原因：
原脚本针对float16测试，是直接以float32类型生成数据，这样直接生成，容易导致 numpy 部分计算精度是高的，但是对应oneflow算子的float16版本，精度丢失，导致一定几率下，验证前向和后向的结果，误差容易增大。

解决方法：
针对float16测试，生成的数据类型设置为 `np.float16`，为了输入给job function，再统一转换为 `np.float32`。这样的做法能保证 numpy 部分 和 oneflow对应算子 实际计算的数据类型一致，验证前向和后向的结果更加稳定。

具体可参考 `test_hardtanh.py` 文件的修改逻辑
