### PR TITLE
Remove outdate PrintSbpLog in test_ops.cpp

### DIFF
--- a/oneflow/user/ops/test_ops.cpp
+++ b/oneflow/user/ops/test_ops.cpp
@@ -18,29 +18,6 @@ limitations under the License.
 
 namespace oneflow {
 
-namespace {
-
-void PrintSbpLog(SbpSignatureList* sbp_list) {
-  for (const auto& sbp_sign : sbp_list->sbp_signature()) {
-    std::cout << "cclog: one sbp sign: ";
-    for (const auto& pair : sbp_sign.bn_in_op2sbp_parallel()) {
-      std::cout << " bn: " << pair.first;
-      if (pair.second.has_split_parallel()) {
-        std::cout << " Split axis = " << pair.second.split_parallel().axis();
-      } else if (pair.second.has_broadcast_parallel()) {
-        std::cout << " Broadcast ";
-      } else if (pair.second.has_partial_sum_parallel()) {
-        std::cout << " PartialSum ";
-      } else {
-        std::cout << " ERROR !";
-      }
-    }
-    std::cout << std::endl;
-  }
-}
-
-}  // namespace
-
 REGISTER_USER_OP("ccrelu")
     .Input("in")
     .Output("out")


### PR DESCRIPTION
移除`oneflow/user/ops/test_ops.cpp`中的无用代码 PrintSbpLog 