### PR TITLE
Optimize PlacementGroup

### DIFF
--- a/oneflow/core/graph/op_graph.cpp
+++ b/oneflow/core/graph/op_graph.cpp
@@ -245,6 +245,7 @@ Maybe<OpGraph> OpGraph::New(const Job& job) {
 
 Maybe<void> OpGraph::Init(const Job& job) {
   InitNodes(job);
+  op_name2op_node_.reserve(job.net().op_size());
   ForEachNode([&](OpNode* node) {
     CHECK(op_name2op_node_.emplace(node->op().op_name(), node).second)
         << "op_name: " << node->op().op_name();
@@ -274,15 +275,17 @@ void OpGraph::CheckIsDAG() const {
 namespace {
 
 std::function<std::shared_ptr<const ParallelDesc>(const std::string&)>
-MakeGetterParallelDesc4OpName(const Placement& placement) {
+MakeGetterParallelDesc4OpName(const Job& job) {
+  const Placement& placement = job.placement();
   auto op_name2parallel_desc =
       std::make_shared<HashMap<std::string, std::shared_ptr<const ParallelDesc>>>();
+  op_name2parallel_desc->reserve(job.net().op_size());
   for (const auto& placement_group : placement.placement_group()) {
+    const ParallelConf& parallel_conf = placement_group.parallel_conf();
+    std::shared_ptr<const ParallelDesc> parallel_desc =
+        std::make_shared<const ParallelDesc>(parallel_conf);
     for (const std::string& op_name : placement_group.op_set().op_name()) {
-      const ParallelConf* parallel_conf = &placement_group.parallel_conf();
-      CHECK(op_name2parallel_desc
-                ->emplace(op_name, std::make_shared<const ParallelDesc>(*parallel_conf))
-                .second)
+      CHECK(op_name2parallel_desc->emplace(op_name, parallel_desc).second)
           << "op_name: " << op_name;
     }
   }
@@ -294,7 +297,7 @@ MakeGetterParallelDesc4OpName(const Placement& placement) {
 }  // namespace
 
 void OpGraph::InitNodes(const Job& job) {
-  auto ParallelDesc4OpName = MakeGetterParallelDesc4OpName(job.placement());
+  auto ParallelDesc4OpName = MakeGetterParallelDesc4OpName(job);
   for (const auto& op_conf : job.net().op()) {
     op_names_.push_back(op_conf.name());
     OpNode* node = new OpNode(ParallelDesc4OpName(op_conf.name()), op_conf);

--- a/oneflow/core/job/job_builder.cpp
+++ b/oneflow/core/job/job_builder.cpp
@@ -105,10 +105,6 @@ JobBuilder::JobBuilder(Job* job) : job_(job) {
   bool all_ops_1d_hierarchy = true;
   FOR_RANGE(int32_t, i, 0, job->placement().placement_group_size()) {
     auto* placemnt_group = job->mutable_placement()->mutable_placement_group(i);
-    for (const auto& op_name : placemnt_group->op_set().op_name()) {
-      CHECK(
-          op_name2parallel_conf_.emplace(op_name, placemnt_group->mutable_parallel_conf()).second);
-    }
     if (placemnt_group->parallel_conf().has_hierarchy()
         && placemnt_group->parallel_conf().hierarchy().dim_size() > 1) {
       all_ops_1d_hierarchy = false;
@@ -136,6 +132,27 @@ JobBuilder::JobBuilder(Job* job) : job_(job) {
       CHECK(lbi2blob_parallel_conf_.emplace(lbi, blob_pg->mutable_parallel_conf()).second);
     }
   }
+  for (auto& placement_group : *job->mutable_placement()->mutable_placement_group()) {
+    if (placement_group.op_set().op_name().empty()) { continue; }
+    const ParallelConf& parallel_conf = placement_group.parallel_conf();
+    auto it = parallel_conf2placement_group_.find(parallel_conf);
+    if (it == parallel_conf2placement_group_.end()) {
+      parallel_conf2placement_group_.emplace(parallel_conf, &placement_group);
+      for (const auto& op_name : placement_group.op_set().op_name()) {
+        CHECK(op_name2parallel_conf_.emplace(op_name, placement_group.mutable_parallel_conf())
+                  .second);
+      }
+    } else {
+      PlacementGroup* existing_placement_group = it->second;
+      for (const auto& op_name : placement_group.op_set().op_name()) {
+        *existing_placement_group->mutable_op_set()->mutable_op_name()->Add() = op_name;
+        CHECK(op_name2parallel_conf_
+                  .emplace(op_name, existing_placement_group->mutable_parallel_conf())
+                  .second);
+      }
+      placement_group.mutable_op_set()->mutable_op_name()->Clear();
+    }
+  }
 }
 
 OperatorConf* JobBuilder::MutableOpConf4OpName(const std::string& op_name) {
@@ -155,57 +172,57 @@ const ParallelConf& JobBuilder::ParallelConf4Lbi(const LogicalBlobId& lbi) const
 }
 
 Maybe<void> JobBuilder::AddOp(const ParallelConf& parallel_conf, const OperatorConf& op_conf) {
-  auto* placemnt_group = job_->mutable_placement()->add_placement_group();
-  *placemnt_group->mutable_parallel_conf() = parallel_conf;
   CHECK_OR_RETURN(op_name2op_conf_.find(op_conf.name()) == op_name2op_conf_.end());
   OperatorConf* mut_op_conf = job_->mutable_net()->add_op();
   *mut_op_conf = op_conf;
   CHECK_OR_RETURN(op_name2op_conf_.emplace(op_conf.name(), mut_op_conf).second);
-  placemnt_group->mutable_op_set()->add_op_name(op_conf.name());
-  CHECK_OR_RETURN(
-      op_name2parallel_conf_.emplace(op_conf.name(), placemnt_group->mutable_parallel_conf())
-          .second);
+  AddOpNamesToPlacementGroup({op_conf.name()}, parallel_conf);
   return Maybe<void>::Ok();
 }
 
 void JobBuilder::AddOps(const ParallelConf& parallel_conf,
                         const std::vector<OperatorConf>& op_confs) {
   if (op_confs.empty()) { return; }
-  auto* placemnt_group = job_->mutable_placement()->add_placement_group();
-  *placemnt_group->mutable_parallel_conf() = parallel_conf;
+  std::vector<std::string> op_names;
+  op_names.reserve(op_confs.size());
   for (const auto& op_conf : op_confs) {
     CHECK(op_name2op_conf_.find(op_conf.name()) == op_name2op_conf_.end());
     OperatorConf* mut_op_conf = job_->mutable_net()->add_op();
     *mut_op_conf = op_conf;
     CHECK(op_name2op_conf_.emplace(op_conf.name(), mut_op_conf).second);
-    placemnt_group->mutable_op_set()->add_op_name(op_conf.name());
-    CHECK(op_name2parallel_conf_.emplace(op_conf.name(), placemnt_group->mutable_parallel_conf())
-              .second);
+    op_names.emplace_back(op_conf.name());
   }
+  AddOpNamesToPlacementGroup(op_names, parallel_conf);
 }
 
-PlacementGroup* JobBuilder::FindPlacementGroup(const std::string& op_name) const {
-  FOR_RANGE(int32_t, i, 0, job_->mutable_placement()->placement_group_size()) {
-    PlacementGroup* const cur_pg = job_->mutable_placement()->mutable_placement_group(i);
-    const auto& op_names = cur_pg->op_set().op_name();
-    if (std::find(op_names.begin(), op_names.end(), op_name) != op_names.end()) { return cur_pg; }
+void JobBuilder::AddOpNamesToPlacementGroup(const std::vector<std::string>& op_names,
+                                            const ParallelConf& parallel_conf) {
+  PlacementGroup* placement_group = nullptr;
+  auto it = parallel_conf2placement_group_.find(parallel_conf);
+  if (it != parallel_conf2placement_group_.end()) {
+    placement_group = it->second;
+  } else {
+    placement_group = job_->mutable_placement()->add_placement_group();
+    *placement_group->mutable_parallel_conf() = parallel_conf;
+    parallel_conf2placement_group_.emplace(parallel_conf, placement_group);
   }
-  UNIMPLEMENTED();
-  return nullptr;
+  for (const auto& op_name : op_names) {
+    placement_group->mutable_op_set()->add_op_name(op_name);
+    CHECK(op_name2parallel_conf_.emplace(op_name, placement_group->mutable_parallel_conf()).second);
+  }
 }
 
 void JobBuilder::MutParallelConfOnlyOnce(const std::string& op_name,
                                          const ParallelConf& parallel_conf) {
   CHECK(modified_parallel_conf_op_names_.emplace(op_name).second);
-  PlacementGroup* placement_group = FindPlacementGroup(op_name);
-  {
-    auto* const op_names = placement_group->mutable_op_set()->mutable_op_name();
-    Erase<PbRpf<std::string>>(*op_names, [&](const std::string& x) { return x == op_name; });
-    Placement* const placement = job_->mutable_placement();
-    if (op_names->size() > 0) { placement_group = placement->mutable_placement_group()->Add(); }
-  }
-  placement_group->mutable_op_set()->add_op_name(op_name);
-  *placement_group->mutable_parallel_conf() = parallel_conf;
+  const auto& parallel_conf_it = op_name2parallel_conf_.find(op_name);
+  CHECK(parallel_conf_it != op_name2parallel_conf_.end());
+  auto old_placement_group_it = parallel_conf2placement_group_.find(*parallel_conf_it->second);
+  CHECK(old_placement_group_it != parallel_conf2placement_group_.end());
+  op_name2parallel_conf_.erase(parallel_conf_it);
+  Erase<PbRpf<std::string>>(*old_placement_group_it->second->mutable_op_set()->mutable_op_name(),
+                            [&](const std::string& x) { return x == op_name; });
+  AddOpNamesToPlacementGroup({op_name}, parallel_conf);
 }
 
 void JobBuilder::RemoveOpByName(const std::string& op_name) {
@@ -263,6 +280,7 @@ void JobBuilder::RemoveOpByName(const std::unordered_set<std::string>& removing_
   op_name2parallel_conf_.swap(builder.op_name2parallel_conf_);
   op_name2parallel_distribution_signature_conf_.swap(
       builder.op_name2parallel_distribution_signature_conf_);
+  parallel_conf2placement_group_.swap(builder.parallel_conf2placement_group_);
 }
 
 void JobBuilder::DelOps(const std::vector<std::string>& op_names) {
@@ -319,18 +337,6 @@ const ParallelConf& JobBuilder::ParallelConf4OpName(const std::string& op_name) 
   const auto& iter = op_name2parallel_conf_.find(op_name);
   CHECK(iter != op_name2parallel_conf_.end());
   return *iter->second;
-}
-
-void JobBuilder::AddParallelConf4OpName(const std::string& op_name,
-                                        const ParallelConf& parallel_conf) {
-  bool update = (op_name2parallel_conf_.count(op_name) == 0);
-  if (update) {
-    // update `op_name2parallel_conf_`
-    PlacementGroup* group = job_->mutable_placement()->add_placement_group();
-    group->mutable_op_set()->add_op_name(op_name);
-    *(group->mutable_parallel_conf()) = parallel_conf;
-    op_name2parallel_conf_[op_name] = group->mutable_parallel_conf();
-  }
 }
 
 SbpParallel* JobBuilder::MutSbpParallel4Oba(const OpBlobArg& oba) const {

--- a/oneflow/core/job/job_builder.h
+++ b/oneflow/core/job/job_builder.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "oneflow/core/job/job_desc.h"
 #include "oneflow/core/register/op_blob_arg.pb.h"
+#include "oneflow/core/job/parallel_desc.h"
 
 namespace oneflow {
 
@@ -67,7 +68,6 @@ class JobBuilder final {
 
   const ParallelConf& ParallelConf4Lbi(const LogicalBlobId& lbi) const;
   const ParallelConf& ParallelConf4OpName(const std::string& op_name) const;
-  void AddParallelConf4OpName(const std::string& op_name, const ParallelConf& parallel_conf);
 
   const SbpSignature SbpSignature4OpName(const std::string& op_name) const;
   void AddSbpSignature4OpName(const std::string& op_name, const SbpSignature& sbp_signature);
@@ -79,7 +79,8 @@ class JobBuilder final {
       const ParallelDistributionSignature& parallel_distribution_signature);
 
  private:
-  PlacementGroup* FindPlacementGroup(const std::string& op_name) const;
+  void AddOpNamesToPlacementGroup(const std::vector<std::string>& op_names,
+                                  const ParallelConf& parallel_conf);
 
   Job* job_;
   HashMap<std::string, OperatorConf*> op_name2op_conf_;
@@ -90,6 +91,7 @@ class JobBuilder final {
 
   HashMap<std::string, ParallelDistributionSignature*>
       op_name2parallel_distribution_signature_conf_;
+  HashMap<ParallelConf, PlacementGroup*> parallel_conf2placement_group_;
 };
 
 }  // namespace oneflow

--- a/oneflow/core/job/parallel_desc.cpp
+++ b/oneflow/core/job/parallel_desc.cpp
@@ -130,8 +130,9 @@ Maybe<void> ParallelDesc::GetParallelContext(ParallelContext* parallel_ctx, int6
 }
 
 bool ParallelDesc::Equals(const ParallelDesc& rhs) const {
-  return device_type_ == rhs.device_type_ && sorted_machine_ids_ == rhs.sorted_machine_ids_
-         && EqualsMachineId2SortedDevPhyIds(rhs) && *hierarchy_ == *rhs.hierarchy_;
+  return (this == &rhs)
+         || (device_type_ == rhs.device_type_ && sorted_machine_ids_ == rhs.sorted_machine_ids_
+             && EqualsMachineId2SortedDevPhyIds(rhs) && *hierarchy_ == *rhs.hierarchy_);
 }
 
 bool ParallelDesc::EqualsIgnoringDeviceType(const ParallelDesc& rhs) const {


### PR DESCRIPTION
尽量将placement相同的op放到相同的placement group里面，可以减少ParallelDesc的构造次数，以及加快ParallelDesc的比较