### PR TITLE
Add Operator::InferInternalBlobDescs

### DIFF
--- a/oneflow/core/operator/acc_tick_op.cpp
+++ b/oneflow/core/operator/acc_tick_op.cpp
@@ -24,9 +24,9 @@ void AccTickOp::InitFromOpConf() {
   EnrollOutputBn("acc", false);
 }
 
-Maybe<void> AccTickOp::InferBlobDescs(
+Maybe<void> AccTickOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   *GetBlobDesc4BnInOp("acc") = *GetBlobDesc4BnInOp("one");
   GetBlobDesc4BnInOp("acc")->mut_shape() = Shape({1LL});
   return Maybe<void>::Ok();

--- a/oneflow/core/operator/acc_tick_op.h
+++ b/oneflow/core/operator/acc_tick_op.h
@@ -30,8 +30,9 @@ class AccTickOp final : public Operator {
   void InitFromOpConf() override;
   LogicalNode* NewProperLogicalNode() const override { return new AccTickLogicalNode; }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   Maybe<void> InferOutputBlobTimeShape(
       std::function<const Shape*(const std::string&)> GetTimeShape4BnInOp,
       const ParallelContext* parallel_ctx, Shape* time_shape) const override;

--- a/oneflow/core/operator/accumulate_op.h
+++ b/oneflow/core/operator/accumulate_op.h
@@ -28,8 +28,9 @@ class AccumulateOp final : public Operator {
 
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     return Maybe<void>::Ok();
   }
   Maybe<void> InferOutputBlobTimeShape(

--- a/oneflow/core/operator/assign_op.cpp
+++ b/oneflow/core/operator/assign_op.cpp
@@ -24,8 +24,9 @@ class AssignOp final : public Operator {
   ~AssignOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(
@@ -49,9 +50,9 @@ std::string DebugString(const BlobDesc& blob_desc) {
   return blob_desc_proto.DebugString();
 }
 
-Maybe<void> AssignOp::InferBlobDescs(
+Maybe<void> AssignOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   CHECK_OR_RETURN(*GetBlobDesc4BnInOp("ref") == *GetBlobDesc4BnInOp("value"))
       << "\nref_blob_desc: " << DebugString(*GetBlobDesc4BnInOp("ref"))
       << "\nvalue_blob_desc: " << DebugString(*GetBlobDesc4BnInOp("value"));

--- a/oneflow/core/operator/boxing_identity_op.cpp
+++ b/oneflow/core/operator/boxing_identity_op.cpp
@@ -26,14 +26,9 @@ class BoxingIdentityOp : public Operator {
   ~BoxingIdentityOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
-
- protected:
-  virtual void VirtualInferBlobDescs(
-      const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-      const ParallelContext* parallel_ctx) const {}
-  virtual void VirtualInitFromOpConf(){};
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   LogicalBlobId lbi4ibn(const std::string& input_bn) const override;
@@ -53,9 +48,9 @@ LogicalBlobId BoxingIdentityOp::lbi4obn(const std::string& output_bn) const {
   return this->op_conf().boxing_identity_conf().lbi();
 }
 
-Maybe<void> BoxingIdentityOp::InferBlobDescs(
+Maybe<void> BoxingIdentityOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   *GetBlobDesc4BnInOp("out") = *GetBlobDesc4BnInOp("in");
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/boxing_op.cpp
+++ b/oneflow/core/operator/boxing_op.cpp
@@ -60,9 +60,9 @@ Symbol<OperatorConf> BoxingOp::GetOpConfWithoutOpNameAndLbn() const {
   return SymbolOf(op_conf);
 }
 
-Maybe<void> BoxingOp::InferBlobDescs(
+Maybe<void> BoxingOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BoxingOpConf& conf = op_conf().boxing_conf();
   BlobDesc* first_in_blob = GetBlobDesc4BnInOp(input_bns().Get(0));
   if (conf.in_box_case() == BoxingOpConf::kAddBox) {

--- a/oneflow/core/operator/boxing_op.h
+++ b/oneflow/core/operator/boxing_op.h
@@ -27,8 +27,9 @@ class BoxingOp final : public Operator {
   ~BoxingOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  protected:
   void VirtualGenKernelConf(std::function<const BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,

--- a/oneflow/core/operator/boxing_zeros_op.cpp
+++ b/oneflow/core/operator/boxing_zeros_op.cpp
@@ -25,8 +25,9 @@ class BoxingZerosOp : public Operator {
   ~BoxingZerosOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   LogicalBlobId lbi4ibn(const std::string& input_bn) const override;
@@ -43,9 +44,9 @@ LogicalBlobId BoxingZerosOp::lbi4obn(const std::string& output_bn) const {
   return this->op_conf().boxing_zeros_conf().lbi();
 }
 
-Maybe<void> BoxingZerosOp::InferBlobDescs(
+Maybe<void> BoxingZerosOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BoxingZerosOpConf& conf = this->op_conf().boxing_zeros_conf();
   BlobDesc* out = GetBlobDesc4BnInOp("out");
   out->set_data_type(conf.data_type());

--- a/oneflow/core/operator/broadcast_to_compatible_with_op.cpp
+++ b/oneflow/core/operator/broadcast_to_compatible_with_op.cpp
@@ -54,8 +54,9 @@ class BroadcastToCompatibleWithOp final : public Operator {
     EnrollOutputBn("y");
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     int64_t num_compatibles = op_conf().broadcast_to_compatible_with_conf().compatible_size();
     const BlobDesc* x_desc = GetBlobDesc4BnInOp("x");
     Shape broadcasted_shape(x_desc->shape());

--- a/oneflow/core/operator/callback_notify_op.cpp
+++ b/oneflow/core/operator/callback_notify_op.cpp
@@ -28,9 +28,9 @@ LogicalNode* CallbackNotifyOp::NewProperLogicalNode() const {
   return new CallbackNotifyLogicalNode();
 }
 
-Maybe<void> CallbackNotifyOp::InferBlobDescs(
+Maybe<void> CallbackNotifyOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   CHECK_EQ_OR_RETURN(parallel_ctx->parallel_num(), 1);
   CHECK_OR_RETURN(GetBlobDesc4BnInOp("in")->shape() == Shape({1}));
   CHECK_OR_RETURN(IsIntegralDataType(GetBlobDesc4BnInOp("in")->data_type()));

--- a/oneflow/core/operator/callback_notify_op.h
+++ b/oneflow/core/operator/callback_notify_op.h
@@ -27,8 +27,9 @@ class CallbackNotifyOp final : public Operator {
   ~CallbackNotifyOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override;
 
  private:

--- a/oneflow/core/operator/case_op.cpp
+++ b/oneflow/core/operator/case_op.cpp
@@ -24,8 +24,9 @@ void CaseOp::InitFromOpConf() {
   EnrollRepeatedOutputBn("out", false);
 }
 
-Maybe<void> CaseOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                                   const ParallelContext* parallel_ctx) const {
+Maybe<void> CaseOp::InferOutBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BlobDesc* in = GetBlobDesc4BnInOp("in");
   CHECK_EQ_OR_RETURN(in->shape().elem_cnt(), 1);
   const DataType data_type = in->data_type();

--- a/oneflow/core/operator/case_op.h
+++ b/oneflow/core/operator/case_op.h
@@ -27,8 +27,9 @@ class CaseOp final : public Operator {
   ~CaseOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/collective_boxing_ops.cpp
+++ b/oneflow/core/operator/collective_boxing_ops.cpp
@@ -42,8 +42,9 @@ class CollectiveBoxingGenericOp : public Operator {
     return this->op_conf().collective_boxing_generic_conf().lbi();
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext*) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext*,
+                                const SbpSignature* sbp_signature) const override {
     const RankDesc& rank_desc = op_conf().collective_boxing_generic_conf().rank_desc();
     const DataType data_type = rank_desc.op_desc().data_type();
     if (GenericOpHasInput(rank_desc)) {

--- a/oneflow/core/operator/collective_boxing_pack_op.cpp
+++ b/oneflow/core/operator/collective_boxing_pack_op.cpp
@@ -27,13 +27,9 @@ class CollectiveBoxingPackOp : public Operator {
 
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
-
- protected:
-  virtual void VirtualInferBlobDescs(
-      const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-      const ParallelContext* parallel_ctx) const {}
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   LogicalBlobId lbi4ibn(const std::string& input_bn) const override;
@@ -53,9 +49,9 @@ LogicalBlobId CollectiveBoxingPackOp::lbi4obn(const std::string& output_bn) cons
   return this->op_conf().collective_boxing_pack_conf().lbi();
 }
 
-Maybe<void> CollectiveBoxingPackOp::InferBlobDescs(
+Maybe<void> CollectiveBoxingPackOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   *out_blob_desc = *in_blob_desc;

--- a/oneflow/core/operator/collective_boxing_unpack_op.cpp
+++ b/oneflow/core/operator/collective_boxing_unpack_op.cpp
@@ -27,8 +27,9 @@ class CollectiveBoxingUnpackOp : public Operator {
 
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  protected:
   virtual void VirtualInferBlobDescs(
@@ -53,9 +54,9 @@ LogicalBlobId CollectiveBoxingUnpackOp::lbi4obn(const std::string& output_bn) co
   return this->op_conf().collective_boxing_unpack_conf().lbi();
 }
 
-Maybe<void> CollectiveBoxingUnpackOp::InferBlobDescs(
+Maybe<void> CollectiveBoxingUnpackOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const CollectiveBoxingUnpackOpConf& unpack_conf = this->op_conf().collective_boxing_unpack_conf();
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");

--- a/oneflow/core/operator/constant_like_op.cpp
+++ b/oneflow/core/operator/constant_like_op.cpp
@@ -29,9 +29,9 @@ class ConstantLikeOp final : public Operator {
     EnrollOutputBn("out", false);
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     const ConstantLikeOpConf& conf = op_conf().constant_like_conf();
     BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
     *out_blob_desc = *GetBlobDesc4BnInOp("like");

--- a/oneflow/core/operator/copy_hd_op.cpp
+++ b/oneflow/core/operator/copy_hd_op.cpp
@@ -24,8 +24,9 @@ class CopyHdOp final : public Operator {
   ~CopyHdOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const;
 
  private:
   Maybe<void> InferBatchAxis(
@@ -52,9 +53,9 @@ void CopyHdOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> CopyHdOp::InferBlobDescs(
+Maybe<void> CopyHdOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   *GetBlobDesc4BnInOp("out") = *GetBlobDesc4BnInOp("in");
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/copy_hd_op.cpp
+++ b/oneflow/core/operator/copy_hd_op.cpp
@@ -26,7 +26,7 @@ class CopyHdOp final : public Operator {
   void InitFromOpConf() override;
   Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                                 const ParallelContext* parallel_ctx,
-                                const SbpSignature* sbp_signature) const;
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/cwise_op.cpp
+++ b/oneflow/core/operator/cwise_op.cpp
@@ -23,8 +23,9 @@ void CWiseOp::InitFromOpConf() {
   VirtualInitFromOpConf();
 }
 
-Maybe<void> CWiseOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                                    const ParallelContext* parallel_ctx) const {
+Maybe<void> CWiseOp::InferOutBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BlobDesc* in_0_blob_desc = GetBlobDesc4BnInOp(input_bns().Get(0));
   for (size_t i = 1; i < input_bns().size(); ++i) {
     const auto* blob_desc = GetBlobDesc4BnInOp(input_bns().Get(i));

--- a/oneflow/core/operator/cwise_op.h
+++ b/oneflow/core/operator/cwise_op.h
@@ -28,8 +28,9 @@ class CWiseOp : public Operator {
 
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  protected:
   virtual void VirtualInitFromOpConf() { UNIMPLEMENTED(); }

--- a/oneflow/core/operator/decode_ofrecord_op.cpp
+++ b/oneflow/core/operator/decode_ofrecord_op.cpp
@@ -47,7 +47,7 @@ void DecodeOFRecordOp::VirtualGenKernelConf(
   kernel_conf->mutable_decode_ofrecord_conf()->set_random_seed(NewRandomSeed());
 }
 
-Maybe<void> DecodeOFRecordOp::InferBlobDescs(
+Maybe<void> DecodeOFRecordOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   int64_t batch_size = op_conf().decode_ofrecord_conf().batch_size();

--- a/oneflow/core/operator/decode_ofrecord_op.h
+++ b/oneflow/core/operator/decode_ofrecord_op.h
@@ -31,9 +31,9 @@ class DecodeOFRecordOp final : public Operator {
 
   LogicalNode* NewProperLogicalNode() const override { return new DecodeLogicalNode; }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   void VirtualGenKernelConf(std::function<const BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                             const ParallelContext* parallel_ctx,
                             KernelConf* kernel_conf) const override;

--- a/oneflow/core/operator/decode_random_op.cpp
+++ b/oneflow/core/operator/decode_random_op.cpp
@@ -29,7 +29,7 @@ void DecodeRandomOp::VirtualGenKernelConf(
   kernel_conf->mutable_decode_random_conf()->set_random_seed(NewRandomSeed());
 }
 
-Maybe<void> DecodeRandomOp::InferBlobDescs(
+Maybe<void> DecodeRandomOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");

--- a/oneflow/core/operator/decode_random_op.h
+++ b/oneflow/core/operator/decode_random_op.h
@@ -30,9 +30,9 @@ class DecodeRandomOp final : public Operator {
   void InitFromOpConf() override;
   LogicalNode* NewProperLogicalNode() const override { return new DecodeRandomLogicalNode; }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/device_tick_op.cpp
+++ b/oneflow/core/operator/device_tick_op.cpp
@@ -24,9 +24,9 @@ void DeviceTickOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> DeviceTickOp::InferBlobDescs(
+Maybe<void> DeviceTickOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   GetBlobDesc4BnInOp("out")->mut_shape() = Shape({1});
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/device_tick_op.h
+++ b/oneflow/core/operator/device_tick_op.h
@@ -28,8 +28,9 @@ class DeviceTickOp final : public Operator {
   ~DeviceTickOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override { return new DeviceTickLogicalNode; }
 
  private:

--- a/oneflow/core/operator/distribute_add_op.cpp
+++ b/oneflow/core/operator/distribute_add_op.cpp
@@ -30,8 +30,9 @@ class DistributeAddOp final : public Operator {
 
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext*) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override { return new DistributeConcatLogicalNode; }
 
  private:
@@ -72,9 +73,9 @@ Maybe<void> DistributeAddOp::InferParallelSignature() {
   return Maybe<void>::Ok();
 }
 
-Maybe<void> DistributeAddOp::InferBlobDescs(
+Maybe<void> DistributeAddOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BlobDesc* first_blob_desc = nullptr;
   FOR_RANGE(int, i, 0, input_bns().size()) {
     first_blob_desc = GetBlobDesc4BnInOp(input_bns().Get(i));

--- a/oneflow/core/operator/distribute_clone_op.cpp
+++ b/oneflow/core/operator/distribute_clone_op.cpp
@@ -42,8 +42,9 @@ class DistributeCloneOp final : public Operator {
       const std::function<int32_t(const SbpSignature&)>& CalcOrderValue4SbpSig,
       std::function<Maybe<const SbpInferHint*>(const std::string&)> SbpInferHint4Ibn,
       const ParallelDesc& parallel_desc) const override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext*) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   Maybe<void> InferOutParallelDesc(
       std::function<ParallelDesc*(const std::string&)> ParallelDesc4Obn,
       std::function<const BlobDesc*(const std::string&)> LogicalBlobDesc4Ibn, const ParallelDesc&,
@@ -59,9 +60,9 @@ void DistributeCloneOp::InitFromOpConf() {
   });
 }
 
-Maybe<void> DistributeCloneOp::InferBlobDescs(
+Maybe<void> DistributeCloneOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const auto& in_blob_desc = *GetBlobDesc4BnInOp("in");
   if (parallel_ctx->parallel_num() > 1) {
     CHECK_EQ_OR_RETURN(parallel_ctx->parallel_num(), output_bns().size());

--- a/oneflow/core/operator/distribute_concat_op.cpp
+++ b/oneflow/core/operator/distribute_concat_op.cpp
@@ -30,8 +30,9 @@ class DistributeConcatOp final : public Operator {
 
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext*) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override { return new DistributeConcatLogicalNode; }
 
  private:
@@ -59,9 +60,9 @@ void DistributeConcatOp::InitFromOpConf() {
   EnrollOutputBn("out");
 }
 
-Maybe<void> DistributeConcatOp::InferBlobDescs(
+Maybe<void> DistributeConcatOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   if (parallel_ctx->parallel_num() > 1) {
     const auto* in_blob_desc = GetBlobDesc4BnInOp(input_bns().Get(parallel_ctx->parallel_id()));
     BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");

--- a/oneflow/core/operator/distribute_split_op.cpp
+++ b/oneflow/core/operator/distribute_split_op.cpp
@@ -42,8 +42,9 @@ class DistributeSplitOp final : public Operator {
       const std::function<int32_t(const SbpSignature&)>& CalcOrderValue4SbpSig,
       std::function<Maybe<const SbpInferHint*>(const std::string&)> SbpInferHint4Ibn,
       const ParallelDesc& parallel_desc) const override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext*) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   Maybe<void> InferOutParallelDesc(
       std::function<ParallelDesc*(const std::string&)> ParallelDesc4Obn,
       std::function<const BlobDesc*(const std::string&)> LogicalBlobDesc4Ibn, const ParallelDesc&,
@@ -65,9 +66,9 @@ void DistributeSplitOp::InitFromOpConf() {
   });
 }
 
-Maybe<void> DistributeSplitOp::InferBlobDescs(
+Maybe<void> DistributeSplitOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const auto& in_blob_desc = *GetBlobDesc4BnInOp("in");
   if (parallel_ctx->parallel_num() > 1) {
     CHECK_EQ(parallel_ctx->parallel_num(), output_bns().size());

--- a/oneflow/core/operator/dynamic_binary_split_concat_op.cpp
+++ b/oneflow/core/operator/dynamic_binary_split_concat_op.cpp
@@ -30,8 +30,9 @@ class DynamicBinarySplitOp final : public Operator {
   Maybe<void> InferBatchAxis(
       const std::function<const BlobDesc&(const std::string&)>& LogicalBlobDesc4Ibn,
       std::function<OptInt64*(const std::string&)> BatchAxis4BnInOp) const override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext*) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   Maybe<void> GetSbpSignatures(
       const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
       SbpSignatureList* sbp_sig_list) const override;
@@ -45,9 +46,9 @@ void DynamicBinarySplitOp::InitFromOpConf() {
   });
 }
 
-Maybe<void> DynamicBinarySplitOp::InferBlobDescs(
+Maybe<void> DynamicBinarySplitOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const auto& in_blob_desc = *GetBlobDesc4BnInOp("in");
   CHECK_OR_RETURN(in_blob_desc.is_dynamic());
   CHECK_GE_OR_RETURN(output_bns().size(), 2);
@@ -112,8 +113,9 @@ class DynamicBinaryConcatOp final : public Operator {
   Maybe<void> InferBatchAxis(
       const std::function<const BlobDesc&(const std::string&)>& LogicalBlobDesc4Ibn,
       std::function<OptInt64*(const std::string&)> BatchAxis4BnInOp) const override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext*) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   Maybe<void> GetSbpSignatures(
       const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
       SbpSignatureList* sbp_sig_list) const override;
@@ -130,9 +132,9 @@ void DynamicBinaryConcatOp::InitFromOpConf() {
   EnrollOutputBn("out");
 }
 
-Maybe<void> DynamicBinaryConcatOp::InferBlobDescs(
+Maybe<void> DynamicBinaryConcatOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const auto& conf = op_conf().dynamic_binary_concat_conf();
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   *out_blob_desc = *GetBlobDesc4BnInOp(input_bns().Get(0));

--- a/oneflow/core/operator/dynamic_reshape_op.cpp
+++ b/oneflow/core/operator/dynamic_reshape_op.cpp
@@ -26,7 +26,7 @@ class DynamicReshapeOp final : public Operator {
   }
   Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                                 const ParallelContext* parallel_ctx,
-                                const SbpSignature* sbp_signature) const {
+                                const SbpSignature* sbp_signature) const override {
     const DynamicReshapeOpConf& conf = op_conf().dynamic_reshape_conf();
     const BlobDesc* in = GetBlobDesc4BnInOp("in");
     BlobDesc* out = GetBlobDesc4BnInOp("out");
@@ -97,7 +97,7 @@ class DynamicReshapeLikeOp final : public Operator {
   }
   Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                                 const ParallelContext* parallel_ctx,
-                                const SbpSignature* sbp_signature) const {
+                                const SbpSignature* sbp_signature) const override {
     CHECK_EQ_OR_RETURN(GetBlobDesc4BnInOp("x")->shape().elem_cnt(),
                        GetBlobDesc4BnInOp("like")->shape().elem_cnt());
     GetBlobDesc4BnInOp("y")->CopyMetaFrom(*GetBlobDesc4BnInOp("like"));

--- a/oneflow/core/operator/dynamic_reshape_op.cpp
+++ b/oneflow/core/operator/dynamic_reshape_op.cpp
@@ -24,9 +24,9 @@ class DynamicReshapeOp final : public Operator {
     EnrollInputBn("in");
     EnrollOutputBn("out")->set_const_inplace_ibn("in");
   }
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const {
     const DynamicReshapeOpConf& conf = op_conf().dynamic_reshape_conf();
     const BlobDesc* in = GetBlobDesc4BnInOp("in");
     BlobDesc* out = GetBlobDesc4BnInOp("out");
@@ -95,8 +95,9 @@ class DynamicReshapeLikeOp final : public Operator {
     EnrollOutputBn("y");
     EnrollInputBn("like", false)->set_use_header_only(true);
   }
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const {
     CHECK_EQ_OR_RETURN(GetBlobDesc4BnInOp("x")->shape().elem_cnt(),
                        GetBlobDesc4BnInOp("like")->shape().elem_cnt());
     GetBlobDesc4BnInOp("y")->CopyMetaFrom(*GetBlobDesc4BnInOp("like"));

--- a/oneflow/core/operator/esac_op.cpp
+++ b/oneflow/core/operator/esac_op.cpp
@@ -24,8 +24,9 @@ void EsacOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> EsacOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                                   const ParallelContext* parallel_ctx) const {
+Maybe<void> EsacOp::InferOutBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   BlobDesc* out = GetBlobDesc4BnInOp("out");
   out->mut_shape() = Shape({1});
   const DataType data_type = op_conf().esac_conf().data_type();

--- a/oneflow/core/operator/esac_op.h
+++ b/oneflow/core/operator/esac_op.h
@@ -27,8 +27,9 @@ class EsacOp final : public Operator {
   ~EsacOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/foreign_input_op.cpp
+++ b/oneflow/core/operator/foreign_input_op.cpp
@@ -30,9 +30,9 @@ void ForeignInputOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> ForeignInputOp::InferBlobDescs(
+Maybe<void> ForeignInputOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   CHECK_EQ_OR_RETURN(parallel_ctx->parallel_num(), 1);
   CheckOpConf(op_conf());
   const auto& conf = op_conf().foreign_input_conf().blob_conf();

--- a/oneflow/core/operator/foreign_input_op.h
+++ b/oneflow/core/operator/foreign_input_op.h
@@ -28,8 +28,9 @@ class ForeignInputOp final : public Operator {
   ~ForeignInputOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override { return new ForeignInputLogicalNode; }
 
  private:

--- a/oneflow/core/operator/foreign_output_op.cpp
+++ b/oneflow/core/operator/foreign_output_op.cpp
@@ -23,9 +23,9 @@ void ForeignOutputOp::InitFromOpConf() {
   EnrollInputBn("in");
 }
 
-Maybe<void> ForeignOutputOp::InferBlobDescs(
+Maybe<void> ForeignOutputOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   CHECK_EQ_OR_RETURN(parallel_ctx->parallel_num(), 1);
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/foreign_output_op.h
+++ b/oneflow/core/operator/foreign_output_op.h
@@ -28,8 +28,9 @@ class ForeignOutputOp final : public Operator {
   ~ForeignOutputOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override { return new ForeignOutputLogicalNode; }
 
  private:

--- a/oneflow/core/operator/foreign_watch_op.cpp
+++ b/oneflow/core/operator/foreign_watch_op.cpp
@@ -23,9 +23,9 @@ void ForeignWatchOp::InitFromOpConf() {
   EnrollInputBn("in");
 }
 
-Maybe<void> ForeignWatchOp::InferBlobDescs(
+Maybe<void> ForeignWatchOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   CHECK_EQ_OR_RETURN(parallel_ctx->parallel_num(), 1);
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/foreign_watch_op.h
+++ b/oneflow/core/operator/foreign_watch_op.h
@@ -28,8 +28,9 @@ class ForeignWatchOp final : public Operator {
   ~ForeignWatchOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/identity_op.cpp
+++ b/oneflow/core/operator/identity_op.cpp
@@ -31,8 +31,9 @@ class IdentityOpTpl final : public Operator {
     EnrollInputBn("in");
     EnrollOutputBn("out")->set_const_inplace_ibn("in");
   }
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     *GetBlobDesc4BnInOp("out") = *GetBlobDesc4BnInOp("in");
     return Maybe<void>::Ok();
   }
@@ -69,8 +70,9 @@ class MirroredCastOp : public Operator {
     EnrollInputBn("in");
     EnrollOutputBn("out")->set_const_inplace_ibn("in");
   }
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     *GetBlobDesc4BnInOp("out") = *GetBlobDesc4BnInOp("in");
     return Maybe<void>::Ok();
   }

--- a/oneflow/core/operator/image_decoder_random_crop_resize_op.cpp
+++ b/oneflow/core/operator/image_decoder_random_crop_resize_op.cpp
@@ -34,8 +34,9 @@ class ImageDecoderRandomCropResizeOp final : public Operator {
     EnrollTmpBn("tmp");
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     const ImageDecoderRandomCropResizeOpConf& conf =
         this->op_conf().image_decoder_random_crop_resize_conf();
     const BlobDesc* in = GetBlobDesc4BnInOp("in");
@@ -48,6 +49,14 @@ class ImageDecoderRandomCropResizeOp final : public Operator {
     out_dim_vec.push_back(conf.target_width());
     out_dim_vec.push_back(3);
     out->mut_shape() = Shape(out_dim_vec);
+    return Maybe<void>::Ok();
+  }
+
+  Maybe<void> InferInternalBlobDescs(
+      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+      const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const override {
+    const ImageDecoderRandomCropResizeOpConf& conf =
+        this->op_conf().image_decoder_random_crop_resize_conf();
     BlobDesc* tmp = GetBlobDesc4BnInOp("tmp");
     tmp->set_data_type(DataType::kUInt8);
     tmp->mut_shape() = Shape({conf.max_num_pixels() * 3 * conf.num_workers()});

--- a/oneflow/core/operator/input_op.cpp
+++ b/oneflow/core/operator/input_op.cpp
@@ -28,9 +28,9 @@ void InputOp::InitFromOpConf() {
   modifier->set_header_infered_before_compute(false);
 }
 
-Maybe<void> InputOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                                    const ParallelContext* parallel_ctx,
-                                    const SbpSignature* sbp_signature) const {
+Maybe<void> InputOp::InferOutBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   JUST(InterfaceOpUtil::InferOutBlobDesc(op_conf().input_conf().blob_conf(), out_blob_desc,
                                          parallel_ctx));

--- a/oneflow/core/operator/input_op.h
+++ b/oneflow/core/operator/input_op.h
@@ -27,9 +27,9 @@ class InputOp final : public Operator {
   ~InputOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferSbpSignature(

--- a/oneflow/core/operator/keep_header_only_op.cpp
+++ b/oneflow/core/operator/keep_header_only_op.cpp
@@ -26,9 +26,9 @@ void KeepHeaderOnlyOp::InitFromOpConf() {
   EnrollRepeatedOutputBn("out", false);
 }
 
-Maybe<void> KeepHeaderOnlyOp::InferBlobDescs(
+Maybe<void> KeepHeaderOnlyOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   size_t in_num = op_conf().keep_header_only_conf().in().size();
   for (size_t i = 0; i < in_num; ++i) {
     BlobDesc* out = GetBlobDesc4BnInOp(GenRepeatedBn("out", i));

--- a/oneflow/core/operator/keep_header_only_op.h
+++ b/oneflow/core/operator/keep_header_only_op.h
@@ -28,8 +28,9 @@ class KeepHeaderOnlyOp final : public Operator {
 
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/learning_rate_schedule_op.cpp
+++ b/oneflow/core/operator/learning_rate_schedule_op.cpp
@@ -24,8 +24,9 @@ class LearningRateScheduleOp final : public Operator {
   ~LearningRateScheduleOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(
@@ -41,9 +42,9 @@ void LearningRateScheduleOp::InitFromOpConf() {
   EnrollOutputBn("out");
 }
 
-Maybe<void> LearningRateScheduleOp::InferBlobDescs(
+Maybe<void> LearningRateScheduleOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BlobDesc* train_step = GetBlobDesc4BnInOp("train_step");
   CHECK_EQ(train_step->shape().elem_cnt(), 1);
   CHECK_EQ(train_step->data_type(), DataType::kInt64);

--- a/oneflow/core/operator/model_init_op.cpp
+++ b/oneflow/core/operator/model_init_op.cpp
@@ -21,8 +21,9 @@ class ModelInitOp : public Operator {
  public:
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(
@@ -38,9 +39,9 @@ void ModelInitOp::InitFromOpConf() {
   EnrollRepeatedOutputBn("out", false);
 }
 
-Maybe<void> ModelInitOp::InferBlobDescs(
+Maybe<void> ModelInitOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const int64_t num_out = op_conf().model_init_conf().out().size();
   FOR_RANGE(int64_t, i, 0, num_out) {
     const VariableOpConf& original_variable_conf =

--- a/oneflow/core/operator/model_io_v2_op.cpp
+++ b/oneflow/core/operator/model_io_v2_op.cpp
@@ -52,8 +52,9 @@ class ModelInitV2Op : public Operator {
     EnrollInputBn("tick", false);
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     BlobDesc* out = GetBlobDesc4BnInOp("out");
     out->set_data_type(DataType::kFloat);
     out->mut_shape() = Shape({1});
@@ -99,8 +100,9 @@ class ModelLoadV2Op : public Operator {
     EnrollInputBn("tick", false);
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     BlobDesc* out = GetBlobDesc4BnInOp("out");
     out->set_data_type(DataType::kFloat);
     out->mut_shape() = Shape({1});
@@ -151,8 +153,9 @@ class ModelSaveV2Op final : public Operator {
     EnrollInputBn("tick", false);
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     BlobDesc* out = GetBlobDesc4BnInOp("out");
     out->set_data_type(DataType::kFloat);
     out->mut_shape() = Shape({1});

--- a/oneflow/core/operator/model_load_op.cpp
+++ b/oneflow/core/operator/model_load_op.cpp
@@ -21,8 +21,9 @@ class ModelLoadOp : public Operator {
  public:
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(
@@ -38,9 +39,9 @@ void ModelLoadOp::InitFromOpConf() {
   EnrollRepeatedOutputBn("out", false);
 }
 
-Maybe<void> ModelLoadOp::InferBlobDescs(
+Maybe<void> ModelLoadOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const int64_t num_out = op_conf().model_load_conf().out().size();
   FOR_RANGE(int64_t, i, 0, num_out) {
     const VariableOpConf& original_variable_conf =

--- a/oneflow/core/operator/model_save_op.cpp
+++ b/oneflow/core/operator/model_save_op.cpp
@@ -26,8 +26,9 @@ class ModelSaveOp final : public Operator {
 
   void InitFromOpConf() override;
   LogicalNode* NewProperLogicalNode() const override { return new PrintLogicalNode; }
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     return Maybe<void>::Ok();
   }
 

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -132,19 +132,8 @@ Maybe<void> Operator::InferLogicalOutBlobDescs(
 Maybe<void> Operator::InferBlobDescsIf(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
-  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature);
-}
-
-Maybe<void> Operator::InferBlobDescs(
-    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
-  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx);
-}
-
-Maybe<void> Operator::InferBlobDescs(
-    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
-  UNIMPLEMENTED() << typeid(*this).name();
+  JUST(InferOutBlobDescsIf(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature));
+  JUST(InferInternalBlobDescsIf(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature));
   return Maybe<void>::Ok();
 }
 
@@ -157,9 +146,20 @@ Maybe<void> Operator::InferOutBlobDescsIf(
 Maybe<void> Operator::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
-  // TODO() separate InferOut and InferTmp
-  // At present, only conv_op infer out blob separately
-  return InferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature);
+  UNIMPLEMENTED() << typeid(*this).name();
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> Operator::InferInternalBlobDescsIf(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
+  return InferInternalBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature);
+}
+
+Maybe<void> Operator::InferInternalBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> Operator::InferInplaceObn2IbnIf(

--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -106,19 +106,13 @@ class Operator {
   // Write: shape of output_blobs
   Maybe<void> InferBlobDescsIf(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                                const ParallelContext*, const SbpSignature* sbp_signature) const;
-  virtual Maybe<void> InferBlobDescs(
-      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp, const ParallelContext*,
-      const SbpSignature* sbp_signature) const;
-  virtual Maybe<void> InferBlobDescs(
-      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-      const ParallelContext*) const;
 
   Maybe<void> InferOutBlobDescsIf(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                                   const ParallelContext*, const SbpSignature* sbp_signature) const;
 
-  virtual Maybe<void> InferOutBlobDescs(
-      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp, const ParallelContext*,
-      const SbpSignature* sbp_signature) const;
+  Maybe<void> InferInternalBlobDescsIf(
+      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+      const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const;
 
   Maybe<void> InferInplaceObn2IbnIf(HashMap<std::string, std::string>* mut_inplace_obn2ibn,
                                     HashMap<std::string, std::string>* con_inplace_obn2ibn,
@@ -195,6 +189,12 @@ class Operator {
 
  protected:
   virtual Maybe<void> InferParallelSignature();
+  virtual Maybe<void> InferOutBlobDescs(
+      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp, const ParallelContext*,
+      const SbpSignature* sbp_signature) const;
+  virtual Maybe<void> InferInternalBlobDescs(
+      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+      const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const;
   virtual Maybe<void> GetSbpSignatures(
       const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
       const ParallelDesc& parallel_desc, SbpSignatureList* sbp_sig_list) const {

--- a/oneflow/core/operator/output_op.cpp
+++ b/oneflow/core/operator/output_op.cpp
@@ -25,9 +25,9 @@ void OutputOp::InitFromOpConf() {
   EnrollOutputBn("out")->set_is_mutable(true);
 }
 
-Maybe<void> OutputOp::InferBlobDescs(
+Maybe<void> OutputOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");
   if (in_blob_desc->is_dynamic()) {

--- a/oneflow/core/operator/output_op.h
+++ b/oneflow/core/operator/output_op.h
@@ -27,8 +27,9 @@ class OutputOp final : public Operator {
   ~OutputOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/partial_tick_op.cpp
+++ b/oneflow/core/operator/partial_tick_op.cpp
@@ -24,9 +24,9 @@ void PartialTickOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> PartialTickOp::InferBlobDescs(
+Maybe<void> PartialTickOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   GetBlobDesc4BnInOp("out")->mut_shape() = Shape({1});
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/partial_tick_op.h
+++ b/oneflow/core/operator/partial_tick_op.h
@@ -28,8 +28,9 @@ class PartialTickOp final : public Operator {
   ~PartialTickOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override { return new TickLogicalNode; }
 
  private:

--- a/oneflow/core/operator/record_load_op.cpp
+++ b/oneflow/core/operator/record_load_op.cpp
@@ -24,7 +24,7 @@ void RecordLoadOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> RecordLoadOp::InferBlobDescs(
+Maybe<void> RecordLoadOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
     const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   BlobDesc* out_blob_desc = GetBlobDesc4BnInOp("out");

--- a/oneflow/core/operator/record_load_op.h
+++ b/oneflow/core/operator/record_load_op.h
@@ -28,9 +28,9 @@ class RecordLoadOp final : public Operator {
   ~RecordLoadOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   void VirtualGenKernelConf(std::function<const BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                             const ParallelContext*, KernelConf*) const override;
 

--- a/oneflow/core/operator/reentrant_lock_op.cpp
+++ b/oneflow/core/operator/reentrant_lock_op.cpp
@@ -25,9 +25,9 @@ void ReentrantLockOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> ReentrantLockOp::InferBlobDescs(
+Maybe<void> ReentrantLockOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   CHECK_EQ_OR_RETURN(parallel_ctx->parallel_num(), 1);
   BlobDesc* out = GetBlobDesc4BnInOp("out");
   out->mut_shape() = Shape({1});

--- a/oneflow/core/operator/reentrant_lock_op.h
+++ b/oneflow/core/operator/reentrant_lock_op.h
@@ -27,8 +27,9 @@ class ReentrantLockOp final : public Operator {
   ~ReentrantLockOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/return_op.cpp
+++ b/oneflow/core/operator/return_op.cpp
@@ -25,9 +25,9 @@ void ReturnOp::InitFromOpConf() {
   EnrollOutputBn("out")->set_is_mutable(true);
 }
 
-Maybe<void> ReturnOp::InferBlobDescs(
+Maybe<void> ReturnOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   *GetBlobDesc4BnInOp("out") = *GetBlobDesc4BnInOp("in");
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/return_op.h
+++ b/oneflow/core/operator/return_op.h
@@ -27,8 +27,9 @@ class ReturnOp final : public Operator {
   ~ReturnOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/scalar_op_base.cpp
+++ b/oneflow/core/operator/scalar_op_base.cpp
@@ -25,9 +25,9 @@ void ScalarOpBase::InitFromOpConf() {
   ;
 }
 
-Maybe<void> ScalarOpBase::InferBlobDescs(
+Maybe<void> ScalarOpBase::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const BlobDesc* in_blob_desc = GetBlobDesc4BnInOp("in");
   const BlobDesc* scalar_blob_desc = GetBlobDesc4BnInOp("scalar");
   CHECK_EQ_OR_RETURN(in_blob_desc->data_type(), scalar_blob_desc->data_type());

--- a/oneflow/core/operator/scalar_op_base.h
+++ b/oneflow/core/operator/scalar_op_base.h
@@ -27,8 +27,9 @@ class ScalarOpBase : public Operator {
   ~ScalarOpBase() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  protected:
   virtual Maybe<void> VirtualGetSbpSignatures(

--- a/oneflow/core/operator/shape_elem_cnt_op.cpp
+++ b/oneflow/core/operator/shape_elem_cnt_op.cpp
@@ -54,9 +54,9 @@ void ShapeElemCntOp::InitFromOpConf() {
   EnrollOutputBn("y", false);
 }
 
-Maybe<void> ShapeElemCntOp::InferBlobDescs(
+Maybe<void> ShapeElemCntOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   GetBlobDesc4BnInOp("y")->set_data_type(op_conf().shape_elem_cnt_conf().data_type());
   GetBlobDesc4BnInOp("y")->mut_shape() = Shape({1});
   return Maybe<void>::Ok();

--- a/oneflow/core/operator/shape_elem_cnt_op.h
+++ b/oneflow/core/operator/shape_elem_cnt_op.h
@@ -27,8 +27,9 @@ class ShapeElemCntOp final : public Operator {
   ~ShapeElemCntOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferBatchAxis(

--- a/oneflow/core/operator/sigmoid_cross_entropy_op.cpp
+++ b/oneflow/core/operator/sigmoid_cross_entropy_op.cpp
@@ -31,8 +31,9 @@ class SigmoidCrossEntropyOp final : public Operator {
     EnrollOutputBn("loss");
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     CHECK_EQ_OR_RETURN(op_conf().sigmoid_cross_entropy_conf().label_type(),
                        GetBlobDesc4BnInOp("label")->data_type());
     CHECK_EQ_OR_RETURN(GetBlobDesc4BnInOp("prediction")->shape(),
@@ -76,8 +77,9 @@ class SigmoidCrossEntropyGradOp final : public Operator {
     EnrollOutputBn("prediction_diff");
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     CHECK_EQ_OR_RETURN(op_conf().sigmoid_cross_entropy_grad_conf().label_type(),
                        GetBlobDesc4BnInOp("label")->data_type());
     CHECK_EQ_OR_RETURN(GetBlobDesc4BnInOp("prediction")->shape(),

--- a/oneflow/core/operator/sink_tick_op.cpp
+++ b/oneflow/core/operator/sink_tick_op.cpp
@@ -24,9 +24,9 @@ void SinkTickOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> SinkTickOp::InferBlobDescs(
+Maybe<void> SinkTickOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   GetBlobDesc4BnInOp("out")->mut_shape() = Shape({1});
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/sink_tick_op.h
+++ b/oneflow/core/operator/sink_tick_op.h
@@ -28,8 +28,9 @@ class SinkTickOp final : public Operator {
   ~SinkTickOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override { return new TickLogicalNode; }
 
  private:

--- a/oneflow/core/operator/slice_boxing_op.cpp
+++ b/oneflow/core/operator/slice_boxing_op.cpp
@@ -26,14 +26,12 @@ class SliceBoxingOp : public Operator {
   ~SliceBoxingOp() override = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  protected:
   virtual const SliceBoxingConf& GetCustomizedBoxingConf() const = 0;
-  virtual void VirtualInferBlobDescs(
-      const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-      const ParallelContext* parallel_ctx) const {}
   virtual void VirtualInitFromOpConf(){};
 
  private:
@@ -65,8 +63,9 @@ class SliceBoxingAddOp final : public SliceBoxingOp {
     return op_conf().slice_boxing_add_conf().slice_boxing_conf();
   }
   void VirtualInitFromOpConf() override;
-  void VirtualInferBlobDescs(const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferInternalBlobDescs(
+      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+      const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const override;
   Symbol<OperatorConf> GetOpConfWithoutOpNameAndLbn() const override;
 };
 
@@ -84,9 +83,9 @@ LogicalBlobId SliceBoxingOp::lbi4obn(const std::string& output_bn) const {
   return GetCustomizedBoxingConf().lbi();
 }
 
-Maybe<void> SliceBoxingOp::InferBlobDescs(
+Maybe<void> SliceBoxingOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const SliceBoxingConf& slice_boxing_conf = GetCustomizedBoxingConf();
   const PbRpf<TensorSliceViewProto>& in_slice_proto = slice_boxing_conf.in_slice();
   const TensorSliceViewProto& out_slice_proto = slice_boxing_conf.out_slice();
@@ -111,7 +110,6 @@ Maybe<void> SliceBoxingOp::InferBlobDescs(
   } else {
     out->mut_shape() = out_slice.shape();
   }
-  VirtualInferBlobDescs(GetBlobDesc4BnInOp, parallel_ctx);
   return Maybe<void>::Ok();
 }
 
@@ -127,10 +125,11 @@ Symbol<OperatorConf> SliceBoxingCopyOp::GetOpConfWithoutOpNameAndLbn() const {
 
 void SliceBoxingAddOp::VirtualInitFromOpConf() { EnrollTmpBn("buf"); }
 
-void SliceBoxingAddOp::VirtualInferBlobDescs(
-    const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+Maybe<void> SliceBoxingAddOp::InferInternalBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   *GetBlobDesc4BnInOp("buf") = *GetBlobDesc4BnInOp("out");
+  return Maybe<void>::Ok();
 }
 
 Symbol<OperatorConf> SliceBoxingAddOp::GetOpConfWithoutOpNameAndLbn() const {

--- a/oneflow/core/operator/source_tick_op.cpp
+++ b/oneflow/core/operator/source_tick_op.cpp
@@ -26,9 +26,9 @@ void SourceTickOp::InitFromOpConf() {
 
 LogicalNode* SourceTickOp::NewProperLogicalNode() const { return new SourceTickLogicalNode(); }
 
-Maybe<void> SourceTickOp::InferBlobDescs(
+Maybe<void> SourceTickOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   CHECK_EQ_OR_RETURN(parallel_ctx->parallel_num(), 1);
   GetBlobDesc4BnInOp("out")->mut_shape() = Shape({1});
   return Maybe<void>::Ok();

--- a/oneflow/core/operator/source_tick_op.h
+++ b/oneflow/core/operator/source_tick_op.h
@@ -28,8 +28,9 @@ class SourceTickOp final : public Operator {
   ~SourceTickOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override;
 
  private:

--- a/oneflow/core/operator/sync_dynamic_resize_op.cpp
+++ b/oneflow/core/operator/sync_dynamic_resize_op.cpp
@@ -29,8 +29,9 @@ class SyncDynamicResizeOp : public Operator {
     EnrollOutputBn("out")->set_header_infered_before_compute(false);
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     const SyncDynamicResizeOpConf& conf = op_conf().sync_dynamic_resize_conf();
     CHECK_EQ_OR_RETURN(conf.axis(), 0);
     const BlobDesc* in = GetBlobDesc4BnInOp("in");

--- a/oneflow/core/operator/tensor_buffer_to_tensor_list_op.cpp
+++ b/oneflow/core/operator/tensor_buffer_to_tensor_list_op.cpp
@@ -30,9 +30,9 @@ class TensorBufferToTensorListOp final : public Operator {
     EnrollOutputBn("out", false)->set_header_infered_before_compute(false);
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     const BlobDesc* in_desc = GetBlobDesc4BnInOp("in");
     CHECK_EQ_OR_RETURN(in_desc->data_type(), DataType::kTensorBuffer);
     CHECK_EQ_OR_RETURN(in_desc->shape().NumAxes(), 1);

--- a/oneflow/core/operator/tensor_list_split_op.cpp
+++ b/oneflow/core/operator/tensor_list_split_op.cpp
@@ -32,8 +32,9 @@ class TensorListSplitOp final : public Operator {
     });
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     const BlobDesc* in_desc = GetBlobDesc4BnInOp(SoleIbn());
     CHECK_OR_RETURN(in_desc->is_tensor_list());
     CHECK_GT_OR_RETURN(in_desc->shape().NumAxes(), 1);

--- a/oneflow/core/operator/tensor_list_to_tensor_buffer_op.cpp
+++ b/oneflow/core/operator/tensor_list_to_tensor_buffer_op.cpp
@@ -30,9 +30,9 @@ class TensorListToTensorBufferOp final : public Operator {
     EnrollOutputBn("out", false)->set_header_infered_before_compute(false);
   }
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const override {
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override {
     const BlobDesc* in_desc = GetBlobDesc4BnInOp("in");
     CHECK_OR_RETURN(in_desc->is_tensor_list());
     const int64_t N = in_desc->shape().At(0);

--- a/oneflow/core/operator/tick_op.cpp
+++ b/oneflow/core/operator/tick_op.cpp
@@ -24,8 +24,9 @@ void TickOp::InitFromOpConf() {
   EnrollOutputBn("out", false);
 }
 
-Maybe<void> TickOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                                   const ParallelContext* parallel_ctx) const {
+Maybe<void> TickOp::InferOutBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   GetBlobDesc4BnInOp("out")->mut_shape() = Shape({1});
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/tick_op.h
+++ b/oneflow/core/operator/tick_op.h
@@ -28,8 +28,9 @@ class TickOp final : public Operator {
   ~TickOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override { return new TickLogicalNode; }
 
  private:

--- a/oneflow/core/operator/user_op.cpp
+++ b/oneflow/core/operator/user_op.cpp
@@ -395,10 +395,9 @@ void UserOp::InitFromOpConf() {
   }
 }
 
-Maybe<void> UserOp::InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                                   const ParallelContext* parallel_ctx,
-                                   const SbpSignature* sbp_signature) const {
-  JUST(InferOutBlobDescs(GetBlobDesc4BnInOp, parallel_ctx, sbp_signature));
+Maybe<void> UserOp::InferInternalBlobDescs(
+    std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   // tmp buffer size must be inferred after out shape/dtype
   UserOpInferContext infer_ctx(op_conf(), parallel_ctx, sbp_signature, job_desc(),
                                GetBlobDesc4BnInOp);

--- a/oneflow/core/operator/user_op.h
+++ b/oneflow/core/operator/user_op.h
@@ -28,9 +28,9 @@ class UserOp final : public Operator {
   ~UserOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx,
-                             const SbpSignature* sbp_signature) const override;
+  Maybe<void> InferInternalBlobDescs(
+      std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+      const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const override;
   Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
                                 const ParallelContext*,
                                 const SbpSignature* sbp_signature) const override;

--- a/oneflow/core/operator/variable_op.cpp
+++ b/oneflow/core/operator/variable_op.cpp
@@ -43,9 +43,9 @@ void VariableOp::InitFromOpConf() {
   EnrollOutputBn("out", is_trainable)->set_is_mutable(true);
 }
 
-Maybe<void> VariableOp::InferBlobDescs(
+Maybe<void> VariableOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   const VariableOpConf& variable_conf = op_conf().variable_conf();
   CHECK_OR_RETURN(job_desc().job_conf().has_default_initializer_conf()
                   || job_desc().job_conf().has_default_initialize_with_snapshot_path()

--- a/oneflow/core/operator/variable_op.h
+++ b/oneflow/core/operator/variable_op.h
@@ -27,8 +27,9 @@ class VariableOp final : public Operator {
   ~VariableOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
 
  private:
   Maybe<void> InferSbpSignature(

--- a/oneflow/core/operator/wait_and_send_ids_op.cpp
+++ b/oneflow/core/operator/wait_and_send_ids_op.cpp
@@ -28,9 +28,9 @@ LogicalNode* WaitAndSendIdsOp::NewProperLogicalNode() const {
   return new WaitAndSendIdsLogicalNode();
 }
 
-Maybe<void> WaitAndSendIdsOp::InferBlobDescs(
+Maybe<void> WaitAndSendIdsOp::InferOutBlobDescs(
     std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-    const ParallelContext* parallel_ctx) const {
+    const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const {
   CHECK_EQ_OR_RETURN(parallel_ctx->parallel_num(), 1);
   GetBlobDesc4BnInOp("out")->mut_shape() = Shape({1});
   GetBlobDesc4BnInOp("out")->set_data_type(op_conf().wait_and_send_ids_conf().data_type());

--- a/oneflow/core/operator/wait_and_send_ids_op.h
+++ b/oneflow/core/operator/wait_and_send_ids_op.h
@@ -27,8 +27,9 @@ class WaitAndSendIdsOp final : public Operator {
   ~WaitAndSendIdsOp() = default;
 
   void InitFromOpConf() override;
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                                const ParallelContext* parallel_ctx,
+                                const SbpSignature* sbp_signature) const override;
   LogicalNode* NewProperLogicalNode() const override;
 
  private:

--- a/oneflow/xrt/launch_op.cpp
+++ b/oneflow/xrt/launch_op.cpp
@@ -39,9 +39,9 @@ void XrtLaunchOp::InitFromOpConf() {
   if (outputs_num > 0) { EnrollRepeatedOutputBn("out"); }
 }
 
-Maybe<void> XrtLaunchOp::InferBlobDescs(
+Maybe<void> XrtLaunchOp::InferOutBlobDescs(
     std::function<BlobDesc *(const std::string &)> GetBlobDesc4BnInOp,
-    const ParallelContext *parallel_ctx) const {
+    const ParallelContext *parallel_ctx, const SbpSignature* sbp_signature) const {
   const auto &launch_conf = op_conf().xrt_launch_conf();
   const auto &io_mapping = launch_conf.input_output_mapping();
   // Prepare outer input blob descs

--- a/oneflow/xrt/launch_op.h
+++ b/oneflow/xrt/launch_op.h
@@ -27,8 +27,8 @@ class XrtLaunchOp : public Operator {
  public:
   void InitFromOpConf() override;
 
-  Maybe<void> InferBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
-                             const ParallelContext* parallel_ctx) const override;
+  Maybe<void> InferOutBlobDescs(std::function<BlobDesc*(const std::string&)> GetBlobDesc4BnInOp,
+                             const ParallelContext* parallel_ctx, const SbpSignature* sbp_signature) const override;
 
   LogicalNode* NewProperLogicalNode() const override {
     return new NormalForwardLogicalNode;


### PR DESCRIPTION
将 `Operator::InferBlobDescsIf` 拆分为 `InferOutBlobDescsIf`与`InferInternalBlobDescsIf`，前者用于推导输出，后者用于推导仅供op内部使用的blob
