### PR TITLE
Add CentOS specific info on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@
     - Please make sure you have G++ and GCC >= 4.8.5 installed. Clang is not supported for now.
 
     - To install dependencies, run:
-
+      
+      On Centos:
+      
       ```
       yum-config-manager --add-repo https://yum.repos.intel.com/setup/intelproducts.repo && \
       rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@
 
     - To install dependencies, run:
       
-      On Centos:
+      On CentOS:
       
       ```
       yum-config-manager --add-repo https://yum.repos.intel.com/setup/intelproducts.repo && \


### PR DESCRIPTION
如果是ubuntu用户,不需要执行yum相关的mkl安装.  如果不特殊说明一下容易让不太熟悉Linux各个版本包i管理工具的用户产生歧义, 卡在源码编译环节.