### PR TITLE
Add parallel_distribution for 2D SBP

### DIFF
--- a/oneflow/core/common/protobuf.h
+++ b/oneflow/core/common/protobuf.h
@@ -242,6 +242,18 @@ struct hash<oneflow::SbpParallel> {
   }
 };
 
+template<>
+struct hash<oneflow::ParallelDistribution> {
+  size_t operator()(const oneflow::ParallelDistribution& parallel_distribution) const {
+    const auto& sbp_hash = std::hash<oneflow::SbpParallel>();
+    size_t hash = 0;
+    for (int i = 0; i < parallel_distribution.sbp_parallel_size(); ++i) {
+      oneflow::HashCombine(&hash, sbp_hash(parallel_distribution.sbp_parallel(i)));
+    }
+    return hash;
+  }
+};
+
 }  // namespace std
 
 #endif  // ONEFLOW_CORE_COMMON_PROTOBUF_H_

--- a/oneflow/core/framework/infer_util.h
+++ b/oneflow/core/framework/infer_util.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "oneflow/core/framework/tensor_desc.h"
 #include "oneflow/core/job/placement.pb.h"
 #include "oneflow/core/job/sbp_parallel.pb.h"
+#include "oneflow/core/job/parallel_desc.h"
 
 namespace oneflow {
 
@@ -50,11 +51,16 @@ class InferContext {
   }
 
   virtual const ParallelContext& parallel_ctx() const = 0;
+  virtual const ParallelDesc& parallel_desc() const = 0;
+
   virtual const JobDesc* job_desc() const {
     UNIMPLEMENTED();
     return nullptr;
   };
   virtual const SbpParallel& SbpParallel4ArgNameAndIndex(const std::string&, int32_t) const = 0;
+
+  virtual const ParallelDistribution& ParallelDistribution4ArgNameAndIndex(const std::string&,
+                                                                           int32_t) const = 0;
 
   virtual bool* IsDynamic4ArgNameAndIndex(const std::string&, int32_t) = 0;
 

--- a/oneflow/core/framework/user_op_registry.cpp
+++ b/oneflow/core/framework/user_op_registry.cpp
@@ -199,22 +199,22 @@ OpRegistry& OpRegistry::Finish() {
         logical_fn(ctx);
       } else {
         for (const auto& pair : ctx->inputs()) {
-          const auto& sbp_parallel = ctx->SbpParallel4ArgNameAndIndex(pair.first, pair.second);
+          const auto& parallel_distribution =
+              ctx->ParallelDistribution4ArgNameAndIndex(pair.first, pair.second);
           const TensorDesc* in_logical =
               ctx->LogicalTensorDesc4ArgNameAndIndex(pair.first, pair.second);
           const TensorDesc* in_physical = ctx->TensorDesc4ArgNameAndIndex(pair.first, pair.second);
-          CHECK_OR_RETURN(*JUST(GetPhysicalShape(in_logical->shape(), sbp_parallel,
-                                                 ctx->parallel_ctx().parallel_num(),
-                                                 ctx->parallel_ctx().parallel_id()))
+          CHECK_OR_RETURN(*JUST(GetPhysicalShape(in_logical->shape(), parallel_distribution,
+                                                 ctx->parallel_desc(), ctx->parallel_ctx()))
                           == in_physical->shape());
         }
         for (const auto& pair : ctx->outputs()) {
           TensorDesc* desc = ctx->TensorDesc4ArgNameAndIndex(pair.first, pair.second);
           *desc = *ctx->LogicalTensorDesc4ArgNameAndIndex(pair.first, pair.second);
-          const auto& sbp_parallel = ctx->SbpParallel4ArgNameAndIndex(pair.first, pair.second);
-          *desc->mut_shape() = *JUST(GetPhysicalShape(desc->shape(), sbp_parallel,
-                                                      ctx->parallel_ctx().parallel_num(),
-                                                      ctx->parallel_ctx().parallel_id()));
+          const auto& parallel_distribution =
+              ctx->ParallelDistribution4ArgNameAndIndex(pair.first, pair.second);
+          *desc->mut_shape() = *JUST(GetPhysicalShape(desc->shape(), parallel_distribution,
+                                                      ctx->parallel_desc(), ctx->parallel_ctx()));
         }
       }
       return Maybe<void>::Ok();

--- a/oneflow/core/graph/exec_graph.cpp
+++ b/oneflow/core/graph/exec_graph.cpp
@@ -71,18 +71,21 @@ void ExecNode::ToProto(const ParallelContext* parallel_ctx, ExecNodeProto* ret) 
 
 namespace {
 
-Maybe<void> CheckPhysicalBlobDesc(const BlobDesc& logical, const SbpParallel& sbp_parallel,
+Maybe<void> CheckPhysicalBlobDesc(const BlobDesc& logical,
+                                  const ParallelDistribution& parallel_distribution,
+                                  const ParallelDesc& parallel_desc,
                                   const ParallelContext* parallel_ctx, const BlobDesc& physical) {
-  CHECK_EQ_OR_RETURN(physical.shape(), *CHECK_JUST(GetPhysicalShape(logical.shape(), sbp_parallel,
-                                                                    parallel_ctx->parallel_num(),
-                                                                    parallel_ctx->parallel_id())));
+  CHECK_EQ_OR_RETURN(physical.shape(),
+                     *CHECK_JUST(GetPhysicalShape(logical.shape(), parallel_distribution,
+                                                  parallel_desc, *parallel_ctx)));
   return Maybe<void>::Ok();
 }
 
 Maybe<void> CheckPhysicalBlobDesc(
     const Operator& op, const PbRpf<std::string>& bns,
     const std::function<Maybe<const BlobDesc>(const std::string&)>& GetLogicalBlobDesc,
-    const SbpSignature* sbp_signature, const ParallelContext* parallel_ctx,
+    const ParallelDistributionSignature* parallel_distribution_signature,
+    const ParallelContext* parallel_ctx,
     const std::function<BlobDesc*(const std::string&)>& GetPhysicalBlobDesc) {
   const std::shared_ptr<const ParallelDesc> op_parallel_desc = CHECK_JUST(op.GetOpParallelDesc());
   for (const auto& bn : bns) {
@@ -92,9 +95,10 @@ Maybe<void> CheckPhysicalBlobDesc(
       continue;
     }
     if (*CHECK_JUST(op.GetParallelDesc4BnInOp(bn)) == *op_parallel_desc) {
-      CHECK_JUST(CheckPhysicalBlobDesc(*CHECK_JUST(GetLogicalBlobDesc(bn)),
-                                       sbp_signature->bn_in_op2sbp_parallel().at(bn), parallel_ctx,
-                                       *physical_blob_desc));
+      CHECK_JUST(CheckPhysicalBlobDesc(
+          *CHECK_JUST(GetLogicalBlobDesc(bn)),
+          parallel_distribution_signature->bn_in_op2parallel_distribution().at(bn),
+          *op_parallel_desc, parallel_ctx, *physical_blob_desc));
     }
   }
   return Maybe<void>::Ok();
@@ -105,20 +109,25 @@ Maybe<void> CheckPhysicalBlobDesc(
 void ExecNode::InferBlobDescs(const ParallelContext* parallel_ctx) {
   auto GetBlobDesc4BnInOp = GetBlobDesc4BnInOpFunc();
   const OpNode* op_node = Global<OpGraph>::Get()->OpNode4OpName(op()->op_name());
-  const SbpSignature* sbp_signature = nullptr;
-  if (op_node != nullptr) { sbp_signature = &op_node->sbp_signature(); }
-  if (op_node != nullptr && parallel_ctx->parallel_num() > 1 && sbp_signature != nullptr) {
+  const ParallelDistributionSignature* parallel_distribution_signature = nullptr;
+  if (op_node != nullptr) {
+    parallel_distribution_signature = &op_node->parallel_distribution_signature();
+  }
+
+  if (op_node != nullptr && parallel_ctx->parallel_num() > 1
+      && parallel_distribution_signature != nullptr) {
     CheckPhysicalBlobDesc(
         *op(), op()->input_bns(),
         std::bind(&Operator::GetLogicalBlobDesc4Ibn, op().get(), std::placeholders::_1),
-        sbp_signature, parallel_ctx, GetBlobDesc4BnInOp);
+        parallel_distribution_signature, parallel_ctx, GetBlobDesc4BnInOp);
   }
   CHECK_JUST(op_->InferBlobDescsIf(GetBlobDesc4BnInOp, parallel_ctx, &GlobalJobDesc()));
-  if (op_node != nullptr && parallel_ctx->parallel_num() > 1 && sbp_signature != nullptr) {
+  if (op_node != nullptr && parallel_ctx->parallel_num() > 1
+      && parallel_distribution_signature != nullptr) {
     CheckPhysicalBlobDesc(
         *op(), op()->output_bns(),
         std::bind(&Operator::GetLogicalBlobDesc4Obn, op().get(), std::placeholders::_1),
-        sbp_signature, parallel_ctx, GetBlobDesc4BnInOp);
+        parallel_distribution_signature, parallel_ctx, GetBlobDesc4BnInOp);
   }
   CHECK_JUST(op_->InferInplaceObn2IbnIf(&mut_inplace_obn2ibn_, &con_inplace_obn2ibn_,
                                         GetBlobDesc4BnInOp, parallel_ctx));

--- a/oneflow/core/graph/op_graph.cpp
+++ b/oneflow/core/graph/op_graph.cpp
@@ -25,19 +25,42 @@ namespace {
 void UpdateJobParallelViewConf(
     const OpNode& op_node, const HashMap<OpBlobArg, std::vector<OpBlobArg>>& oba2sbp_identical_obas,
     JobParallelViewConf* job_parallel_view_conf) {
+  auto* op_name2parallel_distribution_signature =
+      job_parallel_view_conf->mutable_op_name2parallel_distribution_signature_conf();
   auto* op_name2sbp_signature = job_parallel_view_conf->mutable_op_name2sbp_signature_conf();
   auto Update = [&](const std::string& bn) {
-    const auto& sbp_parallel = op_node.sbp_signature().bn_in_op2sbp_parallel().at(bn);
+    const auto& bn_in_op2parallel_distribution =
+        op_node.parallel_distribution_signature().bn_in_op2parallel_distribution();
+    const auto bn_in_op2parallel_distribution_it = bn_in_op2parallel_distribution.find(bn);
+    CHECK(bn_in_op2parallel_distribution_it != bn_in_op2parallel_distribution.end());
+    const auto& parallel_distribution = bn_in_op2parallel_distribution_it->second;
     const OpBlobArg& oba = GenOpBlobArg(op_node.op().op_name(), bn);
     auto iter = oba2sbp_identical_obas.find(oba);
     if (iter == oba2sbp_identical_obas.end()) { return; }
     for (const auto& identical_obas : iter->second) {
-      auto* sbp_signature = &(*op_name2sbp_signature)[identical_obas.op_name()];
-      auto iter = sbp_signature->mutable_bn_in_op2sbp_parallel()->find(identical_obas.bn_in_op());
-      if (iter == sbp_signature->mutable_bn_in_op2sbp_parallel()->end()) {
-        CHECK(iter->second == sbp_parallel);
+      auto* parallel_distribution_signature =
+          &(*op_name2parallel_distribution_signature)[identical_obas.op_name()];
+      auto iter = parallel_distribution_signature->mutable_bn_in_op2parallel_distribution()->find(
+          identical_obas.bn_in_op());
+      if (iter
+          == parallel_distribution_signature->mutable_bn_in_op2parallel_distribution()->end()) {
+        CHECK(iter->second == parallel_distribution);
       } else {
-        iter->second = sbp_parallel;
+        iter->second = parallel_distribution;
+      }
+      if (op_node.parallel_desc().hierarchy()->NumAxes() == 1) {
+        CHECK_EQ(parallel_distribution.sbp_parallel_size(), 1);
+        const auto& sbp_parallel = parallel_distribution.sbp_parallel(0);
+        auto* sbp_signature = &(*op_name2sbp_signature)[identical_obas.op_name()];
+        auto sbp_iter =
+            sbp_signature->mutable_bn_in_op2sbp_parallel()->find(identical_obas.bn_in_op());
+        if (sbp_iter == sbp_signature->mutable_bn_in_op2sbp_parallel()->end()) {
+          CHECK(sbp_iter->second == sbp_parallel);
+        } else {
+          sbp_iter->second = sbp_parallel;
+        }
+      } else {
+        UNIMPLEMENTED();
       }
     }
   };
@@ -72,10 +95,11 @@ bool OpEdge::CalcIsStrict121Connected() const {
     return false;
   }
   for (const LogicalBlobId& lbi : lbis()) {
-    const SbpParallel& obn_sbp = src->SbpParallel4BnInOp(lbi2obn().at(lbi));
+    const ParallelDistribution& obn_distribution =
+        src->ParallelDistribution4BnInOp(lbi2obn().at(lbi));
     for (const std::string& ibn : lbi2ibns().at(lbi)) {
-      const SbpParallel& ibn_sbp = dst->SbpParallel4BnInOp(ibn);
-      if (obn_sbp != ibn_sbp) { return false; }
+      const ParallelDistribution& ibn_distribution = dst->ParallelDistribution4BnInOp(ibn);
+      if (obn_distribution != ibn_distribution) { return false; }
     }
   }
   return true;
@@ -86,9 +110,20 @@ const SbpParallel& OpNode::SbpParallel4BnInOp(const std::string& bn_in_op) const
 }
 
 const SbpParallel& OpNode::SbpParallel4Lbi(const LogicalBlobId& lbi) const {
-  auto it = lbi2sbp_parallel_.find(lbi);
-  CHECK(it != lbi2sbp_parallel_.end());
+  auto it = lbi2parallel_distribution_.find(lbi);
+  CHECK(it != lbi2parallel_distribution_.end());
+  CHECK_EQ(it->second.sbp_parallel_size(), 1);
+  return it->second.sbp_parallel(0);
+}
+
+const ParallelDistribution& OpNode::ParallelDistribution4Lbi(const LogicalBlobId& lbi) const {
+  auto it = lbi2parallel_distribution_.find(lbi);
+  CHECK(it != lbi2parallel_distribution_.end());
   return it->second;
+}
+
+const ParallelDistribution& OpNode::ParallelDistribution4BnInOp(const std::string& bn_in_op) const {
+  return *CHECK_JUST(op().ParallelDistribution4BnInOp(bn_in_op));
 }
 
 std::string OpNode::VisualStr() const {
@@ -177,16 +212,16 @@ void OpNode::InitLbi2SourceNode() {
   }
 }
 
-void OpNode::InitLbi2SbpParallel() {
+void OpNode::InitLbi2ParallelDistribution() {
   const auto Update = [&](const PbRpf<std::string>& bns) {
     for (const auto& bn : bns) {
       const LogicalBlobId& lbi = op().BnInOp2Lbi(bn);
-      const SbpParallel& sbp_parallel = SbpParallel4BnInOp(bn);
-      auto it = lbi2sbp_parallel_.find(lbi);
-      if (it == lbi2sbp_parallel_.end()) {
-        lbi2sbp_parallel_[lbi] = sbp_parallel;
+      const ParallelDistribution& parallel_distribution = ParallelDistribution4BnInOp(bn);
+      auto it = lbi2parallel_distribution_.find(lbi);
+      if (it == lbi2parallel_distribution_.end()) {
+        lbi2parallel_distribution_[lbi] = parallel_distribution;
       } else {
-        CHECK(it->second == sbp_parallel);
+        CHECK(it->second == parallel_distribution);
       }
     }
   };
@@ -311,19 +346,29 @@ void OpGraph::InferTimeShape() const {
   });
 }
 
-void OpGraph::InferOpNodeSbpSignature(OpNode* op_node, const SbpSignature& sbp_sig_conf) const {
-  HashMap<std::string, SbpInferHint> ibn2sbp_infer_hint;
+void OpGraph::InferOpNodeParallelDistributionSignature(
+    OpNode* op_node, const ParallelDistributionSignature& parallel_distribution_sig_conf) const {
+  HashMap<std::string, ParallelDistributionInferHint> ibn2parallel_distribution_infer_hint;
   for (const std::string& ibn : op_node->op().input_bns()) {
     const LogicalBlobId& lbi = op_node->op().BnInOp2Lbi(ibn);
     OpNode* producer = op_node->MutSrcNode4Ibn(ibn);
     const ParallelDesc* parallel_desc = &producer->parallel_desc();
     const BlobDesc* logical_blob_desc = &producer->LogicalBlobDesc4Lbi(lbi);
-    const SbpParallel* sbp = &producer->SbpParallel4Lbi(lbi);
-    ibn2sbp_infer_hint.emplace(ibn, SbpInferHint(parallel_desc, logical_blob_desc, sbp));
+    const ParallelDistribution* parallel_distribution = &producer->ParallelDistribution4Lbi(lbi);
+    CHECK_EQ(parallel_distribution->sbp_parallel_size(), 1);
+    ibn2parallel_distribution_infer_hint.emplace(
+        ibn,
+        ParallelDistributionInferHint(parallel_desc, logical_blob_desc, parallel_distribution));
   }
-  CHECK_JUST(InferOpSbpSignature(op_node->mut_op(), sbp_sig_conf, op_node->parallel_desc(),
-                                 ibn2sbp_infer_hint));
-  op_node->InitLbi2SbpParallel();
+  const auto ParallelDistributionInferHint4Ibn =
+      [&](const std::string& bn) -> Maybe<const ParallelDistributionInferHint*> {
+    auto it = ibn2parallel_distribution_infer_hint.find(bn);
+    CHECK_OR_RETURN(it != ibn2parallel_distribution_infer_hint.end());
+    return Maybe<const ParallelDistributionInferHint*>(&it->second);
+  };
+  CHECK_JUST(op_node->mut_op()->InferParallelDistributionSignatureIf(
+      parallel_distribution_sig_conf, op_node->parallel_desc(), ParallelDistributionInferHint4Ibn));
+  op_node->InitLbi2ParallelDistribution();
 }
 
 Maybe<void> OpGraph::InferOpNodeMirroredSignature(OpNode* op_node, bool is_mirrored_conf) const {
@@ -381,14 +426,25 @@ Maybe<void> OpGraph::InferLogicalBlobDesc(const Job& job) const {
       if (iter != op_name2is_mirrored.end()) { is_mirrored_conf = iter->second; }
     }
     JUST(InferOpNodeMirroredSignature(op_node, is_mirrored_conf));
-    // Infer sbp_signature
-    SbpSignature sbp_sig_conf;
+    ParallelDistributionSignature parallel_distribution_sig_conf;
     {
-      const auto& op_name2sbp_sig_conf = job_parallel_view_conf.op_name2sbp_signature_conf();
-      const auto& iter = op_name2sbp_sig_conf.find(op_node->op().op_name());
-      if (iter != op_name2sbp_sig_conf.end()) { sbp_sig_conf = iter->second; }
+      const auto& op_name2parallel_distribution_sig_conf =
+          job_parallel_view_conf.op_name2parallel_distribution_signature_conf();
+      const auto& iter = op_name2parallel_distribution_sig_conf.find(op_node->op().op_name());
+      if (iter != op_name2parallel_distribution_sig_conf.end()) {
+        parallel_distribution_sig_conf = iter->second;
+        if (op_node->parallel_desc().hierarchy()->NumAxes() == 1) {
+          const auto& op_name2sbp_sig_conf = job_parallel_view_conf.op_name2sbp_signature_conf();
+          const auto& op_name2sbp_sig_conf_it = op_name2sbp_sig_conf.find(op_node->op().op_name());
+          CHECK(op_name2sbp_sig_conf_it != op_name2sbp_sig_conf.end());
+          CheckSbpSignatureAndParallelDistributionEquals(op_name2sbp_sig_conf_it->second,
+                                                         iter->second);
+        } else {
+          UNIMPLEMENTED();
+        }
+      }
     }
-    InferOpNodeSbpSignature(op_node, sbp_sig_conf);
+    InferOpNodeParallelDistributionSignature(op_node, parallel_distribution_sig_conf);
     op_node->InferBlobParallelDesc();
     UpdateJobParallelViewConf(*op_node, oba2sbp_identical_obas, &job_parallel_view_conf);
     JUST(op_node->mut_op()->InferLogicalOutBlobDescsIf());
@@ -405,6 +461,12 @@ const SbpParallel& OpGraph::GetSbpParallel(const std::string& op_name,
                                            const LogicalBlobId& lbi) const {
   return op_name2op_node_.at(GetOpNameKey(op_name, lbi))
       ->SbpParallel4Lbi(GetLogicalBlobIdKey(op_name, lbi));
+}
+
+const ParallelDistribution& OpGraph::GetParallelDistribution(const std::string& op_name,
+                                                             const LogicalBlobId& lbi) const {
+  return op_name2op_node_.at(GetOpNameKey(op_name, lbi))
+      ->ParallelDistribution4Lbi(GetLogicalBlobIdKey(op_name, lbi));
 }
 
 DataType OpGraph::GetBlobDataType(const LogicalBlobId& lbi) const {
@@ -498,10 +560,15 @@ void OpGraph::DumpLogicalBlobDesc(Job* job) const {
   });
 }
 
-void OpGraph::DumpSbpSignature(Job* job) const {
-  ForEachNode([&](const OpNode* node) {
+void OpGraph::DumpParallelDistributionSignature(Job* job) const {
+  ForEachNode([&](const OpNode* node) -> void {
     (*job->mutable_job_parallel_view_conf()
-          ->mutable_op_name2sbp_signature_conf())[node->op().op_name()] = node->sbp_signature();
+          ->mutable_op_name2parallel_distribution_signature_conf())[node->op().op_name()] =
+        *CHECK_JUST(node->op().parallel_distribution_signature());
+    if (node->parallel_desc().hierarchy()->NumAxes() == 1) {
+      (*job->mutable_job_parallel_view_conf()
+            ->mutable_op_name2sbp_signature_conf())[node->op().op_name()] = node->sbp_signature();
+    }
   });
 }
 

--- a/oneflow/core/graph/op_graph.h
+++ b/oneflow/core/graph/op_graph.h
@@ -43,8 +43,13 @@ class OpNode final : public Node<OpNode, OpEdge> {
   std::shared_ptr<const Operator> shared_op() const { return op_; }
   const ParallelDesc& parallel_desc() const { return parallel_desc_; }
   const SbpSignature& sbp_signature() const { return *CHECK_JUST(op().sbp_signature()); }
+  const ParallelDistributionSignature& parallel_distribution_signature() const {
+    return *CHECK_JUST(op().parallel_distribution_signature());
+  }
   const SbpParallel& SbpParallel4Lbi(const LogicalBlobId& lbi) const;
   const SbpParallel& SbpParallel4BnInOp(const std::string& bn_in_op) const;
+  const ParallelDistribution& ParallelDistribution4Lbi(const LogicalBlobId& lbi) const;
+  const ParallelDistribution& ParallelDistribution4BnInOp(const std::string& bn_in_op) const;
   const BlobDesc& LogicalBlobDesc4Lbi(const LogicalBlobId& lbi) const;
   const OpNode& ProducerOpNode4Lbi(const LogicalBlobId& lbi) const;
   const OpNode& SrcNode4Ibn(const std::string& bn_in_op) const;
@@ -62,14 +67,14 @@ class OpNode final : public Node<OpNode, OpEdge> {
   OpNode* MutSrcNode4InputLbi(const LogicalBlobId& lbi) const;
   void InferBlobParallelDesc();
   void InitLbi2SourceNode();
-  void InitLbi2SbpParallel();
+  void InitLbi2ParallelDistribution();
 
   ParallelDesc parallel_desc_;
   HashMap<std::string, ParallelDesc> obn2blob_parallel_desc_;
   std::shared_ptr<Operator> op_;
   HashSet<std::string> ibns_;
   HashMap<LogicalBlobId, OpNode*> lbi2source_node_;
-  HashMap<LogicalBlobId, SbpParallel> lbi2sbp_parallel_;
+  HashMap<LogicalBlobId, ParallelDistribution> lbi2parallel_distribution_;
   std::vector<std::pair<const OpNode*, int32_t>> input_index2producer_and_output_index_;
 };
 
@@ -117,6 +122,8 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
 
   int64_t GetParallelNum(const std::string& op_name) const;
   const SbpParallel& GetSbpParallel(const std::string& op_name, const LogicalBlobId& lbi) const;
+  const ParallelDistribution& GetParallelDistribution(const std::string& op_name,
+                                                      const LogicalBlobId& lbi) const;
   DataType GetBlobDataType(const LogicalBlobId& lbi) const;
   const BlobDesc& GetLogicalBlobDesc(const LogicalBlobId& lbi) const;
 
@@ -129,8 +136,8 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
   std::list<OpNode*> DataOrCtrlSourceNodes() const;
 
   void DumpLogicalBlobDesc(Job* job) const;
-  void DumpSbpSignature(Job* job) const;
   void DumpArgSignature(Job* job) const;
+  void DumpParallelDistributionSignature(Job* job) const;
 
   Maybe<void> Init(const Job& job);
 
@@ -141,7 +148,8 @@ class OpGraph final : public Graph<OpNode, OpEdge> {
   void CheckIsDAG() const;
   void InferBlobLastUsed() const;
   void InferTimeShape() const;
-  void InferOpNodeSbpSignature(OpNode* op_node, const SbpSignature& sbp_sig_conf) const;
+  void InferOpNodeParallelDistributionSignature(
+      OpNode* op_node, const ParallelDistributionSignature& parallel_distribution_sig_conf) const;
   Maybe<void> InferOpNodeMirroredSignature(OpNode* op_node, bool is_mirrored_conf) const;
   Maybe<void> InferLogicalBlobDesc(const Job& job) const;
   std::string GetOpNameKey(const std::string& op_name, const LogicalBlobId& lbi) const;

--- a/oneflow/core/job/job.proto
+++ b/oneflow/core/job/job.proto
@@ -14,6 +14,7 @@ import "oneflow/core/job/lbi_diff_watcher_info.proto";
 message JobParallelViewConf {
   map<string, SbpSignature> op_name2sbp_signature_conf = 1;
   map<string, bool> op_name2is_mirrored_parallel_view = 2;
+  map<string, ParallelDistributionSignature> op_name2parallel_distribution_signature_conf = 3;
 }
 
 message JobHelperConf {

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -171,13 +171,22 @@ Maybe<OperatorConf> JobBuildAndInferCtx::DecodeLbiHintAndReturnNewOpConf(
   return op_conf_without_split_hint;
 }
 
-void JobBuildAndInferCtx::AddOpAndUpdateJobParallelViewConf(const OperatorConf& operator_conf,
-                                                            const SbpSignature& sbp_signature,
-                                                            bool is_mirrored_parallel_view) const {
+void JobBuildAndInferCtx::AddOpAndUpdateJobParallelViewConf(
+    const OperatorConf& operator_conf, const ParallelDesc& parallel_desc,
+    const ParallelDistributionSignature& parallel_distribution_signature,
+    bool is_mirrored_parallel_view) const {
   auto* op_name2sbp_sig =
       job_->mutable_job_parallel_view_conf()->mutable_op_name2sbp_signature_conf();
-  if (sbp_signature.bn_in_op2sbp_parallel().size() > 0) {
-    (*op_name2sbp_sig)[operator_conf.name()] = sbp_signature;
+  auto* op_name2parallel_distribution_sig =
+      job_->mutable_job_parallel_view_conf()
+          ->mutable_op_name2parallel_distribution_signature_conf();
+  if (parallel_distribution_signature.bn_in_op2parallel_distribution().size() > 0) {
+    (*op_name2parallel_distribution_sig)[operator_conf.name()] = parallel_distribution_signature;
+    if (parallel_desc.hierarchy()->NumAxes() == 1) {
+      SbpSignature sbp_signature;
+      ParallelDistributionSignatureToSbpSignature(parallel_distribution_signature, &sbp_signature);
+      (*op_name2sbp_sig)[operator_conf.name()] = sbp_signature;
+    }
   }
   auto* op_name2is_mirrored_parallel_view =
       job_->mutable_job_parallel_view_conf()->mutable_op_name2is_mirrored_parallel_view();
@@ -217,37 +226,47 @@ Maybe<void> JobBuildAndInferCtx::InferMirroredSignature(Operator* op,
   return Maybe<void>::Ok();
 }
 
-Maybe<void> JobBuildAndInferCtx::InferOpOutSbpParallel(Operator* op,
-                                                       const SbpSignature& sbp_sig_conf,
-                                                       const ParallelDesc& parallel_desc) {
-  HashMap<std::string, SbpInferHint> ibn2sbp_infer_hint;
+Maybe<void> JobBuildAndInferCtx::InferOpOutParallelDistribution(
+    Operator* op, const ParallelDistributionSignature& parallel_distribution_sig_conf,
+    const ParallelDesc& parallel_desc) {
+  HashMap<std::string, ParallelDistributionInferHint> ibn2parallel_distribution_infer_hint;
   for (const std::string& ibn : op->input_bns()) {
     const LogicalBlobId& lbi = op->BnInOp2Lbi(ibn);
-    CHECK_OR_RETURN(lbi2logical_blob_desc_.find(lbi) != lbi2logical_blob_desc_.end())
+    auto logical_blob_desc_it = lbi2logical_blob_desc_.find(lbi);
+    CHECK_OR_RETURN(logical_blob_desc_it != lbi2logical_blob_desc_.end())
         << Error::LogicalBlobNameNotExistError()
         << "infer blob desc not found, when infer op_name: \"" << op->op_name()
         << "\", consumed op_name: \"" << lbi.op_name() << "\", blob_name: \"" << lbi.blob_name();
+    const BlobDesc* logical_blob_desc = logical_blob_desc_it->second.get();
     const ParallelDesc* pd = &lbi2parallel_desc_from_producer_view_.at(lbi);
-    const BlobDesc* logical_blob_desc = lbi2logical_blob_desc_.at(lbi).get();
-    CHECK_OR_RETURN(lbi2sbp_parallel_from_producer_view_.find(lbi)
-                    != lbi2sbp_parallel_from_producer_view_.end())
+    auto parallel_distribution_it = lbi2parallel_distribution_from_producer_view_.find(lbi);
+    CHECK_OR_RETURN(parallel_distribution_it != lbi2parallel_distribution_from_producer_view_.end())
         << Error::LogicalBlobNameNotExistError() << "when infer op_name: " << op->op_name()
         << " consumed op_name: " << lbi.op_name() << " blob_name: " << lbi.blob_name()
-        << " not infer split axis";
-    const SbpParallel* sbp_parallel = &lbi2sbp_parallel_from_producer_view_.at(lbi);
-    ibn2sbp_infer_hint.emplace(ibn, SbpInferHint(pd, logical_blob_desc, sbp_parallel));
+        << " not infer parallel distribution";
+    const ParallelDistribution* parallel_distribution = &parallel_distribution_it->second;
+    ibn2parallel_distribution_infer_hint.emplace(
+        ibn, ParallelDistributionInferHint(pd, logical_blob_desc, parallel_distribution));
   }
 
-  JUST(InferOpSbpSignature(op, sbp_sig_conf, parallel_desc, ibn2sbp_infer_hint));
+  const auto ParallelDistributionInferHint4Ibn =
+      [&](const std::string& bn) -> Maybe<const ParallelDistributionInferHint*> {
+    return &ibn2parallel_distribution_infer_hint.at(bn);
+  };
 
-  const auto& bn2sbp_parallel = JUST(op->sbp_signature())->bn_in_op2sbp_parallel();
+  JUST(op->InferParallelDistributionSignatureIf(parallel_distribution_sig_conf, parallel_desc,
+                                                ParallelDistributionInferHint4Ibn));
+
+  const auto& bn2parallel_distribution =
+      JUST(op->parallel_distribution_signature())->bn_in_op2parallel_distribution();
   for (const auto& obn : op->output_bns()) {
     const LogicalBlobId& lbi = op->BnInOp2Lbi(obn);
-    CHECK_OR_RETURN(bn2sbp_parallel.find(obn) != bn2sbp_parallel.end())
+    CHECK_OR_RETURN(bn2parallel_distribution.find(obn) != bn2parallel_distribution.end())
         << Error::BlobSplitAxisInferError() << "op_name: " << lbi.op_name()
         << " blob_name: " << lbi.blob_name() << " not infer split axis";
     CHECK_OR_RETURN(
-        lbi2sbp_parallel_from_producer_view_.emplace(lbi, bn2sbp_parallel.at(obn)).second)
+        lbi2parallel_distribution_from_producer_view_.emplace(lbi, bn2parallel_distribution.at(obn))
+            .second)
         << Error::BlobSplitAxisInferError() << "op_name: " << lbi.op_name()
         << " blob_name: " << lbi.blob_name() << " infer split axis repeated";
     CHECK_OR_RETURN(lbi2parallel_desc_from_producer_view_.emplace(lbi, parallel_desc).second)
@@ -283,28 +302,52 @@ Maybe<void> JobBuildAndInferCtx::GenOpProducedEmptyLogicalBlobDesc(Operator* op)
 }
 
 Maybe<void> JobBuildAndInferCtx::CheckOpBlobSplitability(Operator* op, int64_t parallel_num) {
-  HashSet<std::string> obns(op->output_bns().begin(), op->output_bns().end());
-  auto GetParallelNum = [&](const std::string& bn_in_op) {
-    if (obns.find(bn_in_op) == obns.end()) { return parallel_num; }
-    return lbi2parallel_desc_from_producer_view_.at(op->BnInOp2Lbi(bn_in_op)).parallel_num();
-  };
-  for (const auto& pair : JUST(op->sbp_signature())->bn_in_op2sbp_parallel()) {
-    if (!pair.second.has_split_parallel()) { continue; }
-    if (JUST(op->OptMirroredParallel4BnInOp(pair.first))->has_mirrored_parallel()) { continue; }
-    int64_t axis = pair.second.split_parallel().axis();
-    const LogicalBlobId& lbi = op->BnInOp2Lbi(pair.first);
-    int64_t blob_parallel_num = GetParallelNum(pair.first);
-    const BlobDesc& logical_blob_desc = *(lbi2logical_blob_desc_.at(lbi).get());
-    int64_t num_axes = logical_blob_desc.shape().NumAxes();
-    if (axis < 0) { axis += num_axes; }
-    CHECK_GE_OR_RETURN(axis, 0);
-    CHECK_LT_OR_RETURN(axis, num_axes)
-        << "op: " << op->op_name() << ", blob: " << pair.first << ", axis: " << axis
-        << ", shape: " << logical_blob_desc.shape();
-    CHECK_GE_OR_RETURN(logical_blob_desc.shape().At(axis), blob_parallel_num)
-        << "op_name: " << lbi.op_name() << " blob_name: " << lbi.blob_name()
-        << " cannot split blob by parallel_num: " << std::to_string(blob_parallel_num);
+  const auto& parallel_hierarchy = JUST(op->GetOpParallelDesc())->hierarchy();
+  if (parallel_hierarchy->NumAxes() == 1) {
+    HashSet<std::string> obns(op->output_bns().begin(), op->output_bns().end());
+    auto GetParallelNum = [&](const std::string& bn_in_op) {
+      if (obns.find(bn_in_op) == obns.end()) { return parallel_num; }
+      return lbi2parallel_desc_from_producer_view_.at(op->BnInOp2Lbi(bn_in_op)).parallel_num();
+    };
+    for (const auto& pair : JUST(op->sbp_signature())->bn_in_op2sbp_parallel()) {
+      if (!pair.second.has_split_parallel()) { continue; }
+      if (JUST(op->OptMirroredParallel4BnInOp(pair.first))->has_mirrored_parallel()) { continue; }
+      int64_t axis = pair.second.split_parallel().axis();
+      const LogicalBlobId& lbi = op->BnInOp2Lbi(pair.first);
+      int64_t blob_parallel_num = GetParallelNum(pair.first);
+      const BlobDesc& logical_blob_desc = *(lbi2logical_blob_desc_.at(lbi).get());
+      int64_t num_axes = logical_blob_desc.shape().NumAxes();
+      if (axis < 0) { axis += num_axes; }
+      CHECK_GE_OR_RETURN(axis, 0);
+      CHECK_LT_OR_RETURN(axis, num_axes)
+          << "op: " << op->op_name() << ", blob: " << pair.first << ", axis: " << axis
+          << ", shape: " << logical_blob_desc.shape();
+      CHECK_GE_OR_RETURN(logical_blob_desc.shape().At(axis), blob_parallel_num)
+          << "op_name: " << lbi.op_name() << " blob_name: " << lbi.blob_name()
+          << " cannot split blob by parallel_num: " << std::to_string(blob_parallel_num);
+    }
+  } else {
+    for (const auto& pair :
+         JUST(op->parallel_distribution_signature())->bn_in_op2parallel_distribution()) {
+      if (JUST(op->OptMirroredParallel4BnInOp(pair.first))->has_mirrored_parallel()) { continue; }
+      const LogicalBlobId& lbi = op->BnInOp2Lbi(pair.first);
+      const BlobDesc& logical_blob_desc = *(lbi2logical_blob_desc_.at(lbi).get());
+      Shape current_shape = logical_blob_desc.shape();
+      for (int64_t i = 0; i < pair.second.sbp_parallel_size(); ++i) {
+        const SbpParallel& sbp_parallel = pair.second.sbp_parallel(i);
+        if (sbp_parallel.has_split_parallel()) {
+          const int64_t axis = sbp_parallel.split_parallel().axis();
+          CHECK_GT_OR_RETURN(current_shape.At(axis), 0);
+          CHECK_EQ_OR_RETURN(current_shape.At(axis) % parallel_hierarchy->At(i), 0)
+              << "op_name: " << lbi.op_name() << " blob_name: " << lbi.blob_name()
+              << " cannot split blob by parallel_hierarchy: "
+              << std::to_string(parallel_hierarchy->At(i));
+          current_shape.Set(axis, current_shape.At(axis) / parallel_hierarchy->At(i));
+        }
+      }
+    }
   }
+
   return Maybe<void>::Ok();
 }
 
@@ -356,10 +399,11 @@ bool JobBuildAndInferCtx::HasAnyMirroredBlobInput(const Operator& op) const {
 }
 
 Maybe<const SbpParallel*> JobBuildAndInferCtx::SbpParallel4Lbi(const LogicalBlobId& lbi) const {
-  const auto& iter = lbi2sbp_parallel_from_producer_view_.find(lbi);
-  CHECK_OR_RETURN(iter != lbi2sbp_parallel_from_producer_view_.end())
+  const auto& iter = lbi2parallel_distribution_from_producer_view_.find(lbi);
+  CHECK_OR_RETURN(iter != lbi2parallel_distribution_from_producer_view_.end())
       << "lbn: " << GenLogicalBlobName(lbi) << " undefined";
-  return &iter->second;
+  CHECK_EQ_OR_RETURN(iter->second.sbp_parallel_size(), 1);
+  return &(iter->second.sbp_parallel(0));
 }
 
 Maybe<const ParallelDesc*> JobBuildAndInferCtx::ParallelDesc4Lbi(const LogicalBlobId& lbi) const {
@@ -532,7 +576,6 @@ Maybe<OpAttribute> JobBuildAndInferCtx::AddAndInferOp(const OperatorConf& op_con
   HashMap<std::string, bool> ibn2disable_boxing;
   InitIbn2DisableBoxing(*op, &ibn2disable_boxing);
   auto new_op_conf = JUST(DecodeLbiHintAndReturnNewOpConf(*op, &sbp_sig_conf, &ibn2disable_boxing));
-  AddOpAndUpdateJobParallelViewConf(*new_op_conf, sbp_sig_conf, is_mirrored_parallel_view);
   auto parallel_conf = JUST(InferOpParallelConf(*op, origin_parallel_conf, ibn2disable_boxing));
   ParallelDesc parallel_desc(*parallel_conf);
   JUST(op->FillOpParallelDesc(parallel_desc));
@@ -550,8 +593,13 @@ Maybe<OpAttribute> JobBuildAndInferCtx::AddAndInferOp(const OperatorConf& op_con
 
   // infer mirrored signature
   JUST(InferMirroredSignature(op, is_mirrored_parallel_view, parallel_desc));
-  // infer sbp signature
-  JUST(InferOpOutSbpParallel(op, sbp_sig_conf, parallel_desc));
+
+  // infer parallel_distribution signature
+  ParallelDistributionSignature parallel_distribution_sig_conf;
+  SbpSignatureToParallelDistributionSignature(sbp_sig_conf, &parallel_distribution_sig_conf);
+  AddOpAndUpdateJobParallelViewConf(*new_op_conf, parallel_desc, parallel_distribution_sig_conf,
+                                    is_mirrored_parallel_view);
+  JUST(InferOpOutParallelDistribution(op, parallel_distribution_sig_conf, parallel_desc));
 
   // infer logical blob desc
   JUST(GenOpProducedEmptyLogicalBlobDesc(op));
@@ -637,7 +685,10 @@ Maybe<Operator*> JobBuildAndInferCtx::Op4OpName(const std::string& op_name) cons
 Maybe<OptInt64> JobBuildAndInferCtx::GetSplitAxisFromProducerView(const std::string& lbn) const {
   JUST(CheckLbnValidAndExist(lbn));
   OptInt64 ret;
-  const auto& sbp = lbi2sbp_parallel_from_producer_view_.at(GenLogicalBlobId(lbn));
+  const auto& parallel_distribution =
+      lbi2parallel_distribution_from_producer_view_.at(GenLogicalBlobId(lbn));
+  CHECK_EQ_OR_RETURN(parallel_distribution.sbp_parallel_size(), 1);
+  const auto& sbp = parallel_distribution.sbp_parallel(0);
   if (sbp.has_split_parallel()) { ret.set_value(sbp.split_parallel().axis()); }
   return ret;
 }
@@ -708,7 +759,9 @@ Maybe<OptInt64> JobBuildAndInferCtx::MirroredBlobGetSplitAxisFromProducerView(
     const std::string& lbn_with_hint) const {
   const auto& lbi = *JUST(MirroredBlobGetSubLbi(lbn_with_hint, 0));
   OptInt64 ret;
-  const auto& sbp = lbi2sbp_parallel_from_producer_view_.at(lbi);
+  const auto& parallel_distribution = lbi2parallel_distribution_from_producer_view_.at(lbi);
+  CHECK_EQ_OR_RETURN(parallel_distribution.sbp_parallel_size(), 1);
+  const auto& sbp = parallel_distribution.sbp_parallel(0);
   if (sbp.has_split_parallel()) { ret.set_value(sbp.split_parallel().axis()); }
   return ret;
 }
@@ -768,7 +821,7 @@ Maybe<void> JobBuildAndInferCtx::CheckLbnValidAndExist(const std::string& lbn) c
       << Error::LogicalBlobNameNotExistError() << "lbn:" << lbn;
 
   CHECK_HAS_LBI_KEY(lbi2logical_blob_desc_);
-  CHECK_HAS_LBI_KEY(lbi2sbp_parallel_from_producer_view_);
+  CHECK_HAS_LBI_KEY(lbi2parallel_distribution_from_producer_view_);
   CHECK_HAS_LBI_KEY(lbi2parallel_desc_from_producer_view_);
 #undef CHECK_HAS_LBI_KEY
 
@@ -1158,7 +1211,7 @@ std::string oneflow::JobBuildAndInferCtx::GetJobStructureGraphJson(
 Maybe<void> JobBuildAndInferCtx::Rebuild() {
   // clear old state
   lbi2logical_blob_desc_.clear();
-  lbi2sbp_parallel_from_producer_view_.clear();
+  lbi2parallel_distribution_from_producer_view_.clear();
   lbi2parallel_desc_from_producer_view_.clear();
   lbi2disable_boxing_.clear();
   op_name2op_.clear();
@@ -1209,7 +1262,7 @@ Maybe<void> JobBuildAndInferCtx::Rebuild() {
   });
   // updata job_helper
   op_graph.DumpLogicalBlobDesc(job_);
-  op_graph.DumpSbpSignature(job_);
+  op_graph.DumpParallelDistributionSignature(job_);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/job/job_build_and_infer_ctx.h
+++ b/oneflow/core/job/job_build_and_infer_ctx.h
@@ -111,12 +111,14 @@ class JobBuildAndInferCtx {
   Maybe<OperatorConf> DecodeLbiHintAndReturnNewOpConf(
       const Operator& op, SbpSignature* sbp_sig_conf,
       HashMap<std::string, bool>* ibn2disable_boxing) const;
-  void AddOpAndUpdateJobParallelViewConf(const OperatorConf& operator_conf,
-                                         const SbpSignature& sbp_signature,
-                                         bool is_mirrored_parallel_view) const;
+  void AddOpAndUpdateJobParallelViewConf(
+      const OperatorConf& operator_conf, const ParallelDesc& parallel_desc,
+      const ParallelDistributionSignature& parallel_distribution_signature,
+      bool is_mirrored_parallel_view) const;
   Maybe<void> InferMirroredSignature(Operator*, bool is_mirrored_parallel_view_conf,
                                      const ParallelDesc&);
-  Maybe<void> InferOpOutSbpParallel(Operator*, const SbpSignature&, const ParallelDesc&);
+  Maybe<void> InferOpOutParallelDistribution(Operator*, const ParallelDistributionSignature&,
+                                             const ParallelDesc&);
   Maybe<void> GenOpProducedEmptyLogicalBlobDesc(Operator* op);
   Maybe<void> CheckOpBlobSplitability(Operator*, int64_t parallel_num);
   Maybe<void> CheckPlacement() const;
@@ -136,7 +138,7 @@ class JobBuildAndInferCtx {
   Job* job_;
   int64_t job_id_;
   HashMap<LogicalBlobId, std::unique_ptr<BlobDesc>> lbi2logical_blob_desc_;
-  HashMap<LogicalBlobId, SbpParallel> lbi2sbp_parallel_from_producer_view_;
+  HashMap<LogicalBlobId, ParallelDistribution> lbi2parallel_distribution_from_producer_view_;
   HashMap<LogicalBlobId, ParallelDesc> lbi2parallel_desc_from_producer_view_;
   HashMap<LogicalBlobId, bool> lbi2disable_boxing_;
   HashMap<std::string, std::shared_ptr<Operator>> op_name2op_;

--- a/oneflow/core/job/job_builder.h
+++ b/oneflow/core/job/job_builder.h
@@ -60,15 +60,23 @@ class JobBuilder final {
 
   SbpParallel* MutSbpParallel4Oba(const OpBlobArg& oba) const;
   void BindIdenticalSbpOpBlobArgPair(const OpBlobArg& first, const OpBlobArg& second);
-
+  void SetSbpParallel4Oba(const OpBlobArg& oba, const SbpParallel& sbp_parallel);
+  void SetParallelDistribution4Oba(const OpBlobArg& oba,
+                                   const ParallelDistribution& parallel_distribution);
   void ForEachOperator(const std::function<void(const Operator&)>& Handler) const;
 
   const ParallelConf& ParallelConf4Lbi(const LogicalBlobId& lbi) const;
   const ParallelConf& ParallelConf4OpName(const std::string& op_name) const;
   void AddParallelConf4OpName(const std::string& op_name, const ParallelConf& parallel_conf);
 
-  const SbpSignature& SbpSignature4OpName(const std::string& op_name) const;
+  const SbpSignature SbpSignature4OpName(const std::string& op_name) const;
   void AddSbpSignature4OpName(const std::string& op_name, const SbpSignature& sbp_signature);
+
+  const ParallelDistributionSignature& ParallelDistributionSignature4OpName(
+      const std::string& op_name) const;
+  void AddParallelDistributionSignature4OpName(
+      const std::string& op_name,
+      const ParallelDistributionSignature& parallel_distribution_signature);
 
  private:
   PlacementGroup* FindPlacementGroup(const std::string& op_name) const;
@@ -80,7 +88,8 @@ class JobBuilder final {
   HashSet<std::string> modified_op_conf_op_names_;
   HashSet<std::string> modified_parallel_conf_op_names_;
 
-  HashMap<std::string, SbpSignature*> op_name2sbp_signature_conf_;
+  HashMap<std::string, ParallelDistributionSignature*>
+      op_name2parallel_distribution_signature_conf_;
 };
 
 }  // namespace oneflow

--- a/oneflow/core/job/parallel_distribution_infer_hint.h
+++ b/oneflow/core/job/parallel_distribution_infer_hint.h
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_JOB_PARALLEL_DISTRIBUTION_INFER_HINT_H_
+#define ONEFLOW_CORE_JOB_PARALLEL_DISTRIBUTION_INFER_HINT_H_
+
+#include "oneflow/core/job/sbp_parallel.pb.h"
+#include "oneflow/core/job/parallel_desc.h"
+#include "oneflow/core/register/blob_desc.h"
+
+namespace oneflow {
+
+class ParallelDistributionInferHint final {
+ public:
+  ParallelDistributionInferHint(const ParallelDesc* parallel_desc,
+                                const BlobDesc* logical_blob_desc,
+                                const ParallelDistribution* parallel_distribution)
+      : parallel_desc_(parallel_desc),
+        logical_blob_desc_(logical_blob_desc),
+        parallel_distribution_(parallel_distribution) {}
+  ParallelDistributionInferHint(const ParallelDistributionInferHint&) = default;
+  ~ParallelDistributionInferHint() = default;
+
+  // Getters
+  const ParallelDesc& parallel_desc() const { return *parallel_desc_; }
+  const BlobDesc& logical_blob_desc() const { return *logical_blob_desc_; }
+  const ParallelDistribution& parallel_distribution() const { return *parallel_distribution_; }
+
+ private:
+  const ParallelDesc* parallel_desc_;
+  const BlobDesc* logical_blob_desc_;
+  const ParallelDistribution* parallel_distribution_;
+};
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_JOB_PARALLEL_DISTRIBUTION_INFER_HINT_H_

--- a/oneflow/core/job/sbp_parallel.h
+++ b/oneflow/core/job/sbp_parallel.h
@@ -26,6 +26,11 @@ bool operator!=(const SbpParallel& lhs, const SbpParallel& rhs);
 bool operator==(const SbpSignature& lhs, const SbpSignature& rhs);
 bool operator!=(const SbpSignature& lhs, const SbpSignature& rhs);
 
+bool operator==(const ParallelDistribution& lhs, const ParallelDistribution& rhs);
+bool operator!=(const ParallelDistribution& lhs, const ParallelDistribution& rhs);
+bool operator==(const ParallelDistributionSignature& lhs, const ParallelDistributionSignature& rhs);
+bool operator!=(const ParallelDistributionSignature& lhs, const ParallelDistributionSignature& rhs);
+
 SbpParallel GetDualSbpParallel(const SbpParallel&);
 
 bool IsSbpSignatureContaining(const SbpSignature& bigger, const SbpSignature& smaller);
@@ -43,6 +48,14 @@ bool IsValidSbpParallelString(const std::string& sbp_str);
 bool ParseSbpParallelFromString(const std::string& sbp_str, SbpParallel* sbp_parallel);
 std::string SbpParallelToString(const SbpParallel& sbp_parallel);
 
+void SbpSignatureToParallelDistributionSignature(
+    const SbpSignature& sbp_signature,
+    ParallelDistributionSignature* parallel_distribution_signature);
+void ParallelDistributionSignatureToSbpSignature(
+    const ParallelDistributionSignature& parallel_distribution_signature,
+    SbpSignature* sbp_signature);
+void CheckSbpSignatureAndParallelDistributionEquals(
+    const SbpSignature& sbp_sig, const ParallelDistributionSignature& parallel_distribution_sig);
 }  // namespace oneflow
 
 namespace std {

--- a/oneflow/core/job/sbp_parallel.proto
+++ b/oneflow/core/job/sbp_parallel.proto
@@ -66,6 +66,14 @@ message SbpSignature {
   map<string, SbpParallel> bn_in_op2sbp_parallel = 1;
 }
 
+message ParallelDistribution {
+  repeated SbpParallel sbp_parallel = 1;
+}
+
+message ParallelDistributionSignature {
+  map<string, ParallelDistribution> bn_in_op2parallel_distribution = 1;
+}
+
 message SbpSignatureList {
   repeated SbpSignature sbp_signature = 1;
 }

--- a/oneflow/core/job_rewriter/autograd.cpp
+++ b/oneflow/core/job_rewriter/autograd.cpp
@@ -148,11 +148,13 @@ void GenerateOriginDiffLbi(JobPassCtx* ctx, const OpGraph& op_graph, JobBuilder*
       OpBlobArg cast_in_op_blob_arg;
       cast_in_op_blob_arg.set_op_name(cast_op.op_name());
       cast_in_op_blob_arg.set_bn_in_op(GenRepeatedBn("in", 0));
-      job_builder->MutSbpParallel4Oba(cast_in_op_blob_arg)->mutable_broadcast_parallel();
+      SbpParallel sbp_parallel;
+      sbp_parallel.mutable_broadcast_parallel();
+      job_builder->SetSbpParallel4Oba(cast_in_op_blob_arg, sbp_parallel);
       OpBlobArg cast_out_op_blob_arg;
       cast_out_op_blob_arg.set_op_name(cast_op.op_name());
       cast_out_op_blob_arg.set_bn_in_op(GenRepeatedBn("out", 0));
-      job_builder->MutSbpParallel4Oba(cast_out_op_blob_arg)->mutable_broadcast_parallel();
+      job_builder->SetSbpParallel4Oba(cast_out_op_blob_arg, sbp_parallel);
       op_confs->push_back(cast_op.op_conf());
       loss_scale_val_lbn = cast_op.output("out", 0);
     }

--- a/oneflow/core/job_rewriter/dump_blob_parallel_conf_pass.cpp
+++ b/oneflow/core/job_rewriter/dump_blob_parallel_conf_pass.cpp
@@ -31,8 +31,8 @@ class DumpBlobParallelConfPass final : public JobPass {
 
   Maybe<void> Apply(const OpGraph& op_graph, Job* job) const {
     op_graph.DumpLogicalBlobDesc(job);
-    op_graph.DumpSbpSignature(job);
     op_graph.DumpArgSignature(job);
+    op_graph.DumpParallelDistributionSignature(job);
     return Maybe<void>::Ok();
   }
 

--- a/oneflow/core/job_rewriter/generate_backward_and_optimizer_op_confs.cpp
+++ b/oneflow/core/job_rewriter/generate_backward_and_optimizer_op_confs.cpp
@@ -82,8 +82,8 @@ void SetSbpSignatureHintByIdenticalSbpObaPairs(const OpGraph& op_graph, JobBuild
     } else {
       UNIMPLEMENTED();
     }
-    *job_builder->MutSbpParallel4Oba(pair.first()) = *sbp_parallel;
-    *job_builder->MutSbpParallel4Oba(pair.second()) = *sbp_parallel;
+    job_builder->SetSbpParallel4Oba(pair.first(), *sbp_parallel);
+    job_builder->SetSbpParallel4Oba(pair.second(), *sbp_parallel);
   }
 }
 

--- a/oneflow/core/job_rewriter/group_boxing_by_dst_parallel.cpp
+++ b/oneflow/core/job_rewriter/group_boxing_by_dst_parallel.cpp
@@ -20,9 +20,9 @@ limitations under the License.
 namespace oneflow {
 
 void GroupBoxingByDstParallel(const OpGraph& op_graph, JobBuilder* job_builder) {
-  HashMap<LogicalBlobId, HashMap<std::pair<ParallelDesc, SbpParallel>,
+  HashMap<LogicalBlobId, HashMap<std::pair<ParallelDesc, ParallelDistribution>,
                                  std::vector<std::pair<const OpNode*, std::string>>>>
-      lbi2consumer_grouped_by_parallel_sbp;
+      lbi2consumer_grouped_by_parallel;
   HashMap<const OpNode*, OperatorConf> op_node2op_conf;
   op_graph.ForEachNode([&](const OpNode* node) {
     OperatorConf::OpTypeCase op_type_case = node->op().op_conf().op_type_case();
@@ -30,36 +30,43 @@ void GroupBoxingByDstParallel(const OpGraph& op_graph, JobBuilder* job_builder) 
     for (const std::string& ibn : node->op().input_bns()) {
       const LogicalBlobId& lbi = node->op().BnInOp2Lbi(ibn);
       const OpNode& producer = node->ProducerOpNode4Lbi(lbi);
-      const SbpParallel& producer_sbp = producer.SbpParallel4Lbi(lbi);
-      const SbpParallel& consumer_sbp = node->SbpParallel4BnInOp(ibn);
+      const ParallelDistribution& producer_parallel_distribution =
+          producer.ParallelDistribution4Lbi(lbi);
+      const ParallelDistribution& consumer_parallel_distribution =
+          node->ParallelDistribution4BnInOp(ibn);
+
       if (producer.parallel_desc() != node->parallel_desc()
-          || (node->parallel_desc().parallel_num() != 1 && producer_sbp != consumer_sbp)) {
-        lbi2consumer_grouped_by_parallel_sbp[lbi][{node->parallel_desc(), consumer_sbp}].push_back(
-            {node, ibn});
+          || (node->parallel_desc().parallel_num() != 1
+              && producer_parallel_distribution != consumer_parallel_distribution)) {
+        lbi2consumer_grouped_by_parallel[lbi]
+                                        [{node->parallel_desc(), consumer_parallel_distribution}]
+                                            .push_back({node, ibn});
         if (op_node2op_conf.find(node) == op_node2op_conf.end()) {
           op_node2op_conf[node] = node->op().op_conf();
         }
       }
     }
   });
-  for (const auto& lbi7groups : lbi2consumer_grouped_by_parallel_sbp) {
+  for (const auto& lbi7groups : lbi2consumer_grouped_by_parallel) {
     const LogicalBlobId& lbi = lbi7groups.first;
     for (const auto& parallel7group : lbi7groups.second) {
       if (parallel7group.second.size() < 2) { continue; }
       const ParallelDesc& dst_parallel_desc = parallel7group.first.first;
-      const SbpParallel& dst_sbp_parallel = parallel7group.first.second;
+      const ParallelDistribution& dst_parallel_distribution = parallel7group.first.second;
       OperatorConf identity_op_conf{};
       identity_op_conf.set_name("System-Boxing-Identity-" + NewUniqueId());
       IdentityOpConf* identity_conf = identity_op_conf.mutable_identity_conf();
       identity_conf->set_in(GenLogicalBlobName(lbi));
       identity_conf->set_out("out");
       job_builder->AddOps(dst_parallel_desc.parallel_conf(), {identity_op_conf});
-      SbpSignature identity_sbp_signature;
-      (*identity_sbp_signature.mutable_bn_in_op2sbp_parallel())["in"] = dst_sbp_parallel;
-      (*identity_sbp_signature.mutable_bn_in_op2sbp_parallel())["out"] = dst_sbp_parallel;
-      (*job_builder->mutable_job_parallel_view_conf()
-            ->mutable_op_name2sbp_signature_conf())[identity_op_conf.name()] =
-          identity_sbp_signature;
+      ParallelDistributionSignature identity_parallel_distribution_signature;
+      (*identity_parallel_distribution_signature.mutable_bn_in_op2parallel_distribution())["in"] =
+          dst_parallel_distribution;
+      (*identity_parallel_distribution_signature.mutable_bn_in_op2parallel_distribution())["out"] =
+          dst_parallel_distribution;
+      job_builder->AddParallelDistributionSignature4OpName(
+          identity_op_conf.name(), identity_parallel_distribution_signature);
+
       LogicalBlobId grouped_lbi;
       grouped_lbi.set_op_name(identity_op_conf.name());
       grouped_lbi.set_blob_name(identity_conf->out());

--- a/oneflow/core/job_rewriter/optimizer_placement_optimization_pass.cpp
+++ b/oneflow/core/job_rewriter/optimizer_placement_optimization_pass.cpp
@@ -121,7 +121,9 @@ void SetBroadcastParallel4OpNodeIbn(JobBuilder* builder, const OpNode* node,
   OpBlobArg op_blob_arg;
   op_blob_arg.set_op_name(node->op().op_name());
   op_blob_arg.set_bn_in_op(ibn);
-  builder->MutSbpParallel4Oba(op_blob_arg)->mutable_broadcast_parallel();
+  SbpParallel sbp_parallel;
+  sbp_parallel.mutable_broadcast_parallel();
+  builder->SetSbpParallel4Oba(op_blob_arg, sbp_parallel);
 }
 
 void SetBroadcastParallel4Consumers(JobBuilder* builder, const SequencePtr& sequence) {

--- a/oneflow/core/operator/op_attribute.proto
+++ b/oneflow/core/operator/op_attribute.proto
@@ -30,6 +30,7 @@ message OpAttribute {
   optional BlobDescSignature logical_blob_desc_signature = 106;
   optional ParallelSignature parallel_signature = 108;
   optional ParallelConfSignature parallel_conf_signature = 109;
+  optional ParallelDistributionSignature parallel_distribution_signature = 110;
 }
 
 message OpAttributeList {

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -331,21 +331,23 @@ Maybe<void> Operator::InferOutBlobDescs(
   if (parallel_ctx->parallel_num() == 1) {
     JUST(InferLogicalOutBlobDescs(GetBlobDesc4BnInOp, *JUST(GetOpParallelDesc())));
   } else {
-    const auto sbp_signature = JUST(this->sbp_signature());
+    const auto& parallel_distribution_signature = JUST(this->parallel_distribution_signature());
+    const auto& parallel_desc = JUST(this->GetOpParallelDesc());
     for (const auto& bn : input_bns()) {
-      const auto& sbp_parallel = sbp_signature->bn_in_op2sbp_parallel().at(bn);
+      const auto& parallel_distribution =
+          parallel_distribution_signature->bn_in_op2parallel_distribution().at(bn);
       std::shared_ptr<const BlobDesc> in_logical = JUST(GetLogicalBlobDesc4Ibn(bn));
-      CHECK_OR_RETURN(
-          *JUST(GetPhysicalShape(in_logical->shape(), sbp_parallel, parallel_ctx->parallel_num(),
-                                 parallel_ctx->parallel_id()))
-          == GetBlobDesc4BnInOp(bn)->shape());
+      CHECK_OR_RETURN(*JUST(GetPhysicalShape(in_logical->shape(), parallel_distribution,
+                                             *parallel_desc, *parallel_ctx))
+                      == GetBlobDesc4BnInOp(bn)->shape());
     }
     for (const auto& bn : output_bns()) {
       BlobDesc* desc = GetBlobDesc4BnInOp(bn);
       *desc = *JUST(GetLogicalBlobDesc4Obn(bn));
-      const auto& sbp_parallel = sbp_signature->bn_in_op2sbp_parallel().at(bn);
-      desc->mut_shape() = *JUST(GetPhysicalShape(
-          desc->shape(), sbp_parallel, parallel_ctx->parallel_num(), parallel_ctx->parallel_id()));
+      const auto& parallel_distribution =
+          parallel_distribution_signature->bn_in_op2parallel_distribution().at(bn);
+      desc->mut_shape() = *JUST(
+          GetPhysicalShape(desc->shape(), parallel_distribution, *parallel_desc, *parallel_ctx));
     }
   }
   return Maybe<void>::Ok();
@@ -471,8 +473,23 @@ void Operator::ForEachBnInOp(std::function<void(const std::string&)> Handler) co
 }
 
 Maybe<void> Operator::FillSbpSignature(const SbpSignature& sbp_signature) {
+  ParallelDistributionSignature parallel_distribution_signature;
+  SbpSignatureToParallelDistributionSignature(sbp_signature, &parallel_distribution_signature);
+  FillParallelDistributionSignature(parallel_distribution_signature);
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> Operator::FillParallelDistributionSignature(
+    const ParallelDistributionSignature& signature) {
+  CHECK_OR_RETURN(!parallel_distribution_signature_);
   CHECK_OR_RETURN(!sbp_signature_);
-  sbp_signature_.reset(new SbpSignature(sbp_signature));
+  parallel_distribution_signature_.reset(new ParallelDistributionSignature(signature));
+  CHECK_OR_RETURN(op_parallel_desc_);
+  if (op_parallel_desc_->hierarchy()->NumAxes() == 1) {
+    SbpSignature sbp_signature;
+    ParallelDistributionSignatureToSbpSignature(signature, &sbp_signature);
+    sbp_signature_.reset(new SbpSignature(sbp_signature));
+  }
   return Maybe<void>::Ok();
 }
 
@@ -493,6 +510,68 @@ Maybe<void> Operator::InferSbpSignatureIf(
     UNIMPLEMENTED();
   }
   JUST(FillSbpSignature(signature));
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> Operator::InferSbpSignature(
+    SbpSignature* infered_sbp_signature, const SbpSignature& sbp_sig_conf,
+    const HashMap<std::string, SbpInferHint>& ibn2sbp_infer_hint) {
+  auto SbpInferHint4Ibn = [&](const std::string& ibn) -> Maybe<const SbpInferHint*> {
+    auto it = ibn2sbp_infer_hint.find(ibn);
+    if (it == ibn2sbp_infer_hint.end()) {
+      return Error::CheckFailedError()
+             << "cannot find corresponding SbpInferHint for input_blob_name : " << ibn;
+    }
+    return &(it->second);
+  };
+  std::function<int32_t(const SbpSignature&)> CalcOrderValue4SbpSig;
+  auto OrderValue4SourceDefaultSplit0 = [&](const std::string& bn,
+                                            const SbpParallel& sbp_parallel) -> int32_t {
+    return -1 * (sbp_parallel.has_split_parallel() && sbp_parallel.split_parallel().axis() == 0);
+  };
+  auto OrderValue4SbpHint = [&](const std::string& ibn,
+                                const SbpParallel& sbp_parallel) -> int32_t {
+    const auto* hint = CHECK_JUST(SbpInferHint4Ibn(ibn));
+    // NOTE(chengcheng): one to one connect.
+    return -10
+           * (hint->sbp_parallel() == sbp_parallel
+              && hint->parallel_desc().parallel_num() == op_parallel_desc_->parallel_num());
+  };
+
+  if (sbp_sig_conf.bn_in_op2sbp_parallel().empty()) {
+    CalcOrderValue4SbpSig = [&](const SbpSignature& sbp_signature) -> int32_t {
+      int32_t order_value = 0;
+      if (input_bns().size() > 0) {
+        // NOTE(chengcheng): non-source op only ordered by input sbp match.
+        for (const auto& ibn : input_bns()) {
+          const auto& sbp_parallel_it = sbp_signature.bn_in_op2sbp_parallel().find(ibn);
+          CHECK(sbp_parallel_it != sbp_signature.bn_in_op2sbp_parallel().end());
+          order_value += OrderValue4SbpHint(ibn, sbp_parallel_it->second);
+        }
+      } else {
+        // NOTE(chengcheng): source op default split(0)
+        //   ONLY data source op will consider order here. variable op sbp is set by user.
+        for (const auto& obn : output_bns()) {
+          const auto& sbp_parallel_it = sbp_signature.bn_in_op2sbp_parallel().find(obn);
+          CHECK(sbp_parallel_it != sbp_signature.bn_in_op2sbp_parallel().end());
+          order_value += OrderValue4SourceDefaultSplit0(obn, sbp_parallel_it->second);
+        }
+      }
+      return order_value;
+    };
+  } else {
+    CalcOrderValue4SbpSig = [](const SbpSignature&) -> int32_t { return 0; };
+  }
+  if (op_parallel_desc_->parallel_num() == 1) {
+    auto* bn2sbp = infered_sbp_signature->mutable_bn_in_op2sbp_parallel();
+    for (const auto& ibn : input_bns()) { (*bn2sbp)[ibn].mutable_split_parallel()->set_axis(0); }
+    for (const auto& obn : output_bns()) { (*bn2sbp)[obn].mutable_split_parallel()->set_axis(0); }
+  } else if (op_parallel_desc_->parallel_num() > 1) {
+    JUST(InferSbpSignature(infered_sbp_signature, sbp_sig_conf, CalcOrderValue4SbpSig,
+                           SbpInferHint4Ibn, *op_parallel_desc_));
+  } else {
+    UNIMPLEMENTED();
+  }
   return Maybe<void>::Ok();
 }
 
@@ -579,6 +658,47 @@ Maybe<void> Operator::InferSbpSignature(
   return Maybe<void>::Ok();
 }
 
+Maybe<void> Operator::InferParallelDistributionSignatureIf(
+    const ParallelDistributionSignature& parallel_distribution_sig_constraints,
+    const ParallelDesc& parallel_desc,
+    std::function<Maybe<const ParallelDistributionInferHint*>(const std::string&)>
+        ParallelDistributionInferHint4Ibn) {
+  ParallelDistributionSignature signature;
+  JUST(InferParallelDistributionSignature(&signature, parallel_distribution_sig_constraints,
+                                          parallel_desc, ParallelDistributionInferHint4Ibn));
+  JUST(FillParallelDistributionSignature(signature));
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> Operator::InferParallelDistributionSignature(
+    ParallelDistributionSignature* signature,
+    const ParallelDistributionSignature& parallel_distribution_sig_constraints,
+    const ParallelDesc& parallel_desc,
+    std::function<Maybe<const ParallelDistributionInferHint*>(const std::string&)>
+        ParallelDistributionInferHint4Ibn) {
+  const auto& parallel_hierarchy = parallel_desc.hierarchy();
+  CHECK_GT(parallel_hierarchy->NumAxes(), 0);
+  if (parallel_hierarchy->NumAxes() == 1) {
+    HashMap<std::string, SbpInferHint> ibn2sbp_infer_hint;
+    for (const auto& ibn : input_bns()) {
+      const ParallelDistributionInferHint* hint = JUST(ParallelDistributionInferHint4Ibn(ibn));
+      CHECK_EQ(hint->parallel_distribution().sbp_parallel_size(), 1);
+      ibn2sbp_infer_hint.emplace(ibn,
+                                 SbpInferHint(&hint->parallel_desc(), &hint->logical_blob_desc(),
+                                              &hint->parallel_distribution().sbp_parallel(0)));
+    }
+    SbpSignature sbp_sig_constraints;
+    ParallelDistributionSignatureToSbpSignature(parallel_distribution_sig_constraints,
+                                                &sbp_sig_constraints);
+    SbpSignature sbp_signature;
+    CHECK_JUST(InferSbpSignature(&sbp_signature, sbp_sig_constraints, ibn2sbp_infer_hint));
+    SbpSignatureToParallelDistributionSignature(sbp_signature, signature);
+    return Maybe<void>::Ok();
+  } else {
+    UNIMPLEMENTED();
+  }
+}
+
 Maybe<void> Operator::InferMirroredSignatureIf(
     std::function<Maybe<const MirroredSigInferHint*>(const std::string&)> MirroredSigInferHint4Ibn,
     bool is_mirrored_parallel_view_conf, const ParallelDesc& parallel_desc) {
@@ -638,6 +758,12 @@ Maybe<const SbpSignature*> Operator::sbp_signature() const {
   return sbp_signature_.get();
 }
 
+Maybe<const ParallelDistributionSignature*> Operator::parallel_distribution_signature() const {
+  CHECK_OR_RETURN(parallel_distribution_signature_)
+      << "parallel distribution signature not infered";
+  return parallel_distribution_signature_.get();
+}
+
 BlobLastUsedSignature* Operator::mut_blob_last_used_signature() {
   if (!blob_last_used_signature_) { blob_last_used_signature_.reset(new BlobLastUsedSignature()); }
   return blob_last_used_signature_.get();
@@ -655,6 +781,17 @@ Maybe<const SbpParallel*> Operator::SbpParallel4BnInOp(const std::string& bn_in_
   const auto& map = sbp_signature_->bn_in_op2sbp_parallel();
   const auto& iter = map.find(bn_in_op);
   CHECK_OR_RETURN(iter != map.end()) << "blob_name " << bn_in_op << " not found in sbp signature";
+  return &iter->second;
+}
+
+Maybe<const ParallelDistribution*> Operator::ParallelDistribution4BnInOp(
+    const std::string& bn_in_op) const {
+  CHECK_OR_RETURN(parallel_distribution_signature_)
+      << "parallel distribution signature not infered";
+  const auto& map = parallel_distribution_signature_->bn_in_op2parallel_distribution();
+  const auto& iter = map.find(bn_in_op);
+  CHECK_OR_RETURN(iter != map.end())
+      << "blob_name " << bn_in_op << " not found in parallel distribution";
   return &iter->second;
 }
 
@@ -957,6 +1094,11 @@ Maybe<void> Operator::ToOpAttribute(OpAttribute* op_attribute) const {
   } else {
     op_attribute->clear_sbp_signature();
   }
+  if (parallel_distribution_signature_) {
+    *op_attribute->mutable_parallel_distribution_signature() = *parallel_distribution_signature_;
+  } else {
+    op_attribute->clear_parallel_distribution_signature();
+  }
   if (mirrored_signature_) {
     *op_attribute->mutable_mirrored_signature() = *mirrored_signature_;
   } else {
@@ -1047,60 +1189,6 @@ Maybe<bool> ParseDisableBoxingFlag(const std::string& lbn_with_hint, bool* disab
   return true;
 }
 
-Maybe<void> InferOpSbpSignature(Operator* op, const SbpSignature& sbp_sig_conf,
-                                const ParallelDesc& parallel_desc,
-                                const HashMap<std::string, SbpInferHint>& ibn2sbp_infer_hint) {
-  auto SbpInferHint4Ibn = [&](const std::string& ibn) -> Maybe<const SbpInferHint*> {
-    auto it = ibn2sbp_infer_hint.find(ibn);
-    if (it == ibn2sbp_infer_hint.end()) {
-      return Error::CheckFailedError()
-             << "cannot find corresponding SbpInferHint for input_blob_name : " << ibn;
-    }
-    return &(it->second);
-  };
-  std::function<int32_t(const SbpSignature&)> CalcOrderValue4SbpSig;
-  auto OrderValue4SourceDefaultSplit0 = [&](const std::string& bn,
-                                            const SbpParallel& sbp_parallel) -> int32_t {
-    return -1 * (sbp_parallel.has_split_parallel() && sbp_parallel.split_parallel().axis() == 0);
-  };
-  auto OrderValue4SbpHint = [&](const std::string& ibn,
-                                const SbpParallel& sbp_parallel) -> int32_t {
-    const auto* hint = CHECK_JUST(SbpInferHint4Ibn(ibn));
-    // NOTE(chengcheng): one to one connect.
-    return -10
-           * (hint->sbp_parallel() == sbp_parallel
-              && hint->parallel_desc().parallel_num() == parallel_desc.parallel_num());
-  };
-
-  if (sbp_sig_conf.bn_in_op2sbp_parallel().empty()) {
-    CalcOrderValue4SbpSig = [&](const SbpSignature& sbp_signature) -> int32_t {
-      int32_t order_value = 0;
-      if (op->input_bns().size() > 0) {
-        // NOTE(chengcheng): non-source op only ordered by input sbp match.
-        for (const auto& ibn : op->input_bns()) {
-          const auto& sbp_parallel_it = sbp_signature.bn_in_op2sbp_parallel().find(ibn);
-          CHECK(sbp_parallel_it != sbp_signature.bn_in_op2sbp_parallel().end());
-          order_value += OrderValue4SbpHint(ibn, sbp_parallel_it->second);
-        }
-      } else {
-        // NOTE(chengcheng): source op default split(0)
-        //   ONLY data source op will consider order here. variable op sbp is set by user.
-        for (const auto& obn : op->output_bns()) {
-          const auto& sbp_parallel_it = sbp_signature.bn_in_op2sbp_parallel().find(obn);
-          CHECK(sbp_parallel_it != sbp_signature.bn_in_op2sbp_parallel().end());
-          order_value += OrderValue4SourceDefaultSplit0(obn, sbp_parallel_it->second);
-        }
-      }
-      return order_value;
-    };
-  } else {
-    CalcOrderValue4SbpSig = [](const SbpSignature&) -> int32_t { return 0; };
-  }
-  JUST(op->InferSbpSignatureIf(sbp_sig_conf, CalcOrderValue4SbpSig, SbpInferHint4Ibn,
-                               parallel_desc));
-  return Maybe<void>::Ok();
-}
-
 std::string GetInputLbnInOpCustomizedConf(const OperatorConf& op_conf,
                                           const std::string& fd_name_may_have_idx) {
   const PbMessage& msg = GetMessageInPbMessage(op_conf, op_conf.op_type_case());
@@ -1167,8 +1255,9 @@ Maybe<void> InferOpOutSbpParallel(
     const SbpParallel* sbp_parallel = SbpParallel4Ibn(ibn);
     ibn2sbp_infer_hint.emplace(ibn, SbpInferHint(pd, logical_blob_desc, sbp_parallel));
   }
-
-  JUST(InferOpSbpSignature(op, sbp_sig_conf, parallel_desc, ibn2sbp_infer_hint));
+  SbpSignature sbp_signature;
+  JUST(op->InferSbpSignature(&sbp_signature, sbp_sig_conf, ibn2sbp_infer_hint));
+  JUST(op->FillSbpSignature(sbp_signature));
   return Maybe<void>::Ok();
 }
 
@@ -1242,9 +1331,11 @@ Maybe<Operator> ConstructAndInferOp(const OperatorConf& op_conf,
   return op;
 }
 
-Maybe<Shape> GetPhysicalShape(const Shape& logical_shape, const SbpParallel& sbp_parallel,
-                              const int64_t parallel_num, const int64_t parallel_id) {
-  CHECK_LT_OR_RETURN(parallel_id, parallel_num);
+namespace {
+
+Maybe<Shape> Get1dHierarchyPhysicalShape(const Shape& logical_shape,
+                                         const SbpParallel& sbp_parallel,
+                                         const int64_t parallel_num, const int64_t parallel_id) {
   std::shared_ptr<Shape> physical = std::make_shared<Shape>(logical_shape);
   if (sbp_parallel.has_split_parallel()) {
     const int64_t axis = sbp_parallel.split_parallel().axis();
@@ -1257,6 +1348,40 @@ Maybe<Shape> GetPhysicalShape(const Shape& logical_shape, const SbpParallel& sbp
     UNIMPLEMENTED();
   }
   return physical;
+}
+
+Maybe<Shape> GetNdHierarchyPhysicalShape(const Shape& logical_shape,
+                                         const ParallelDistribution& parallel_distribution,
+                                         const Shape& parallel_hierarchy) {
+  std::shared_ptr<Shape> physical = std::make_shared<Shape>(logical_shape);
+  FOR_RANGE(int64_t, i, 0, parallel_hierarchy.NumAxes()) {
+    const SbpParallel& sbp_parallel = parallel_distribution.sbp_parallel(i);
+    if (sbp_parallel.has_split_parallel()) {
+      const int64_t split_axis = sbp_parallel.split_parallel().axis();
+      CHECK_EQ_OR_RETURN(physical->At(split_axis) % parallel_hierarchy.At(i), 0);
+      physical->Set(split_axis, physical->At(split_axis) / parallel_hierarchy.At(i));
+    }
+  }
+  return physical;
+}
+
+}  // namespace
+
+Maybe<Shape> GetPhysicalShape(const Shape& logical_shape,
+                              const ParallelDistribution& parallel_distribution,
+                              const ParallelDesc& parallel_desc,
+                              const ParallelContext& parallel_ctx) {
+  CHECK_LT_OR_RETURN(parallel_ctx.parallel_id(), parallel_desc.hierarchy()->elem_cnt());
+  CHECK_EQ_OR_RETURN(parallel_desc.hierarchy()->NumAxes(),
+                     parallel_distribution.sbp_parallel_size());
+  if (parallel_desc.hierarchy()->NumAxes() == 1) {
+    return Get1dHierarchyPhysicalShape(logical_shape, parallel_distribution.sbp_parallel(0),
+                                       parallel_desc.hierarchy()->elem_cnt(),
+                                       parallel_ctx.parallel_id());
+  } else {
+    return GetNdHierarchyPhysicalShape(logical_shape, parallel_distribution,
+                                       *parallel_desc.hierarchy());
+  }
 }
 
 }  // namespace oneflow

--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "oneflow/core/job/job_builder.h"
 #include "oneflow/core/job/sbp_signature_builder.h"
 #include "oneflow/core/kernel/kernel.pb.h"
+#include "oneflow/core/job/parallel_distribution_infer_hint.h"
 
 namespace oneflow {
 
@@ -137,12 +138,20 @@ class Operator {
   Maybe<const Shape> GetInputBlobFastestTimeShape() const;
   Maybe<const Shape> GetInputOutputFastestTimeShape() const;
 
+  Maybe<void> InferSbpSignature(SbpSignature* sbp_signature, const SbpSignature& sbp_sig_conf,
+                                const HashMap<std::string, SbpInferHint>& ibn2sbp_infer_hint);
   Maybe<void> FillSbpSignature(const SbpSignature& sbp_signature);
+  Maybe<void> FillParallelDistributionSignature(const ParallelDistributionSignature& signature);
   Maybe<void> InferSbpSignatureIf(
       const SbpSignature& sbp_sig_conf,
       const std::function<int32_t(const SbpSignature&)>& CalcOrderValue4SbpSig,
       std::function<Maybe<const SbpInferHint*>(const std::string&)> SbpInferHint4Ibn,
       const ParallelDesc& parallel_desc);
+  Maybe<void> InferParallelDistributionSignatureIf(
+      const ParallelDistributionSignature& parallel_distribution_sig_conf,
+      const ParallelDesc& parallel_desc,
+      std::function<Maybe<const ParallelDistributionInferHint*>(const std::string&)>
+          ParallelDistributionInferHint4Ibn);
   // Infer blob's MirroredSignature
   Maybe<void> InferMirroredSignatureIf(
       std::function<Maybe<const MirroredSigInferHint*>(const std::string&)>
@@ -153,6 +162,7 @@ class Operator {
   const InputBlobModifier& InputBlobModifier4Ibn(const std::string& ibn) const;
   const OutputBlobModifier& OutputBlobModifier4Obn(const std::string& obn) const;
   Maybe<const SbpParallel*> SbpParallel4BnInOp(const std::string& bn_in_op) const;
+  Maybe<const ParallelDistribution*> ParallelDistribution4BnInOp(const std::string& bn_in_op) const;
   Maybe<const OptMirroredParallel*> OptMirroredParallel4BnInOp(const std::string& bn_in_op) const;
 
   Maybe<void> GetSbpSignaturesIf(
@@ -165,6 +175,7 @@ class Operator {
   std::shared_ptr<OpAttribute> GetOpAttributeWithoutOpNameAndLbn() const;
 
   Maybe<const SbpSignature*> sbp_signature() const;
+  Maybe<const ParallelDistributionSignature*> parallel_distribution_signature() const;
   BlobLastUsedSignature* mut_blob_last_used_signature();
   BlobBackwardUsedSignature* mut_blob_backward_used_signature();
 
@@ -199,6 +210,12 @@ class Operator {
       const std::function<int32_t(const SbpSignature&)>& CalcOrderValue4SbpSig,
       std::function<Maybe<const SbpInferHint*>(const std::string&)> SbpInferHint4Ibn,
       const ParallelDesc& parallel_desc) const;
+  virtual Maybe<void> InferParallelDistributionSignature(
+      ParallelDistributionSignature* signature,
+      const ParallelDistributionSignature& parallel_distribution_sig_conf,
+      const ParallelDesc& parallel_desc,
+      std::function<Maybe<const ParallelDistributionInferHint*>(const std::string&)>
+          ParallelDistributionInferHint4Ibn);
   virtual Maybe<void> GetSbpSignatures(SbpSignatureList* sbp_sig_list) const {
     UNIMPLEMENTED() << " GetSbpSignatures unimplemented, op name: " << op_name();
     return Maybe<void>::Ok();
@@ -284,6 +301,7 @@ class Operator {
   std::shared_ptr<const Shape> input_output_fastest_time_shape_;
   std::shared_ptr<const Shape> op_time_shape_;
   std::shared_ptr<const SbpSignature> sbp_signature_;
+  std::shared_ptr<const ParallelDistributionSignature> parallel_distribution_signature_;
   PbRpf<std::string> input_bns_;
   PbRpf<std::string> output_bns_;
   PbRpf<std::string> tmp_bns_;
@@ -411,9 +429,10 @@ bool operator==(const OperatorConf& lhs, const OperatorConf& rhs);
 
 Maybe<Operator> ConstructAndInferOp(const OperatorConf& op_conf,
                                     const OpNodeSignature& upstream_signature, const Scope& scope);
-Maybe<Shape> GetPhysicalShape(const Shape& logical_shape, const SbpParallel& sbp_parallel,
-                              int64_t parallel_num, int64_t parallel_id);
-
+Maybe<Shape> GetPhysicalShape(const Shape& logical_shape,
+                              const ParallelDistribution& parallel_distribution,
+                              const ParallelDesc& parallel_desc,
+                              const ParallelContext& parallel_ctx);
 }  // namespace oneflow
 
 namespace std {


### PR DESCRIPTION
为了支持多维SBP，引入ParallelDistribution (是repeated的sbp_parallel)、ParallelDistributionSignature类型及相关推导。

由于很多未合并代码及eager部分对sbp相关接口有依赖，以及可能修改JobParallelViewConf中sbp相关信息。因此为了兼容，虽然parallel_distribution已可以完整表示1d 时 sbp信息，本次改动暂时未删除sbp相关接口、proto中数据结构，原有接口都保留且在1D SBP时保持原有功能。

主要改动：
1、增加parallel_distribution类型
- sbp_parallel.proto中增加ParallelDistribution和ParallelDistribution
- sbp_parallel.h、sbp_parallel.cpp中增加一些工具函数

2、operator中
- op_attribute.proto中增加parallel_distribution_signature成员
- 增加推导函数InferParallelDistributionSignature，在一维时仍然调用原有的InferSbpSignature推导，高维时的实现在下一个pr中。
- 修改原有GetPhysicalShape 函数，改成按照ParallelDistribution切割
- 为了兼容，FillSbpSignature、FillParallelDistributionSignature函数在一维情况下会同时填充sbp_signature和parallel_distribution_signature。

3、job_builder
- job.proto中JobParallelViewConf中增加op_name2parallel_distribution_signature_conf
- 增加SetSbpParallel4Oba、SetSbpParallel4Oba等函数。
为了兼容，在一维情况下，外部调用都会同时填充op_name2sbp_signature_conf和op_name2parallel_distribution_signature_conf，并增加check确保一维情况下op_name2sbp_signature_conf和op_name2parallel_distribution_signature_conf信息一致。
所以不建议再使用MutSbpParallel4Oba函数应该改用SetSbpParallel4Oba，因为它直接修改op_name2sbp_signature_conf，会导致和op_name2parallel_distribution_signature_conf中信息不一致。

4、job_build_and_infer_ctx和op_graph中 
- 推导改成调用op的InferParallelDistributionSignatureIf推导。
- 增加与sbp_parallel对应的parallel_distribution接口函数，如parallel_distribution_signature()、ParallelDistribution4Lbi、ParallelDistribution4BnInOp等
- 对JobParallelViewConf的修改改为同时修改op_name2parallel_distribution_signature_conf和op_name2sbp_signature_conf

5、一些pass中的改动
- group_boxing_by_dst_parallel.cpp中group的方式由sbp换成parallel_distribution。
- generate_backward_and_optimizer_op_confs.cpp、optimizer_placement_optimization_pass.cpp split_sparse_softmax_cross_entropy_op_pass.cpp、auto_grad.cpp中由调用MutSbpParallel4Oba直接修改job_parallel_view_conf改成调用MutSbpParallel4Oba接口。

6、user_op中infer_ctx增加ParallelDistribution4ArgNameAndIndex接口和parallel_desc()接口