### PR TITLE
Yangfei/zero pad2d

### DIFF
--- a/oneflow/python/ops/pad.py
+++ b/oneflow/python/ops/pad.py
@@ -306,7 +306,7 @@ def reflection_pad2d(
 
     return (
         oneflow.user_op_builder(
-            name if name is not None else id_util.UniqueStr("Reflection_Pad2d")
+            name if name is not None else id_util.UniqueStr("Reflection_Pad2d_")
         )
         .Op("reflection_pad2d")
         .Input("x", [x])
@@ -387,7 +387,7 @@ def replication_pad2d(
 
     return (
         oneflow.user_op_builder(
-            name if name is not None else id_util.UniqueStr("Replication_Pad2d")
+            name if name is not None else id_util.UniqueStr("Replication_Pad2d_")
         )
         .Op("replication_pad2d")
         .Input("x", [x])
@@ -412,6 +412,7 @@ def constant_pad2d(
         x (oneflow_api.BlobDesc): input blob, only support "NCHW" format.
         padding (Union[int, oneflow_api.BlobDesc]): The size or bundary of padding, if is int uses the same padding in all dimension;
         if 4-dims tuple, uses (\text{padding\_left}padding_left , \text{padding\_right}padding_right , \text{padding\_top}padding_top , \text{padding\_bottom}padding_bottom )
+        constant_value (Union[int, float]): The constant value used for padding. Defaults to Zero.
         name (Optional[str], optional): The name for the operation. Defaults to None.
 
     Returns:
@@ -481,7 +482,7 @@ def constant_pad2d(
 
     return (
         oneflow.user_op_builder(
-            name if name is not None else id_util.UniqueStr("Constant_Pad2d")
+            name if name is not None else id_util.UniqueStr("Constant_Pad2d_")
         )
         .Op("constant_pad2d")
         .Input("x", [x])
@@ -493,3 +494,57 @@ def constant_pad2d(
         .InferAndTryRun()
         .RemoteBlobList()[0]
     )
+
+
+@oneflow_export("zero_pad2d")
+def zero_pad2d(
+    x: oneflow_api.BlobDesc,
+    padding: Union[int, tuple, list],
+    name: Optional[str] = None,
+) -> oneflow_api.BlobDesc:
+    """Pads the input tensor using zeros. 
+
+    Args:
+        x (oneflow_api.BlobDesc): input blob, only support "NCHW" format.
+        padding (Union[int, oneflow_api.BlobDesc]): The size or bundary of padding, if is int uses the same padding in all dimension;
+        if 4-dims tuple, uses (\text{padding\_left}padding_left , \text{padding\_right}padding_right , \text{padding\_top}padding_top , \text{padding\_bottom}padding_bottom )
+        name (Optional[str], optional): The name for the operation. Defaults to None.
+
+    Returns:
+        oneflow_api.BlobDesc: [description]
+
+    For example: 
+
+    .. code-block:: python 
+
+        import oneflow as flow
+        import oneflow.typing as tp
+        import numpy as np 
+
+
+        @flow.global_function()
+        def pad_Job(x: tp.Numpy.Placeholder((1, 2, 3, 3), const_value)
+        ) -> tp.Numpy:
+            return flow.constant_pad2d(x, padding=[2, 2, 1, 1], const_value)
+
+
+        x = np.arange(18).reshape((1, 2, 3, 3)).astype(np.float32)
+        const_value = 1.5
+        out = pad_Job(x, const_value)
+
+        # out [[[[ 0.  0.  0.  0.  0.  0.  0.]
+        #    [ 0.  0.  0.  1.  2.  0.  0.]
+        #    [ 0.  0.  3.  4.  5.  0.  0.]
+        #    [ 0.  0.  6.  7.  8.  0.  0.]
+        #    [ 0.  0.  0.  0.  0.  0.  0.]]
+
+        #   [[ 0.  0.  0.  0.  0.  0.  0.]
+        #    [ 0.  0.  9.  10.  11.  0.  0.]
+        #    [ 0.  0.  12.  13.  14.  0.  0.]
+        #    [ 0.  0.  15.  16.  17.  0.  0.]
+        #    [ 0.  0.  0.  0.  0.  0.  0.]]]]
+
+    """
+    if name is None:
+        name = id_util.UniqueStr("Zero_Pad2d_")
+    return constant_pad2d(x, padding, 0., name)

--- a/oneflow/python/ops/pad.py
+++ b/oneflow/python/ops/pad.py
@@ -547,4 +547,4 @@ def zero_pad2d(
     """
     if name is None:
         name = id_util.UniqueStr("Zero_Pad2d_")
-    return constant_pad2d(x, padding, 0., name)
+    return constant_pad2d(x, padding, 0.0, name)

--- a/oneflow/python/test/ops/test_zero_pad2d.py
+++ b/oneflow/python/test/ops/test_zero_pad2d.py
@@ -1,0 +1,295 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+import os
+from collections import OrderedDict
+
+import numpy as np
+import oneflow as flow
+import oneflow.typing as tp
+from test_util import (
+    Args,
+    GenArgDict,
+    GenArgList,
+    FlattenArray,
+    Array2Numpy,
+    Index2Coordinate,
+    Coordinate2Index,
+)
+
+
+def _make_op_function(
+    test_case,
+    input,
+    padding,
+    grad,
+    device_type,
+    value_type,
+    machine_ids,
+    device_counts,
+):
+    flow.clear_default_session()
+    if device_type == "cpu":
+        flow.config.cpu_device_num(device_counts)
+    else:
+        flow.config.gpu_device_num(device_counts)
+
+    func_config = flow.FunctionConfig()
+
+    # global function needs float32 as type of argument and return value
+    if value_type == flow.float16:
+        func_config.default_data_type(flow.float32)
+    else:
+        func_config.default_data_type(value_type)
+
+    func_config.default_placement_scope(flow.scope.placement(device_type, machine_ids))
+    func_config.default_logical_view(flow.scope.consistent_view())
+
+    def _compare_diff(blob: tp.Numpy):
+        test_case.assertTrue(np.allclose(grad, blob, 1e-3, 1e-3))
+
+    if value_type == flow.float32 or value_type == flow.float64:
+
+        @flow.global_function(type="train", function_config=func_config)
+        def op_function(x: tp.Numpy.Placeholder(input.shape, dtype=value_type)):
+            with flow.scope.placement(device_type, "0:0"):
+                x += flow.get_variable(
+                    name="input",
+                    shape=input.shape,
+                    dtype=value_type,
+                    initializer=flow.zeros_initializer(),
+                )
+                out = flow.zero_pad2d(x, padding)
+                flow.optimizer.SGD(
+                    flow.optimizer.PiecewiseConstantScheduler([], [0]), momentum=0
+                ).minimize(out)
+
+            flow.watch_diff(x, _compare_diff)
+            return out
+
+        return op_function
+
+    elif value_type == flow.int32:
+
+        @flow.global_function(type="train", function_config=func_config)
+        def op_function(x: tp.Numpy.Placeholder(input.shape, dtype=flow.float32)):
+            with flow.scope.placement(device_type, "0:0"):
+                x += flow.get_variable(
+                    name="input",
+                    shape=input.shape,
+                    dtype=flow.float32,
+                    initializer=flow.zeros_initializer(),
+                )
+                y_int32 = flow.zero_pad2d(x, padding)
+                y_fp32 = flow.cast(y_int32, dtype=flow.float32)
+                flow.optimizer.SGD(
+                    flow.optimizer.PiecewiseConstantScheduler([], [0]), momentum=0
+                ).minimize(y_fp32)
+
+            flow.watch_diff(x, _compare_diff)
+            return y_fp32
+
+        return op_function
+
+    elif value_type == flow.float16:
+
+        @flow.global_function(type="train", function_config=func_config)
+        def op_function(x: tp.Numpy.Placeholder(input.shape, dtype=flow.float32)):
+            with flow.scope.placement(device_type, "0:0"):
+                x_var = flow.get_variable(
+                    name="input",
+                    shape=input.shape,
+                    dtype=flow.float32,
+                    initializer=flow.constant_initializer(0),
+                )
+                x_var = flow.cast_to_current_logical_view(x_var)
+                input_x = x_var + x
+                x_fp32 = flow.cast(input_x, flow.float32)
+                x_fp16 = flow.cast(input_x, dtype=flow.float16)
+                y_fp16 = flow.zero_pad2d(x_fp16, padding)
+                y_fp32 = flow.cast(y_fp16, dtype=flow.float32)
+                flow.optimizer.SGD(
+                    flow.optimizer.PiecewiseConstantScheduler([], [0]), momentum=0
+                ).minimize(y_fp32)
+
+            flow.watch_diff(x_fp32, _compare_diff)
+            return y_fp32
+
+        return op_function
+
+
+def gen_numpy_test_sample(input_shape, padding, is_float=True):
+    c_idx, h_idx, w_idx = 1, 2, 3
+    pad_left = padding[0]
+    pad_right = padding[1]
+    pad_top = padding[2]
+    pad_bottom = padding[3]
+    pad_shape = ((0, 0), (0, 0), (pad_top, pad_bottom), (pad_left, pad_right))
+
+    def _np_zero_pad2d(input, pad_shape4):
+        numpy_zero = np.pad(
+            input, pad_shape, "constant", constant_values=0.
+        )
+        return numpy_zero
+
+    def _np_zero_pad2d_grad(src, dest):
+        dx_height, dx_width = input.shape[h_idx], input.shape[w_idx]
+        dy_height, dy_width = output.shape[h_idx], output.shape[w_idx]
+
+        numpy_src = np.ones(src.shape, np.int32)
+        numpy_dest = np.zeros(dest.shape, np.int32)
+        array_src = FlattenArray(numpy_src)
+        array_dest = FlattenArray(numpy_dest)
+
+        src_num = src.shape[c_idx] * src.shape[h_idx] * src.shape[w_idx]
+        dest_num = dest.shape[c_idx] * dest.shape[h_idx] * dest.shape[w_idx]
+        elements_num = src.shape[0] * src_num
+        for iter_n in range(elements_num):
+            coords = Index2Coordinate(iter_n, src.shape)
+            n, c, i, j = coords[0], coords[c_idx], coords[h_idx], coords[w_idx]
+            ip_x = ip_y = 0
+            if (
+                j >= pad_left
+                and j < (dx_width + pad_left)
+                and i >= pad_top
+                and i < (dx_height + pad_top)
+            ):
+                ip_x = j - pad_left
+                ip_y = i - pad_top
+                src_index = n * src_num + c * dy_width * dy_height + i * dy_width + j
+                dest_index = (
+                    n * dest_num + c * dx_width * dx_height + ip_y * dx_width + ip_x
+                )
+                array_dest[dest_index] += array_src[src_index]
+        numpy_dest = Array2Numpy(array_dest, dest.shape)
+        return numpy_dest
+
+    if is_float:
+        input = np.random.random(input_shape).astype(np.float32)
+    else:
+        input = np.random.randint(0, 100, input_shape)
+
+    output = _np_zero_pad2d(input, pad_shape)
+    grad = _np_zero_pad2d_grad(output, input)
+
+    numpy_results = {
+        "input": input,
+        "padding": padding,
+        "output": output,
+        "grad": grad,
+    }
+
+    return numpy_results
+
+
+def _compare_op_function_with_samples(
+    test_case, device_type, sample, value_type, machine_ids, device_count
+):
+    op_function = _make_op_function(
+        test_case,
+        sample["input"].astype(value_type[0]),
+        sample["padding"],
+        sample["grad"].astype(value_type[0]),
+        device_type,
+        value_type[1],
+        machine_ids,
+        device_count,
+    )
+    y = (
+        op_function(sample["input"].astype(value_type[0]))
+        .get()
+        .numpy()
+        .astype(value_type[0])
+    )
+
+    if value_type == flow.float16:
+        test_case.assertTrue(
+            np.allclose(y, sample["output"].astype(np.float32), 1e-3, 1e-3)
+        )
+    else:
+        test_case.assertTrue(np.allclose(y, sample["output"].astype(value_type[0])))
+
+
+def _gen_arg_dict(
+    device_type="gpu", value_type="float", machine_ids="0:0", device_count=1
+):
+    arg_dict = OrderedDict()
+    arg_dict["device_type"] = [device_type]
+    arg_dict["samples"] = []
+    arg_dict["samples"].append(gen_numpy_test_sample((2, 1, 2, 2), [1, 1, 1, 1]))
+    arg_dict["samples"].append(gen_numpy_test_sample((4, 2, 3, 3), [2, 2, 2, 2]))
+    arg_dict["samples"].append(gen_numpy_test_sample((2, 3, 4, 5), [3, 2, 1, 2]))
+    if value_type == "float":
+        if device_type == "gpu":
+            arg_dict["value_type"] = [
+                (np.float32, flow.float32),
+                # (np.float16, flow.float16),
+            ]
+        else:
+            arg_dict["value_type"] = [(np.float32, flow.float32)]
+
+    elif value_type == "int":
+        arg_dict["value_type"] = [(np.float32, flow.int32)]
+    else:
+        raise "float or int for value type only"
+
+    arg_dict["machine_ids"] = [machine_ids]
+    arg_dict["device_count"] = [device_count]
+    return arg_dict
+
+
+@flow.unittest.skip_unless_1n1d()
+class TestZeroPad2d1n1d(flow.unittest.TestCase):
+    def test_op_function_int_cpu(test_case):
+        arg_dict = _gen_arg_dict("cpu", "int", "0:0", 1)
+        for arg in GenArgList(arg_dict):
+            _compare_op_function_with_samples(test_case, *arg)
+
+    def test_op_function_float_cpu(test_case):
+        arg_dict = _gen_arg_dict("cpu", "float", "0:0", 1)
+        for arg in GenArgList(arg_dict):
+            _compare_op_function_with_samples(test_case, *arg)
+
+    @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+    def test_op_function_int_gpu(test_case):
+        arg_dict = _gen_arg_dict("gpu", "int", "0:0", 1)
+        for arg in GenArgList(arg_dict):
+            _compare_op_function_with_samples(test_case, *arg)
+
+    @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+    def test_op_function_float_gpu(test_case):
+        arg_dict = _gen_arg_dict("gpu", "float", "0:0", 1)
+        for arg in GenArgList(arg_dict):
+            _compare_op_function_with_samples(test_case, *arg)
+
+
+@flow.unittest.skip_unless_1n2d()
+class TestZeroPad2d1n2d(flow.unittest.TestCase):
+    @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+    def test_op_function_float(test_case):
+        arg_dict = _gen_arg_dict("gpu", "float", "0:0-1", 2)
+        for arg in GenArgList(arg_dict):
+            _compare_op_function_with_samples(test_case, *arg)
+
+    @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+    def test_op_function_int(test_case):
+        arg_dict = _gen_arg_dict("gpu", "int", "0:0-1", 2)
+        for arg in GenArgList(arg_dict):
+            _compare_op_function_with_samples(test_case, *arg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oneflow/python/test/ops/test_zero_pad2d.py
+++ b/oneflow/python/test/ops/test_zero_pad2d.py
@@ -140,9 +140,7 @@ def gen_numpy_test_sample(input_shape, padding, is_float=True):
     pad_shape = ((0, 0), (0, 0), (pad_top, pad_bottom), (pad_left, pad_right))
 
     def _np_zero_pad2d(input, pad_shape4):
-        numpy_zero = np.pad(
-            input, pad_shape, "constant", constant_values=0.
-        )
+        numpy_zero = np.pad(input, pad_shape, "constant", constant_values=0.0)
         return numpy_zero
 
     def _np_zero_pad2d_grad(src, dest):


### PR DESCRIPTION
## 概述
实现flow.zero_pad2d，对标pytorch：[torch.nn.ZeroPad2d](https://pytorch.org/docs/stable/generated/torch.nn.ZeroPad2d.html)
- 支持 NCHW 格式输入 
- 支持输入 int, list, tuple 类型的 padding 参数
- 利用 flow.constant_pad2d 实现的 python op
## 功能 CheckList

### Op: constant_pad2d_op
 - [ ] Op SetBatchAxisInferFn
 - [ ] Op SetGetSbpFn
 - [ ] Op SetInputArgModifyFn
 - [ ] Op 反向梯度注册

### Kernel: constant_pad2d_kernel
 - [ ] CPU in:float32 
 - [ ] CPU in:float64
 - [ ] CPU in:int32
 - [ ] CPU in:int64
 - [ ] CPU in:int8

 - [ ] GPU in:float32 
 - [ ] GPU in:float64
 - [ ] GPU in:int32
 - [ ] GPU in:int64
 - [ ] GPU in:float16
 - [ ] GPU in:int8


### Python Wrapper
 - [x] Python API 参数检查及异常提示
 - [x] 接口注释
 - [x] Example 

### 测试
 - [x] 单机单卡  CPU Test Case 
 - [x] 单机单卡  GPU Test Case 
 - [x] 单机多卡  CPU Test Case 
 - [x] 单机多卡  GPU Test Case
 - [ ] 分布式  CPU Test Case  
 - [ ] 分布式  GPU Test Case  

## GPU 有效带宽
理论带宽：
```text
 Device to Device Bandwidth, 1 Device(s)
 PINNED Memory Transfers
   Transfer Size (Bytes)        Bandwidth(GB/s)
   32000000                     729.7
```

实际带宽：
```
PROFILER::KERNEL::CUDA_MEMORY_BANDWIDTH op_name: Zero_Pad2d2 elapsed(ms): 0.117728 memory_size(Byte): 50430048 bandwidth(GB/s): 398.942
PROFILER::KERNEL::CUDA_MEMORY_BANDWIDTH op_name: Zero_Pad2d2_grad elapsed(ms): 0.153632 memory_size(Byte): 50430048 bandwidth(GB/s): 305.709
```


## PR Checklist
 - [x] PR 标题语句通畅，明确表达 PR 内容，适合直接作为新版本发布时的 changelog
 - [x] 代码格式化 
 - [x] 已经本地编译通过
 - [x] 已本地针对改动测试
 - [x] 已添加 type 标签:(填写 type 标签名，如 `bug, enhancement, purge, feature, documentation`)
 - [x] 已添加 component 标签:(填写 component 标签名，如 `op, system, eager, build, xla, python, ci, test, tooling, onnx`)
 - [x] Draft 转正式 PR 前已请人 Review
