### PR TITLE
Check and complete op_conf.scope_symbol_id in JobPass

### DIFF
--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -821,6 +821,7 @@ Maybe<void> JobBuildAndInferCtx::CheckOpScope() const {
                    << " net. \n op_conf = " << op_conf.DebugString();
     }
   }
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> JobBuildAndInferCtx::CheckLbnValidAndExist(const std::string& lbn) const {
@@ -999,6 +1000,7 @@ Maybe<void> LazyJobBuildAndInferCtx::Complete() {
     JUST(DoPass("DumpVariableInfoPass"));
   }
   JUST(DoPass("DumpBlobParallelConfPass"));
+  JUST(CheckJob());
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -812,12 +812,12 @@ Maybe<void> JobBuildAndInferCtx::CheckJobConf() const {
   return Maybe<void>::Ok();
 }
 
-Maybe<void> CheckOpScope() const {
-   for (const OperatorConf& op_conf : job_->net().op()) {
+Maybe<void> JobBuildAndInferCtx::CheckOpScope() const {
+  for (const OperatorConf& op_conf : job_->net().op()) {
     CHECK_OR_RETURN(op_conf.has_scope_symbol_id())
         << " ERROR! op_name: " << op_conf.name()
-        << " has NOT set scope(scope_symbol_id) in job: " << job_->job_conf().job_name() << " net. \n op_conf = "
-        << op_conf.DebugString();
+        << " has NOT set scope(scope_symbol_id) in job: " << job_->job_conf().job_name()
+        << " net. \n op_conf = " << op_conf.DebugString();
   }
 }
 

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -814,10 +814,12 @@ Maybe<void> JobBuildAndInferCtx::CheckJobConf() const {
 
 Maybe<void> JobBuildAndInferCtx::CheckOpScope() const {
   for (const OperatorConf& op_conf : job_->net().op()) {
-    CHECK_OR_RETURN(op_conf.has_scope_symbol_id())
-        << " ERROR! op_name: " << op_conf.name()
-        << " has NOT set scope(scope_symbol_id) in job: " << job_->job_conf().job_name()
-        << " net. \n op_conf = " << op_conf.DebugString();
+    if (!op_conf.has_scope_symbol_id()) {
+      // NOTE(chengcheng): LOG(WARNING) instead of CHECK_OR_RETURN() for transition
+      LOG(WARNING) << " ERROR! op_name: " << op_conf.name()
+                   << " has NOT set scope(scope_symbol_id) in job: " << job_->job_conf().job_name()
+                   << " net. \n op_conf = " << op_conf.DebugString();
+    }
   }
 }
 

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -775,6 +775,7 @@ Maybe<const ParallelDesc*> JobBuildAndInferCtx::MirroredBlobGetParallelDescFromP
 Maybe<void> JobBuildAndInferCtx::CheckJob() const {
   JUST(CheckPlacement());
   JUST(CheckJobConf());
+  JUST(CheckOpScope());
   return Maybe<void>::Ok();
 }
 
@@ -809,6 +810,15 @@ Maybe<void> JobBuildAndInferCtx::CheckJobConf() const {
     return Error::JobTypeNotSetError() << "job_type not set, please set predict_conf or train_conf";
   }
   return Maybe<void>::Ok();
+}
+
+Maybe<void> CheckOpScope() const {
+   for (const OperatorConf& op_conf : job_->net().op()) {
+    CHECK_OR_RETURN(op_conf.has_scope_symbol_id())
+        << " ERROR! op_name: " << op_conf.name()
+        << " has NOT set scope(scope_symbol_id) in job: " << job_->job_conf().job_name() << " net. \n op_conf = "
+        << op_conf.DebugString();
+  }
 }
 
 Maybe<void> JobBuildAndInferCtx::CheckLbnValidAndExist(const std::string& lbn) const {

--- a/oneflow/core/job/job_build_and_infer_ctx.h
+++ b/oneflow/core/job/job_build_and_infer_ctx.h
@@ -123,6 +123,7 @@ class JobBuildAndInferCtx {
   Maybe<void> CheckOpBlobSplitability(Operator*, int64_t parallel_num);
   Maybe<void> CheckPlacement() const;
   Maybe<void> CheckJobConf() const;
+  Maybe<void> CheckOpScope() const;
   Maybe<LogicalBlobId> GetMirroredLbi(const std::string& lbn_with_hint) const;
   bool HasAnyMirroredBlobInput(const Operator& op) const;
   Maybe<void> CheckAllInputsConvertableToMirroredBlob(const Operator& op) const;

--- a/oneflow/core/job_rewriter/broadcast_to_compatible_with_grad.cpp
+++ b/oneflow/core/job_rewriter/broadcast_to_compatible_with_grad.cpp
@@ -46,6 +46,7 @@ Maybe<void> GenBroadcastToCompatibleWithGradOpConf(
             .Input("like", GenLogicalBlobName(op.BnInOp2Lbi("x")))
             .Attr<std::vector<int32_t>>("axis", reduced_axes)
             .Output("y")
+            .ScopeSymbolId(op.op_conf().scope_symbol_id())
             .Build();
     op_confs->push_back(reduce_sum_like_op.op_conf());
     *DiffLbi4BnInOp("x") = GenLogicalBlobId(reduce_sum_like_op.output("y", 0));

--- a/oneflow/core/job_rewriter/fuse_update_ops_pass.cpp
+++ b/oneflow/core/job_rewriter/fuse_update_ops_pass.cpp
@@ -190,6 +190,8 @@ Maybe<void> FuseUpdateOpsPass::Apply(const OpGraph& op_graph, JobBuilder* job_bu
     } else {
       UNIMPLEMENTED();
     }
+    CHECK(user_op_conf.op_conf().has_scope_symbol_id());
+    fused_op_builder.ScopeSymbolId(user_op_conf.op_conf().scope_symbol_id());
     OperatorConf new_op_conf = user_op_conf.op_conf();
     *new_op_conf.mutable_user_conf() = fused_op_builder.Build().op_conf().user_conf();
     job_builder->MutOpsOnlyOnce({new_op_conf});

--- a/oneflow/core/job_rewriter/indexed_slices_optimizer_rewrite_pass.cpp
+++ b/oneflow/core/job_rewriter/indexed_slices_optimizer_rewrite_pass.cpp
@@ -140,7 +140,8 @@ Maybe<void> IndexedSlicesOptimizerRewritePass::Apply(const OpGraph& op_graph,
       }
     }
     indexed_slices_op_builder.Input("model_diff_indices", indices_lbn)
-        .Input("model_diff_values", values_lbn);
+        .Input("model_diff_values", values_lbn)
+        .ScopeSymbolId(src_op_conf.scope_symbol_id());
     job_builder->DelOps({src_op_conf, user_op_conf.op_conf()});
     job_builder->AddOps(dst_node->parallel_desc().parallel_conf(),
                         {indexed_slices_op_builder.Build().op_conf()});

--- a/oneflow/python/serving/inference_session.py
+++ b/oneflow/python/serving/inference_session.py
@@ -254,6 +254,7 @@ class InferenceSession(object):
         else:
             job_conf = job_conf_proto_cfg.JobConfigProto()
             job_conf.set_job_name(job_name)
+            job_conf.mutable_predict_conf()
             self.job_name2job_conf_[job_name] = job_conf
             return job_conf
 


### PR DESCRIPTION
在所有的JobPass执行完之后，对Job内的所有Op检查其scope_symbol_id 是否设置。我们保证所有用户定义的、以及在JobBuildAndInferCtx里的优化Pass新增的Op都维护好了scope_symbol_id属性。