### PR TITLE
TaskGraph add ctrl in chain build real edge of graph

### DIFF
--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -387,8 +387,17 @@ void TaskGraph::BuildCtrlRegstDescInSameChain() {
     if (iter == chain_id2node.end()) {
       CHECK(chain_id2node.emplace(chain_id, node).second);
     } else {
-      iter->second->BuildCtrlRegstDescIfNeed(node);
-      iter->second = node;
+      TaskNode* src_node = iter->second;
+      TaskNode* dst_node = node;
+      std::string ctrl_regst_name;
+      bool build_ctrl_edge = src_node->BuildCtrlRegstDescIfNeed(dst_node, &ctrl_regst_name);
+      if (build_ctrl_edge) {
+        CHECK(!ctrl_regst_name.empty());
+        TaskEdge* edge = NewEdge();
+        Connect<TaskNode>(src_node, edge, dst_node);
+        src_node->BindEdgeWithProducedRegst(edge, ctrl_regst_name);
+      }
+      iter->second = dst_node;
     }
   }
 }

--- a/oneflow/core/graph/task_node.cpp
+++ b/oneflow/core/graph/task_node.cpp
@@ -239,12 +239,13 @@ int64_t TaskNode::MemZoneId121() const {
   }
 }
 
-void TaskNode::BuildCtrlRegstDescIfNeed(TaskNode* dst_node) {
-  if (IsMeaningLess() || dst_node->IsMeaningLess()) { return; }
+bool TaskNode::BuildCtrlRegstDescIfNeed(TaskNode* dst_node, std::string* name) {
+  if (IsMeaningLess() || dst_node->IsMeaningLess()) { return false; }
   for (const TaskEdge* in_edge : dst_node->in_edges()) {
-    if (in_edge->src_node() == this) { return; }
+    if (in_edge->src_node() == this) { return false; }
   }
-  BuildCtrlRegstDesc(dst_node);
+  BuildCtrlRegstDesc(dst_node, name);
+  return true;
 }
 
 RegstDesc* TaskNode::BuildCtrlRegstDesc(TaskNode* dst_node) {

--- a/oneflow/core/graph/task_node.h
+++ b/oneflow/core/graph/task_node.h
@@ -99,7 +99,7 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
   virtual bool IsIndependent() const { return false; }
   void BindEdgeWithProducedRegst(TaskEdge*, const std::string& name);
   virtual int64_t MemZoneId121() const;
-  void BuildCtrlRegstDescIfNeed(TaskNode* dst_node);
+  bool BuildCtrlRegstDescIfNeed(TaskNode* dst_node, std::string* name);
   RegstDesc* BuildCtrlRegstDesc(TaskNode* dst_node);
   RegstDesc* BuildCtrlRegstDesc(TaskNode* dst_node, std::string* name);
   std::shared_ptr<Shape> GetFastestInputOutputTimeShape() const;


### PR DESCRIPTION
`TaskGraph::BuildCtrlRegstDescInSameChain()` 中给Chain内的顺序化task node增加控制边时，之前没有实际在task graph上增加边，而是直接让src和dst node生产/消费regst，这样对于后面的图遍历（IsReachable）算法会遍历不到这些控制边新增的消费关系，这算一个BUG。