### PR TITLE
fix typo when add optimizer op

### DIFF
--- a/oneflow/core/job_rewriter/generate_backward_and_optimizer_op_confs.cpp
+++ b/oneflow/core/job_rewriter/generate_backward_and_optimizer_op_confs.cpp
@@ -204,7 +204,7 @@ Maybe<void> GenerateBackwardAndOptimizerOpConfs::Apply(Job* job, JobPassCtx* ctx
         const VariableOp* var_op = dynamic_cast<const VariableOp*>(&op_node->op());
         if (var_op == nullptr
             || cur_model_lbi2model_diff_lbi.find(var_op->BnInOp2Lbi(var_op->SoleObn()))
-                   == lbi2diff_lbi.end()) {
+                   == cur_model_lbi2model_diff_lbi.end()) {
           return;
         }
         const std::string& model_diff_lbn = GenLogicalBlobName(


### PR DESCRIPTION
修复一个typo，这个typo会在阅读代码时产生误解，误以为这个compare恒为false，在不同编译环境下也可能产生风险。

PS：在现有编译环境下，这个typo并不会产生正确性问题，在当前var不在cur_model_lbi2model_diff_lbi时会正确return。

测试代码如下：

```c++
#include <unordered_map>
#include <string>
#include <iostream>

int main() {
  std::unordered_map<std::string, int> foo{{"one", 1}, {"two", 2}, {"three", 3}};
  std::unordered_map<std::string, int> bar{{"four", 4}, {"five", 5}, {"six", 6}};
  std::cout << (foo.end() == bar.end() ? "True" : "False") << std::endl;
}

// output: True
```