### PR TITLE
Treat warning in docs as error when building docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -382,6 +382,12 @@ jobs:
             $extra_docker_args \
             oneflow-test:$USER \
             ${bin_dir}/oneflow_testexe
+      - name: Build documentation
+        if: matrix.test_suite == 'cuda'
+        run: |
+          docker run $extra_docker_args \
+            oneflow-test:$USER \
+            bash -c "bash ci/test/try_install.sh && bash ci/test/build_docs.sh"
       - name: Op test (distributed)
         if: matrix.test_suite == 'cuda'
         run: |
@@ -482,12 +488,6 @@ jobs:
           docker run $extra_docker_args \
             oneflow-test:$USER \
             bash -c "bash ci/test/try_install.sh && bash ci/test/onnx_export_model_test.sh"
-      - name: Build documentation
-        if: matrix.test_suite == 'cuda'
-        run: |
-          docker run $extra_docker_args \
-            oneflow-test:$USER \
-            bash -c "bash ci/test/try_install.sh && bash ci/test/build_docs.sh"
       - name: Query system status
         if: ${{ failure() }}
         run: |

--- a/ci/test/build_docs.sh
+++ b/ci/test/build_docs.sh
@@ -1,4 +1,4 @@
 set -ex
 cp -r docs /docs
 cd /docs
-make html SPHINXOPTS="-W --keep-going -n"
+make html SPHINXOPTS="-W --keep-going"

--- a/ci/test/build_docs.sh
+++ b/ci/test/build_docs.sh
@@ -1,4 +1,4 @@
 set -ex
 cp -r docs /docs
 cd /docs
-make html
+make html SPHINXOPTS="-W --keep-going -n"

--- a/docker/ci/test/Dockerfile
+++ b/docker/ci/test/Dockerfile
@@ -4,7 +4,7 @@ RUN apt remove openmpi-common libfabric1 openmpi-bin librdmacm1:amd64 libopenmpi
 ENV MOFED_DIR MLNX_OFED_LINUX-4.3-1.0.1.0-ubuntu18.04-x86_64
 RUN wget https://oneflow-static.oss-cn-beijing.aliyuncs.com/deps/${MOFED_DIR}.tgz && \
     tar -xzvf ${MOFED_DIR}.tgz && \
-    ${MOFED_DIR}/mlnxofedinstall --user-space-only --without-fw-update --all -q && \
+    ${MOFED_DIR}/mlnxofedinstall --user-space-only --without-fw-update --all -q --force && \
     cd .. && \
     rm -rf ${MOFED_DIR} && \
     rm -rf *.tgz

--- a/docker/ci/test/build.sh
+++ b/docker/ci/test/build.sh
@@ -4,6 +4,7 @@ test_img_dir="$(realpath "${test_img_dir}")"
 cd $test_img_dir
 
 proxy_args=""
+proxy_args+=" --network=host"
 proxy_args+=" --build-arg HTTP_PROXY=${HTTP_PROXY}"
 proxy_args+=" --build-arg HTTPS_PROXY=${HTTPS_PROXY}"
 proxy_args+=" --build-arg http_proxy=${http_proxy}"

--- a/docker/ci/test/build.sh
+++ b/docker/ci/test/build.sh
@@ -2,5 +2,12 @@ set -ex
 test_img_dir="$(dirname "${BASH_SOURCE[0]}")"
 test_img_dir="$(realpath "${test_img_dir}")"
 cd $test_img_dir
-docker build --rm \
+
+proxy_args=""
+proxy_args+=" --build-arg HTTP_PROXY=${HTTP_PROXY}"
+proxy_args+=" --build-arg HTTPS_PROXY=${HTTPS_PROXY}"
+proxy_args+=" --build-arg http_proxy=${http_proxy}"
+proxy_args+=" --build-arg https_proxy=${https_proxy}"
+
+docker build --rm $proxy_args \
     -t oneflow-test:$USER .

--- a/docker/ci/test/requirements.txt
+++ b/docker/ci/test/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==3.5.4
+Sphinx==2.2.0
 recommonmark==0.6.0
 sphinx_rtd_theme==0.5.0
 # dependencies above must be identical to docs/requirements.txt

--- a/docker/ci/test/requirements.txt
+++ b/docker/ci/test/requirements.txt
@@ -4,7 +4,6 @@ sphinx_rtd_theme==0.5.0
 # dependencies above must be identical to docs/requirements.txt
 pycocotools
 opencv-python==4.2.0.34
-recommonmark
 scipy
 pillow
 tensorflow-addons==0.9.1

--- a/docker/ci/test/requirements.txt
+++ b/docker/ci/test/requirements.txt
@@ -1,8 +1,9 @@
 pycocotools
 opencv-python==4.2.0.34
-sphinx
+Sphinx==3.5.4
+recommonmark==0.6.0
+sphinx_rtd_theme==0.5.0
 recommonmark
 scipy
 pillow
-sphinx_rtd_theme
 tensorflow-addons==0.9.1

--- a/docker/ci/test/requirements.txt
+++ b/docker/ci/test/requirements.txt
@@ -1,8 +1,9 @@
-pycocotools
-opencv-python==4.2.0.34
 Sphinx==3.5.4
 recommonmark==0.6.0
 sphinx_rtd_theme==0.5.0
+# dependencies above must be identical to docs/requirements.txt
+pycocotools
+opencv-python==4.2.0.34
 recommonmark
 scipy
 pillow

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
-Sphinx==2.2.0
+Sphinx==3.5.4
 recommonmark==0.6.0
-sphinx_material==0.0.30
 sphinx_rtd_theme==0.5.0
 --find-links https://staging.oneflow.info/branch/master/cu102
 oneflow

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==3.5.4
+Sphinx==2.2.0
 recommonmark==0.6.0
 sphinx_rtd_theme==0.5.0
 --find-links https://staging.oneflow.info/branch/master/cu102

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,20 +76,6 @@ pygments_style = None
 #
 html_theme = "sphinx_rtd_theme"
 
-# Material theme options (see theme.conf for more information)
-html_theme_options = {
-    # Set the name of the project to appear in the navigation.
-    "nav_title": "OneFlow APIs",
-    # Set the color and the accent color
-    "color_primary": "blue",
-    "color_accent": "light-blue",
-    # Set the repo location to get a badge with stats
-    "repo_url": "https://github.com/Oneflow-Inc/oneflow",
-    "repo_name": "oneflow",
-    # Visible levels of the global TOC; -1 means unlimited
-    "globaltoc_depth": 2,
-}
-
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/oneflow/python/nn/modules/atanh.py
+++ b/oneflow/python/nn/modules/atanh.py
@@ -35,6 +35,7 @@ def atanh_op(input):
 
     .. math::
         \text{out}_{i} = \tanh^{-1}(\text{input}_{i})
+
     Args:
         input (Tensor): the input tensor.
 
@@ -50,6 +51,7 @@ def atanh_op(input):
         >>> output = flow.atanh(input)
         >>> print(output.numpy())
         [0.54930615 0.6931472  0.8673005 ]
+
     """
 
     return Atanh()(input)

--- a/oneflow/python/nn/modules/conv.py
+++ b/oneflow/python/nn/modules/conv.py
@@ -99,16 +99,14 @@ class Conv2d(Module):
 
     * :attr:`stride` controls the stride for the cross-correlation, a single
       number or a tuple.
-
     * :attr:`padding` controls the amount of implicit padding on both
       sides for :attr:`padding` number of points for each dimension.
-
     * :attr:`dilation` controls the spacing between the kernel points; also
       known as the à trous algorithm. It is harder to describe, but this `link`_
       has a nice visualization of what :attr:`dilation` does.
-
-    * :attr:`groups` controls the connections between inputs and outputs. :attr:`in_channels` 
-       and :attr:`out_channels` must both be divisible by :attr:`groups`. For example,
+    * :attr:`groups` controls the connections between inputs and outputs.
+      :attr:`in_channels` and :attr:`out_channels` must both be divisible by
+      :attr:`groups`. For example,
 
         * At groups=1, all inputs are convolved to all outputs.
         * At groups=2, the operation becomes equivalent to having two conv

--- a/oneflow/python/nn/modules/dropout.py
+++ b/oneflow/python/nn/modules/dropout.py
@@ -50,8 +50,8 @@ class Dropout(_DropoutNd):
 
     This has proven to be an effective technique for regularization and
     preventing the co-adaptation of neurons as described in the paper
-    `Improving neural networks by preventing co-adaptation of feature
-    detectors`_ .
+    "Improving neural networks by preventing co-adaptation of feature
+    detectors".
 
     Furthermore, the outputs are scaled by a factor of :math:`\frac{1}{1-p}` during
     training. This means that during evaluation the module simply computes an

--- a/oneflow/python/nn/modules/expand.py
+++ b/oneflow/python/nn/modules/expand.py
@@ -62,6 +62,7 @@ class Expand(Module):
         )[0]
 
 
+@oneflow_export("expand")
 @register_tensor_op("expand")
 @experimental_api
 def expand_op(x, *sizes):
@@ -97,6 +98,7 @@ def expand_op(x, *sizes):
         >>> out = input.expand(1, 3, 2, 2)
         >>> print(out.shape)
         flow.Size([1, 3, 2, 2])
+
     """
     return Expand(sizes)(x)
 

--- a/oneflow/python/nn/modules/gather.py
+++ b/oneflow/python/nn/modules/gather.py
@@ -66,13 +66,11 @@ class Gather(Module):
 def gather_op(input, index, dim=0, sparse_grad=False):
     r"""Gathers values along an axis specified by `dim`.
 
-    For a 3-D tensor the output is specified by::
+    For a 3-D tensor the output is specified by:
 
-    out[i][j][k] = input[index[i][j][k]][j][k]  # if dim == 0
-
-    out[i][j][k] = input[i][index[i][j][k]][k]  # if dim == 1
-
-    out[i][j][k] = input[i][j][index[i][j][k]]  # if dim == 2
+        out[i][j][k] = input[index[i][j][k]][j][k]  # if dim == 0
+        out[i][j][k] = input[i][index[i][j][k]][k]  # if dim == 1
+        out[i][j][k] = input[i][j][index[i][j][k]]  # if dim == 2
 
     :attr:`input` and :attr:`index` must have the same number of dimensions.
     It is also required that ``index.size(d) <= input.size(d)`` for all

--- a/oneflow/python/nn/modules/linear.py
+++ b/oneflow/python/nn/modules/linear.py
@@ -59,8 +59,6 @@ class Identity(Module):
 class Linear(Module):
     """Applies a linear transformation to the incoming data: :math:`y = xA^T + b`
 
-    This module supports :ref:`TensorFloat32<tf32_on_ampere>`.
-
     Args:
 
         - in_features: size of each input sample

--- a/oneflow/python/nn/modules/math_ops.py
+++ b/oneflow/python/nn/modules/math_ops.py
@@ -578,6 +578,7 @@ def _add(x, y):
 
     .. math::
         out = x + y
+
     For example:
 
     .. code-block:: python
@@ -635,8 +636,10 @@ def asin_op(input):
 
     .. math::
         \text{out}_{i} = \sin^{-1}(\text{input}_{i})
+
     Args:
         input (Tensor): the input tensor.
+
     For example:
 
     .. code-block:: python
@@ -708,8 +711,10 @@ def asinh_op(input):
 
     .. math::
         \text{out}_{i} = \sinh^{-1}(\text{input}_{i})
+
     Args:
         input (Tensor): the input tensor.
+
     For example:
 
     .. code-block:: python
@@ -841,6 +846,7 @@ def cos_op(tensor):
 
     .. math::
         \text{out}_{i} = \cos(\text{input}_{i})
+
     Args:
         input (Tensor): the input tensor.
 
@@ -877,6 +883,7 @@ def log_op(tensor):
 
     .. math::
         y_{i} = \log_{e} (x_{i})
+
     Args:
         input (Tensor): the input tensor.
 
@@ -1149,6 +1156,7 @@ def cosh_op(tensor):
 
     .. math::
         \text{out}_{i} = \cosh(\text{input}_{i})
+
     Args:
         input (Tensor): the input tensor.
 

--- a/oneflow/python/nn/modules/normalization.py
+++ b/oneflow/python/nn/modules/normalization.py
@@ -44,6 +44,7 @@ class LayerNorm(Module):
         scalar scale and bias for each entire channel/plane with the
         :attr:`affine` option, Layer Normalization applies per-element scale and
         bias with :attr:`elementwise_affine`.
+
     This layer uses statistics computed from input data in both training and
     evaluation modes.
 
@@ -61,6 +62,7 @@ class LayerNorm(Module):
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters initialized to ones (for weights)
             and zeros (for biases). Default: ``True``.
+
     Shape:
         - Input: :math:`(N, *)`
         - Output: :math:`(N, *)` (same shape as input)

--- a/oneflow/python/nn/modules/pooling.py
+++ b/oneflow/python/nn/modules/pooling.py
@@ -115,8 +115,7 @@ class AvgPool2d(Module):
 @experimental_api
 class MaxPool1d(Module):
     r"""The interface is consistent with PyTorch.
-    The documentation is referenced from:
-        https://pytorch.org/docs/stable/generated/torch.nn.MaxPool1d.html#torch.nn.MaxPool1d
+    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.MaxPool1d.html#torch.nn.MaxPool1d
 
     Applies a 1D max pooling over an input signal composed of several input planes.
 
@@ -172,8 +171,7 @@ class MaxPool1d(Module):
 @experimental_api
 class MaxPool2d(Module):
     r"""The interface is consistent with PyTorch.
-    The documentation is referenced from:
-        https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html#torch.nn.MaxPool2d
+    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html#torch.nn.MaxPool2d
 
     Applies a 2D max pooling over an input signal composed of several input planes.
 
@@ -302,8 +300,7 @@ class MaxPool2d(Module):
 @experimental_api
 class MaxPool3d(Module):
     r"""The interface is consistent with PyTorch.
-    The documentation is referenced from:
-        https://pytorch.org/docs/stable/generated/torch.nn.MaxPool3d.html#torch.nn.MaxPool3d
+    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.MaxPool3d.html#torch.nn.MaxPool3d
 
     Applies a 3D max pooling over an input signal composed of several input planes.
 

--- a/oneflow/python/nn/modules/sparse.py
+++ b/oneflow/python/nn/modules/sparse.py
@@ -34,10 +34,10 @@ class Embedding(Module):
         num_embeddings (int): size of the dictionary of embeddings
         embedding_dim (int): the size of each embedding vector
         padding_idx (int, optional): If specified, the entries at :attr:`padding_idx` do not contribute to the gradient;
-        therefore, the embedding vector at :attr:`padding_idx` is not updated during training,
-        i.e. it remains as a fixed "pad". For a newly constructed Embedding,
-        the embedding vector at :attr:`padding_idx` will default to all zeros,
-        but can be updated to another value to be used as the padding vector.
+                                    therefore, the embedding vector at :attr:`padding_idx` is not updated during training,
+                                    i.e. it remains as a fixed "pad". For a newly constructed Embedding,
+                                    the embedding vector at :attr:`padding_idx` will default to all zeros,
+                                    but can be updated to another value to be used as the padding vector.
     
     For example:
 

--- a/oneflow/python/nn/modules/tan.py
+++ b/oneflow/python/nn/modules/tan.py
@@ -35,6 +35,7 @@ def tan_op(input):
 
     .. math::
         \text{out}_{i} = \tan(\text{input}_{i})
+
     Args:
         input (Tensor): the input tensor.
 
@@ -50,6 +51,7 @@ def tan_op(input):
         >>> output = flow.tan(input)
         >>> print(output.numpy())
         [-1.  0.  1.]
+
     """
 
     return Tan()(input)

--- a/oneflow/python/nn/modules/to.py
+++ b/oneflow/python/nn/modules/to.py
@@ -47,9 +47,9 @@ def to_op(input, *args, **kwargs):
         A flow.dtype and flow.device are inferred from the arguments of `input.to(*args, **kwargs)`.
     
     .. note::
-    If the ``input`` Tensor already
-    has the correct :class:`flow.dtype` and :class:`flow.device`, then ``input`` is returned.
-    Otherwise, the returned tensor is a copy of ``input`` with the desired.
+        If the ``input`` Tensor already
+        has the correct :class:`flow.dtype` and :class:`flow.device`, then ``input`` is returned.
+        Otherwise, the returned tensor is a copy of ``input`` with the desired.
 
     Args:
         input (oneflow.Tensor): An input tensor.

--- a/oneflow/python/nn/modules/where.py
+++ b/oneflow/python/nn/modules/where.py
@@ -106,9 +106,8 @@ def where_op(condition, x, y):
 
     .. note::
 
-    The tensors :attr:`condition`, :attr:`x`, :attr:`y` must be broadcastable.
-
-    it will take the `x` element, else it will take the `y` element.
+        The tensors :attr:`condition`, :attr:`x`, :attr:`y` must be broadcastable.
+        It will take the `x` element, else it will take the `y` element.
 
     Args:
         condition (IntTensor): When 1 (nonzero), yield x, otherwise yield y

--- a/oneflow/python/ops/nn_ops.py
+++ b/oneflow/python/ops/nn_ops.py
@@ -383,15 +383,15 @@ def conv2d(
         filters (oneflow._oneflow_internal.BlobDesc): A `Blob` with the same type as `input` and has the shape `[out_channels, in_channels//groups, filter_height, filter_width] for NCHW, or [out_channels, filter_height, filter_width, in_channels//groups] for NHWC`
         strides (Union[int, IntPair]): An int or list of `ints` that has length `2`. The stride of the sliding window for each dimension of `input`.
         padding (Union[str, Tuple[IntPair, IntPair, IntPair, IntPair]]): padding: `string` `"SAME"` or `"SAME_LOWER"` or `"SAME_UPPER"` or `"VALID" or Tuple[IntPair, IntPair, IntPair, IntPair]` indicating the type of padding algorithm to use, or a list indicating the explicit paddings at the start and end of each dimension.
-        data_format (str, optional): `"NHWC" or "NCHW"`. Defaults to `"NCHW"`.
+        data_format (str, optional): `"NHWC"` or `"NCHW"`. Defaults to `"NCHW"`.
         dilations (Optional[Union[int, IntPair]], optional): An int or list of `ints` that has length `2`. The dilation factor for each dimension of `input`. Defaults to None.
         groups (int, optional): int value greater than 0. Defaults to 1.
         name (Optional[str], optional): This operator's name. Defaults to None.
 
     Raises:
         ValueError: strides must be an int or a list.
-        ValueError: padding must be "SAME" or `"SAME_LOWER" or "SAME_UPPER" or "VALID" or Tuple[IntPair, IntPair, IntPair, IntPair].
-        ValueError: data_format must be "NHWC" or "NCHW".
+        ValueError: padding must be `"SAME"` or `"SAME_LOWER" or `"SAME_UPPER"` or `"VALID"` or Tuple[IntPair, IntPair, IntPair, IntPair].
+        ValueError: data_format must be `"NHWC"` or `"NCHW"`.
         ValueError: dilations must be an int or a list.
         ValueError: invalid data_format.
         ValueError: data_format NHWC not support groups > 1
@@ -598,7 +598,7 @@ def conv3d(
         input (oneflow._oneflow_internal.BlobDesc):  A 5D input `Blob`. [batch_num, channel, depth, height, width]
         filters (oneflow._oneflow_internal.BlobDesc): A `Blob` with the same type as `input` and has the shape `[out_channels, in_channels//groups, filter_depth, filter_height, filter_width] for NCDHW, or [out_channels, filter_depth, filter_height, filter_width, in_channels//groups] for NDHWC`
         strides (Union[int, Sequence[int]]): An `int` or `list of ints` that has length `3`. The stride of the sliding window for each dimension of `input`.
-        padding (Union[str, Tuple[IntPair, IntPair, IntPair, IntPair, IntPair]]): padding: `string` `"SAME"` or `"SAME_LOWER"` or `"SAME_UPPER"` or `"VALID" or Tuple[IntPair, IntPair, IntPair, IntPair, IntPair]` indicating the type of padding algorithm to use, or a list indicating the explicit paddings at the start and end of each dimension.
+        padding (Union[str, Tuple[IntPair, IntPair, IntPair, IntPair, IntPair]]): padding: `string` `"SAME"` or `"SAME_LOWER"` or `"SAME_UPPER"` or `"VALID"` or Tuple[IntPair, IntPair, IntPair, IntPair, IntPair]` indicating the type of padding algorithm to use, or a list indicating the explicit paddings at the start and end of each dimension.
         data_format (str, optional): `"NDHWC" or "NCDHW"`. Defaults to `"NCDHW"`.
         dilations (Optional[Union[int, Sequence[int]]], optional): An int or list of `ints` that has length `3`. The dilation factor for each dimension of `input`. Defaults to None.
         groups (int, optional): int value greater than 0. Defaults to 1.
@@ -3470,7 +3470,6 @@ def hardtanh(
         import oneflow.typing as tp
         import numpy as np
 
-
         @flow.global_function()
         def hardtanh_job(x: tp.Numpy.Placeholder(shape=(2, 3)))->tp.Numpy:
             return flow.nn.hardtanh(x, min_val=-1.25, max_val=1.2)
@@ -3482,11 +3481,13 @@ def hardtanh(
 
         # output [[-1.25 -1.1   0.6 ]
         #         [ 1.2   1.2   1.2 ]]
+
     Args:
         x (oneflow._oneflow_internal.BlobDesc): The input Tensor.
         min_val (float, optional): The minimum value of the linear region range. Defaults to -1.
         max_val (float, optional): The maximum value of the linear region range. Defaults to 1.
         name (Optional[str], optional): The name for the operation. Defaults to None.
+
     Returns:
         oneflow._oneflow_internal.BlobDesc: The activated tensor.
     """

--- a/oneflow/python/ops/tensor_buffer_ops.py
+++ b/oneflow/python/ops/tensor_buffer_ops.py
@@ -169,6 +169,7 @@ def gen_tensor_buffer(
         BlobDesc: The result Blob.
 
     For example:
+
     .. code-block:: python
 
         import oneflow as flow
@@ -181,6 +182,7 @@ def gen_tensor_buffer(
                 return y
 
         # y_0.shape (2, 1), y_1.shape (1. 2)
+
     """
     return (
         flow.user_op_builder(
@@ -222,8 +224,11 @@ def tensor_buffer_to_list_of_tensors(
         List[BlobDesc]: result blobs
 
     For example:
+
     .. code-block:: python
+
         # the same with `gen_tensor_buffer` op
+
     """
     return (
         flow.user_op_builder(


### PR DESCRIPTION
- 修复文档的各种 warning
- CI 如果发现文档有 warning，直接失败
- 使用这个命令会将文档的 warning 改成 error
```
make html SPHINXOPTS="-W --keep-going"
make html SPHINXOPTS="-W" # 只显示一个 warning
```