### PR TITLE
NCCL logical support Pipeline Parallel By independent NcclComputeStream.

### DIFF
--- a/oneflow/core/device/cuda_stream_index.h
+++ b/oneflow/core/device/cuda_stream_index.h
@@ -28,6 +28,12 @@ class CudaStreamIndexGenerator final : public StreamIndexGenerator {
   stream_index_t GenerateMixStreamIndex() { return kMix; }
   stream_index_t GenerateNcclStreamIndex() { return kNccl; }
   stream_index_t GenerateDecodeH2DStreamIndex() { return kDecodeH2D; }
+  stream_index_t GenerateNcclComputeStreamIndex(const uint32_t id) {
+    stream_index_t idx = kNcclComputeBegin + id;
+    CHECK_LE(idx, kNcclComputeEnd);
+    return idx;
+  }
+  uint32_t GetNcclComputeStreamCount() const { return kNcclComputeEnd - kNcclComputeBegin + 1; }
 
  private:
   static const stream_index_t kCompute = 0;
@@ -36,6 +42,8 @@ class CudaStreamIndexGenerator final : public StreamIndexGenerator {
   static const stream_index_t kMix = 3;
   static const stream_index_t kNccl = 4;
   static const stream_index_t kDecodeH2D = 5;
+  static const stream_index_t kNcclComputeBegin = 10;
+  static const stream_index_t kNcclComputeEnd = 17;
 };
 
 }  // namespace oneflow

--- a/oneflow/core/framework/op_kernel.h
+++ b/oneflow/core/framework/op_kernel.h
@@ -108,6 +108,7 @@ class KernelInitContext {
   const std::string& op_name() const { return user_op_conf().op_name(); }
   const std::string& op_type_name() const { return user_op_conf().op_type_name(); }
   const std::string& device_tag() const { return user_op_conf().op_conf().device_tag(); }
+  const OperatorConf& op_conf() const { return user_op_conf().op_conf(); }
 
   template<typename T>
   const T& Attr(const std::string& attr_name) const;

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -283,15 +283,14 @@ void GenSortedCompTaskNodes(const OpNode* op_node, std::vector<CompTaskNode*>* s
               : static_cast<DeviceId::device_index_t>(dev_phy_id);
       DeviceId device_id{static_cast<DeviceId::rank_t>(machine_id), parallel_desc.device_type(),
                          device_index};
-      StreamId::stream_index_t stream_index =
-          StreamIndexGetterRegistryManager::Get().StreamIndex4DeviceIdAndTaskType(
-              device_id, comp_task_node->GetTaskType());
+      StreamId::stream_index_t stream_index;
       if (op_node->op().op_conf().has_stream_index_hint()) {
         int32_t stream_index_hint = op_node->op().op_conf().stream_index_hint();
-        if (stream_index_hint >= 0) {
-          LOG(INFO) << "set op: " << op_node->op().op_name() << " to stream: " << stream_index_hint;
-          stream_index = static_cast<StreamId::stream_index_t>(stream_index_hint);
-        }
+        LOG(INFO) << "set op: " << op_node->op().op_name() << " to stream: " << stream_index_hint;
+        stream_index = static_cast<StreamId::stream_index_t>(stream_index_hint);
+      } else {
+        stream_index = StreamIndexGetterRegistryManager::Get().StreamIndex4DeviceIdAndTaskType(
+            device_id, comp_task_node->GetTaskType());
       }
       comp_task_node->set_thrd_id(SerializeStreamIdToInt64(StreamId{device_id, stream_index}));
       comp_task_node->set_op_node(op_node);

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -286,11 +286,11 @@ void GenSortedCompTaskNodes(const OpNode* op_node, std::vector<CompTaskNode*>* s
       StreamId::stream_index_t stream_index =
           StreamIndexGetterRegistryManager::Get().StreamIndex4DeviceIdAndTaskType(
               device_id, comp_task_node->GetTaskType());
-      if (op_node->op().op_conf().has_stream_id_hint()) {
-        int32_t stream_id_hint = op_node->op().op_conf().stream_id_hint();
-        if (stream_id_hint > 90) { /* NOTE(chengcheng): magic number for GPT independent stream. */
-          LOG(INFO) << "set op: " << op_node->op().op_name() << " to stream: " << stream_id_hint;
-          stream_index = static_cast<StreamId::stream_index_t>(stream_id_hint);
+      if (op_node->op().op_conf().has_stream_index_hint()) {
+        int32_t stream_index_hint = op_node->op().op_conf().stream_index_hint();
+        if (stream_index_hint >= 0) {
+          LOG(INFO) << "set op: " << op_node->op().op_name() << " to stream: " << stream_index_hint;
+          stream_index = static_cast<StreamId::stream_index_t>(stream_index_hint);
         }
       }
       comp_task_node->set_thrd_id(SerializeStreamIdToInt64(StreamId{device_id, stream_index}));

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -286,6 +286,13 @@ void GenSortedCompTaskNodes(const OpNode* op_node, std::vector<CompTaskNode*>* s
       StreamId::stream_index_t stream_index =
           StreamIndexGetterRegistryManager::Get().StreamIndex4DeviceIdAndTaskType(
               device_id, comp_task_node->GetTaskType());
+      if (op_node->op().op_conf().has_stream_id_hint()) {
+        int32_t stream_id_hint = op_node->op().op_conf().stream_id_hint();
+        if (stream_id_hint > 90) { /* NOTE(chengcheng): magic number for GPT independent stream. */
+          LOG(INFO) << "set op: " << op_node->op().op_name() << " to stream: " << stream_id_hint;
+          stream_index = static_cast<StreamId::stream_index_t>(stream_id_hint);
+        }
+      }
       comp_task_node->set_thrd_id(SerializeStreamIdToInt64(StreamId{device_id, stream_index}));
       comp_task_node->set_op_node(op_node);
       sorted_comp_tasks->push_back(comp_task_node);

--- a/oneflow/core/job/eager_nccl_comm_manager.cpp
+++ b/oneflow/core/job/eager_nccl_comm_manager.cpp
@@ -32,12 +32,44 @@ std::string GetNcclUniqueIdRpcKey(const std::vector<std::pair<int64_t, int64_t>>
   return oss.str();
 }
 
-std::string NcclUniqueId2String(ncclUniqueId id) {
+std::string NcclUniqueId2String(ncclUniqueId* id) {
   std::stringstream ss;
   for (int i = 0; i < NCCL_UNIQUE_ID_BYTES; ++i) {
-    ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(id.internal[i]);
+    ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(id->internal[i]);
   }
   return ss.str();
+}
+
+bool CompareDeviceSetPair(const std::pair<int64_t, int64_t>& a,
+                          const std::pair<int64_t, int64_t>& b) {
+  if (a.first == b.first) {
+    return a.second < b.second;
+  } else {
+    return a.first < b.first;
+  }
+}
+
+void CreateNcclUniqueIdAndComm(ncclUniqueId* nccl_unique_id, ncclComm_t* comm, const int dev,
+                               const std::string& key,
+                               const std::vector<std::pair<int64_t, int64_t>>& device_vec) {
+  int64_t machine = GlobalProcessCtx::Rank();
+  std::pair<int64_t, int64_t> this_device(machine, dev);
+  auto it = std::find(device_vec.cbegin(), device_vec.cend(), this_device);
+  CHECK(it != device_vec.end());
+  int rank = std::distance(device_vec.cbegin(), it);
+  if (rank == 0) {
+    OF_NCCL_CHECK(ncclGetUniqueId(nccl_unique_id));
+    Global<CtrlClient>::Get()->PushKV(key,
+                                      std::string(nccl_unique_id->internal, NCCL_UNIQUE_ID_BYTES));
+  } else {
+    Global<CtrlClient>::Get()->PullKV(key, [&](const std::string& val) {
+      memcpy(nccl_unique_id->internal, val.data(), NCCL_UNIQUE_ID_BYTES);
+    });
+  }
+  LOG(INFO) << " EagerNcclCommMgr::ncclCommInitRank device_vec.size() = " << device_vec.size()
+            << ", nccl_unique_id = " << NcclUniqueId2String(nccl_unique_id) << ", rank = " << rank
+            << ", key = {" << key << "}\n";
+  OF_NCCL_CHECK(ncclCommInitRank(comm, device_vec.size(), *nccl_unique_id, rank));
 }
 
 }  // namespace
@@ -65,35 +97,13 @@ ncclComm_t EagerNcclCommMgr::GetCommForDevice(
     if (it != device_set2device_id2comm_.end()) { return it->second.at(dev); }
   }
   std::vector<std::pair<int64_t, int64_t>> device_vec(device_set.cbegin(), device_set.cend());
-  std::sort(device_vec.begin(), device_vec.end(),
-            [](const std::pair<int64_t, int64_t>& a, const std::pair<int64_t, int64_t>& b) {
-              if (a.first == b.first) {
-                return a.second < b.second;
-              } else {
-                return a.first < b.first;
-              }
-            });
-  int64_t machine = GlobalProcessCtx::Rank();
-  std::pair<int64_t, int64_t> this_device(machine, dev);
-  auto it = std::find(device_vec.cbegin(), device_vec.cend(), this_device);
-  CHECK(it != device_vec.end());
-  int rank = std::distance(device_vec.cbegin(), it);
+  std::sort(device_vec.begin(), device_vec.end(), CompareDeviceSetPair);
+
   ncclUniqueId nccl_unique_id{};
-  std::string nccl_unique_id_rpc_key = GetNcclUniqueIdRpcKey(device_vec);
-  if (rank == 0) {
-    OF_NCCL_CHECK(ncclGetUniqueId(&nccl_unique_id));
-    Global<CtrlClient>::Get()->PushKV(nccl_unique_id_rpc_key,
-                                      std::string(nccl_unique_id.internal, NCCL_UNIQUE_ID_BYTES));
-  } else {
-    Global<CtrlClient>::Get()->PullKV(
-        nccl_unique_id_rpc_key, [&nccl_unique_id](const std::string& val) {
-          memcpy(nccl_unique_id.internal, val.data(), NCCL_UNIQUE_ID_BYTES);
-        });
-  }
   ncclComm_t comm;
-  LOG(INFO) << " EagerNcclCommMgr::ncclCommInitRank device_vec.size() = " << device_vec.size()
-            << ", nccl_unique_id = " << NcclUniqueId2String(nccl_unique_id) << ", rank = " << rank;
-  OF_NCCL_CHECK(ncclCommInitRank(&comm, device_vec.size(), nccl_unique_id, rank));
+  std::string nccl_unique_id_rpc_key = GetNcclUniqueIdRpcKey(device_vec);
+  CreateNcclUniqueIdAndComm(&nccl_unique_id, &comm, dev, nccl_unique_id_rpc_key, device_vec);
+
   {
     std::lock_guard<std::mutex> lock(mutex_);
     device_set2device_id2comm_[device_set][dev] = comm;
@@ -103,20 +113,13 @@ ncclComm_t EagerNcclCommMgr::GetCommForDevice(
 
 ncclComm_t EagerNcclCommMgr::GetCommForDeviceAndStreamId(
     const std::set<std::pair<int64_t, int64_t>>& device_set, const int32_t stream_id) {
-  std::vector<std::pair<int64_t, int64_t>> device_vec(device_set.cbegin(), device_set.cend());
-  std::sort(device_vec.begin(), device_vec.end(),
-            [](const std::pair<int64_t, int64_t>& a, const std::pair<int64_t, int64_t>& b) {
-              if (a.first == b.first) {
-                return a.second < b.second;
-              } else {
-                return a.first < b.first;
-              }
-            });
-  std::string key =
-      GetNcclUniqueIdRpcKey(device_vec) + "-stream_id_hint:" + std::to_string(stream_id);
-
   int dev;
   OF_CUDA_CHECK(cudaGetDevice(&dev));
+
+  std::vector<std::pair<int64_t, int64_t>> device_vec(device_set.cbegin(), device_set.cend());
+  std::sort(device_vec.begin(), device_vec.end(), CompareDeviceSetPair);
+  std::string key =
+      GetNcclUniqueIdRpcKey(device_vec) + "-stream_id_hint:" + std::to_string(stream_id);
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -124,26 +127,10 @@ ncclComm_t EagerNcclCommMgr::GetCommForDeviceAndStreamId(
     if (it != device7stream2device_id2comm_.end()) { return it->second.at(dev); }
   }
 
-  int64_t machine = GlobalProcessCtx::Rank();
-  std::pair<int64_t, int64_t> this_device(machine, dev);
-  auto it = std::find(device_vec.cbegin(), device_vec.cend(), this_device);
-  CHECK(it != device_vec.end());
-  int rank = std::distance(device_vec.cbegin(), it);
   ncclUniqueId nccl_unique_id{};
-  if (rank == 0) {
-    OF_NCCL_CHECK(ncclGetUniqueId(&nccl_unique_id));
-    Global<CtrlClient>::Get()->PushKV(key,
-                                      std::string(nccl_unique_id.internal, NCCL_UNIQUE_ID_BYTES));
-  } else {
-    Global<CtrlClient>::Get()->PullKV(key, [&nccl_unique_id](const std::string& val) {
-      memcpy(nccl_unique_id.internal, val.data(), NCCL_UNIQUE_ID_BYTES);
-    });
-  }
   ncclComm_t comm;
-  LOG(INFO) << " EagerNcclCommMgr::ncclCommInitRank device_vec.size() = " << device_vec.size()
-            << ", nccl_unique_id = " << NcclUniqueId2String(nccl_unique_id) << ", rank = " << rank
-            << ", key = {" << key << "}\n";
-  OF_NCCL_CHECK(ncclCommInitRank(&comm, device_vec.size(), nccl_unique_id, rank));
+  CreateNcclUniqueIdAndComm(&nccl_unique_id, &comm, dev, key, device_vec);
+
   {
     std::lock_guard<std::mutex> lock(mutex_);
     device7stream2device_id2comm_[key][dev] = comm;

--- a/oneflow/core/job/eager_nccl_comm_manager.h
+++ b/oneflow/core/job/eager_nccl_comm_manager.h
@@ -31,8 +31,8 @@ class EagerNcclCommMgr final {
   ~EagerNcclCommMgr();
 
   ncclComm_t GetCommForDevice(const std::set<std::pair<int64_t, int64_t>>& device_set);
-  ncclComm_t GetCommForDeviceAndOpName(const std::set<std::pair<int64_t, int64_t>>& device_set,
-                                       const std::string& name);
+  ncclComm_t GetCommForDeviceAndStreamId(const std::set<std::pair<int64_t, int64_t>>& device_set,
+                                         const int32_t stream_id);
 
  private:
   friend class Global<EagerNcclCommMgr>;
@@ -40,6 +40,7 @@ class EagerNcclCommMgr final {
 
   std::map<std::set<std::pair<int64_t, int64_t>>, HashMap<int64_t, ncclComm_t>>
       device_set2device_id2comm_;
+  std::map<std::string, HashMap<int64_t, ncclComm_t>> device7stream2device_id2comm_;
   std::mutex mutex_;
 };
 

--- a/oneflow/core/job/eager_nccl_comm_manager.h
+++ b/oneflow/core/job/eager_nccl_comm_manager.h
@@ -31,6 +31,8 @@ class EagerNcclCommMgr final {
   ~EagerNcclCommMgr();
 
   ncclComm_t GetCommForDevice(const std::set<std::pair<int64_t, int64_t>>& device_set);
+  ncclComm_t GetCommForDeviceAndOpName(const std::set<std::pair<int64_t, int64_t>>& device_set,
+                                       const std::string& name);
 
  private:
   friend class Global<EagerNcclCommMgr>;

--- a/oneflow/core/job_rewriter/job_completer.cpp
+++ b/oneflow/core/job_rewriter/job_completer.cpp
@@ -117,12 +117,14 @@ void JobCompleter::Complete(Job* job) const {
 #endif  // OF_WITH_XRT
   }
 
+#ifdef WITH_CUDA
   if (Global<ResourceDesc, ForSession>::Get()->nccl_use_compute_stream()) {
     // NOTE(chengcheng): this pass need as last pass for insert correct op with nccl boxing.
     JobPass4Name("InsertNcclLogicalOpPass")(job, &job_pass_ctx);
     // NOTE(chengcheng): Becasue insert new logical nccl op, MUST dump time shape, sbp again.
     JobPass4Name("DumpBlobParallelConfPass")(job, &job_pass_ctx);
   }
+#endif  // WITH_CUDA
   CheckOpGraph(OpGraph(*job));
 }
 

--- a/oneflow/core/job_rewriter/pipeline_buffer_pass.cpp
+++ b/oneflow/core/job_rewriter/pipeline_buffer_pass.cpp
@@ -228,6 +228,7 @@ Maybe<void> PipelineBufferPass::Apply(const OpGraph& op_graph, JobBuilder* job_b
   op_graph.ForEachNode([&](const OpNode* this_node) {
     if (!OpNodeHasScope(this_node)) {
       LOG(WARNING) << " op : " << this_node->op().op_conf().DebugString() << " has NOT scope!";
+      return;
     }
     max_stage_id = std::max(max_stage_id, GetStageIdHint(this_node));
   });

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -449,6 +449,7 @@ message OperatorConf {
   optional string device_tag = 4 [default = "invalid_device"];
   repeated string ctrl_in_op_name = 7;
   optional int64 scope_symbol_id = 8;
+  optional int32 stream_id_hint = 9 [default = -1];
   optional string pass_tag = 10;
   oneof op_type {
     // system op

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -449,7 +449,7 @@ message OperatorConf {
   optional string device_tag = 4 [default = "invalid_device"];
   repeated string ctrl_in_op_name = 7;
   optional int64 scope_symbol_id = 8;
-  optional int32 stream_index_hint = 9 [default = -1];
+  optional uint32 stream_index_hint = 9;
   optional string pass_tag = 10;
   oneof op_type {
     // system op

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -449,7 +449,7 @@ message OperatorConf {
   optional string device_tag = 4 [default = "invalid_device"];
   repeated string ctrl_in_op_name = 7;
   optional int64 scope_symbol_id = 8;
-  optional int32 stream_id_hint = 9 [default = -1];
+  optional int32 stream_index_hint = 9 [default = -1];
   optional string pass_tag = 10;
   oneof op_type {
     // system op

--- a/oneflow/user/kernels/nccl_logical_2d_sbp_kernels.cpp
+++ b/oneflow/user/kernels/nccl_logical_2d_sbp_kernels.cpp
@@ -30,6 +30,7 @@ class NcclLogical2DSameDim0KernelCommState final : public user_op::OpKernelState
  public:
   NcclLogical2DSameDim0KernelCommState(user_op::KernelInitContext* ctx)
       : is_init_(false),
+        stream_id_(ctx->op_conf().stream_id_hint()),
         parallel_desc_(ctx->parallel_desc()),
         this_parallel_id_(ctx->parallel_ctx().parallel_id()) {}
   ~NcclLogical2DSameDim0KernelCommState() = default;
@@ -62,12 +63,14 @@ class NcclLogical2DSameDim0KernelCommState final : public user_op::OpKernelState
       const int64_t device_id = CHECK_JUST(parallel_desc_.DeviceId4ParallelId(parallel_id));
       device_set.emplace(std::make_pair(machine_id, device_id));
     }
-    comm_ = CHECK_NOTNULL(Global<EagerNcclCommMgr>::Get())->GetCommForDevice(device_set);
+    comm_ = CHECK_NOTNULL(Global<EagerNcclCommMgr>::Get())
+                ->GetCommForDeviceAndStreamId(device_set, stream_id_);
     num_ranks_ = group_size;
     is_init_ = true;
   }
 
   bool is_init_;
+  int32_t stream_id_;
   ParallelDesc parallel_desc_;
   int64_t this_parallel_id_;
   int64_t num_ranks_;

--- a/oneflow/user/kernels/nccl_logical_2d_sbp_kernels.cpp
+++ b/oneflow/user/kernels/nccl_logical_2d_sbp_kernels.cpp
@@ -30,7 +30,7 @@ class NcclLogical2DSameDim0KernelCommState final : public user_op::OpKernelState
  public:
   NcclLogical2DSameDim0KernelCommState(user_op::KernelInitContext* ctx)
       : is_init_(false),
-        stream_id_(ctx->op_conf().stream_id_hint()),
+        stream_id_(ctx->op_conf().stream_index_hint()),
         parallel_desc_(ctx->parallel_desc()),
         this_parallel_id_(ctx->parallel_ctx().parallel_id()) {}
   ~NcclLogical2DSameDim0KernelCommState() = default;

--- a/oneflow/user/kernels/nccl_logical_kernels.cpp
+++ b/oneflow/user/kernels/nccl_logical_kernels.cpp
@@ -30,7 +30,7 @@ class NcclLogicalKernelCommState final : public user_op::OpKernelState {
  public:
   NcclLogicalKernelCommState(user_op::KernelInitContext* ctx)
       : is_init_(false),
-        stream_id_(ctx->op_conf().stream_id_hint()),
+        stream_id_(ctx->op_conf().stream_index_hint()),
         parallel_desc_(ctx->parallel_desc()) {}
   ~NcclLogicalKernelCommState() = default;
 


### PR DESCRIPTION
解决流水并行下， 一个PlacementGroup（Stage）里有多个SubGraph均需要插入NCCL logical op（比如前向和后向），这些子图执行顺序导致NCCL出错的问题。 解决思路是将不同的SubGraph使用不同的计算stream隔离开。

在CudaStreamIndexGenerator中增加了一个range：

```c++
static const stream_index_t kNcclComputeBegin = 10;
static const stream_index_t kNcclComputeEnd = 17;
```

10 - 17 被列为NCCL logical的计算stream。最多支持一个PlacementGroup下有8个独立的包含NCCL logical op的计算SubGraph。