### PR TITLE
remove MakeParallelDescByDevice

### DIFF
--- a/oneflow/core/framework/device.cpp
+++ b/oneflow/core/framework/device.cpp
@@ -82,14 +82,6 @@ std::string Device::ToString() const {
   return ss.str();
 }
 
-Maybe<const ParallelDesc> Device::MakeParallelDescByDevice(const Device& device) {
-  int64_t machine_id = GlobalProcessCtx::Rank() / GlobalProcessCtx::NumOfProcessPerNode();
-  int64_t device_id = device.device_id();
-  std::string machine_device_id = std::to_string(machine_id) + ":" + std::to_string(device_id);
-  return std::const_pointer_cast<const ParallelDesc>(
-      JUST(ParallelDesc::New(JUST(device.of_type()), {machine_device_id}, nullptr)));
-}
-
 Maybe<const Device> Device::MakeDeviceByParallelDesc(const ParallelDesc& parallel_desc) {
   std::string type = parallel_desc.device_tag();
   if (parallel_desc.device_tag() == "gpu") { type = "cuda"; }

--- a/oneflow/core/framework/device.h
+++ b/oneflow/core/framework/device.h
@@ -45,7 +45,6 @@ class Device final {
   static Maybe<const Device> New(const std::string& type, int64_t device_id);
   static Maybe<const Device> New(const std::string& typed);
 
-  static Maybe<const ParallelDesc> MakeParallelDescByDevice(const Device& device);
   static Maybe<const Device> MakeDeviceByParallelDesc(const ParallelDesc& parallel_desc);
   static const std::unordered_set<std::string> type_supported;
 

--- a/oneflow/core/framework/instructions_builder.cpp
+++ b/oneflow/core/framework/instructions_builder.cpp
@@ -653,7 +653,7 @@ Maybe<void> InstructionsBuilder::LocalCallOpKernel(
       ObjectMsgPtr<vm::InstructionMsg>::New(instr_type_name);
   auto phy_instr_operand = std::make_shared<vm::LocalCallOpKernelPhyInstrOperand>(
       opkernel, input_eager_blob_objects, output_eager_blob_objects, attrs);
-  instruction->set_parallel_desc_symbol_id(JUST(parallel_desc_sym->symbol_id()));
+  *instruction->mut_parallel_desc() = parallel_desc_sym;
   *instruction->mutable_phy_instr_operand() = phy_instr_operand;
   instruction_list_->EmplaceBack(std::move(instruction));
   return Maybe<void>::Ok();
@@ -879,7 +879,7 @@ Maybe<void> InstructionsBuilder::ReleaseTensor(
       JUST(eager_blob_object->compute_local_dep_object());
   *instruction->mutable_phy_instr_operand() = std::make_shared<vm::ReleaseTensorArgPhyInstrOperand>(
       eager_blob_object, infer_local_dep_object, compute_local_dep_object);
-  instruction->set_parallel_desc_symbol_id(JUST(parallel_desc->symbol_id()));
+  *instruction->mut_parallel_desc() = parallel_desc;
   instruction_list_->EmplaceBack(std::move(instruction.Mutable()));
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/framework/op_expr.cpp
+++ b/oneflow/core/framework/op_expr.cpp
@@ -70,8 +70,7 @@ Maybe<StatefulLocalOpKernel> UserOpExpr::MutKernel4Device(const Device& device) 
   std::shared_ptr<OperatorConf> op_conf = std::make_shared<OperatorConf>();
   BuildOpConf(op_conf.get(), {});
   op_conf->set_device_tag(JUST(device.of_type()));
-  std::shared_ptr<const ParallelDesc> parallel_desc =
-      JUST(Device::MakeParallelDescByDevice(device));
+  std::shared_ptr<const ParallelDesc> parallel_desc = device.parallel_desc_ptr();
   const auto& opkernel = JUST(StatefulLocalOpKernel::New(op_conf, device.mem_case(), parallel_desc,
                                                          input_arg_tuple(), output_arg_tuple()));
   device2kernel_.emplace(device, opkernel);

--- a/oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp
@@ -62,7 +62,7 @@ Maybe<void> NaiveInterpret(const UserOpExpr& user_op_expr, const TensorTuple& in
   CHECK_EQ(out_devices->size(), output_eager_blob_objects->size());
   if (!user_op_expr.has_device_infer_fn()) {
     op_device = default_device;
-    op_parallel_desc = JUST(Device::MakeParallelDescByDevice(*op_device));
+    op_parallel_desc = op_device->parallel_desc_ptr();
     for (int i = 0; i < output_eager_blob_objects->size(); i++) {
       const auto& eager_blob_object = std::make_shared<vm::EagerBlobObject>(
           op_device->mem_case(), std::make_shared<Shape>(), DataType::kInvalidDataType,
@@ -72,11 +72,11 @@ Maybe<void> NaiveInterpret(const UserOpExpr& user_op_expr, const TensorTuple& in
     }
   } else {
     op_device = JUST(user_op_expr.InferDevices(attrs, inputs, out_devices));
-    op_parallel_desc = JUST(Device::MakeParallelDescByDevice(*op_device));
+    op_parallel_desc = op_device->parallel_desc_ptr();
     for (int i = 0; i < output_eager_blob_objects->size(); i++) {
       const auto& tensor_device = out_devices->at(i);
       CHECK_OR_RETURN(static_cast<bool>(tensor_device));
-      const auto& tensor_parallel_desc = JUST(Device::MakeParallelDescByDevice(*op_device));
+      const auto& tensor_parallel_desc = op_device->parallel_desc_ptr();
       const auto& eager_blob_object = std::make_shared<vm::EagerBlobObject>(
           tensor_device->mem_case(), std::make_shared<Shape>(), DataType::kInvalidDataType,
           std::make_shared<vm::TensorBuffer>(), tensor_parallel_desc);

--- a/oneflow/core/framework/tensor_impl.cpp
+++ b/oneflow/core/framework/tensor_impl.cpp
@@ -39,7 +39,7 @@ Maybe<void> TensorImpl::SyncBlobObject2Attributes(
 
 Maybe<void> MirroredTensorImpl::set_device(const std::shared_ptr<const Device>& device) {
   device_ = device;
-  parallel_desc_ = JUST(Device::MakeParallelDescByDevice(*device));
+  parallel_desc_ = device->parallel_desc_ptr();
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/vm/instruction.cpp
+++ b/oneflow/core/vm/instruction.cpp
@@ -78,6 +78,7 @@ void InstructionMsg::__Init__(const InstructionMsg& instr_msg) {
   __Init__();
   mutable_instr_type_id()->CopyFrom(instr_msg.instr_type_id());
   *mutable_instr_type_name() = instr_msg.instr_type_name();
+  if (instr_msg.parallel_desc()) { *mut_parallel_desc() = instr_msg.parallel_desc(); }
   if (instr_msg.has_parallel_desc_symbol_id()) {
     set_parallel_desc_symbol_id(instr_msg.parallel_desc_symbol_id());
   }


### PR DESCRIPTION
删掉 Device::MakeParallelDescByDevice，用 device.parallel_desc_ptr() 代替
修复 instr_msg 拷贝初始化时没有设置 parallel_desc 导致 infer 指令 parallel_desc 不正确的错误