### PR TITLE
widening_type_cast_pass use hierarchical_parallel_cast

### DIFF
--- a/oneflow/core/job_rewriter/do_parallel_cast_before_widening_type_cast_pass.cpp
+++ b/oneflow/core/job_rewriter/do_parallel_cast_before_widening_type_cast_pass.cpp
@@ -48,7 +48,9 @@ Maybe<void> DoParallelCastBeforeWideningTypeCast::Apply(const OpGraph& op_graph,
     const OperatorConf& parallel_cast_op_conf =
         op_conf_cache.GetLatest(parallel_cast_node->op().op_conf());
     if (!(parallel_cast_op_conf.has_user_conf()
-          && parallel_cast_op_conf.user_conf().op_type_name() == "parallel_cast")) {
+          && (parallel_cast_op_conf.user_conf().op_type_name() == "parallel_cast"
+              || parallel_cast_op_conf.user_conf().op_type_name()
+                     == "hierarchical_parallel_cast"))) {
       return;
     }
     auto* cast_node = parallel_cast_node->SoleInEdge()->src_node();


### PR DESCRIPTION
修复在将variable diff的parallel_cast替换成hierarchical_parallel_cast后造成了pass无法识别op的问题