### PR TITLE
Fix bug: cast_to_static_shape test raise unimplemented error in eager

### DIFF
--- a/oneflow/python/test/ops/test_cast_to_static_shape.py
+++ b/oneflow/python/test/ops/test_cast_to_static_shape.py
@@ -49,9 +49,12 @@ def _make_cast_to_static_shape_fn(
         x: flow.typing.ListNumpy.Placeholder(shape=shape, dtype=dtype)
     ) -> flow.typing.ListNumpy:
         x_var = flow.get_variable(
-            name="x_var", shape=(1,), dtype=dtype, initializer=flow.zeros_initializer(),
+            name="x_var",
+            shape=(1,),
+            dtype=flow.float32,
+            initializer=flow.zeros_initializer(),
         )
-        x = x + x_var
+        x = x + flow.cast(x_var, dtype=dtype)
         y = flow.cast_to_static_shape(x)
         test_case.assertFalse(y.is_dynamic)
         if require_grad:


### PR DESCRIPTION
修复在测试用例中 get_variable dtype 类型设置为整型时，Initializer 在 eager 模式下无法正常工作，所以不会调用整型的 get_variable