### PR TITLE
Refactor Global CommNetwork struct and remove deprecated init

### DIFF
--- a/oneflow/core/comm_network/comm_network.cpp
+++ b/oneflow/core/comm_network/comm_network.cpp
@@ -87,21 +87,6 @@ void CommNet::AddWorkToStream(void* actor_read_id, const std::function<void()>& 
   }
 }
 
-CommNet::CommNet(const Plan& plan) {
-  int64_t this_machine_id = GlobalProcessCtx::Rank();
-  HashMap<int64_t, MachineIds> net_topo;
-  net_topo = PbMap2HashMap(plan.net_topo().peer_machine_ids());
-  auto machine_ids_it = net_topo.find(this_machine_id);
-  CHECK(machine_ids_it != net_topo.end());
-  std::vector<int64_t> peer_machine_ids = PbRf2StdVec(machine_ids_it->second.machine_id());
-  peer_machine_id_.insert(peer_machine_ids.begin(), peer_machine_ids.end());
-
-  ready_cb_poller_ = std::thread([this]() {
-    std::function<void()> cb;
-    while (ready_cbs_.Receive(&cb) == kChannelStatusSuccess) { cb(); }
-  });
-}
-
 CommNet::CommNet() {
   int64_t this_machine_id = GlobalProcessCtx::Rank();
   for (int64_t i : Global<ResourceDesc, ForSession>::Get()->process_ranks()) {

--- a/oneflow/core/comm_network/comm_network.h
+++ b/oneflow/core/comm_network/comm_network.h
@@ -20,7 +20,6 @@ limitations under the License.
 
 #include "oneflow/core/actor/actor_message.h"
 #include "oneflow/core/common/platform.h"
-#include "oneflow/core/job/plan.pb.h"
 #include "oneflow/core/common/channel.h"
 
 namespace oneflow {
@@ -54,7 +53,6 @@ class CommNet {
 
  protected:
   CommNet();
-  DEPRECATED CommNet(const Plan& plan);
 
   virtual void DoRead(void* read_id, int64_t src_machine_id, void* src_token, void* dst_token) = 0;
   const HashSet<int64_t>& peer_machine_id() { return peer_machine_id_; }
@@ -80,8 +78,7 @@ template<typename MemDescType>
 class CommNetIf : public CommNet {
  public:
   OF_DISALLOW_COPY_AND_MOVE(CommNetIf);
-  CommNetIf() = default;
-  DEPRECATED CommNetIf(const Plan& plan) : CommNet(plan) {}
+  CommNetIf() : CommNet() {}
   virtual ~CommNetIf() {}
 
   void* RegisterMemory(void* ptr, size_t byte_size) override {

--- a/oneflow/core/comm_network/epoll/epoll_comm_network.cpp
+++ b/oneflow/core/comm_network/epoll/epoll_comm_network.cpp
@@ -122,14 +122,7 @@ SocketMemDesc* EpollCommNet::NewMemDesc(void* ptr, size_t byte_size) {
   return mem_desc;
 }
 
-EpollCommNet::EpollCommNet() {
-  pollers_.resize(Global<ResourceDesc, ForSession>::Get()->CommNetWorkerNum(), nullptr);
-  for (size_t i = 0; i < pollers_.size(); ++i) { pollers_[i] = new IOEventPoller; }
-  InitSockets();
-  for (IOEventPoller* poller : pollers_) { poller->Start(); }
-}
-
-EpollCommNet::EpollCommNet(const Plan& plan) : CommNetIf(plan) {
+EpollCommNet::EpollCommNet() : CommNetIf() {
   pollers_.resize(Global<ResourceDesc, ForSession>::Get()->CommNetWorkerNum(), nullptr);
   for (size_t i = 0; i < pollers_.size(); ++i) { pollers_[i] = new IOEventPoller; }
   InitSockets();

--- a/oneflow/core/comm_network/epoll/epoll_comm_network.h
+++ b/oneflow/core/comm_network/epoll/epoll_comm_network.h
@@ -29,10 +29,6 @@ class EpollCommNet final : public CommNetIf<SocketMemDesc> {
   OF_DISALLOW_COPY_AND_MOVE(EpollCommNet);
   ~EpollCommNet();
 
-  DEPRECATED static void Init(const Plan& plan) {
-    Global<CommNet>::SetAllocated(new EpollCommNet(plan));
-  }
-
   void RegisterMemoryDone() override;
 
   void SendActorMsg(int64_t dst_machine_id, const ActorMsg& msg) override;
@@ -44,7 +40,6 @@ class EpollCommNet final : public CommNetIf<SocketMemDesc> {
 
   friend class Global<EpollCommNet>;
   EpollCommNet();
-  DEPRECATED EpollCommNet(const Plan& plan);
   void InitSockets();
   SocketHelper* GetSocketHelper(int64_t machine_id);
   void DoRead(void* read_id, int64_t src_machine_id, void* src_token, void* dst_token) override;

--- a/oneflow/core/comm_network/ibverbs/ibverbs_comm_network.cpp
+++ b/oneflow/core/comm_network/ibverbs/ibverbs_comm_network.cpp
@@ -57,6 +57,7 @@ void IBVerbsCommNet::RegisterMemoryDone() {
     this_tokens_msg.mutable_token2mem_desc()->insert(
         {reinterpret_cast<uint64_t>(mem_desc), mem_desc->ToProto()});
   }
+  // TODO(chengcheng): Use Global<Transport> to sync session tokens.
   Global<CtrlClient>::Get()->PushKV(GenTokensMsgKey(this_machine_id), this_tokens_msg);
   for (int64_t peer_id : peer_machine_id()) {
     IBVerbsTokensMsg peer_tokens_msg;
@@ -76,8 +77,8 @@ void IBVerbsCommNet::SendActorMsg(int64_t dst_machine_id, const ActorMsg& msg) {
   qp_vec_.at(dst_machine_id)->PostSendRequest(msg);
 }
 
-IBVerbsCommNet::IBVerbsCommNet(const Plan& plan)
-    : CommNetIf(plan),
+IBVerbsCommNet::IBVerbsCommNet()
+    : CommNetIf(),
       token2mem_desc_(Global<ResourceDesc, ForEnv>::Get()->process_ranks().size()),
       poll_exit_flag_(ATOMIC_FLAG_INIT) {
   ibv_device** device_list = ibv_get_device_list(nullptr);

--- a/oneflow/core/comm_network/ibverbs/ibverbs_comm_network.h
+++ b/oneflow/core/comm_network/ibverbs/ibverbs_comm_network.h
@@ -31,23 +31,20 @@ namespace oneflow {
 class IBVerbsCommNet final : public CommNetIf<IBVerbsMemDesc> {
  public:
   OF_DISALLOW_COPY_AND_MOVE(IBVerbsCommNet);
-  IBVerbsCommNet() = delete;
   ~IBVerbsCommNet();
-
-  DEPRECATED static void Init(const Plan& plan) {
-    Global<CommNet>::SetAllocated(new IBVerbsCommNet(plan));
-  }
 
   void RegisterMemoryDone() override;
 
   void SendActorMsg(int64_t dst_machine_id, const ActorMsg& msg) override;
 
  private:
+  friend class Global<IBVerbsCommNet>;
+  IBVerbsCommNet();
+
   IBVerbsMemDesc* NewMemDesc(void* ptr, size_t byte_size) override {
     return new IBVerbsMemDesc(pd_, ptr, byte_size);
   }
 
-  DEPRECATED IBVerbsCommNet(const Plan&);
   void DoRead(void* read_id, int64_t src_machine_id, void* src_token, void* dst_token) override;
   void PollCQ();
 
@@ -60,13 +57,6 @@ class IBVerbsCommNet final : public CommNetIf<IBVerbsMemDesc> {
   std::vector<IBVerbsQP*> qp_vec_;
   std::atomic_flag poll_exit_flag_;
   std::thread poll_thread_;
-};
-
-// DEPRECATED
-template<>
-class Global<IBVerbsCommNet> final {
- public:
-  static IBVerbsCommNet* Get() { return static_cast<IBVerbsCommNet*>(Global<CommNet>::Get()); }
 };
 
 }  // namespace oneflow

--- a/oneflow/core/job/runtime.cpp
+++ b/oneflow/core/job/runtime.cpp
@@ -99,20 +99,17 @@ void Runtime::NewAllGlobal(const Plan& plan, size_t total_piece_num, bool is_exp
   if (GlobalProcessCtx::IsThisProcessMaster() && Global<RuntimeCtx>::Get()->NeedCollectActEvent()) {
     Global<ActEventLogger>::New(is_experiment_phase);
   }
-  // TODO(chengcheng)
-  // this code should be called before Runtime::NewAllGlobal, maybe after Eager ENV init
-  // and should be called before Global<Transport>::New()
   if (Global<ResourceDesc, ForSession>::Get()->process_ranks().size() > 1) {
 #ifdef __linux__
-    // NOTE(chengcheng): Global<EpollCommNet> will new in any case.
+    // NOTE(chengcheng): Global<EpollCommNet> will new in any case, and will new in env start.
     // if use RDMA,
     //   The Global<CommNet> is set allocated by new Global<IBVerbsCommNet>
     // else,
     //   The Global<CommNet> is set allocated by Global<EpollCommNet>
     if (Global<ResourceDesc, ForSession>::Get()->use_rdma()) {
 #ifdef WITH_RDMA
-      // DEPRECATED
-      IBVerbsCommNet::Init(plan);
+      Global<IBVerbsCommNet>::New();
+      Global<CommNet>::SetAllocated(Global<IBVerbsCommNet>::Get());
 #else
       LOG(FATAL) << "RDMA components not found";
 #endif


### PR DESCRIPTION
移除了`Global<CommNet>`、`Global<EpollCommNet>`、`Global<IBVerbsCommNet>` 里的deprecated 初始化方法，移除commnet对plan的依赖。消除了相关的编译代码时的WARNING。