### PR TITLE
add default dtype for oneflow range

### DIFF
--- a/oneflow/python/ops/math_ops.py
+++ b/oneflow/python/ops/math_ops.py
@@ -2159,7 +2159,8 @@ def range(
 
     """
     # Ensure the dtype is not None
-    assert dtype is not None, "Please specified data type"
+    if dtype is None:
+        dtype = flow.int64
 
     if limit is None:
         # If limit is None, We start from zero.


### PR DESCRIPTION
给`flow.range`默认数据类型值，设定为`flow.int64`