### PR TITLE
remove deprecated checkpoint init code in ops unittest

### DIFF
--- a/oneflow/python/test/ops/test_TestMultiInputGrad.py
+++ b/oneflow/python/test/ops/test_TestMultiInputGrad.py
@@ -77,8 +77,6 @@ class Test_TestMultiInputGrad(flow.unittest.TestCase):
                 flow.watch_diff(x2, test_global_storage.Setter("x2_diff"))
                 return loss
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         out = TestMultiInputJob().get()
         x1_diff = test_global_storage.Get("x1_diff")
         x2_diff = test_global_storage.Get("x2_diff")

--- a/oneflow/python/test/ops/test_activations.py
+++ b/oneflow/python/test/ops/test_activations.py
@@ -74,8 +74,6 @@ def compare_with_tensorflow(device_type, activation_type, shape, data_type):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ActivationJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_all_reduce_group.py
+++ b/oneflow/python/test/ops/test_all_reduce_group.py
@@ -39,8 +39,6 @@ def do_test(test_case, mirrored):
         flow.optimizer.SGD(lr_scheduler, momentum=0).minimize(w)
         return w
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     r1 = Foo().get().numpy()
     test_case.assertTrue(np.all(r1 == 1.0))
     r2 = Foo().get().numpy()

--- a/oneflow/python/test/ops/test_batch_gather.py
+++ b/oneflow/python/test/ops/test_batch_gather.py
@@ -120,9 +120,6 @@ def _compare_gather_with_tf(
         params, indices, axis, batch_dims, device_type, mirrored, compare_dy
     )
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
-
     if mirrored:
         of_y = gather_fn([params], [indices]).get().numpy_list()[0]
     else:

--- a/oneflow/python/test/ops/test_batch_normalization.py
+++ b/oneflow/python/test/ops/test_batch_normalization.py
@@ -109,8 +109,6 @@ def CompareNnBnWithTensorFlow(
             flow.watch_diff(x_full_precision, test_global_storage.Setter("x_diff"))
             return y
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_y = FlowNnBnJob(x, mean, variance, offset, scale).get().numpy()
     of_x_diff = test_global_storage.Get("x_diff")
 
@@ -212,8 +210,6 @@ def RunOneflowLayerBn(
 
             return y
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     y = FlowJob(x).get().numpy()
     if trainable:
         x_diff = test_global_storage.Get("x_diff")
@@ -406,9 +402,6 @@ def _test_batchnorm_add_relu(test_case, input_shape, axis, data_type):
 
         return loss
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
-
     x = np.random.rand(*input_shape).astype(np.float32)
     addend = np.random.rand(*input_shape).astype(np.float32)
 
@@ -472,9 +465,6 @@ def _test_batchnorm_relu(test_case, input_shape, axis, data_type):
         ).minimize(flow.math.reduce_sum(loss))
 
         return loss
-
-    check_point = flow.train.CheckPoint()
-    check_point.init()
 
     x = np.random.rand(*input_shape).astype(np.float32)
 

--- a/oneflow/python/test/ops/test_bias_add.py
+++ b/oneflow/python/test/ops/test_bias_add.py
@@ -71,8 +71,6 @@ def RunOneflowBiasAdd(data_type, device_type, value, bias, flow_args):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     y = FlowJob(value, bias).get().numpy()
     value_diff = test_global_storage.Get("value_diff")
     bias_diff = test_global_storage.Get("bias_diff")

--- a/oneflow/python/test/ops/test_binary_elementwise_ops.py
+++ b/oneflow/python/test/ops/test_binary_elementwise_ops.py
@@ -71,8 +71,6 @@ def RunOneflowBinaryOp(device_type, flow_op, x, y, data_type):
             return loss
 
     # Oneflow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     out = FlowJob(x, y).get().numpy()
     x_diff = test_global_storage.Get("x_diff")
     y_diff = test_global_storage.Get("y_diff")

--- a/oneflow/python/test/ops/test_broadcast_normal.py
+++ b/oneflow/python/test/ops/test_broadcast_normal.py
@@ -71,8 +71,6 @@ def RunOneflowOp(device_type, flow_op, x, y, data_type):
             return loss
 
     # Oneflow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     out = FlowJob(x, y).get().numpy()
     x_diff = test_global_storage.Get("x_diff")
     y_diff = test_global_storage.Get("y_diff")

--- a/oneflow/python/test/ops/test_cast.py
+++ b/oneflow/python/test/ops/test_cast.py
@@ -80,8 +80,6 @@ def compare_with_tensorflow(device_type, input_shape, dtype):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = CastJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_categorical_ordinal_encoder.py
+++ b/oneflow/python/test/ops/test_categorical_ordinal_encoder.py
@@ -42,9 +42,6 @@ def _test_categorical_ordinal_encoder(
             # z = flow.layers.categorical_ordinal_encoder(x, capacity=320)
             return y, z
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
-
     tokens = np.random.randint(-sys.maxsize, sys.maxsize, size=[num_tokens]).astype(
         flow.convert_oneflow_dtype_to_numpy_dtype(dtype)
     )

--- a/oneflow/python/test/ops/test_clip_by_value.py
+++ b/oneflow/python/test/ops/test_clip_by_value.py
@@ -80,8 +80,6 @@ def _of_clip_by_value(values, min, max, device_type="gpu", dynamic=False, grad_c
         ):
             return clip(values_def)
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         return clip_fn([values]).get().numpy_list()[0]
 
     else:
@@ -91,8 +89,6 @@ def _of_clip_by_value(values, min, max, device_type="gpu", dynamic=False, grad_c
         def clip_fn(values_def: oft.Numpy.Placeholder(values.shape, dtype=data_type)):
             return clip(values_def)
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         return clip_fn(values).get().numpy()
 
 

--- a/oneflow/python/test/ops/test_compat_conv2d.py
+++ b/oneflow/python/test/ops/test_compat_conv2d.py
@@ -107,8 +107,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConvJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_concat.py
+++ b/oneflow/python/test/ops/test_concat.py
@@ -72,8 +72,6 @@ def compare_with_tensorflow(device_type, x_shape, y_shape, dtype, axis):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConcatJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:
@@ -156,8 +154,6 @@ def _of_dynamic_concat(
         flow.watch_diff(var_1, make_watch_diff_cb(1))
         return result
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     ret = dynamic_concat_job([inputs[0]], [inputs[1]]).get()
     return ret.numpy(0)
 

--- a/oneflow/python/test/ops/test_deconv2d.py
+++ b/oneflow/python/test/ops/test_deconv2d.py
@@ -88,8 +88,6 @@ def compare_with_tensorflow(device_type, params_case, dilations, data_format):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = DeconvJob().get()
     # Tensorflow
     if data_format == "NCHW":

--- a/oneflow/python/test/ops/test_dropout.py
+++ b/oneflow/python/test/ops/test_dropout.py
@@ -67,8 +67,6 @@ def of_run(device_type, x_shape, data_type, rate, seed):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = DropoutJob().get()
 
     of_out = test_global_storage.Get("out")
@@ -107,8 +105,6 @@ def of_run_module(device_type, x_shape, data_type, rate, seed):
             ).minimize(loss)
             return of_out
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = DropoutJob()
     of_out2 = DropoutJob()
 

--- a/oneflow/python/test/ops/test_dynamic_loss_scale_schedule.py
+++ b/oneflow/python/test/ops/test_dynamic_loss_scale_schedule.py
@@ -95,9 +95,6 @@ def _run_test(
             )
         return good_step_counter, loss_scale
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
-
     count_not_finite = np.array([op_param["count_not_finite"]]).astype(np.int64)
     schedule_job(count_not_finite).get()
     good_step_counter, loss_scale = fetch_job().get()

--- a/oneflow/python/test/ops/test_expand_dims.py
+++ b/oneflow/python/test/ops/test_expand_dims.py
@@ -53,8 +53,6 @@ def compare_with_tensorflow(device_type, x_shape, axis):
             return loss
 
     # # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ExpandDimsJob().get().numpy()
     # # TensorFlow
     tf_out = tf.expand_dims(np.ones(x_shape, dtype=np.float32), axis).numpy()

--- a/oneflow/python/test/ops/test_flatten.py
+++ b/oneflow/python/test/ops/test_flatten.py
@@ -54,8 +54,6 @@ def compare_with_numpy(test_case, device_type, input_shape, start_end_dim):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = FlattenJob()
 
     # Numpy

--- a/oneflow/python/test/ops/test_fuse_cast_scale.py
+++ b/oneflow/python/test/ops/test_fuse_cast_scale.py
@@ -87,8 +87,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = FusedCastScaleJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_fused_scale_tril.py
+++ b/oneflow/python/test/ops/test_fused_scale_tril.py
@@ -71,8 +71,6 @@ def _test_fused_scale_tril_fw_bw(
             flow.watch_diff(out, test_global_storage.Setter("out_diff"))
             return out
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     x = np.random.randint(low=0, high=100, size=shape)
     test_fused_scale_tril_fw_bw_job(x.astype(np_type)).get()
 

--- a/oneflow/python/test/ops/test_gather.py
+++ b/oneflow/python/test/ops/test_gather.py
@@ -124,9 +124,6 @@ def _compare_gather_with_tf(
         params, indices, axis, batch_dims, device_type, mirrored, compare_dy
     )
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
-
     if mirrored:
         of_y = gather_fn([params], [indices]).get().numpy_list()[0]
     else:

--- a/oneflow/python/test/ops/test_get_variable.py
+++ b/oneflow/python/test/ops/test_get_variable.py
@@ -44,8 +44,6 @@ class TestGetVariable(flow.unittest.TestCase):
         def TestJob1():
             return get_v()
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         j0_v1, j0_v2 = TestJob0().get()
         j1_v = TestJob1().get()
         test_case.assertTrue(np.array_equal(j0_v1.numpy(), j0_v2.numpy()))
@@ -78,9 +76,6 @@ class TestGetVariable(flow.unittest.TestCase):
         @flow.global_function()
         def eval():
             return get_var("var")
-
-        check_point = flow.train.CheckPoint()
-        check_point.init()
 
         variables = []
         for i in range(10):
@@ -130,9 +125,6 @@ class TestGetVariable(flow.unittest.TestCase):
             v1 = get_var("var")
             v2 = get_var("var")
             return v1, v2
-
-        check_point = flow.train.CheckPoint()
-        check_point.init()
 
         variables = []
         for i in range(10):

--- a/oneflow/python/test/ops/test_global_function_input_output.py
+++ b/oneflow/python/test/ops/test_global_function_input_output.py
@@ -112,8 +112,6 @@ class TestGlobalFunctionInputOutput(flow.unittest.TestCase):
             output = var + input_def
             return output
 
-        checkpoint = flow.train.CheckPoint()
-        checkpoint.init()
         input = np.arange(10).reshape(2, 5).astype(np.single)
         ret = foo_job(input).get()
         output = input + np.ones(shape=(2, 5), dtype=np.single)

--- a/oneflow/python/test/ops/test_inplace.py
+++ b/oneflow/python/test/ops/test_inplace.py
@@ -38,7 +38,6 @@ def TrainCompare(test_case, func):
     def DisableInplace():
         return func("w1")
 
-    flow.train.CheckPoint().init()
     num_iter = 10
     enable_inplace_losses = np.array(
         [EnableInplace().get().tolist() for _ in range(num_iter)]
@@ -71,7 +70,6 @@ class TestInplace(flow.unittest.TestCase):
             y = flow.math.relu(w)
             return y
 
-        flow.train.CheckPoint().init()
         test_case.assertTrue(
             np.allclose(InplaceVariable().get().numpy(), np.ones((10,), np.float32))
         )
@@ -108,7 +106,6 @@ class TestInplace(flow.unittest.TestCase):
             y = flow.reshape(w, (10,))
             return y
 
-        flow.train.CheckPoint().init()
         of_ret = InplaceVariable().get().numpy()
         test_case.assertTrue(np.allclose(of_ret, np.ones((10,), np.float32)))
 

--- a/oneflow/python/test/ops/test_interface_op_read_and_write.py
+++ b/oneflow/python/test/ops/test_interface_op_read_and_write.py
@@ -47,8 +47,6 @@ class TestInterfaceOpReadAndWrite(flow.unittest.TestCase):
                 )
                 return flow.math.add_n([x, y])
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         x_value = np.random.random((2, 3)).astype(np.float32)
         y_value = np.random.random((2, 3)).astype(np.float32)
         flow.experimental.set_interface_blob_value("x", x_value)

--- a/oneflow/python/test/ops/test_interface_op_read_and_write.py
+++ b/oneflow/python/test/ops/test_interface_op_read_and_write.py
@@ -47,6 +47,9 @@ class TestInterfaceOpReadAndWrite(flow.unittest.TestCase):
                 )
                 return flow.math.add_n([x, y])
 
+        # NOTE(chengcheng): Should retain for session init before set_interface_blob_value
+        flow.train.CheckPoint().init()
+
         x_value = np.random.random((2, 3)).astype(np.float32)
         y_value = np.random.random((2, 3)).astype(np.float32)
         flow.experimental.set_interface_blob_value("x", x_value)

--- a/oneflow/python/test/ops/test_l2_normalize.py
+++ b/oneflow/python/test/ops/test_l2_normalize.py
@@ -57,8 +57,6 @@ def compare_with_tensorflow(device_type, x_shape, data_type, axis, epsilon):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = L2NormalizeJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_lamb.py
+++ b/oneflow/python/test/ops/test_lamb.py
@@ -68,9 +68,6 @@ def compare_with_tensorflow_addons_lamb(
             ).minimize(loss)
             return x
 
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
-
     # generate random number sequences
     random_masks_seq = []
     for i in range(train_iters + 1):

--- a/oneflow/python/test/ops/test_layer_norm.py
+++ b/oneflow/python/test/ops/test_layer_norm.py
@@ -241,8 +241,6 @@ class TestLayerNorm(flow.unittest.TestCase):
                 ).minimize(z)
                 return y
 
-            check_point = flow.train.CheckPoint()
-            check_point.init()
             y = test_job(x).get()
 
             assert y.numpy().shape == y_tf.numpy().shape, (

--- a/oneflow/python/test/ops/test_layers_conv1d.py
+++ b/oneflow/python/test/ops/test_layers_conv1d.py
@@ -109,8 +109,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConvJob().get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_layers_conv2d.py
+++ b/oneflow/python/test/ops/test_layers_conv2d.py
@@ -109,8 +109,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConvJob().get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_layers_conv3d.py
+++ b/oneflow/python/test/ops/test_layers_conv3d.py
@@ -115,8 +115,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConvJob().get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_leaky_relu.py
+++ b/oneflow/python/test/ops/test_leaky_relu.py
@@ -57,8 +57,6 @@ def compare_with_tensorflow(device_type, x_shape, data_type, alpha):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = LeakyReluJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_logical_slice.py
+++ b/oneflow/python/test/ops/test_logical_slice.py
@@ -43,9 +43,6 @@ def _test_logical_slice(
             ret = flow.experimental.logical_slice(var, slice_tuples)
             return ret
 
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
-
     of_res = slice_fn().get().numpy()
 
     var_np = test_global_storage.Get("var")

--- a/oneflow/python/test/ops/test_masked_fill.py
+++ b/oneflow/python/test/ops/test_masked_fill.py
@@ -96,8 +96,6 @@ def _test_masked_fill_fw_bw(test_case, device, x_shape, mask_shape, type_name, v
             flow.watch_diff(out, test_global_storage.Setter("out_diff"))
             return out
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     x = np.random.randint(low=0, high=100, size=x_shape)
     mask = np.random.randint(low=0, high=2, size=mask_shape)
 

--- a/oneflow/python/test/ops/test_matmul.py
+++ b/oneflow/python/test/ops/test_matmul.py
@@ -110,8 +110,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = MatmulJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_model_io.py
+++ b/oneflow/python/test/ops/test_model_io.py
@@ -62,6 +62,7 @@ def _load_snapshot_manually(path, shape, dtype):
 
 def _test_model_io(test_case, shape, dtype, lr, num_iters):
     flow.clear_default_session()
+    flow.config.enable_legacy_model_io(True)
     gen_var = _make_gen_var_func(shape, dtype, lr)
 
     model_save_root_dir = "./log/snapshot/"

--- a/oneflow/python/test/ops/test_moments.py
+++ b/oneflow/python/test/ops/test_moments.py
@@ -61,8 +61,6 @@ def compare_with_tensorflow(device_type, x_shape, data_type, axes):
             return (m, v)
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = MomentsJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_multiply.py
+++ b/oneflow/python/test/ops/test_multiply.py
@@ -76,8 +76,6 @@ def _test_element_wise_mul_fw_bw(test_case, device, shape, type_name):
             flow.watch_diff(out, test_global_storage.Setter("out_diff"))
             return out
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     x = np.random.randint(low=0, high=10, size=shape).astype(np.float32)
     y = np.random.randint(low=0, high=10, size=shape).astype(np.float32)
     test_element_wise_mul_job(x, y).get()

--- a/oneflow/python/test/ops/test_name_scope.py
+++ b/oneflow/python/test/ops/test_name_scope.py
@@ -45,8 +45,6 @@ class TestNameScope(flow.unittest.TestCase):
             var3 = get_var("backbone-branch-var")
             return var1, var2, var3
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         var1, var2, var3 = test_name_scope_job().get()
         test_case.assertTrue(np.array_equal(var1.numpy(), var2.numpy()))
         test_case.assertTrue(np.array_equal(var1.numpy(), var3.numpy()))

--- a/oneflow/python/test/ops/test_nn_conv1d.py
+++ b/oneflow/python/test/ops/test_nn_conv1d.py
@@ -96,8 +96,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConvJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_nn_conv2d.py
+++ b/oneflow/python/test/ops/test_nn_conv2d.py
@@ -119,8 +119,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConvJob().get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_nn_conv2d_padding.py
+++ b/oneflow/python/test/ops/test_nn_conv2d_padding.py
@@ -98,8 +98,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConvJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_nn_conv2d_padding_dynamic.py
+++ b/oneflow/python/test/ops/test_nn_conv2d_padding_dynamic.py
@@ -108,8 +108,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     data = [np.random.rand(*x_shape).astype(np.float32)]
     of_out = DynamicConvJob(data).get().numpy_list()[0]
     # TensorFlow

--- a/oneflow/python/test/ops/test_nn_conv3d.py
+++ b/oneflow/python/test/ops/test_nn_conv3d.py
@@ -112,8 +112,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ConvJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_ones.py
+++ b/oneflow/python/test/ops/test_ones.py
@@ -60,9 +60,6 @@ def _compare_ones_with_np(input_shape, device_type, machine_ids, device_counts):
 
         return of_ones
 
-    check = flow.train.CheckPoint()
-    check.init()
-
     of_out_ones = oneflow_ones()
     assert np.allclose(of_out_ones, np_out_ones)
 

--- a/oneflow/python/test/ops/test_optimizers.py
+++ b/oneflow/python/test/ops/test_optimizers.py
@@ -58,9 +58,6 @@ def compare_with_tensorflow_rmsprop(
             ).minimize(loss)
             return x
 
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
-
     # generate random number sequences
     random_masks_seq = []
     for i in range(train_iters + 1):
@@ -122,9 +119,6 @@ def compare_with_tensorflow_adam(
                 do_bias_correction=True,
             ).minimize(loss)
             return x
-
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
 
     # generate random number sequences
     random_masks_seq = []
@@ -193,9 +187,6 @@ def compare_with_numpy_adamw(
                 do_bias_correction=True,
             ).minimize(loss)
             return x
-
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
 
     # generate random number sequences
     random_masks_seq = []
@@ -278,9 +269,6 @@ def compare_with_numpy_lazy_adam(
 
             return x
 
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
-
     init_value = None
     for i in range(train_iters + 1):
         x = testLazyAdam()
@@ -358,9 +346,6 @@ def compare_with_numpy_lars(
                 lars_coefficient=lars_coefficient,
             ).minimize(loss)
             return x
-
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
 
     # generate random number sequences
     random_masks_seq = []
@@ -444,9 +429,6 @@ def compare_with_tensorflow_sgd(
             ).minimize(loss)
             return x
 
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
-
     # generate random number sequences
     random_masks_seq = []
     for i in range(train_iters + 1):
@@ -526,9 +508,6 @@ def compare_with_numpy_indexed_slices_sgd(
 
             return embedding_table
 
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
-
     sparse_ids = np.random.randint(model_shape[0], size=ids_shape).astype(np.int32)
 
     init_value = None
@@ -602,9 +581,6 @@ def compare_with_numpy_indexed_slices_sgdw(
             ).minimize(loss)
 
             return embedding_table
-
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
 
     sparse_ids = np.random.randint(model_shape[0], size=ids_shape).astype(np.int32)
 
@@ -683,9 +659,6 @@ def compare_with_numpy_indexed_slices_adam(
             ).minimize(loss)
 
             return embedding_table
-
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
 
     sparse_ids = np.random.randint(model_shape[0], size=ids_shape).astype(np.int32)
 
@@ -771,9 +744,6 @@ def compare_with_numpy_indexed_slices_adamw(
             ).minimize(loss)
 
             return embedding_table
-
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
 
     sparse_ids = np.random.randint(model_shape[0], size=ids_shape).astype(np.int32)
 
@@ -889,8 +859,6 @@ def compare_with_flow_job_fused_sgd_model_update(
 
     sgd_job = make_sgd_job()
     fused_sgd_job = make_fused_sgd_job()
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
 
     # generate random number sequences
     random_masks_seq = []
@@ -964,8 +932,6 @@ def compare_with_flow_job_fused_adam_model_update(
 
     adam_job = make_adam_job()
     fused_adam_job = make_fused_adam_job()
-    checkpoint = flow.train.CheckPoint()
-    checkpoint.init()
 
     # generate random number sequences
     random_masks_seq = []

--- a/oneflow/python/test/ops/test_polyval.py
+++ b/oneflow/python/test/ops/test_polyval.py
@@ -69,8 +69,6 @@ def compare_with_numpy(device_type, device_num, in_shape, data_type, coeffs):
 
         return out
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = PolyValJob(x).get().numpy()
     np_out = np.polyval(coeffs, x)
     assert np.allclose(of_out, np_out, rtol=1e-5, atol=1e-5)

--- a/oneflow/python/test/ops/test_prelu.py
+++ b/oneflow/python/test/ops/test_prelu.py
@@ -92,8 +92,6 @@ def _run_test(test_case, device_type, dtype, x_shape, shared_axes):
 
             return loss
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     x = (np.random.random(x_shape) - 1).astype(type_name_to_np_type[dtype])
     y = PreluJob(x).get()
     _check(test_case, x, y.numpy(), shared_axes)

--- a/oneflow/python/test/ops/test_quantize_op.py
+++ b/oneflow/python/test/ops/test_quantize_op.py
@@ -109,8 +109,6 @@ def _run_test_min_max_observer(
             )
         return scale, zero_point
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     weight = (np.random.random(weight_shape) - 0.5).astype(type_name_to_np_type[dtype])
     scale, zero_point = QuantizeJob(weight).get()
     _check_min_max_observer(
@@ -237,9 +235,6 @@ def _run_test_moving_average_min_max_observer(
                 flow.optimizer.PiecewiseConstantScheduler([], [0.001]),
             ).minimize(loss)
         return scale, zero_point
-
-    check_point = flow.train.CheckPoint()
-    check_point.init()
 
     moving_max_np = np.zeros((1,))
     moving_min_np = np.zeros((1,))
@@ -380,9 +375,6 @@ def _run_test_fake_quantize(
             ).minimize(loss)
 
         return out
-
-    check_point = flow.train.CheckPoint()
-    check_point.init()
 
     input = (np.random.random(in_shape) - 0.5).astype(type_name_to_np_type[dtype])
     out = QuantizeJob(input).get()

--- a/oneflow/python/test/ops/test_reduce_mean.py
+++ b/oneflow/python/test/ops/test_reduce_mean.py
@@ -59,8 +59,6 @@ def compare_with_tensorflow(device_type, input_shape, axis, keepdims):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ReduceMeanJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_reduce_opsV2.py
+++ b/oneflow/python/test/ops/test_reduce_opsV2.py
@@ -60,8 +60,6 @@ def compare_reduce_sum_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ReduceSumJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_reshapeV2.py
+++ b/oneflow/python/test/ops/test_reshapeV2.py
@@ -59,8 +59,6 @@ def compare_with_tensorflow(device_type, input_shape, shape):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ReshapeJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_reshapeV3.py
+++ b/oneflow/python/test/ops/test_reshapeV3.py
@@ -48,8 +48,6 @@ def distribute_reshape_test(device_type, device_num, input_shape, shape):
             return x, loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     x, loss = ReshapeJob().get()
 
 

--- a/oneflow/python/test/ops/test_scalar_by_tensor_ops.py
+++ b/oneflow/python/test/ops/test_scalar_by_tensor_ops.py
@@ -73,8 +73,6 @@ def compare_with_tensorflow(device_type, data_type, x_shape, case):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = ScalarAddByTensorJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_scatter_nd.py
+++ b/oneflow/python/test/ops/test_scatter_nd.py
@@ -141,9 +141,6 @@ def _compare_scatter_nd_with_tf(
         indices, updates, params_shape, device_type, mirrored, compare_dy
     )
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
-
     if mirrored:
         of_y = scatter_nd_fn([indices], [updates]).get().numpy_list()[0]
     else:
@@ -228,8 +225,6 @@ def _compare_scatter_nd_update_with_tf(
         flow.watch_diff(y, compare_dz_dy)
         return z
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_z = scatter_nd_update_grad_fn(params, indices, updates).get()
 
     if verbose is True:
@@ -296,8 +291,6 @@ def _of_tensor_scatter_nd_add(
         ):
             return do_tensor_scatter_nd_add(params_def, indices_def, updates_def)
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         return (
             tensor_scatter_nd_add_fn([params], [indices], [updates])
             .get()
@@ -315,8 +308,6 @@ def _of_tensor_scatter_nd_add(
         ):
             return do_tensor_scatter_nd_add(params_def, indices_def, updates_def)
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         return tensor_scatter_nd_add_fn(params, indices, updates).get().numpy()
 
 

--- a/oneflow/python/test/ops/test_softmax.py
+++ b/oneflow/python/test/ops/test_softmax.py
@@ -72,8 +72,6 @@ def compare_with_tensorflow(device_type, x_shape, data_type, axis):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = SoftmaxJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_softmax_cross_entropy.py
+++ b/oneflow/python/test/ops/test_softmax_cross_entropy.py
@@ -93,8 +93,6 @@ def compare_with_tensorflow(device_type, data_type, shape):
         )
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = SoftmaxCrossEntropyWithLogitsJob(labels).get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_sparse_cross_entropy.py
+++ b/oneflow/python/test/ops/test_sparse_cross_entropy.py
@@ -70,8 +70,6 @@ def compare_with_tensorflow(
     )
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = SparseSoftmaxCrossEntropyWithLogitsJob(labels).get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_sparse_cross_entropy_ms.py
+++ b/oneflow/python/test/ops/test_sparse_cross_entropy_ms.py
@@ -84,8 +84,6 @@ def compare_with_tensorflow(
     )
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = SparseSoftmaxCrossEntropyWithLogitsJob(labels).get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_sparse_softmax_cross_entropy.py
+++ b/oneflow/python/test/ops/test_sparse_softmax_cross_entropy.py
@@ -71,8 +71,6 @@ def compare_with_tensorflow(
     )
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = SparseSoftmaxCrossEntropyWithLogitsJob(labels).get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_sparse_softmax_cross_entropy_ms.py
+++ b/oneflow/python/test/ops/test_sparse_softmax_cross_entropy_ms.py
@@ -82,8 +82,6 @@ def compare_with_tensorflow(
     )
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = SparseSoftmaxCrossEntropyWithLogitsJob(labels).get()
 
     # TensorFlow

--- a/oneflow/python/test/ops/test_split_like.py
+++ b/oneflow/python/test/ops/test_split_like.py
@@ -75,8 +75,6 @@ def compare_with_np(device_type, x_shape, like0_shape, like1_shape, dtype):
         return y0, y1
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     x = np.random.randn(*x_shape).astype(np.float32)
     y0, y1 = SplitLikeJob(x).get()
     assert (like0_shape[0] + like1_shape[0]) == x_shape[0]

--- a/oneflow/python/test/ops/test_square.py
+++ b/oneflow/python/test/ops/test_square.py
@@ -57,8 +57,6 @@ def compare_with_tensorflow(device_type, x_shape):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = SquareJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_squeeze.py
+++ b/oneflow/python/test/ops/test_squeeze.py
@@ -54,8 +54,6 @@ def compare_with_tensorflow(device_type, x_shape, axis):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = SqueezeJob().get().numpy()
     # TensorFlow
     tf_out = tf.squeeze(np.ones(x_shape, dtype=np.float32), axis).numpy()

--- a/oneflow/python/test/ops/test_ssp_variable_proxy.py
+++ b/oneflow/python/test/ops/test_ssp_variable_proxy.py
@@ -49,8 +49,6 @@ class Test1dSspVariableProxy(flow.unittest.TestCase):
                 flow.assign(ref, value + ones)
                 return value
 
-        checkpoint = flow.train.CheckPoint()
-        checkpoint.init()
         zeros = np.zeros((10,)).astype(np.float32)
         ones = np.ones((10,)).astype(np.float32)
 
@@ -96,8 +94,6 @@ class Test1dSspVariableProxy(flow.unittest.TestCase):
                 flow.assign(ref, ref + ones)
                 return value
 
-        checkpoint = flow.train.CheckPoint()
-        checkpoint.init()
         zeros = np.zeros((10,)).astype(np.float32)
         ones = np.ones((10,)).astype(np.float32)
 
@@ -153,8 +149,6 @@ class Test1dSspVariableProxy(flow.unittest.TestCase):
                 ).minimize(loss)
                 return loss
 
-        checkpoint = flow.train.CheckPoint()
-        checkpoint.init()
         zeros = np.zeros((10,)).astype(np.float32)
         ones = np.ones((10,)).astype(np.float32)
 

--- a/oneflow/python/test/ops/test_transpose.py
+++ b/oneflow/python/test/ops/test_transpose.py
@@ -60,8 +60,6 @@ def compare_with_tensorflow(device_type, input_shape, perm):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = TransposeJob().get()
     # TensorFlow
     with tf.GradientTape(persistent=True) as tape:

--- a/oneflow/python/test/ops/test_tril.py
+++ b/oneflow/python/test/ops/test_tril.py
@@ -64,8 +64,6 @@ def _test_tril_fw_bw(test_case, device, shape, type_name, diagonal, fill_value):
             flow.watch_diff(out, test_global_storage.Setter("out_diff"))
             return out
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     x = np.random.randint(low=0, high=100, size=shape)
     test_tril_fw_bw_job(x.astype(np_type)).get()
 

--- a/oneflow/python/test/ops/test_unsorted_batch_segment_sum.py
+++ b/oneflow/python/test/ops/test_unsorted_batch_segment_sum.py
@@ -101,8 +101,6 @@ def _run_test(test_case, device, out_shape, num_segments, segment_ids_shape):
     out_ndarray = unsorted_batch_segment_sum_out.numpy()
     grad_in_ndarray = test_global_storage.Get("x_diff")
     grad_out_ndarray = test_global_storage.Get("loss_diff")
-    check_point = flow.train.CheckPoint()
-    check_point.init()
 
     _check(test_case, data, segment_ids, out_shape, out_ndarray)
     _check_bw(

--- a/oneflow/python/test/ops/test_unsorted_segment_sum_fw_bw.py
+++ b/oneflow/python/test/ops/test_unsorted_segment_sum_fw_bw.py
@@ -125,9 +125,6 @@ def _compare_unsorted_segment_sum_with_tf(
         data, segment_ids, axis, num_segments, device_type, mirrored, compare_dy
     )
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
-
     if mirrored:
         of_y = unsorted_segment_sum_fn([data], [segment_ids]).get().numpy_list()[0]
     else:

--- a/oneflow/python/test/ops/test_upsample.py
+++ b/oneflow/python/test/ops/test_upsample.py
@@ -63,8 +63,6 @@ def compare_with_tensorflow(
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     of_out = UpsampleJob().get()
     channel_pos = "channels_first" if data_format.startswith("NC") else "channels_last"
     # TensorFlow

--- a/oneflow/python/test/ops/test_util.py
+++ b/oneflow/python/test/ops/test_util.py
@@ -85,8 +85,6 @@ def RunOneflowOp(device_type, flow_op, x, flow_args):
             return loss
 
     # OneFlow
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     y = FlowJob(x).get().numpy()
     x_diff = test_global_storage.Get("x_diff")
     return y, x_diff

--- a/oneflow/python/test/ops/test_watch_diff.py
+++ b/oneflow/python/test/ops/test_watch_diff.py
@@ -50,8 +50,6 @@ def WatchDiff(test_case, device_type, input_shape, dtype):
                 flow.optimizer.PiecewiseConstantScheduler([], [1e-4]), momentum=0
             ).minimize(x)
 
-    check_point = flow.train.CheckPoint()
-    check_point.init()
     TrainJob()
 
 

--- a/oneflow/python/test/ops/test_where.py
+++ b/oneflow/python/test/ops/test_where.py
@@ -100,8 +100,6 @@ def _of_where(
         ):
             return do_where(condition_def, x_def, y_def)
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         return where_fn([condition], [x], [y]).get().numpy_list()[0]
 
     else:
@@ -118,8 +116,6 @@ def _of_where(
         ):
             return do_where(condition_def, x_def, y_def)
 
-        check_point = flow.train.CheckPoint()
-        check_point.init()
         return where_fn(condition, x, y).get().numpy()
 
 

--- a/oneflow/python/test/ops/test_zeros.py
+++ b/oneflow/python/test/ops/test_zeros.py
@@ -60,9 +60,6 @@ def _compare_zeros_with_np(input_shape, device_type, machine_ids, device_counts)
 
         return of_zeros
 
-    check = flow.train.CheckPoint()
-    check.init()
-
     of_out_zeros = oneflow_zeros()
     assert np.allclose(of_out_zeros, np_out_zeros)
 


### PR DESCRIPTION
移除掉单元测试里大量的跟Checkpoint相关的过时代码：

```python
check_point = flow.train.CheckPoint()	
check_point.init()
```

因为新版的Checkpoint会自动init，无需手动调用。这个手动调用会导致CI进行Op单测时弹出大量的warning，导致CI的log太长，难以阅读。