### PR TITLE
[WIP]trace demo

### DIFF
--- a/oneflow/python/framework/compiler_util.py
+++ b/oneflow/python/framework/compiler_util.py
@@ -1,0 +1,75 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import absolute_import
+
+import inspect
+from typing import Callable, Union
+
+import oneflow.python.framework.session_context as session_ctx
+import oneflow.python.framework.typing_util as oft_util
+from oneflow.python.framework.function_util import (
+    FunctionConfig as ExecutionConfig,
+    _CloneFunctionDesc,
+)
+from oneflow.python.framework.env_util import api_enable_eager_execution
+from oneflow.python.oneflow_export import oneflow_export
+
+
+class GraphFunction(object):
+    def __init__(self, func=None, function_config=ExecutionConfig()):
+        assert func is not None
+        self._func = func
+        if not hasattr(self._func, "__oneflow_function_signature__"):
+            self._func.__oneflow_function_signature__ = inspect.signature(func)
+        oft_util.CheckGlobalFunctionAnnotation(
+            self._func.__oneflow_function_signature__
+        )
+        self._sess = session_ctx.GetDefaultSession()
+        self._sess.AddJob(_CloneFunctionDesc(function_config.function_desc, self._func))
+
+    def __call__(self, *args, **kwargs):
+        return self._sess.TryInit().LazyRun(self._func, *args, **kwargs)
+
+
+@oneflow_export("compiler.trace")
+def compiler_trace(
+    func=None, *, execution_config: ExecutionConfig = None, type: str = "predict",
+) -> Union[Callable[[Callable], GraphFunction], GraphFunction]:
+    api_enable_eager_execution(False)
+    if execution_config is None:
+        execution_config = ExecutionConfig()
+    if type == "train":
+        execution_config.function_desc.job_config_proto.mutable_train_conf()
+    else:
+        execution_config.function_desc.job_config_proto.mutable_predict_conf()
+    # TODO(): rm type
+    assert type in ["train", "predict"]
+    if func is None:
+        # Using compile_trace as decorator
+        return _graph_function_deco(execution_config)
+    else:
+        # Using compile_trace as function
+        return _graph_function_deco(execution_config)(func)
+
+
+def _graph_function_deco(function_config=ExecutionConfig()):
+    assert isinstance(function_config, ExecutionConfig)
+
+    def _decorator(func):
+        graph_func = GraphFunction(func, function_config)
+        return graph_func
+
+    return _decorator

--- a/oneflow/python/framework/function_util.py
+++ b/oneflow/python/framework/function_util.py
@@ -33,7 +33,6 @@ import oneflow.python.framework.placement_context as placement_ctx
 import oneflow.python.framework.typing_util as oft_util
 import oneflow.python.framework.runtime_mode as rt_mode
 import oneflow.python.lib.core.pb_util as pb_util
-from oneflow.python.framework.function_desc import FunctionDesc
 from oneflow.python.oneflow_export import oneflow_export
 import oneflow_api.oneflow.core.common.data_type as data_type_cfg
 import oneflow_api

--- a/oneflow/python/test/ops/test_compiler_util.py
+++ b/oneflow/python/test/ops/test_compiler_util.py
@@ -1,0 +1,85 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+import os
+from collections import OrderedDict
+
+import numpy as np
+import oneflow as flow
+import test_global_storage
+from test_util import GenArgList, type_name_to_flow_type
+
+
+def run_leaky_relu(device_type, x_shape, data_type, alpha, use_deco=True):
+    assert device_type in ["gpu", "cpu"]
+    flow.clear_default_session()
+    exe_config = flow.ExecutionConfig()
+    exe_config.default_data_type(flow.float)
+
+    leaky_relu_graph_func = None
+
+    def func():
+        with flow.scope.placement(device_type, "0:0"):
+            x = flow.get_variable(
+                "x",
+                shape=x_shape,
+                dtype=type_name_to_flow_type[data_type],
+                initializer=flow.constant_initializer(-0.5),
+                trainable=True,
+            )
+            loss = flow.nn.leaky_relu(x, alpha=alpha)
+            flow.optimizer.SGD(
+                flow.optimizer.PiecewiseConstantScheduler([], [1e-4]), momentum=0
+            ).minimize(loss)
+
+            flow.watch(x, test_global_storage.Setter("x"))
+            flow.watch_diff(x, test_global_storage.Setter("x_diff"))
+            flow.watch(loss, test_global_storage.Setter("loss"))
+            flow.watch_diff(loss, test_global_storage.Setter("loss_diff"))
+
+            return loss
+
+    if use_deco:
+
+        @flow.compiler.trace(type="train", execution_config=exe_config)
+        def LeakyReluFunc():
+            return func()
+
+        leaky_relu_graph_func = LeakyReluFunc
+    else:
+        leaky_relu_graph_func = flow.compiler.trace(
+            func, type="train", execution_config=exe_config
+        )
+
+    of_out = leaky_relu_graph_func().get()
+    loss_diff = test_global_storage.Get("loss_diff")
+    assert np.allclose(of_out.numpy(), np.full(x_shape, -0.05), rtol=1e-5, atol=1e-5)
+    assert np.allclose(
+        test_global_storage.Get("x_diff"), np.full(x_shape, 0.1), rtol=1e-5, atol=1e-5
+    )
+
+
+@flow.unittest.skip_unless_1n1d()
+class TestTrace(flow.unittest.TestCase):
+    def test_trace_decorator(test_case):
+        run_leaky_relu("cpu", (1, 2), "float32", 0.1, True)
+
+    def test_trace_function(test_case):
+        run_leaky_relu("cpu", (1, 2), "float32", 0.1, False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
eager 的代码在往不依赖global_function就可以执行的方向演化。

eager切换到lazy，有两种方式，一种是一键切换，一种是增量开发。

一键切换：
- 代码一样，eager lazy都使用类似global_function的方式定义，lazy执行需要的信息eager也准备好；
- eager和lazy会有相互制约；
- 有不一致的地方在一键切换的设定下不好处理；

增量开发：
- 默认是eager模式，可以定义和执行eager代码；
- eager的代码经过wrap处理后，就能变成lazy代码去执行；
- eager和lazy可以组合执行的一个起点；

这里尝试做个“增量开发”的方式的demo。