### PR TITLE
Fix receive blob instruction stream and deadlock

### DIFF
--- a/oneflow/core/eager/transport_blob_instruction_type.h
+++ b/oneflow/core/eager/transport_blob_instruction_type.h
@@ -49,8 +49,8 @@ class ReceiveBlobInstructionType : public vm::InstructionType {
   ReceiveBlobInstructionType() = default;
   virtual ~ReceiveBlobInstructionType() override = default;
 
-  using stream_type = vm::TransportSenderStreamType;
-  using RefCntType = vm::TransportSenderStreamType::RefCntType;
+  using stream_type = vm::TransportReceiverStreamType;
+  using RefCntType = vm::TransportReceiverStreamType::RefCntType;
 
   void Infer(vm::Instruction* instruction) const override {
     // do nothing


### PR DESCRIPTION
之前 ReceiveBlobInstructionType 的 stream type 设置成了 TransportSenderStreamType，导致多机死锁。改掉之后同时用四个窗口跑测试测了一天半没有发现死锁（改之前用一个窗口跑半天左右会出现死锁）

具体原因是 最近虚拟机的 python 接口改成异步了，正常情况两台机器应该各按 receive - send 和 send-receive 的顺序执行，异步之后偶然情况下两台机器都变成了一样的 receive - send 的顺序，receive 和 send 又共用了一个 stream，就因为互相等待而死锁了