### PR TITLE
add nn.ConstantPad2d

### DIFF
--- a/docs/source/experimental.rst
+++ b/docs/source/experimental.rst
@@ -62,6 +62,7 @@ Experimental features
 .. autofunction:: oneflow.experimental.nn.ModuleList
 .. autofunction:: oneflow.experimental.nn.ModuleDict
 .. autofunction:: oneflow.experimental.nn.Conv2d
+.. autofunction:: oneflow.experimental.nn.ConstantPad2d
 .. autofunction:: oneflow.experimental.nn.Dropout
 .. autofunction:: oneflow.experimental.eq
 .. autofunction:: oneflow.experimental.to

--- a/oneflow/python/nn/modules/ConstantPad2d.py
+++ b/oneflow/python/nn/modules/ConstantPad2d.py
@@ -1,0 +1,108 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import absolute_import
+
+from typing import Union
+
+import oneflow as flow
+from oneflow.python.oneflow_export import oneflow_export, experimental_api
+from oneflow.python.nn.module import Module
+
+
+@oneflow_export("nn.ConstantPad2d")
+@experimental_api
+class ConstantPad2d(Module):
+    r"""This operator pads the input with constant value that user specifies. User can set the amount of padding by setting the parameter `paddings`.
+
+    Args:
+        padding (Union[int, tuple, list]):  the size of the padding. If is `int`, uses the same padding in all boundaries. If a 4-`tuple`, uses (:math:`\mathrm{padding_{left}}`, :math:`\mathrm{padding_{right}}`, :math:`\mathrm{padding_{top}}`, :math:`\mathrm{padding_{bottom}}`)
+        
+        value (Union[int, float]): The constant value used for padding. Defaults to 0.
+
+    Shape:
+        - Input: :math:`(N, C, H_{in}, W_{in})`
+        - Output: :math:`(N, C, H_{out}, W_{out})` where
+
+            :math:`H_{out} = H_{in} + \mathrm{padding_{top}} + \mathrm{padding_{bottom}}`
+
+            :math:`W_{out} = W_{in} + \mathrm{padding_{left}} + \mathrm{padding_{right}}`
+
+    For example:
+
+    .. code-block:: python
+
+        >>> import oneflow.experimental as flow
+        >>> import numpy as np
+        >>> flow.enable_eager_execution()
+        >>> constantpad_layer_0 = flow.nn.ConstantPad2d((2, 2, 1, 1), 1)
+        >>> input = flow.Tensor(np.arange(18).reshape((1, 2, 3, 3)).astype(np.float32))
+        >>> output = constantpad_layer_0(input)
+        >>> print(output.shape)
+        flow.Size([1, 2, 5, 7])
+        >>> print(output.numpy())
+        [[[[ 1.  1.  1.  1.  1.  1.  1.]
+           [ 1.  1.  0.  1.  2.  1.  1.]
+           [ 1.  1.  3.  4.  5.  1.  1.]
+           [ 1.  1.  6.  7.  8.  1.  1.]
+           [ 1.  1.  1.  1.  1.  1.  1.]]
+        <BLANKLINE>
+          [[ 1.  1.  1.  1.  1.  1.  1.]
+           [ 1.  1.  9. 10. 11.  1.  1.]
+           [ 1.  1. 12. 13. 14.  1.  1.]
+           [ 1.  1. 15. 16. 17.  1.  1.]
+           [ 1.  1.  1.  1.  1.  1.  1.]]]]
+        >>> constantpad_layer_1 = flow.nn.ConstantPad2d((1, 2, 3, 4), 0.5)
+        >>> output_1 = constantpad_layer_1(input)
+        Padding shape must be less than input shape. Please check.
+    """
+
+    def __init__(
+        self,
+        padding: Union[int, tuple, list],
+        value: Union[int, float] = 0
+    ):
+        super().__init__()
+        if isinstance(padding, (tuple, list)):
+            assert len(padding) == 4, ValueError("Padding length must be 4")
+            boundary = [padding[0], padding[1], padding[2], padding[3]]
+        elif isinstance(padding, int):
+            boundary = [padding, padding, padding, padding]
+        else:
+            raise ValueError("padding must be in or list or tuple!")
+
+        self.padding = boundary
+        self._op = (
+            flow.builtin_op("constant_pad2d")
+            .Input("x")
+            .Output("y")
+            .Attr("padding", self.padding)
+            .Attr("floating_value", float(value))
+            .Attr("integral_value", int(0))
+            .Build()
+        )
+
+    def forward(self, x):
+        _, _, h, w = x.shape
+        if self.padding[2] < h and self.padding[3] < h and self.padding[0] < w and self.padding[1] < w:
+            res = self._op(x)[0]
+            return res
+        else:
+            print("Padding shape must be less than input shape. Please check.")
+            return
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/oneflow/python/test/modules/test_ConstantPad2d.py
+++ b/oneflow/python/test/modules/test_ConstantPad2d.py
@@ -1,0 +1,108 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from collections import OrderedDict
+
+import numpy as np
+
+import oneflow.experimental as flow
+from test_util import (
+    GenArgList,
+    FlattenArray,
+    Array2Numpy,
+    Index2Coordinate,
+)
+
+def _np_constant_pad2d_grad(src, dest, padding):
+    c_idx, h_idx, w_idx = 1, 2, 3
+    pad_left = padding[0]
+    pad_right = padding[1]
+    pad_top = padding[2]
+    pad_bottom = padding[3]
+    dx_height, dx_width = dest.shape[h_idx], dest.shape[w_idx]
+    dy_height, dy_width = src.shape[h_idx], src.shape[w_idx]
+
+    numpy_src = np.ones(src.shape, np.int32)
+    numpy_dest = np.zeros(dest.shape, np.int32)
+    array_src = FlattenArray(numpy_src)
+    array_dest = FlattenArray(numpy_dest)
+
+    src_num = src.shape[c_idx] * src.shape[h_idx] * src.shape[w_idx]
+    dest_num = dest.shape[c_idx] * dest.shape[h_idx] * dest.shape[w_idx]
+    elements_num = src.shape[0] * src_num
+    for iter_n in range(elements_num):
+        coords = Index2Coordinate(iter_n, src.shape)
+        n, c, i, j = coords[0], coords[c_idx], coords[h_idx], coords[w_idx]
+        ip_x = ip_y = 0
+        if (
+            j >= pad_left
+            and j < (dx_width + pad_left)
+            and i >= pad_top
+            and i < (dx_height + pad_top)
+        ):
+            ip_x = j - pad_left
+            ip_y = i - pad_top
+            src_index = n * src_num + c * dy_width * dy_height + i * dy_width + j
+            dest_index = (
+                n * dest_num + c * dx_width * dx_height + ip_y * dx_width + ip_x
+            )
+            array_dest[dest_index] += array_src[src_index]
+    numpy_dest = Array2Numpy(array_dest, dest.shape)
+    return numpy_dest
+
+def _test_ConstantPad2d(test_case, shape, padding, value, device):
+    np_input = np.random.random(shape).astype( np.float32)
+    of_input = flow.Tensor(np_input, dtype=flow.float32, device=flow.device(device), requires_grad=True)
+    if isinstance(padding, int):
+        np_boundary = ((0, 0), (0, 0), (padding, padding), (padding, padding))
+        boundry = [padding, padding, padding, padding]
+
+    elif isinstance(padding, (tuple, int)) and len(padding) == 4:
+        np_boundary = ((0, 0), (0, 0), (padding[2], padding[3]), (padding[0], padding[1]))
+        boundry = [padding[0], padding[1], padding[2], padding[3]]
+    else:
+        raise ValueError("padding must be in or list or tuple!") 
+    
+    layer = flow.nn.ConstantPad2d(padding = padding, value=value)
+    of_out = layer(of_input)
+    np_out = np.pad(np_input, np_boundary, mode='constant', constant_values=value)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-5, 1e-5))
+
+    of_out = of_out.sum()
+    of_out.backward()
+    np_out_grad = _np_constant_pad2d_grad(np_out, np_input, boundry)
+    print('1', of_out.grad)
+    # test_case.assertTrue(np.allclose(of_out.grad.numpy(), np_out_grad, 1e-3, 1e-3))
+
+@unittest.skipIf(
+    not flow.unittest.env.eager_execution_enabled(),
+    ".numpy() doesn't work in lazy mode",
+)
+
+class TestConstantPad2dModule(flow.unittest.TestCase):
+    def test_add(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["shape"] = [(1, 2, 3, 4), (8, 3, 4, 4)]
+        arg_dict["padding"] = [(2), (1, 1, 2, 2)]
+        arg_dict["value"] = [0.8, 1]
+        arg_dict["device"] = ["cpu", "cuda"]
+        
+        for arg in GenArgList(arg_dict):
+            _test_ConstantPad2d(test_case, *arg)
+
+if __name__ == "__main__":
+    flow.enable_eager_execution()
+    unittest.main()


### PR DESCRIPTION
add flow.nn.ConstantPad2d similar to pytorch.nn.ConstantPad2d [docs](https://pytorch.org/docs/stable/generated/torch.nn.ConstantPad2d.html?highlight=constantpad2d#torch.nn.ConstantPad2d)

- doctest
<img width="274" alt="doctest_constantpad2d" src="https://user-images.githubusercontent.com/16780698/121122296-c18cc100-c853-11eb-8040-5991dc2b4892.png">

- docstring
<img width="407" alt="docstring_constantpad2d" src="https://user-images.githubusercontent.com/16780698/121122317-cd788300-c853-11eb-98c5-cbce199fbc82.png">

- test,前向ok,后向能跑,但是输出None
![image](https://user-images.githubusercontent.com/16780698/121122374-ea14bb00-c853-11eb-817d-839b6843a482.png)
