### PR TITLE
bugfixes for multi device types support

### DIFF
--- a/oneflow/core/framework/to_string.cpp
+++ b/oneflow/core/framework/to_string.cpp
@@ -23,9 +23,7 @@ namespace oneflow {
 Maybe<const char*> DeviceTag4DeviceType(DeviceType device_type) {
   auto device_type_to_tag = DeviceRegistryMgr::Get().DeviceType4Tag();
   if (device_type_to_tag.find(device_type) == device_type_to_tag.end()) {
-    //  TODO(yaochi): replace by UNIMPLEMENTED();
-    std::cout << "Unregistered device_type: " << device_type << " \n";
-    return static_cast<const char*>("");
+    return Error::DeviceTagNotFoundError() << "invalid_device";
   }
   return device_type_to_tag[device_type].c_str();
 }
@@ -33,9 +31,7 @@ Maybe<const char*> DeviceTag4DeviceType(DeviceType device_type) {
 Maybe<DeviceType> DeviceType4DeviceTag(const std::string& device_tag) {
   auto device_tag_to_type = DeviceRegistryMgr::Get().DeviceTag4Type();
   if (device_tag_to_type.find(device_tag) == device_tag_to_type.end()) {
-    //  TODO(yaochi): replace by UNIMPLEMENTED();
-    std::cout << "Unregistered device_tag: " << device_tag << " \n";
-    return DeviceType::kInvalidDevice;
+    return Error::DeviceTagNotFoundError() << "device tag `" << device_tag << "' not found";
   }
   return device_tag_to_type[device_tag];
 }

--- a/oneflow/core/kernel/foreign_watch_kernel.cpp
+++ b/oneflow/core/kernel/foreign_watch_kernel.cpp
@@ -32,7 +32,9 @@ void ForeignWatchKernel<device_type>::ForwardDataContent(
 REGISTER_KERNEL_WITH_DEVICE(OperatorConf::kForeignWatchConf, DeviceType::kCPU,
                             ForeignWatchKernel<DeviceType::kCPU>);
 
+#ifdef WITH_CUDA
 REGISTER_KERNEL_WITH_DEVICE(OperatorConf::kForeignWatchConf, DeviceType::kGPU,
                             ForeignWatchKernel<DeviceType::kGPU>);
+#endif
 
 }  // namespace oneflow

--- a/oneflow/python/framework/placement_util.py
+++ b/oneflow/python/framework/placement_util.py
@@ -76,7 +76,7 @@ def api_placement(
 
     """
 
-    if oneflow_api.flags.with_cuda() == False:
+    if oneflow_api.flags.with_cuda() == False and device_tag == "gpu":
         device_tag = "cpu"
     func = enable_if.unique(
         [


### PR DESCRIPTION
添加缺失的 ifdef WITH_CUDA，解决 to_string.cpp 里的 TODO
修改 placement_util.py，cpu only 版本只在原 device_tag 是 gpu 的时候才强制设置 device_tag 为 cpu 