### PR TITLE
model inherit new module

### DIFF
--- a/oneflow/python/framework/model.py
+++ b/oneflow/python/framework/model.py
@@ -52,7 +52,7 @@ class DataModule(Module):
     def __init__(self, *args, **kwargs):
         super().__init__()
 
-    def forward(self, *args):
+    def forward(self):
         # Do nothing, to be overrided by subclass.
         pass
 
@@ -236,7 +236,7 @@ class Model(
     def forward(self, *args, **kwargs):
         r"""Same as `nn.Module.forward()`, here is to define the operations you want to use for prediction.
         """
-        return super().forward(*args, **kwargs)
+        raise NotImplementedError
 
     def training_step(self, *args, **kwargs):
         r"""Operates on a single batch of data from the training set and return loss.

--- a/oneflow/python/framework/model.py
+++ b/oneflow/python/framework/model.py
@@ -39,7 +39,7 @@ from oneflow.python.framework.check_point_v2 import (
 from oneflow.python.framework.function_util import api_oneflow_function
 from oneflow.python.framework.function_util import FunctionConfig as ExecutionConfig
 from oneflow.python.framework.local_blob import LocalBlob
-from oneflow.python.framework.module import Module as DeprecatedModule
+from oneflow.python.nn.module import Module
 from oneflow.python.framework.session_util import api_clear_default_session
 from oneflow.python.oneflow_export import oneflow_export
 from oneflow.python.ops.optimizer import Optimizer
@@ -48,7 +48,7 @@ import oneflow.python.framework.dtype as dtype_util
 
 
 @oneflow_export("model.DataModule")
-class DataModule(DeprecatedModule):
+class DataModule(Module):
     def __init__(self, *args, **kwargs):
         super().__init__()
 
@@ -70,6 +70,10 @@ class NumpyDataModule(DataModule):
     def forward(self, step_idx: int = 0, optimizer_idx: int = 0):
         # Do nothing, to be overrided by subclass.
         pass
+
+    def __call__(self, *args):
+        ret = self.forward(*args)
+        return ret
 
     def infer_oneflow_data_placeholder(
         self, batch: Tuple[np.ndarray, ...] = None, optimizer_idx: int = 0
@@ -213,7 +217,7 @@ class Callback(ABC):
 
 @oneflow_export("Model", "model.Model")
 class Model(
-    ABC, DeprecatedModule,
+    ABC, Module,
 ):
     r"""A high level API for model training and validation.
     """


### PR DESCRIPTION
oneflow.Model继承oneflow.nn.Module。当前只依赖其 `__call__`重载；如果采用numpy输入，无需构建job。