### PR TITLE
Remove RegstDesc::Lock() and TaskNode::LockRegst()

### DIFF
--- a/oneflow/core/graph/normal_forward_compute_task_node.h
+++ b/oneflow/core/graph/normal_forward_compute_task_node.h
@@ -28,10 +28,8 @@ class NormalForwardCompTaskNode final : public CompTaskNode {
 
   void ProduceAllRegstsAndBindEdges() override;
   void ConsumeAllRegsts() override;
-  bool IsReadyForBuild() override;
 
   TaskType GetTaskType() const override { return TaskType::kNormalForward; }
-  bool HasBackwardCompTaskNode();
 
  private:
   void ProduceOutRegstByNameAndBlockNum(const std::string& name, size_t mem_block_num);

--- a/oneflow/core/graph/task_node.h
+++ b/oneflow/core/graph/task_node.h
@@ -84,7 +84,6 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
   void ForEachConsumedDataRegst(
       const std::function<void(const std::string&, const RegstDesc*)>& Handler) const;
   void Build();
-  virtual bool IsReadyForBuild() { return IsAllConsumedDataRegstLocked(); }
 
   void EraseZeroSizeProducedBlob();
   void EraseZeroSizeConsumedRegst();
@@ -130,13 +129,10 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
   virtual void PinConsumedRegstMemCase(MemoryCase*);
   void ConsumeRegst(const std::string& name);
   void ConsumeRegst(const std::string& name, const std::shared_ptr<RegstDesc>&);
-  bool IsAllConsumedDataRegstLocked();
   ExecGraph& mut_exec_gph() { return exec_gph_; }
-  void TryLockConsumedRegst(const std::string& name);
   void EraseConsumedRegstsByName(const std::string& name);
 
   virtual void BuildExecGphAndRegst() = 0;
-  virtual void LockRegsts();
 
   virtual void InferProducedDataRegstTimeShape() = 0;
   void NaiveInferProducedDataRegstTimeShape();

--- a/oneflow/core/graph_impl/distribute_concat_compute_task_node.cpp
+++ b/oneflow/core/graph_impl/distribute_concat_compute_task_node.cpp
@@ -27,18 +27,14 @@ class DistributeConcatCompTaskNode final : public CompTaskNode {
 
   void ProduceAllRegstsAndBindEdges() override;
   void ConsumeAllRegsts() override;
-  bool IsReadyForBuild() override;
 
   TaskType GetTaskType() const override { return TaskType::kDistributeConcat; }
-  bool HasBackwardCompTaskNode();
 
  private:
   void BuildExecGphAndRegst() override;
   void BuildExecGphStructAndBindInRegst();
   void BuildOutRegst();
 };
-
-bool DistributeConcatCompTaskNode::HasBackwardCompTaskNode() { return false; }
 
 void DistributeConcatCompTaskNode::ProduceAllRegstsAndBindEdges() {
   ProduceRegst("out", true);
@@ -52,10 +48,6 @@ void DistributeConcatCompTaskNode::ConsumeAllRegsts() {
     ConsumeRegst("in", edge->GetSoleRegst());
   });
   CHECK_EQ(cnt, 1);
-}
-
-bool DistributeConcatCompTaskNode::IsReadyForBuild() {
-  return GetSoleConsumedRegst("in")->IsLocked();
 }
 
 void DistributeConcatCompTaskNode::BuildExecGphAndRegst() {

--- a/oneflow/core/graph_impl/distribute_split_compute_task_node.cpp
+++ b/oneflow/core/graph_impl/distribute_split_compute_task_node.cpp
@@ -27,18 +27,14 @@ class DistributeSplitCompTaskNode final : public CompTaskNode {
 
   void ProduceAllRegstsAndBindEdges() override;
   void ConsumeAllRegsts() override;
-  bool IsReadyForBuild() override;
 
   TaskType GetTaskType() const override { return TaskType::kDistributeSplit; }
-  bool HasBackwardCompTaskNode();
 
  private:
   void BuildExecGphAndRegst() override;
   void BuildExecGphStructAndBindInRegst();
   void BuildOutRegst();
 };
-
-bool DistributeSplitCompTaskNode::HasBackwardCompTaskNode() { return false; }
 
 void DistributeSplitCompTaskNode::ProduceAllRegstsAndBindEdges() {
   ProduceRegst("out", true);
@@ -47,10 +43,6 @@ void DistributeSplitCompTaskNode::ProduceAllRegstsAndBindEdges() {
 
 void DistributeSplitCompTaskNode::ConsumeAllRegsts() {
   ForEachInDataEdge([&](TaskEdge* edge) { ConsumeRegst("in", edge->GetSoleRegst()); });
-}
-
-bool DistributeSplitCompTaskNode::IsReadyForBuild() {
-  return GetSoleConsumedRegst("in")->IsLocked();
 }
 
 void DistributeSplitCompTaskNode::BuildExecGphAndRegst() {

--- a/oneflow/core/graph_impl/normal_forward_compute_task_node.cpp
+++ b/oneflow/core/graph_impl/normal_forward_compute_task_node.cpp
@@ -36,8 +36,6 @@ std::string GetOutRegstNameByObn(const std::string& obn) { return "__" + obn; }
 
 }  // namespace
 
-bool NormalForwardCompTaskNode::HasBackwardCompTaskNode() { return false; }
-
 void NormalForwardCompTaskNode::ProduceOutRegstByNameAndBlockNum(const std::string& name,
                                                                  size_t mem_block_num) {
   if (mem_block_num != -1) {
@@ -83,13 +81,6 @@ void NormalForwardCompTaskNode::ConsumeAllRegsts() {
   ForEachInDataEdge([&](TaskEdge* edge) {
     for (const auto& regst : edge->GetRegsts()) { ConsumeRegst("in", regst); }
   });
-}
-
-bool NormalForwardCompTaskNode::IsReadyForBuild() {
-  for (std::shared_ptr<RegstDesc> regst_desc : GetConsumedRegst("in")) {
-    if (regst_desc->IsLocked() == false) { return false; }
-  }
-  return true;
 }
 
 void NormalForwardCompTaskNode::BuildExecGphAndRegst() {

--- a/oneflow/core/register/register_desc.cpp
+++ b/oneflow/core/register/register_desc.cpp
@@ -27,7 +27,6 @@ RegstDesc::RegstDesc() {
   producer_ = nullptr;
   min_register_num_ = 1;
   max_register_num_ = kMaxRegisterNum;
-  is_locked_ = false;
   enable_reuse_mem_ = false;
   mem_block_id_ = -1;
   mem_block_offset_ = -1;
@@ -57,13 +56,7 @@ void RegstDesc::UpdtMaxRegstNumIfNeed(int32_t val) {
   max_register_num_ = std::min(max_register_num_, val);
 }
 
-void RegstDesc::Lock() {
-  CHECK_EQ(is_locked_, false);
-  is_locked_ = true;
-}
-
 void RegstDesc::CopyBlobDescFrom(const RegstDesc* rhs) {
-  CHECK_EQ(is_locked_, false);
   CHECK(lbi2blob_desc_.empty());
   for (const auto& pair : rhs->lbi2blob_desc_) {
     const LogicalBlobId& lbi = pair.first;
@@ -79,7 +72,6 @@ void RegstDesc::CopyMemBlockInfoFrom(const RegstDesc* rhs) {
 }
 
 void RegstDesc::CopyBlobDescWithoutAddLbi(const RegstDesc* rhs) {
-  CHECK_EQ(is_locked_, false);
   for (const auto& pair : lbi2blob_desc_) {
     auto rhs_it = rhs->lbi2blob_desc_.find(pair.first);
     if (rhs_it != rhs->lbi2blob_desc_.end()) { *(pair.second) = *(rhs_it->second); }
@@ -87,7 +79,6 @@ void RegstDesc::CopyBlobDescWithoutAddLbi(const RegstDesc* rhs) {
 }
 
 BlobDesc* RegstDesc::AddLbi(const LogicalBlobId& lbi) {
-  CHECK_EQ(is_locked_, false);
   CHECK(lbi2blob_desc_.find(lbi) == lbi2blob_desc_.end());
   BlobDesc* blob_desc = new BlobDesc(GlobalJobDesc().DefaultDataType());
   lbi2blob_desc_[lbi].reset(blob_desc);

--- a/oneflow/core/register/register_desc.h
+++ b/oneflow/core/register/register_desc.h
@@ -51,8 +51,6 @@ class RegstDesc final {
   void UpdtMaxRegstNumIfNeed(int32_t val);
 
   // lbi2blob_desc_
-  bool IsLocked() const { return is_locked_; }
-  void Lock();
   void CopyBlobDescFrom(const RegstDesc*);
   void CopyBlobDescWithoutAddLbi(const RegstDesc*);
   BlobDesc* AddLbi(const LogicalBlobId&);
@@ -113,7 +111,6 @@ class RegstDesc final {
   int32_t max_register_num_;
 
   HashMap<LogicalBlobId, std::unique_ptr<BlobDesc>> lbi2blob_desc_;
-  bool is_locked_;
 
   MemoryCase mem_case_;
   RegstDescTypeProto regst_desc_type_;


### PR DESCRIPTION

移除过时的Regst.is_locked 逻辑。该逻辑之前是为了一个Regst多个Blob需要加上Lock之后去计算PackedBlob。

- [x] 移除RegstDesc::Lock() & RegstDesc::IsLocked()
- [x] 移除TaskNode::LockRegsts(), TryLockConsumedRegst(), IsAllConsumedDataRegstLocked(), IsReadyForBuild()
- [x] 移除没有意义的 NormalForward/DisConcat/DisSplit::HasBackwardCompTaskNode()