### PR TITLE
wrap Receive by WithScopedRelease, only release/acquire gil when necessary

### DIFF
--- a/oneflow/api/python/gil_foreign_lock_helper.cpp
+++ b/oneflow/api/python/gil_foreign_lock_helper.cpp
@@ -24,13 +24,21 @@ namespace py = pybind11;
 namespace oneflow {
 class GILForeignLockHelper final : public ForeignLockHelper {
   void WithScopedRelease(const std::function<void()>& callback) const override {
-    py::gil_scoped_release release;
-    callback();
+    if (PyGILState_Check()) {
+      py::gil_scoped_release release;
+      callback();
+    } else {
+      callback();
+    }
   }
 
   void WithScopedAcquire(const std::function<void()>& callback) const override {
-    py::gil_scoped_acquire acquire;
-    callback();
+    if (!PyGILState_Check()) {
+      py::gil_scoped_acquire acquire;
+      callback();
+    } else {
+      callback();
+    }
   }
 };
 


### PR DESCRIPTION
给 Receive 加上 WithScopedRelease，@ouyangyu 测试没有再遇到死锁

以及在没有 gil 锁时调用 gil_scoped_release 会偶尔报错 `Fatal Python error: PyEval_SaveThread: NULL tstate`（这里有 pytorch 开发者给 pybind11 的 issue https://github.com/pybind/pybind11/issues/2961 ）所以加了判断