### PR TITLE
Remove Pod and header in BlobDesc

### DIFF
--- a/oneflow/core/eager/lazy_ref_blob_object.h
+++ b/oneflow/core/eager/lazy_ref_blob_object.h
@@ -29,7 +29,8 @@ class LazyRefBlobObject : public BlobObject {
       : BlobObject(std::make_shared<MemoryCase>(blob->mem_case()),
                    std::make_shared<Shape>(blob->static_shape()), blob->data_type()) {
     const auto& rt_blob_desc = blob->blob_desc();
-    blob_desc_ = BlobDesc(rt_blob_desc.body(), rt_blob_desc.is_dynamic());
+    blob_desc_ =
+        BlobDesc(rt_blob_desc.body_shape(), rt_blob_desc.data_type(), rt_blob_desc.is_dynamic());
     ref_blob_ = blob;
   }
   virtual ~LazyRefBlobObject() override = default;

--- a/oneflow/core/framework/op_arg_util.cpp
+++ b/oneflow/core/framework/op_arg_util.cpp
@@ -23,7 +23,7 @@ OpArgBlobAttribute::OpArgBlobAttribute(const std::shared_ptr<cfg::BlobDescProto>
                                        const std::string& logical_blob_name)
     : blob_desc_(blob_desc), logical_blob_name_(logical_blob_name) {
   ShapeProto shape_proto;
-  blob_desc_->body().shape().ToProto(&shape_proto);
+  blob_desc_->shape().ToProto(&shape_proto);
   shape_ = std::make_shared<Shape>(shape_proto);
 }
 
@@ -33,7 +33,7 @@ std::shared_ptr<Shape> OpArgBlobAttribute::shape() const { return shape_; }
 
 std::string OpArgBlobAttribute::logical_blob_name() const { return logical_blob_name_; }
 
-cfg::DataType OpArgBlobAttribute::get_dtype() const { return blob_desc_->body().data_type(); }
+cfg::DataType OpArgBlobAttribute::get_dtype() const { return blob_desc_->data_type(); }
 
 bool OpArgBlobAttribute::is_dynamic() const { return blob_desc_->is_dynamic(); }
 
@@ -49,7 +49,7 @@ std::shared_ptr<OpArgBlobAttribute> OpArgBlobAttribute::GetPhysicalOpArgBlobAttr
   blob_desc->CopyFrom(*blob_desc_);
   int64_t physical_len =
       BalancedSplitter(shape_->At(split_axis), parallel_num).At(parallel_id).size();
-  blob_desc->mutable_body()->mutable_shape()->set_dim(split_axis, physical_len);
+  blob_desc->mutable_shape()->set_dim(split_axis, physical_len);
   return std::make_shared<OpArgBlobAttribute>(blob_desc, logical_blob_name_);
 }
 
@@ -58,7 +58,7 @@ void OpArgBlobAttribute::DumpToInterfaceBlobConf(
   for (int i = 0; i < shape_->NumAxes(); ++i) {
     interface_blob_conf->mutable_shape()->add_dim(shape_->At(i));
   }
-  interface_blob_conf->set_data_type(blob_desc_->body().data_type());
+  interface_blob_conf->set_data_type(blob_desc_->data_type());
   interface_blob_conf->set_is_dynamic(is_dynamic());
 }
 

--- a/oneflow/core/framework/tensor_desc.cpp
+++ b/oneflow/core/framework/tensor_desc.cpp
@@ -36,8 +36,8 @@ NaiveTensorDesc::NaiveTensorDesc(const NaiveTensorDesc& rhs) { *this = rhs; }
 NaiveTensorDesc::NaiveTensorDesc(const BlobDescProto& proto) { *this = proto; }
 
 NaiveTensorDesc& NaiveTensorDesc::operator=(const BlobDescProto& proto) {
-  data_type_ = proto.body().data_type();
-  shape_ = Shape(proto.body().shape());
+  data_type_ = proto.data_type();
+  shape_ = Shape(proto.shape());
   is_dynamic_ = proto.is_dynamic();
   return *this;
 }

--- a/oneflow/core/kernel/runtime_blob_shape_infer_helper.cpp
+++ b/oneflow/core/kernel/runtime_blob_shape_infer_helper.cpp
@@ -80,7 +80,8 @@ BlobDesc* RuntimeBlobShapeInferHelper::BlobDesc4BnInOp(const std::string& bn_in_
                                                        const RtBlobDesc& rt_blob_desc) {
   BlobDesc* blob_desc = bn_in_op2blob_desc_.at(bn_in_op).get();
   if (blob_desc != nullptr) { return blob_desc; }
-  blob_desc = new BlobDesc(rt_blob_desc.body(), rt_blob_desc.is_dynamic());
+  blob_desc =
+      new BlobDesc(rt_blob_desc.body_shape(), rt_blob_desc.data_type(), rt_blob_desc.is_dynamic());
   bn_in_op2blob_desc_.at(bn_in_op).reset(blob_desc);
   return blob_desc;
 }

--- a/oneflow/core/kernel/user_kernel.cpp
+++ b/oneflow/core/kernel/user_kernel.cpp
@@ -36,8 +36,8 @@ namespace {
 
 void FillTensorDescWithBlob(const Blob* blob, user_op::NaiveTensorDesc* tensor_desc) {
   BlobDescProto proto;
-  blob->blob_desc().header_pod_desc().ToProto(proto.mutable_header());
-  blob->blob_desc().body().ToProto(proto.mutable_body());
+  blob->blob_desc().body_shape().ToProto(proto.mutable_shape());
+  proto.set_data_type(blob->blob_desc().data_type());
   proto.set_is_dynamic(blob->blob_desc().is_dynamic());
   *tensor_desc = proto;
   tensor_desc->mut_shape()->CheckNumAxesIdenticalAndAssign(blob->shape());

--- a/oneflow/core/register/blob.cpp
+++ b/oneflow/core/register/blob.cpp
@@ -61,8 +61,8 @@ void Blob::CopyValidDataContentFrom(DeviceCtx* device_ctx, const Blob* rhs) {
 
 void Blob::CopyHeaderFrom(DeviceCtx* device_ctx, const Blob* rhs) {
   size_t header_size = blob_desc().ByteSizeOfBlobHeader();
-  if (this == rhs || header_size == 0) { return; }
   CHECK_EQ(header_size, rhs->blob_desc().ByteSizeOfBlobHeader());
+  if (this == rhs || header_size == 0) { return; }
   Memcpy<DeviceType::kCPU>(device_ctx, header_ptr_, rhs->header_ptr(), header_size);
 }
 

--- a/oneflow/core/register/blob.h
+++ b/oneflow/core/register/blob.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include "oneflow/core/memory/memory_case.pb.h"
 #include "oneflow/core/register/runtime_blob_desc.h"
 #include "oneflow/core/common/shape_view.h"
-#include "oneflow/core/register/pod_ptr.h"
 #include "oneflow/core/record/record.pb.h"
 #include "oneflow/core/common/symbol.h"
 
@@ -55,8 +54,8 @@ class Blob final {
   virtual ~Blob() = default;
 
   DataType data_type() const { return blob_desc_->data_type(); }
-  const char* header_ptr() const { return header_ptr_->ptr(); }
-  char* mut_header_ptr() { return header_ptr_->ptr(); }
+  const char* header_ptr() const { return header_ptr_; }
+  char* mut_header_ptr() { return header_ptr_; }
   char* mut_contiguous_header_ptr();
   const RtBlobDesc& blob_desc() const { return *blob_desc_; }
   const RtBlobDesc* blob_desc_ptr() const { return blob_desc_; }
@@ -112,28 +111,14 @@ class Blob final {
  private:
   void Init(const MemoryCase& mem_case, const RtBlobDesc* blob_desc, char* header_ptr,
             char* body_ptr);
-  template<FieldKey key>
-  const int64_t* header_field() const {
-    return header_fields_[key];
-  }
-  template<FieldKey key>
-  int64_t* mut_header_field() {
-    return header_fields_[key];
-  }
-  template<FieldKey key>
-  size_t header_field_capacity() const {
-    return header_field_capacities_[key];
-  }
 
   const BlobAccessChecker* blob_access_checker_;
   MemoryCase mem_case_;
   const RtBlobDesc* blob_desc_;
   void* dptr_;
-  int64_t* header_fields_[FieldKey::kFieldKeySize];
-  size_t header_field_capacities_[FieldKey::kFieldKeySize];
+  char* header_ptr_;
   std::unique_ptr<ShapeView> shape_view_;
   std::unique_ptr<MutShapeView> mut_shape_view_;
-  std::unique_ptr<PodPtr> header_ptr_;
   // TODO(chengcheng); remove record num and record_blob
   int32_t record_num_;
 };

--- a/oneflow/core/register/blob_desc.cpp
+++ b/oneflow/core/register/blob_desc.cpp
@@ -21,6 +21,17 @@ bool CompareLbiBlobDescPair(const LbiBlobDescPair& lhs, const LbiBlobDescPair& r
   return lhs.lbi() < rhs.lbi();
 }
 
+BlobDesc::BlobDesc(const Shape& shape, DataType dtype, bool is_dynamic)
+    : shape_(std::make_shared<Shape>(shape)), data_type_(dtype), is_dynamic_(is_dynamic) {}
+
+BlobDesc::BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype, bool is_dynamic)
+    : shape_(shape), data_type_(dtype), is_dynamic_(is_dynamic) {}
+
+BlobDesc::BlobDesc(const Shape& shape, DataType dtype) : BlobDesc(shape, dtype, false) {}
+BlobDesc::BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype)
+    : BlobDesc(shape, dtype, false) {}
+BlobDesc::BlobDesc(DataType dtype) : BlobDesc(Shape(), dtype, false) {}
+
 BlobDesc::BlobDesc(const BlobDescProto& proto) {
   shape_ = std::make_shared<Shape>(proto.shape());
   data_type_ = proto.data_type();

--- a/oneflow/core/register/blob_desc.h
+++ b/oneflow/core/register/blob_desc.h
@@ -20,8 +20,8 @@ limitations under the License.
 #include "oneflow/core/common/data_type.h"
 #include "oneflow/core/common/shape.h"
 #include "oneflow/core/common/maybe.h"
+#include "oneflow/core/common/protobuf.h"
 #include "oneflow/core/register/blob_desc.pb.h"
-#include "oneflow/core/register/pod_desc.h"
 #include "oneflow/core/register/register_desc.pb.h"
 
 namespace oneflow {
@@ -30,22 +30,28 @@ class BlobDesc final {
  public:
   BlobDesc() = delete;
   ~BlobDesc() = default;
-  BlobDesc(const Shape&, DataType);
-  BlobDesc(const std::shared_ptr<Shape>&, DataType);
-  explicit BlobDesc(DataType dtype) : BlobDesc(Shape(), dtype) {}
+
+  BlobDesc(const Shape& shape, DataType dtype, bool is_dynamic)
+      : shape_(std::make_shared<Shape>(shape)), data_type_(dtype), is_dynamic_(is_dynamic) {}
+  BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype, bool is_dynamic)
+      : shape_(shape), data_type_(dtype), is_dynamic_(is_dynamic) {}
+
+  BlobDesc(const Shape& shape, DataType dtype) : BlobDesc(shape, dtype, false) {}
+  BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype) : BlobDesc(shape, dtype, false) {}
+  explicit BlobDesc(DataType dtype) : BlobDesc(Shape(), dtype, false) {}
   explicit BlobDesc(const BlobDescProto& proto);
   explicit BlobDesc(const BlobDesc&);
-  BlobDesc(const TensorPodDesc& body, bool is_dynamic) : body_(body), is_dynamic_(is_dynamic) {}
 
   static const int32_t kAlignSize = 512;
 
   BlobDesc& operator=(const BlobDesc&);
 
-  const Shape& shape() const { return body_.shape(); }
-  Shape& mut_shape() { return *body_.mut_shape(); }
+  const Shape& shape() const { return *CHECK_NOTNULL(shape_.get()); }
+  Shape& mut_shape() { return *CHECK_NOTNULL(shape_.get()); }
+  void set_shape(const Shape& shape) { *CHECK_NOTNULL(shape_.get()) = shape; }
 
-  DataType data_type() const { return body_.data_type(); }
-  void set_data_type(DataType val) { body_.set_data_type(val); }
+  DataType data_type() const { return data_type_; }
+  void set_data_type(DataType val) { data_type_ = val; }
 
   bool is_dynamic() const { return is_dynamic_; }
   void set_is_dynamic(bool);
@@ -56,9 +62,8 @@ class BlobDesc final {
   void CopyFrom(const BlobDesc&);
 
  private:
-  void InitFromProto(const BlobDescProto& proto);
-
-  TensorPodDesc body_;
+  std::shared_ptr<Shape> shape_;
+  DataType data_type_;
   bool is_dynamic_;
 };
 

--- a/oneflow/core/register/blob_desc.h
+++ b/oneflow/core/register/blob_desc.h
@@ -31,14 +31,14 @@ class BlobDesc final {
   BlobDesc() = delete;
   ~BlobDesc() = default;
 
-  BlobDesc(const Shape& shape, DataType dtype, bool is_dynamic)
-      : shape_(std::make_shared<Shape>(shape)), data_type_(dtype), is_dynamic_(is_dynamic) {}
-  BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype, bool is_dynamic)
-      : shape_(shape), data_type_(dtype), is_dynamic_(is_dynamic) {}
+  // NOTE(chengcheng): Cannot using std::make_shared in header file, because it will cause
+  //  Segmentation fault with unknown reason.
+  BlobDesc(const Shape& shape, DataType dtype, bool is_dynamic);
+  BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype, bool is_dynamic);
 
-  BlobDesc(const Shape& shape, DataType dtype) : BlobDesc(shape, dtype, false) {}
-  BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype) : BlobDesc(shape, dtype, false) {}
-  explicit BlobDesc(DataType dtype) : BlobDesc(Shape(), dtype, false) {}
+  BlobDesc(const Shape& shape, DataType dtype);
+  BlobDesc(const std::shared_ptr<Shape>& shape, DataType dtype);
+  explicit BlobDesc(DataType dtype);
   explicit BlobDesc(const BlobDescProto& proto);
   explicit BlobDesc(const BlobDesc&);
 

--- a/oneflow/core/register/blob_desc.proto
+++ b/oneflow/core/register/blob_desc.proto
@@ -1,12 +1,13 @@
 syntax = "proto2";
 package oneflow;
 
-import "oneflow/core/register/pod.proto";
+import "oneflow/core/common/shape.proto";
+import "oneflow/core/common/data_type.proto";
 
 message BlobDescProto {
-  required StructPodProto header = 1;
-  required TensorPodProto body = 2;
-  required bool is_dynamic = 5;
+  required ShapeProto shape = 1;
+  required DataType data_type = 2;
+  required bool is_dynamic = 3;
 }
 
 message BlobDescSignature {

--- a/oneflow/core/register/runtime_blob_desc.cpp
+++ b/oneflow/core/register/runtime_blob_desc.cpp
@@ -18,22 +18,20 @@ limitations under the License.
 namespace oneflow {
 
 RtBlobDesc::RtBlobDesc(const BlobDesc& blob_desc) {
-  BlobDescProto proto;
-  blob_desc.ToProto(&proto);
-  InitFromProto(proto);
+  shape_ = blob_desc.shape();
+  data_type_ = blob_desc.data_type();
+  is_dynamic_ = blob_desc.is_dynamic();
 }
 
-RtBlobDesc::RtBlobDesc(const BlobDescProto& proto) { InitFromProto(proto); }
-
-void RtBlobDesc::InitFromProto(const BlobDescProto& proto) {
-  body_.InitFromProto(proto.body());
-  header_.InitFromProto(proto.header());
+RtBlobDesc::RtBlobDesc(const BlobDescProto& proto) {
+  shape_ = Shape(proto.shape());
+  data_type_ = proto.data_type();
   is_dynamic_ = proto.is_dynamic();
 }
 
-size_t RtBlobDesc::ByteSizeOfBlobHeader() const { return header_.ByteSize(); }
+size_t RtBlobDesc::ByteSizeOfBlobHeader() const { return shape_.NumAxes() * sizeof(int64_t); }
 
-size_t RtBlobDesc::ByteSizeOfBlobBody() const { return body_.ByteSize(); }
+size_t RtBlobDesc::ByteSizeOfBlobBody() const { return Capacity(); }
 
 size_t RtBlobDesc::AlignedByteSizeOfBlobBody() const {
   return RoundUp(ByteSizeOfBlobBody(), BlobDesc::kAlignSize);
@@ -44,7 +42,8 @@ size_t RtBlobDesc::AlignedTotalByteSize() const {
 }
 
 bool RtBlobDesc::operator==(const RtBlobDesc& rhs) const {
-  return (body_ == rhs.body_) && (header_ == rhs.header_) && (is_dynamic_ == rhs.is_dynamic_);
+  return (shape_ == rhs.shape_) && (data_type_ == rhs.data_type_)
+         && (is_dynamic_ == rhs.is_dynamic_);
 }
 
 }  // namespace oneflow

--- a/oneflow/core/register/runtime_blob_desc.h
+++ b/oneflow/core/register/runtime_blob_desc.h
@@ -31,14 +31,12 @@ class RtBlobDesc final {
   explicit RtBlobDesc(const BlobDesc& blob_desc);
   explicit RtBlobDesc(const BlobDescProto& blob_desc_proto);
 
-  const StructPodDesc& header_pod_desc() const { return header_; }
   bool is_dynamic() const { return is_dynamic_; }
 
-  DataType data_type() const { return body_.data_type(); }
-  int64_t NumAxes() const { return body_.shape().NumAxes(); }
-  int64_t Capacity() const { return body_.shape().elem_cnt() * GetSizeOfDataType(data_type()); }
-  const Shape& body_shape() const { return body_.shape(); }
-  const TensorPodDesc& body() const { return body_; }
+  DataType data_type() const { return data_type_; }
+  int64_t NumAxes() const { return shape_.NumAxes(); }
+  int64_t Capacity() const { return shape_.elem_cnt() * GetSizeOfDataType(data_type()); }
+  const Shape& body_shape() const { return shape_; }
 
   size_t ByteSizeOfBlobHeader() const;
   size_t ByteSizeOfBlobBody() const;
@@ -48,10 +46,8 @@ class RtBlobDesc final {
   bool operator==(const RtBlobDesc& rhs) const;
 
  private:
-  void InitFromProto(const BlobDescProto& proto);
-
-  TensorPodDesc body_;
-  StructPodDesc header_;
+  Shape shape_;
+  DataType data_type_;
   bool is_dynamic_;
 };
 

--- a/oneflow/python/onnx/flow2onnx.py
+++ b/oneflow/python/onnx/flow2onnx.py
@@ -59,8 +59,8 @@ def FlowToOnnxNaive(graph, shape_override):
     for lbn in graph.helper.lbn2logical_blob_desc:
         lbd = graph.helper.lbn2logical_blob_desc[lbn]
         if lbn not in shape_override:
-            shape_override[lbn] = list(lbd.body.shape.dim)
-        dtypes[lbn] = util.Flow2OnnxDtype(lbd.body.data_type)
+            shape_override[lbn] = list(lbd.shape.dim)
+        dtypes[lbn] = util.Flow2OnnxDtype(lbd.data_type)
 
     # some stats
     op_cnt = collections.Counter()


### PR DESCRIPTION
- [x] 移除BlobDescProto中的POD header、body，可以简化Plan proto的大小
- [x] 移除BlobDesc 中的header field设计，移除系统中对PodDesc、PodPtr的依赖
- [x] 新的Blob header仅为保存动态shape的一段buffer，buffer的size = shape.NumAxes() * sizeof(int64_t)