### PR TITLE
Forbid in-source build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,12 @@ project(oneflow C CXX)
 
 set(oneflow_cmake_dir ${PROJECT_SOURCE_DIR}/cmake)
 
+get_filename_component(real_src_dir "${CMAKE_SOURCE_DIR}" REALPATH)
+get_filename_component(real_bin_dir "${CMAKE_BINARY_DIR}" REALPATH)
+if("${real_src_dir}" STREQUAL "${real_bin_dir}")
+  message(FATAL_ERROR "In-source build not allowed")
+endif()
+
 # Modules
 list(APPEND CMAKE_MODULE_PATH ${oneflow_cmake_dir}/third_party)
 list(APPEND CMAKE_MODULE_PATH ${oneflow_cmake_dir})


### PR DESCRIPTION
因为 oneflow 的 cmake 大量使用了 glob，所以在 cmake in source build 的时候就会造成错乱，比如
```
In file included from [source dir]/_deps/pybind11-src/include/pybind11/pytypes.h:12:0,
                 from [source dir]/_deps/pybind11-src/include/pybind11/cast.h:13,
                 from [source dir]/_deps/pybind11-src/include/pybind11/attr.h:13,
                 from [source dir]/_deps/pybind11-src/include/pybind11/pybind11.h:45,
                 from [source dir]/oneflow/core/common/data_type.cfg.pybind.cpp:1:
[source dir]/_deps/pybind11-src/include/pybind11/detail/common.h:122:10: fatal error: Python.h: No such file or directory
 #include <Python.h>
          ^~~~~~~~~~
compilation terminated.
````