### PR TITLE
add gradient funs for unary and binary math op

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -78,6 +78,10 @@
 - Failed to compile because C++ 17 is enabled
     - In some cases, environment variable `CXXFLAGS` is not empty and contains `--std c++17`.
     - Check if it is empty by running `echo $CXXFLAGS` and clear it with `unset CXXFLAGS`.
+    - If you are using conda, to make the changes on environment variables permanent, you can run:
+        ```bash
+        conda env config vars set CXXFLAGS="-fPIC"
+        ```
 
 - cmake outputs error `No CMAKE_ASM_NASM_COMPILER could be found.`
     - Install `nasm`. For instance, run `sudo yum install nasm` if you are on centos.

--- a/oneflow/core/autograd/gradient_funcs/math_binary_op.cpp
+++ b/oneflow/core/autograd/gradient_funcs/math_binary_op.cpp
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "oneflow/core/framework/op_expr_grad_function.h"
+#include "oneflow/core/framework/op_builder.h"
+#include "oneflow/core/framework/op_interpreter/op_interpreter_util.h"
+#include "oneflow/core/framework/op_expr.h"
+#include "oneflow/core/framework/op_expr_helper.h"
+#include "oneflow/user/ops/math_binary_elementwise_seq.h"
+
+namespace oneflow {
+namespace one {
+
+struct BinaryMathOpExprInterpState : public OpExprInterpState {
+  bool x_requires_grad;
+  bool y_requires_grad;
+};
+
+class BinaryMathOp : public OpExprGradFunction<BinaryMathOpExprInterpState> {
+  Maybe<void> Capture(BinaryMathOpExprInterpState* ctx, const TensorTuple& inputs,
+                      const TensorTuple& outputs, const AttrMap& attrs) const override {
+    ctx->x_requires_grad = inputs.at(0)->requires_grad();
+    ctx->y_requires_grad = inputs.at(1)->requires_grad();
+    ctx->SaveTensorForBackward(inputs.at(0));
+    ctx->SaveTensorForBackward(inputs.at(1));
+    return Maybe<void>::Ok();
+  }
+
+  Maybe<void> Apply(const BinaryMathOpExprInterpState* ctx, const TensorTuple& out_grads,
+                    TensorTuple* in_grads) const override {
+    if (!(ctx->x_requires_grad || ctx->y_requires_grad)) { return Maybe<void>::Ok(); }
+
+    const std::shared_ptr<oneflow::one::Tensor>& x = ctx->SavedTensors().at(0);
+    const std::shared_ptr<oneflow::one::Tensor>& y = ctx->SavedTensors().at(1);
+    if (ctx->x_requires_grad) {
+      in_grads->at(0) = JUST(OpInterpUtil::Dispatch<Tensor>(*x_grad_op_, {x, y, out_grads.at(0)}));
+    }
+
+    if (ctx->y_requires_grad) {
+      in_grads->at(1) = JUST(OpInterpUtil::Dispatch<Tensor>(*y_grad_op_, {x, y, out_grads.at(0)}));
+    }
+    return Maybe<void>::Ok();
+  }
+
+ protected:
+  std::shared_ptr<OpExpr> x_grad_op_;
+  std::shared_ptr<OpExpr> y_grad_op_;
+};
+
+#define INSTANSE_BINARY_MATHOP_CLASS(op_type_name, op_cls)                \
+  class op_cls##Cls final : public BinaryMathOp {                         \
+    Maybe<void> Init(const OpExpr& op) override {                         \
+      x_grad_op_ = JUST(op_expr_helper::BinaryMathOpXGrad(op_type_name)); \
+      y_grad_op_ = JUST(op_expr_helper::BinaryMathOpYGrad(op_type_name)); \
+      return Maybe<void>::Ok();                                           \
+    }                                                                     \
+  };                                                                      \
+                                                                          \
+  REGISTER_OP_EXPR_GRAD_FUNCTION(op_type_name, op_cls##Cls);
+
+OF_PP_FOR_EACH_TUPLE(INSTANSE_BINARY_MATHOP_CLASS, MATH_BINARY_ELEMENTWISE_FUNC_SEQ);
+
+}  // namespace one
+}  // namespace oneflow

--- a/oneflow/core/autograd/gradient_funcs/math_binary_op.cpp
+++ b/oneflow/core/autograd/gradient_funcs/math_binary_op.cpp
@@ -62,18 +62,17 @@ class BinaryMathOp : public OpExprGradFunction<BinaryMathOpExprInterpState> {
   std::shared_ptr<OpExpr> y_grad_op_;
 };
 
-#define INSTANSE_BINARY_MATHOP_CLASS(op_type_name, op_cls)            \
-  class op_cls##Cls final : public BinaryMathOp {                     \
-    Maybe<void> Init(const OpExpr& op) override {                     \
-      x_grad_op_ = JUST(op_expr_helper::BinaryXGradOp(op_type_name)); \
-      y_grad_op_ = JUST(op_expr_helper::BinaryYGradOp(op_type_name)); \
-      return Maybe<void>::Ok();                                       \
-    }                                                                 \
-  };                                                                  \
-                                                                      \
+#define INSTANTIAT_AND_REGISTER_BINARY_MATHOP_CLASS(op_type_name, op_cls) \
+  class op_cls##Cls final : public BinaryMathOp {                         \
+    Maybe<void> Init(const OpExpr& op) override {                         \
+      x_grad_op_ = JUST(op_expr_helper::BinaryXGradOp(op_type_name));     \
+      y_grad_op_ = JUST(op_expr_helper::BinaryYGradOp(op_type_name));     \
+      return Maybe<void>::Ok();                                           \
+    }                                                                     \
+  };                                                                      \
   REGISTER_OP_EXPR_GRAD_FUNCTION(op_type_name, op_cls##Cls);
 
-OF_PP_FOR_EACH_TUPLE(INSTANSE_BINARY_MATHOP_CLASS, MATH_BINARY_ELEMENTWISE_FUNC_SEQ);
+OF_PP_FOR_EACH_TUPLE(INSTANTIAT_AND_REGISTER_BINARY_MATHOP_CLASS, MATH_BINARY_ELEMENTWISE_FUNC_SEQ);
 
 }  // namespace one
 }  // namespace oneflow

--- a/oneflow/core/autograd/gradient_funcs/math_unary_op.cpp
+++ b/oneflow/core/autograd/gradient_funcs/math_unary_op.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 #include "oneflow/core/framework/op_expr_grad_function.h"
-#include "oneflow/core/framework/dtype.h"
 #include "oneflow/core/framework/op_builder.h"
 #include "oneflow/core/framework/op_interpreter/op_interpreter_util.h"
 #include "oneflow/core/framework/op_expr.h"
@@ -41,8 +40,7 @@ class UnaryMathOp : public OpExprGradFunction<UnaryMathOpExprInterpState> {
                     TensorTuple* in_grads) const override {
     if (!ctx->x_requires_grad) { return Maybe<void>::Ok(); }
     const auto& x = ctx->SavedTensors().at(0);
-    const auto& grads = JUST(OpInterpUtil::Dispatch<TensorTuple>(*grad_op_, {x, out_grads.at(0)}));
-    in_grads->at(0) = grads->at(0);
+    in_grads->at(0) = JUST(OpInterpUtil::Dispatch<Tensor>(*grad_op_, {x, out_grads.at(0)}));
     return Maybe<void>::Ok();
   }
 

--- a/oneflow/core/autograd/gradient_funcs/math_unary_op.cpp
+++ b/oneflow/core/autograd/gradient_funcs/math_unary_op.cpp
@@ -47,17 +47,16 @@ class UnaryMathOp : public OpExprGradFunction<UnaryMathOpExprInterpState> {
   std::shared_ptr<OpExpr> grad_op_;
 };
 
-#define INSTANSE_UNARY_MATHOP_CLASS(op_type_name, op_cls)         \
-  class op_cls##Cls final : public UnaryMathOp {                  \
-    Maybe<void> Init(const OpExpr& op) override {                 \
-      grad_op_ = JUST(op_expr_helper::UnaryGradOp(op_type_name)); \
-      return Maybe<void>::Ok();                                   \
-    }                                                             \
-  };                                                              \
-                                                                  \
+#define INSTANTIAT_AND_REGISTER_UNARY_MATHOP_CLASS(op_type_name, op_cls) \
+  class op_cls##Cls final : public UnaryMathOp {                         \
+    Maybe<void> Init(const OpExpr& op) override {                        \
+      grad_op_ = JUST(op_expr_helper::UnaryGradOp(op_type_name));        \
+      return Maybe<void>::Ok();                                          \
+    }                                                                    \
+  };                                                                     \
   REGISTER_OP_EXPR_GRAD_FUNCTION(op_type_name, op_cls##Cls);
 
-OF_PP_FOR_EACH_TUPLE(INSTANSE_UNARY_MATHOP_CLASS, MATH_UNARY_ELEMENTWISE_FUNC_SEQ);
+OF_PP_FOR_EACH_TUPLE(INSTANTIAT_AND_REGISTER_UNARY_MATHOP_CLASS, MATH_UNARY_ELEMENTWISE_FUNC_SEQ);
 
 }  // namespace one
 }  // namespace oneflow

--- a/oneflow/core/autograd/gradient_funcs/unary_math_op.cpp
+++ b/oneflow/core/autograd/gradient_funcs/unary_math_op.cpp
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "oneflow/core/framework/op_expr_grad_function.h"
+#include "oneflow/core/framework/dtype.h"
+#include "oneflow/core/framework/op_builder.h"
+#include "oneflow/core/framework/op_interpreter/op_interpreter_util.h"
+#include "oneflow/core/framework/op_expr.h"
+#include "oneflow/core/framework/op_expr_helper.h"
+#include "oneflow/user/ops/math_unary_elementwise_seq.h"
+
+namespace oneflow {
+namespace one {
+
+struct UnaryMathOpExprInterpState : public OpExprInterpState {
+  bool x_requires_grad;
+};
+
+class UnaryMathOp : public OpExprGradFunction<UnaryMathOpExprInterpState> {
+  Maybe<void> Capture(UnaryMathOpExprInterpState* ctx, const TensorTuple& inputs,
+                      const TensorTuple& outputs, const AttrMap& attrs) const override {
+    ctx->x_requires_grad = inputs.at(0)->requires_grad();
+    ctx->SaveTensorForBackward(inputs.at(0));
+    return Maybe<void>::Ok();
+  }
+
+  Maybe<void> Apply(const UnaryMathOpExprInterpState* ctx, const TensorTuple& out_grads,
+                    TensorTuple* in_grads) const override {
+    if (!ctx->x_requires_grad) { return Maybe<void>::Ok(); }
+    const auto& x = ctx->SavedTensors().at(0);
+    const auto& grads = JUST(OpInterpUtil::Dispatch<TensorTuple>(*grad_op_, {x, out_grads.at(0)}));
+    in_grads->at(0) = grads->at(0);
+    return Maybe<void>::Ok();
+  }
+
+ protected:
+  std::shared_ptr<OpExpr> grad_op_;
+};
+
+#define INSTANSE_UNARY_MATHOP_CLASS(op_type_name, op_cls)             \
+  class op_cls##Cls final : public UnaryMathOp {                      \
+    Maybe<void> Init(const OpExpr& op) override {                     \
+      grad_op_ = JUST(op_expr_helper::UnaryMathOpGrad(op_type_name)); \
+      return Maybe<void>::Ok();                                       \
+    }                                                                 \
+  };                                                                  \
+                                                                      \
+  REGISTER_OP_EXPR_GRAD_FUNCTION(op_type_name, op_cls##Cls);
+
+OF_PP_FOR_EACH_TUPLE(INSTANSE_UNARY_MATHOP_CLASS, MATH_UNARY_ELEMENTWISE_FUNC_SEQ);
+
+}  // namespace one
+}  // namespace oneflow

--- a/oneflow/core/framework/op_expr_helper.cpp
+++ b/oneflow/core/framework/op_expr_helper.cpp
@@ -550,12 +550,35 @@ Maybe<one::UserOpExpr> PReLUGradOp(const std::string& name) {
 Maybe<one::UserOpExpr> TransposeOp(const std::vector<int32_t>& perm) {
   return TransposeOp(perm, UniqueOpName("transpose"));
 }
-
 Maybe<one::UserOpExpr> TransposeOp(const std::vector<int32_t>& perm, const std::string& name) {
   return one::OpBuilder("transpose", name)
       .Input("input")
       .Output("output")
       .Attr<std::vector<int32_t>>("perm", perm)
+      .Build();
+}
+
+Maybe<one::UserOpExpr> UnaryMathOpGrad(const std::string& op_type_name) {
+  return one::OpBuilder(op_type_name + "_grad", UniqueOpName(op_type_name + "_grad"))
+      .Input("x")
+      .Input("dy")
+      .Output("dx")
+      .Build();
+}
+Maybe<one::UserOpExpr> BinaryMathOpXGrad(const std::string& op_type_name) {
+  return one::OpBuilder(op_type_name + "_x_grad", UniqueOpName(op_type_name + "_x_grad"))
+      .Input("x")
+      .Input("y")
+      .Input("dz")
+      .Output("dx")
+      .Build();
+}
+Maybe<one::UserOpExpr> BinaryMathOpYGrad(const std::string& op_type_name) {
+  return one::OpBuilder(op_type_name + "_y_grad", UniqueOpName(op_type_name + "_y_grad"))
+      .Input("x")
+      .Input("y")
+      .Input("dz")
+      .Output("dy")
       .Build();
 }
 

--- a/oneflow/core/framework/op_expr_helper.cpp
+++ b/oneflow/core/framework/op_expr_helper.cpp
@@ -558,23 +558,30 @@ Maybe<one::UserOpExpr> TransposeOp(const std::vector<int32_t>& perm, const std::
       .Build();
 }
 
-Maybe<one::UserOpExpr> UnaryMathOpGrad(const std::string& op_type_name) {
-  return one::OpBuilder(op_type_name + "_grad", UniqueOpName(op_type_name + "_grad"))
-      .Input("x")
-      .Input("dy")
-      .Output("dx")
-      .Build();
+Maybe<one::UserOpExpr> UnaryGradOp(const std::string& unary_op_type) {
+  return UnaryGradOp(unary_op_type, UniqueOpName(unary_op_type + "_grad"));
 }
-Maybe<one::UserOpExpr> BinaryMathOpXGrad(const std::string& op_type_name) {
-  return one::OpBuilder(op_type_name + "_x_grad", UniqueOpName(op_type_name + "_x_grad"))
+Maybe<one::UserOpExpr> UnaryGradOp(const std::string& unary_op_type, const std::string& name) {
+  return one::OpBuilder(unary_op_type + "_grad", name).Input("x").Input("dy").Output("dx").Build();
+}
+
+Maybe<one::UserOpExpr> BinaryXGradOp(const std::string& binary_op_type) {
+  return BinaryXGradOp(binary_op_type, UniqueOpName(binary_op_type + "_x_grad"));
+}
+Maybe<one::UserOpExpr> BinaryXGradOp(const std::string& binary_op_type, const std::string& name) {
+  return one::OpBuilder(binary_op_type + "_x_grad", name)
       .Input("x")
       .Input("y")
       .Input("dz")
       .Output("dx")
       .Build();
 }
-Maybe<one::UserOpExpr> BinaryMathOpYGrad(const std::string& op_type_name) {
-  return one::OpBuilder(op_type_name + "_y_grad", UniqueOpName(op_type_name + "_y_grad"))
+
+Maybe<one::UserOpExpr> BinaryYGradOp(const std::string& binary_op_type) {
+  return BinaryYGradOp(binary_op_type, UniqueOpName(binary_op_type + "_y_grad"));
+}
+Maybe<one::UserOpExpr> BinaryYGradOp(const std::string& binary_op_type, const std::string& name) {
+  return one::OpBuilder(binary_op_type + "_y_grad", name)
       .Input("x")
       .Input("y")
       .Input("dz")

--- a/oneflow/core/framework/op_expr_helper.h
+++ b/oneflow/core/framework/op_expr_helper.h
@@ -183,5 +183,9 @@ Maybe<one::UserOpExpr> PReLUGradOp(const std::string& name);
 Maybe<one::UserOpExpr> TransposeOp(const std::vector<int32_t>& perm);
 Maybe<one::UserOpExpr> TransposeOp(const std::vector<int32_t>& perm, const std::string& name);
 
+Maybe<one::UserOpExpr> UnaryMathOpGrad(const std::string& op);
+Maybe<one::UserOpExpr> BinaryMathOpXGrad(const std::string& op);
+Maybe<one::UserOpExpr> BinaryMathOpYGrad(const std::string& op);
+
 }  // namespace op_expr_helper
 }  // namespace oneflow

--- a/oneflow/core/framework/op_expr_helper.h
+++ b/oneflow/core/framework/op_expr_helper.h
@@ -183,9 +183,14 @@ Maybe<one::UserOpExpr> PReLUGradOp(const std::string& name);
 Maybe<one::UserOpExpr> TransposeOp(const std::vector<int32_t>& perm);
 Maybe<one::UserOpExpr> TransposeOp(const std::vector<int32_t>& perm, const std::string& name);
 
-Maybe<one::UserOpExpr> UnaryMathOpGrad(const std::string& op);
-Maybe<one::UserOpExpr> BinaryMathOpXGrad(const std::string& op);
-Maybe<one::UserOpExpr> BinaryMathOpYGrad(const std::string& op);
+Maybe<one::UserOpExpr> UnaryGradOp(const std::string& unary_op_type);
+Maybe<one::UserOpExpr> UnaryGradOp(const std::string& unary_op_type, const std::string& name);
+
+Maybe<one::UserOpExpr> BinaryXGradOp(const std::string& binary_op_type);
+Maybe<one::UserOpExpr> BinaryXGradOp(const std::string& binary_op_type, const std::string& name);
+
+Maybe<one::UserOpExpr> BinaryYGradOp(const std::string& binary_op_type);
+Maybe<one::UserOpExpr> BinaryYGradOp(const std::string& binary_op_type, const std::string& name);
 
 }  // namespace op_expr_helper
 }  // namespace oneflow

--- a/oneflow/python/nn/modules/math_ops.py
+++ b/oneflow/python/nn/modules/math_ops.py
@@ -24,6 +24,10 @@ from oneflow.python.framework.tensor import register_tensor_op
 from oneflow.python.nn.modules.utils import _check_axis
 
 
+def _build_math_binary_elementwise_op(math_op):
+    return flow.builtin_op(math_op).Input("x").Input("y").Output("z").Build()
+
+
 class Sum(Module):
     def __init__(
         self, axis: Optional[Union[int, Sequence[int]]] = None, keepdims: bool = False
@@ -922,10 +926,16 @@ def std_op(tensor, dim, unbiased=True, keepdim=False):
 class Pow(Module):
     def __init__(self) -> None:
         super().__init__()
-        self._op = flow.builtin_op("scalar_pow").Input("in").Output("out").Build()
+        self._scalar_pow_op = (
+            flow.builtin_op("scalar_pow").Input("in").Output("out").Build()
+        )
+        self._elementwise_pow_op = _build_math_binary_elementwise_op("pow")
 
-    def forward(self, x, exponent: Union[int, float]):
-        return self._op(x, exponent=float(exponent))[0]
+    def forward(self, x, y):
+        if isinstance(y, (int, float)):
+            return self._scalar_pow_op(x, exponent=float(y))[0]
+        else:
+            return self._elementwise_pow_op(x, y)[0]
 
 
 @oneflow_export("pow")

--- a/oneflow/python/test/modules/test_math_ops.py
+++ b/oneflow/python/test/modules/test_math_ops.py
@@ -197,23 +197,5 @@ class TestSquare(flow.unittest.TestCase):
         )
 
 
-@unittest.skipIf(
-    not flow.unittest.env.eager_execution_enabled(),
-    ".numpy() doesn't work in lazy mode",
-)
-class TestPow(flow.unittest.TestCase):
-    def test_pow(test_case):
-        input = flow.Tensor(np.array([1, 2, 3, 4, 5, 6]), dtype=flow.float32)
-        of_out = flow.pow(input, 2.1)
-        np_out = np.power(input.numpy(), 2.1)
-        test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
-
-    def test_pow_tensor_function(test_case):
-        input = flow.Tensor(np.array([1, 2, 3, 4, 5, 6]), dtype=flow.float32)
-        of_out = input.pow(2.1)
-        np_out = np.power(input.numpy(), 2.1)
-        test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/oneflow/python/test/modules/test_pow.py
+++ b/oneflow/python/test/modules/test_pow.py
@@ -22,19 +22,51 @@ import oneflow.experimental as flow
 from test_util import GenArgList
 
 
-def _test_pow_impl(test_case, shape, device):
-    np_input = np.random.randn(*shape)
-    of_input = flow.Tensor(
-        np_input, dtype=flow.float32, device=flow.device(device), requires_grad=True
+def _test_pow_scalar_impl(test_case, shape, scalar, device):
+    np_input = 10 * np.random.rand(*shape)
+    of_input = flow.Tensor(np_input, dtype=flow.float32, device=flow.device(device))
+    of_out = flow.pow(of_input, scalar)
+    np_out = np.power(np_input, scalar)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
+
+
+def _test_pow_elementwise_impl(test_case, shape, scalar, device):
+    np_input_x = 10 * np.random.rand(*shape)
+    np_input_y = 10 * np.random.randn(*shape)
+    of_input_x = flow.Tensor(np_input_x, dtype=flow.float32, device=flow.device(device))
+    of_input_y = flow.Tensor(np_input_y, dtype=flow.float32, device=flow.device(device))
+    of_out = flow.pow(of_input_x, of_input_y)
+    np_out = np.power(np_input_x, np_input_y)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
+
+
+def _test_pow_backward_impl(test_case, device):
+    # elementwise-pow backward test
+    np_input_x = np.array(
+        [[0.86895168, 0.51427012, 0.8693118], [0.27302601, 0.68126282, 0.85506865]]
     )
+    np_input_y = np.array(
+        [[0.42736459, 0.0727016, 0.90737411], [0.7220017, 0.32741095, 0.49669031]]
+    )
+    np_x_grad = np.array([[0.4632, 0.1347, 0.9192], [1.0358, 0.4238, 0.5374]])
+    np_y_grad = np.array([[-0.1323, -0.6336, -0.1233], [-0.5085, -0.3385, -0.1449]])
 
-    of_out = flow.exp(of_input)
-    np_out = np.exp(np_input)
-    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-4, 1e-4))
+    of_input_x = flow.Tensor(
+        np_input_x, dtype=flow.float32, device=flow.device(device), requires_grad=True
+    )
+    of_input_y = flow.Tensor(
+        np_input_y, dtype=flow.float32, device=flow.device(device), requires_grad=True
+    )
+    of_out = flow.pow(of_input_x, of_input_y)
+    of_out_sum = of_out.sum()
+    of_out_sum.backward()
+    print(of_input_x.grad.numpy())
+    print(of_input_y.grad.numpy())
+    test_case.assertTrue(np.allclose(of_input_x.grad.numpy(), np_x_grad, 1e-4, 1e-4))
+    test_case.assertTrue(np.allclose(of_input_y.grad.numpy(), np_y_grad, 1e-4, 1e-4))
 
-    of_out = of_out.sum()
-    of_out.backward()
-    test_case.assertTrue(np.allclose(of_input.grad.numpy(), np_out, 1e-4, 1e-4))
+    # TODO(liupeihong): scalar-pow backward test
+    # ...
 
 
 @unittest.skipIf(
@@ -42,30 +74,20 @@ def _test_pow_impl(test_case, shape, device):
     ".numpy() doesn't work in lazy mode",
 )
 class TestPow(flow.unittest.TestCase):
-    def test_pow(test_case):
-        input = flow.Tensor(np.array([1, 2, 3, 4, 5, 6]), dtype=flow.float32)
-        of_out = flow.pow(input, 2.1)
-        np_out = np.power(input.numpy(), 2.1)
-        test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
+    def test_pow_forward(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["shape"] = [(2, 3), (2, 3, 4, 5)]
+        arg_dict["scalar"] = [2.1, 0.8]
+        arg_dict["device"] = ["cpu", "cuda"]
+        for arg in GenArgList(arg_dict):
+            _test_pow_scalar_impl(test_case, *arg)
+            _test_pow_elementwise_impl(test_case, *arg)
 
-    def test_pow_tensor_function(test_case):
-        input = flow.Tensor(np.array([1, 2, 3, 4, 5, 6]), dtype=flow.float32)
-        of_out = input.pow(2.1)
-        np_out = np.power(input.numpy(), 2.1)
-        test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
-
-
-# @unittest.skipIf(
-#     not flow.unittest.env.eager_execution_enabled(),
-#     ".numpy() doesn't work in lazy mode",
-# )
-# class TestExp(flow.unittest.TestCase):
-#     def test_pow(test_case):
-#         arg_dict = OrderedDict()
-#         arg_dict["shape"] = [(2, 3), (2, 4, 5, 6)]
-#         arg_dict["device"] = ["cpu", "cuda"]
-#         for arg in GenArgList(arg_dict):
-#             _test_exp_impl(test_case, *arg)
+    def test_pow_backward(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["device"] = ["cpu", "cuda"]
+        for arg in GenArgList(arg_dict):
+            _test_pow_backward_impl(test_case, *arg)
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_pow.py
+++ b/oneflow/python/test/modules/test_pow.py
@@ -51,19 +51,66 @@ def _test_pow_backward_impl(test_case, device):
     np_x_grad = np.array([[0.4632, 0.1347, 0.9192], [1.0358, 0.4238, 0.5374]])
     np_y_grad = np.array([[-0.1323, -0.6336, -0.1233], [-0.5085, -0.3385, -0.1449]])
 
-    of_input_x = flow.Tensor(
-        np_input_x, dtype=flow.float32, device=flow.device(device), requires_grad=True
-    )
-    of_input_y = flow.Tensor(
-        np_input_y, dtype=flow.float32, device=flow.device(device), requires_grad=True
-    )
-    of_out = flow.pow(of_input_x, of_input_y)
-    of_out_sum = of_out.sum()
-    of_out_sum.backward()
-    print(of_input_x.grad.numpy())
-    print(of_input_y.grad.numpy())
-    test_case.assertTrue(np.allclose(of_input_x.grad.numpy(), np_x_grad, 1e-4, 1e-4))
-    test_case.assertTrue(np.allclose(of_input_y.grad.numpy(), np_y_grad, 1e-4, 1e-4))
+    def test_x_y_grad():
+        of_input_x = flow.Tensor(
+            np_input_x,
+            dtype=flow.float32,
+            device=flow.device(device),
+            requires_grad=True,
+        )
+        of_input_y = flow.Tensor(
+            np_input_y,
+            dtype=flow.float32,
+            device=flow.device(device),
+            requires_grad=True,
+        )
+        of_out = flow.pow(of_input_x, of_input_y)
+        of_out_sum = of_out.sum()
+        of_out_sum.backward()
+        test_case.assertTrue(
+            np.allclose(of_input_x.grad.numpy(), np_x_grad, 1e-4, 1e-4)
+        )
+        test_case.assertTrue(
+            np.allclose(of_input_y.grad.numpy(), np_y_grad, 1e-4, 1e-4)
+        )
+
+    def test_x_grad():
+        of_input_x = flow.Tensor(
+            np_input_x,
+            dtype=flow.float32,
+            device=flow.device(device),
+            requires_grad=True,
+        )
+        of_input_y = flow.Tensor(
+            np_input_y, dtype=flow.float32, device=flow.device(device)
+        )
+        of_out = flow.pow(of_input_x, of_input_y)
+        of_out_sum = of_out.sum()
+        of_out_sum.backward()
+        test_case.assertTrue(
+            np.allclose(of_input_x.grad.numpy(), np_x_grad, 1e-4, 1e-4)
+        )
+
+    def test_y_grad():
+        of_input_x = flow.Tensor(
+            np_input_x, dtype=flow.float32, device=flow.device(device)
+        )
+        of_input_y = flow.Tensor(
+            np_input_y,
+            dtype=flow.float32,
+            device=flow.device(device),
+            requires_grad=True,
+        )
+        of_out = flow.pow(of_input_x, of_input_y)
+        of_out_sum = of_out.sum()
+        of_out_sum.backward()
+        test_case.assertTrue(
+            np.allclose(of_input_y.grad.numpy(), np_y_grad, 1e-4, 1e-4)
+        )
+
+    test_x_y_grad()
+    test_x_grad()
+    test_y_grad()
 
     # TODO(liupeihong): scalar-pow backward test
     # ...

--- a/oneflow/python/test/modules/test_pow.py
+++ b/oneflow/python/test/modules/test_pow.py
@@ -22,7 +22,7 @@ import oneflow.experimental as flow
 from test_util import GenArgList
 
 
-def _test_exp_impl(test_case, shape, device):
+def _test_pow_impl(test_case, shape, device):
     np_input = np.random.randn(*shape)
     of_input = flow.Tensor(
         np_input, dtype=flow.float32, device=flow.device(device), requires_grad=True
@@ -41,13 +41,31 @@ def _test_exp_impl(test_case, shape, device):
     not flow.unittest.env.eager_execution_enabled(),
     ".numpy() doesn't work in lazy mode",
 )
-class TestExp(flow.unittest.TestCase):
-    def test_exp(test_case):
-        arg_dict = OrderedDict()
-        arg_dict["shape"] = [(2, 3), (2, 4, 5, 6)]
-        arg_dict["device"] = ["cpu", "cuda"]
-        for arg in GenArgList(arg_dict):
-            _test_exp_impl(test_case, *arg)
+class TestPow(flow.unittest.TestCase):
+    def test_pow(test_case):
+        input = flow.Tensor(np.array([1, 2, 3, 4, 5, 6]), dtype=flow.float32)
+        of_out = flow.pow(input, 2.1)
+        np_out = np.power(input.numpy(), 2.1)
+        test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
+
+    def test_pow_tensor_function(test_case):
+        input = flow.Tensor(np.array([1, 2, 3, 4, 5, 6]), dtype=flow.float32)
+        of_out = input.pow(2.1)
+        np_out = np.power(input.numpy(), 2.1)
+        test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
+
+
+# @unittest.skipIf(
+#     not flow.unittest.env.eager_execution_enabled(),
+#     ".numpy() doesn't work in lazy mode",
+# )
+# class TestExp(flow.unittest.TestCase):
+#     def test_pow(test_case):
+#         arg_dict = OrderedDict()
+#         arg_dict["shape"] = [(2, 3), (2, 4, 5, 6)]
+#         arg_dict["device"] = ["cpu", "cuda"]
+#         for arg in GenArgList(arg_dict):
+#             _test_exp_impl(test_case, *arg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
针对 `oneflow/user/ops/math_unary_elementwise_seq.h`, `oneflow/user/ops/math_binary_elementwise_seq.h`
中的算子，统一添加新接口的反向。

本 PR 中带 2 个 test case 的示例：
- 二元算子请参考：oneflow/python/test/modules/test_pow.py
- 一元算子请参考：oneflow/python/test/modules/test_exp.py

以下 `op_type_name` 的算子，不需要再单独添加新版本的后向。

- abs
- acos
- acosh
- asin
- asinh
- atan
- atanh
- ceil
- cos
- cosh
- erf
- erfc
- exp
- expm1
- floor
- lgamma
- log
- log1p
- log_sigmoid
- negative
- reciprocal
- reciprocal_no_nan
- rint
- round
- rsqrt
- sigmoid_v2
- sign
- sin
- sinh
- softplus
- sqrt
- square
- tan
- tanh

（二元）
- pow
- atan2
- floordiv
- xdivy
- xlogy


TODO：
pow ( https://github.com/Oneflow-Inc/oneflow/pull/4723 ) 的作者刘沛宏 @mosout 需要：

- 更新 `flow.pow` 接口的文档 
- 进一步完善 `flow.pow` 的后向测试（现在只有hardcode版本的 elementwise 的测试），需要覆盖 `scalar_pow`、`pow`，并且最好用 numpy 模拟的方式做 baseline。