### PR TITLE
Fix groupnorm

### DIFF
--- a/oneflow/user/ops/reshape_like_op.cpp
+++ b/oneflow/user/ops/reshape_like_op.cpp
@@ -69,4 +69,31 @@ REGISTER_USER_OP("reshape_like")
       return Maybe<void>::Ok();
     });
 
+REGISTER_USER_OP_GRAD("reshape_like")
+    .SetGenBackwardOpConfFn([](const user_op::UserOpWrapper& op, user_op::AddOpFn AddOp) {
+      if (op.NeedGenGradTensor4OpInput("in", 0)) {
+        const auto& in_desc = op.TensorDesc4ArgNameAndIndex("in", 0);
+        user_op::UserOpConfWrapperBuilder builder(op.op_name() + "_grad");
+        if (in_desc.is_dynamic()) {
+          user_op::UserOpConfWrapper reshape_grad_op =
+              builder.Op("reshape_like")
+                  .Input("in", op.GetGradTensorWithOpOutput("out", 0))
+                  .Input("like", op.input("in", 0))
+                  .Output("out")
+                  .Build();
+          op.BindGradTensorWithOpInput(reshape_grad_op.output("out", 0), "in", 0);
+          AddOp(reshape_grad_op);
+        } else {
+          user_op::UserOpConfWrapper reshape_grad_op =
+              builder.Op("reshape")
+                  .Input("in", op.GetGradTensorWithOpOutput("out", 0))
+                  .Attr("shape", in_desc.shape())
+                  .Output("out")
+                  .Build();
+          op.BindGradTensorWithOpInput(reshape_grad_op.output("out", 0), "in", 0);
+          AddOp(reshape_grad_op);
+        }
+      }
+    });
+
 }  // namespace oneflow


### PR DESCRIPTION
When I reproduce FCOS, I found the previous GroupNorm implementation is wrong which gets the two learnable parameters gamma and beta **per group** while the correct implementation is **per channel**.

I fix this bug and modify the test cases. Also, the previous GroupNorm could only be used in a static shape context while in most detection algorithms, the shape is dynamic. So I used reshape_like op and add its grad op for compatibility.

All test cases are passed and the inference performance of  FCOS is 38.7mAP which proves the correctness of the GroupNorm implementation.