### PR TITLE
Remove ExperimentalRun and refine oneflow LOG(INFO) compile time

### DIFF
--- a/oneflow/core/graph/boxing/collective_boxing_sub_task_graph_builder.cpp
+++ b/oneflow/core/graph/boxing/collective_boxing_sub_task_graph_builder.cpp
@@ -91,9 +91,7 @@ int64_t FindRootParallelId(const ParallelDesc& multi_device, const ParallelDesc&
   return root_parallel_id;
 }
 
-bool IsSourceTimeShape(const Shape& shape) {
-  return shape.elem_cnt() == GlobalJobDesc().TotalBatchNum() * GlobalJobDesc().NumOfPiecesInBatch();
-}
+bool IsSourceTimeShape(const Shape& shape) { return shape.elem_cnt() == 1; }
 
 class NcclCollectiveBoxingAllReduceSubTskGphBuilder final : public SubTskGphBuilder {
  public:

--- a/oneflow/core/graph/collective_boxing_task_node.cpp
+++ b/oneflow/core/graph/collective_boxing_task_node.cpp
@@ -56,10 +56,7 @@ void CollectiveBoxingGenericTaskNode::BuildExecGphAndRegst() {
 
 void CollectiveBoxingGenericTaskNode::InferProducedDataRegstTimeShape() {
   auto out_regst = GetProducedRegst("out");
-  if (out_regst != nullptr) {
-    out_regst->mut_data_regst_time_shape()->reset(
-        new Shape({GlobalJobDesc().TotalBatchNum(), GlobalJobDesc().NumOfPiecesInBatch()}));
-  }
+  if (out_regst != nullptr) { out_regst->mut_data_regst_time_shape()->reset(new Shape({1, 1})); }
 }
 
 }  // namespace oneflow

--- a/oneflow/core/graph/decode_random_compute_task_node.cpp
+++ b/oneflow/core/graph/decode_random_compute_task_node.cpp
@@ -38,9 +38,7 @@ void DecodeRandomCompTaskNode::BuildExecGphAndRegst() {
 }
 
 void DecodeRandomCompTaskNode::InferProducedDataRegstTimeShape() {
-  std::shared_ptr<Shape> time_shape(
-      new Shape({GlobalJobDesc().TotalBatchNum(), GlobalJobDesc().NumOfPiecesInBatch()}));
-
+  std::shared_ptr<Shape> time_shape(new Shape({1, 1}));
   ForEachProducedDataRegst([time_shape](const std::string& name, RegstDesc* regst) {
     *regst->mut_data_regst_time_shape() = time_shape;
   });

--- a/oneflow/core/graph/wait_and_send_ids_compute_task_node.cpp
+++ b/oneflow/core/graph/wait_and_send_ids_compute_task_node.cpp
@@ -36,8 +36,7 @@ void WaitAndSendIdsCompTaskNode::BuildExecGphAndRegst() {
 }
 
 void WaitAndSendIdsCompTaskNode::InferProducedDataRegstTimeShape() {
-  std::shared_ptr<Shape> time_shape(
-      new Shape({GlobalJobDesc().TotalBatchNum(), GlobalJobDesc().NumOfPiecesInBatch()}));
+  std::shared_ptr<Shape> time_shape(new Shape({1, 1}));
   ForEachProducedDataRegst([time_shape](const std::string& name, RegstDesc* regst) {
     *regst->mut_data_regst_time_shape() = time_shape;
   });

--- a/oneflow/core/graph_impl/source_tick_compute_task_node.cpp
+++ b/oneflow/core/graph_impl/source_tick_compute_task_node.cpp
@@ -38,8 +38,7 @@ void SourceTickCompTaskNode::BuildExecGphAndRegst() {
 }
 
 void SourceTickCompTaskNode::InferProducedDataRegstTimeShape() {
-  std::shared_ptr<Shape> time_shape(
-      new Shape({GlobalJobDesc().TotalBatchNum(), GlobalJobDesc().NumOfPiecesInBatch()}));
+  std::shared_ptr<Shape> time_shape(new Shape({1, 1}));
   ForEachProducedDataRegst([time_shape](const std::string& name, RegstDesc* regst) {
     *regst->mut_data_regst_time_shape() = time_shape;
   });

--- a/oneflow/core/job/improver.cpp
+++ b/oneflow/core/job/improver.cpp
@@ -372,8 +372,7 @@ void FixReliantCtrlRegstNum(const Plan& plan, const std::function<uint64_t(int64
           && regst_type.ctrl_regst_desc().has_reliant_regst_desc_id()) {
         // set ctrl regst num between copyHd and MdUpdt
         CHECK(task_proto.task_type() == kCopyHd);
-        uint64_t regst_num = GetRegstNum(regst_type.ctrl_regst_desc().reliant_regst_desc_id())
-                             + GlobalJobDesc().NumOfPiecesInBatch() - 1;
+        uint64_t regst_num = GetRegstNum(regst_type.ctrl_regst_desc().reliant_regst_desc_id());
         SetRegstNum(regst.regst_desc_id(), regst_num);
       }
     }

--- a/oneflow/core/job/intra_job_mem_sharing_util.cpp
+++ b/oneflow/core/job/intra_job_mem_sharing_util.cpp
@@ -130,7 +130,7 @@ void InitMemoryChains(Plan* plan,
 bool TryMergeMemChain2MergedChains(
     std::vector<MemoryChain*>* merged_chains, MemoryChain* mem_chain,
     const std::function<bool(const MemoryChain*, const MemoryChain*)>& IsStrictOrderL2R) {
-  Shape meta_shape({GlobalJobDesc().TotalBatchNum(), GlobalJobDesc().NumOfPiecesInBatch()});
+  Shape meta_shape({1, 1});
   std::sort(merged_chains->begin(), merged_chains->end(), [&](MemoryChain* lhs, MemoryChain* rhs) {
     return lhs->total_mem_reused_size > rhs->total_mem_reused_size;
   });

--- a/oneflow/core/job/job_conf.proto
+++ b/oneflow/core/job/job_conf.proto
@@ -132,11 +132,6 @@ message TrainConf {
 message PredictConf {
 }
 
-message ExperimentalRunConf {
-  optional int64 piece_num_of_experiment_phase = 1 [default = -1];
-  optional bool enable_experiment_run = 2 [default = false];
-}
-
 message MemoryAllocationAlgorithmConf {
   optional bool use_mem_size_first_algo = 1 [default = true];
   optional bool use_mutual_exclusion_first_algo = 2 [default = true];
@@ -198,14 +193,12 @@ message JobConfigProto {
     TrainConf train_conf = 3;
     PredictConf predict_conf = 4;
   }
-  optional int64 total_batch_num = 7 [default = 1];
   optional DataType default_data_type = 8 [default = kFloat]; // kFloat or kDouble
   oneof default_initialize_conf {
     InitializerConf default_initializer_conf = 10;
     string default_initialize_with_snapshot_path = 11;
   }
 
-  optional ExperimentalRunConf exp_run_conf = 100;
   optional bool use_memory_allocation_algorithm_v2 = 101 [default = true];
   optional MemoryAllocationAlgorithmConf memory_allocation_algorithm_conf = 102;
 

--- a/oneflow/core/job/job_desc.cpp
+++ b/oneflow/core/job/job_desc.cpp
@@ -42,17 +42,6 @@ void CheckFunctionConfig(const JobConfigProto& job_conf) {
 
 }  // namespace
 
-int64_t JobDesc::piece_num_of_experiment_phase() const {
-  return job_conf_.exp_run_conf().piece_num_of_experiment_phase();
-}
-
-bool JobDesc::enable_experiment_run() const {
-  return job_conf_.exp_run_conf().enable_experiment_run();
-}
-
-int64_t JobDesc::TotalBatchNum() const { return job_conf_.total_batch_num(); }
-int64_t JobDesc::NumOfPiecesInBatch() const { return 1; }
-
 JobDesc::JobDesc(const JobConfigProto& job_conf, int64_t job_id)
     : job_conf_(job_conf), job_id_(job_id), symbol_id_(Error::SymbolIdUninitialized()) {
   CHECK_JUST(Init());
@@ -71,16 +60,7 @@ Maybe<void> JobDesc::Init() {
   CHECK_EQ_OR_RETURN((Global<ResourceDesc, ForSession>::Get()->use_rdma()), false)
       << "Please compile ONEFLOW with RDMA";
 #endif
-  int64_t piece_exp = job_conf_.exp_run_conf().piece_num_of_experiment_phase();
-  if (job_conf_.has_train_conf()) {
-    if (piece_exp == -1) { piece_exp = 19 * NumOfPiecesInBatch(); }
-    piece_exp = std::max(piece_exp, NumOfPiecesInBatch());
-    piece_exp = std::min(piece_exp, job_conf_.total_batch_num() * NumOfPiecesInBatch());
-  } else {
-    if (piece_exp == -1) { piece_exp = 19; }
-  }
-  LOG(INFO) << "Set piece_num_of_experiment_phase " << piece_exp;
-  job_conf_.mutable_exp_run_conf()->set_piece_num_of_experiment_phase(piece_exp);
+
 #ifndef WITH_CUDA
   CHECK_EQ_OR_RETURN((Global<ResourceDesc, ForSession>::Get()->GpuDeviceNum()), 0);
 #endif

--- a/oneflow/core/job/job_desc.h
+++ b/oneflow/core/job/job_desc.h
@@ -53,11 +53,9 @@ class JobDesc final {
   bool EnableCudnn() const { return job_conf_.enable_cudnn(); }
   bool IsTrain() const { return job_conf_.has_train_conf(); }
   bool IsPredict() const { return job_conf_.has_predict_conf(); }
-  int64_t piece_num_of_experiment_phase() const;
   bool use_memory_allocation_algorithm_v2() const {
     return job_conf_.use_memory_allocation_algorithm_v2();
   }
-  bool enable_experiment_run() const;
   bool enable_reuse_mem() const { return job_conf_.enable_reuse_mem(); }
   bool enable_inplace() const { return job_conf_.enable_inplace(); }
   bool enable_auto_mixed_precision() const { return job_conf_.enable_auto_mixed_precision(); }
@@ -81,10 +79,6 @@ class JobDesc final {
   DEFINE_FUNCTION_CONFIG_GETTER(int64_t, Int64, at_int64);
   DEFINE_FUNCTION_CONFIG_GETTER(double, Double, at_double);
   DEFINE_FUNCTION_CONFIG_GETTER(const std::string&, String, at_string);
-
-  // Train conf
-  int64_t TotalBatchNum() const;
-  int64_t NumOfPiecesInBatch() const;
 
  private:
   Maybe<void> Init();

--- a/oneflow/core/job/model_io_job.cpp
+++ b/oneflow/core/job/model_io_job.cpp
@@ -51,7 +51,6 @@ OperatorConf GenForeignInputOpConf(const std::string& job_name, const int64_t in
 void SetModelIoDefaultJobConf(JobConfigProto* job_conf, const std::string& job_name) {
   job_conf->set_job_name(job_name);
   job_conf->mutable_predict_conf();
-  job_conf->set_total_batch_num(1);
 }
 
 OperatorConf GenOutputOpConf(const std::string& op_name, const std::string& in,

--- a/oneflow/core/job/model_io_v2_job.cpp
+++ b/oneflow/core/job/model_io_v2_job.cpp
@@ -51,7 +51,6 @@ OperatorConf GenForeignInputOpConf(const std::string& job_name, const int64_t in
 void SetModelIoDefaultJobConf(JobConfigProto* job_conf, const std::string& job_name) {
   job_conf->set_job_name(job_name);
   job_conf->mutable_predict_conf();
-  job_conf->set_total_batch_num(1);
 }
 
 OperatorConf GenTickOpConf(const std::string& op_name) {

--- a/oneflow/core/job_rewriter/autograd.cpp
+++ b/oneflow/core/job_rewriter/autograd.cpp
@@ -749,8 +749,7 @@ Maybe<void> ScaleModelDiffByLossInstanceNum(const OpGraph& op_graph, JobBuilder*
     const auto& lbi = GenLogicalBlobId(loss_lbn);
     CHECK(loss_lbi2op_node.emplace(lbi, LossOpNode4OpName(lbi.op_name())).second);
   }
-  const Shape src_time_shape(
-      {GlobalJobDesc().TotalBatchNum(), GlobalJobDesc().NumOfPiecesInBatch()});
+  const Shape src_time_shape({1, 1});
   const int64_t source_time_shape_elem_cnt = src_time_shape.elem_cnt();
   bool all_loss_time_shape_eq_src = true;
   for (const auto& pair : loss_lbi2op_node) {

--- a/oneflow/core/job_rewriter/autotick.cpp
+++ b/oneflow/core/job_rewriter/autotick.cpp
@@ -358,8 +358,7 @@ void AddGlobalInputOutputCriticalSection(const HashSet<const OpNode*>& op_nodes,
     *io_cs->mutable_lbi_producer_op_name() = {lbi_producer_op_names.begin(),
                                               lbi_producer_op_names.end()};
   }
-  auto time_shape = std::make_unique<Shape>(
-      DimVector{GlobalJobDesc().TotalBatchNum(), GlobalJobDesc().NumOfPiecesInBatch()});
+  auto time_shape = std::make_unique<Shape>(DimVector{1, 1});
   HashMap<ParallelDesc, HashSet<const OpNode*>> parallel_desc2op_nodes;
   for (const OpNode* op_node : op_nodes) {
     CHECK(parallel_desc2op_nodes[op_node->parallel_desc()].insert(op_node).second);


### PR DESCRIPTION
移除OneFlow.cpp中CompileOnMaster过程中的试跑（experimental run），该接口已经过时了2年以上了。  未来即使需要推导regst num，也不应该依赖试跑的数据，而是通过向AutoSBP一样分析op的时间复杂度得到每个actor的预估执行时间。

- [x] 清理了一部分job_conf.proto 和 job_desc.h 中的接口。
- [x] refine了每个job编译时间的日志输出信息。