### PR TITLE
enable sharing shape between BlobDescs

### DIFF
--- a/oneflow/core/eager/blob_object.h
+++ b/oneflow/core/eager/blob_object.h
@@ -28,8 +28,9 @@ namespace eager {
 
 class BlobObject : public vm::Object {
  public:
-  BlobObject(const std::shared_ptr<MemoryCase>& mem_case, DataType data_type)
-      : mem_case_(mem_case), blob_desc_(data_type) {}
+  BlobObject(const std::shared_ptr<MemoryCase>& mem_case, const std::shared_ptr<Shape>& shape,
+             DataType data_type)
+      : mem_case_(mem_case), blob_desc_(shape, data_type) {}
   BlobObject(const BlobObject&) = delete;
   BlobObject(BlobObject&&) = delete;
   virtual ~BlobObject() override = default;

--- a/oneflow/core/eager/eager_blob_object.h
+++ b/oneflow/core/eager/eager_blob_object.h
@@ -28,8 +28,9 @@ class EagerBlobObject : public BlobObject {
  public:
   EagerBlobObject(const EagerBlobObject&) = delete;
   EagerBlobObject(EagerBlobObject&&) = delete;
-  EagerBlobObject(const std::shared_ptr<MemoryCase>& mem_case, DataType data_type)
-      : BlobObject(mem_case, data_type), blob_body_bytes_(0) {}
+  EagerBlobObject(const std::shared_ptr<MemoryCase>& mem_case, const std::shared_ptr<Shape>& shape,
+                  DataType data_type)
+      : BlobObject(mem_case, shape, data_type), blob_body_bytes_(0) {}
   virtual ~EagerBlobObject() override = default;
 
   virtual BlobDesc* mut_blob_desc() override { return &blob_desc_; }

--- a/oneflow/core/eager/lazy_ref_blob_object.h
+++ b/oneflow/core/eager/lazy_ref_blob_object.h
@@ -26,7 +26,8 @@ class LazyRefBlobObject : public BlobObject {
   LazyRefBlobObject(const LazyRefBlobObject&) = delete;
   LazyRefBlobObject(LazyRefBlobObject&&) = delete;
   LazyRefBlobObject(Blob* blob)
-      : BlobObject(std::make_shared<MemoryCase>(blob->mem_case()), blob->data_type()) {
+      : BlobObject(std::make_shared<MemoryCase>(blob->mem_case()),
+                   std::make_shared<Shape>(blob->static_shape()), blob->data_type()) {
     const auto& rt_blob_desc = blob->blob_desc();
     blob_desc_ = BlobDesc(rt_blob_desc.body(), rt_blob_desc.is_dynamic());
     ref_blob_ = blob;

--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -262,7 +262,7 @@ void InitOutputBlobObjects(vm::Instruction* instruction, const T& args,
       // mutable input
       CHECK(rw_mutexed_object->Has<BlobObject>());
     } else {
-      rw_mutexed_object->Init<EagerBlobObject>(mem_case, data_type);
+      rw_mutexed_object->Init<EagerBlobObject>(mem_case, std::make_shared<Shape>(), data_type);
     }
   };
   FOR_RANGE(int, i, 0, args.output_blob_size()) {

--- a/oneflow/core/register/blob_desc.cpp
+++ b/oneflow/core/register/blob_desc.cpp
@@ -23,7 +23,10 @@ bool CompareLbiBlobDescPair(const LbiBlobDescPair& lhs, const LbiBlobDescPair& r
   return lhs.lbi() < rhs.lbi();
 }
 
-BlobDesc::BlobDesc(const Shape& shape, DataType dtype) : body_(shape, dtype), is_dynamic_(false) {}
+BlobDesc::BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype)
+    : body_(shape, dtype), is_dynamic_(false) {}
+BlobDesc::BlobDesc(const Shape& shape, DataType dtype)
+    : BlobDesc(std::make_shared<Shape>(shape), dtype) {}
 
 BlobDesc::BlobDesc(const BlobDescProto& proto) { InitFromProto(proto); }
 
@@ -39,8 +42,9 @@ void BlobDesc::ToProto(BlobDescProto* proto) const {
   proto->set_is_dynamic(is_dynamic_);
 
   StructPodDesc header;
-  header.AddField(FieldKey::kTensorShape,
-                  TensorPodDesc(Shape(DimVector{shape().NumAxes()}), DataType::kInt64));
+  header.AddField(
+      FieldKey::kTensorShape,
+      TensorPodDesc(std::make_shared<Shape>(DimVector{shape().NumAxes()}), DataType::kInt64));
   header.ToProto(proto->mutable_header());
 }
 

--- a/oneflow/core/register/blob_desc.h
+++ b/oneflow/core/register/blob_desc.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef ONEFLOW_CORE_REGISTER_BLOB_DESC_H_
 #define ONEFLOW_CORE_REGISTER_BLOB_DESC_H_
 
+#include <memory>
 #include "oneflow/core/common/data_type.h"
 #include "oneflow/core/common/shape.h"
 #include "oneflow/core/common/maybe.h"
@@ -30,6 +31,7 @@ class BlobDesc final {
   BlobDesc() = delete;
   ~BlobDesc() = default;
   BlobDesc(const Shape&, DataType);
+  BlobDesc(const std::shared_ptr<Shape>&, DataType);
   explicit BlobDesc(DataType dtype) : BlobDesc(Shape(), dtype) {}
   explicit BlobDesc(const BlobDescProto& proto);
   explicit BlobDesc(const BlobDesc&);

--- a/oneflow/core/register/pod_desc.cpp
+++ b/oneflow/core/register/pod_desc.cpp
@@ -41,20 +41,26 @@ FieldId NewFieldId(const LogicalBlobId& lbi) {
   return ret;
 }
 
-TensorPodDesc::TensorPodDesc(const TensorPodProto& tensor_pod) { InitFromProto(tensor_pod); }
+TensorPodDesc::TensorPodDesc(const TensorPodProto& tensor_pod) {
+  shape_ = std::make_shared<Shape>();
+  InitFromProto(tensor_pod);
+}
 
 TensorPodDesc::TensorPodDesc(const TensorPodDesc& tensor_pod) {
+  shape_ = std::make_shared<Shape>();
   PodProto pod_proto;
   tensor_pod.ToProto(&pod_proto);
   InitFromProto(pod_proto.tensor_pod());
 }
 
 void TensorPodDesc::InitFromProto(const TensorPodProto& tensor_pod) {
-  shape_ = Shape(tensor_pod.shape());
+  *mut_shape() = Shape(tensor_pod.shape());
   data_type_ = tensor_pod.data_type();
 }
 
-size_t TensorPodDesc::ByteSize() const { return shape_.elem_cnt() * GetSizeOfDataType(data_type_); }
+size_t TensorPodDesc::ByteSize() const {
+  return shape().elem_cnt() * GetSizeOfDataType(data_type_);
+}
 
 bool TensorPodDesc::operator==(const PodDesc& rhs) const {
   const auto* tensor_rhs = dynamic_cast<const TensorPodDesc*>(&rhs);
@@ -65,7 +71,7 @@ bool TensorPodDesc::operator==(const PodDesc& rhs) const {
 void TensorPodDesc::ToProto(PodProto* pod_proto) const { ToProto(pod_proto->mutable_tensor_pod()); }
 
 void TensorPodDesc::ToProto(TensorPodProto* proto) const {
-  shape_.ToProto(proto->mutable_shape());
+  shape().ToProto(proto->mutable_shape());
   proto->set_data_type(data_type_);
 }
 

--- a/oneflow/core/register/pod_desc.h
+++ b/oneflow/core/register/pod_desc.h
@@ -64,14 +64,15 @@ class PodDesc {
 
 class TensorPodDesc final : public PodDesc {
  public:
-  TensorPodDesc() = default;
-  TensorPodDesc(const Shape& shape, DataType data_type) : shape_(shape), data_type_(data_type) {}
+  TensorPodDesc() : PodDesc(), shape_(std::make_shared<Shape>()), data_type_(kInvalidDataType) {}
+  TensorPodDesc(const std::shared_ptr<Shape>& shape, DataType data_type)
+      : PodDesc(), shape_(shape), data_type_(data_type) {}
   explicit TensorPodDesc(const TensorPodProto& shape_pod_proto);
   explicit TensorPodDesc(const TensorPodDesc& shape_pod);
   ~TensorPodDesc() = default;
-  const Shape& shape() const { return shape_; }
+  const Shape& shape() const { return *shape_; }
   DataType data_type() const { return data_type_; }
-  Shape* mut_shape() { return &shape_; }
+  Shape* mut_shape() { return shape_.get(); }
   void set_data_type(DataType data_type) { data_type_ = data_type; }
 
   void InitFromProto(const TensorPodProto& shape_pod);
@@ -83,7 +84,7 @@ class TensorPodDesc final : public PodDesc {
   bool operator==(const PodDesc& rhs) const override;
 
  private:
-  Shape shape_;
+  std::shared_ptr<Shape> shape_;
   DataType data_type_;
 };
 


### PR DESCRIPTION
本pr变TensorDesc的shape的类型为std::shared_ptr<Shape>
后续的代码需要让TensorImpl的对象和BlobDesc的对象共享Shape对象。
