### PR TITLE
Fix bug of worker exit

### DIFF
--- a/oneflow/core/job/cluster.cpp
+++ b/oneflow/core/job/cluster.cpp
@@ -83,7 +83,6 @@ Maybe<void> Cluster::WorkerLoop() {
     }
   }
   ClusterInstruction::HaltBarrier();
-  Global<EnvGlobalObjectsScope>::Delete();
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/job/oneflow_worker.cpp
+++ b/oneflow/core/job/oneflow_worker.cpp
@@ -37,6 +37,7 @@ Maybe<void> Run(const std::string& env_proto_filepath) {
   Global<EnvGlobalObjectsScope>::SetAllocated(new EnvGlobalObjectsScope());
   JUST(Global<EnvGlobalObjectsScope>::Get()->Init(env_proto));
   JUST(Cluster::WorkerLoop());
+  Global<EnvGlobalObjectsScope>::Delete();
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
修复worker退出时`EnvGlobalObjectsScope`过早销毁导致的bug