### PR TITLE
support rle poly_to_mask

### DIFF
--- a/oneflow/user/kernels/image_object_preprocess_kernels.cpp
+++ b/oneflow/user/kernels/image_object_preprocess_kernels.cpp
@@ -232,17 +232,15 @@ void Rle4DensePoints(std::vector<std::vector<cv::Point_<T>>> &poly_point_vec,
       temp_rle_vec[j] -= p;
       p = temp;
     }
-    int m = 0, j = 0;
+    int j = 0;
     upsample_poly_point_vec[i].push_back(temp_rle_vec[j++]);
-    ++m;
     while (j < rle_size) {
       if (temp_rle_vec[j] > 0) {
         upsample_poly_point_vec[i].push_back(temp_rle_vec[j++]);
-        ++m;
       } else {
         ++j;
         if (j < rle_size) {
-          upsample_poly_point_vec[i][m - 1] += temp_rle_vec[j++];
+          upsample_poly_point_vec[i].back() += temp_rle_vec[j++];
         }
       }
     }


### PR DESCRIPTION
coco的segmentation标注需要从poly形式转换到binarymask，最初的op使用了opencv的fillPoly转换，会导致mask边缘不对齐：
![image](https://user-images.githubusercontent.com/32785733/104407710-36a5e400-559d-11eb-9abf-d31208fba441.png)
绝大多数detection框架采用的是cocoapi进行转换，这里为了对齐按照cocoapi的逻辑实现了poly->upsample->downsample->rle->merge->decode to binarymask.

暂时不用合并，目前仅为了对齐。
