### PR TITLE
fix_multi_node_dead_lock_bug

### DIFF
--- a/oneflow/core/actor/actor_message.cpp
+++ b/oneflow/core/actor/actor_message.cpp
@@ -60,6 +60,7 @@ ActorMsg ActorMsg::BuildRegstMsgToProducer(int64_t consumer, int64_t producer,
   msg.dst_actor_id_ = producer;
   msg.msg_type_ = ActorMsgType::kRegstMsg;
   msg.regst_wrapper_.regst = regst_raw_ptr;
+  msg.regst_wrapper_.regst_status.regst_desc_id = -1;
   msg.regst_wrapper_.comm_net_token = nullptr;
   // you can NOT access the regst ptr when multi nodes, because the address is in another machine
   msg.regst_wrapper_.has_sole_empty_blob = false;


### PR DESCRIPTION
 解决gcc 7.3 编译时，test_assign.py 多机测试退出时死锁的bug