### PR TITLE
[WIP] Fix crash when loading value in debug mode.

### DIFF
--- a/oneflow/api/python/framework/tensor.cpp
+++ b/oneflow/api/python/framework/tensor.cpp
@@ -201,7 +201,7 @@ void SpecializedDef(py::class_<MirroredTensor, Tensor, std::shared_ptr<MirroredT
   using T = MirroredTensor;
   api->def_property_readonly("device", &TensorGetDevice);
   api->def_property_readonly("data", &T::data);
-  api->def_property_readonly("_tensor_buffer_shapes_and_dtypes", &GetTensorBufferShapesAndDTypes);
+//  api->def_property_readonly("_tensor_buffer_shapes_and_dtypes", &GetTensorBufferShapesAndDTypes);
 #define DEFINE_TENSOR_METHOD(T, type_proto)                         \
   api->def("_copy_to_numpy_" #T, &ApiCopyMirroredTensorToNumpy<T>); \
   api->def("_copy_from_numpy_" #T, &ApiCopyMirroredTensorFromNumpy<T>);

--- a/oneflow/core/job/env_global_objects_scope.cpp
+++ b/oneflow/core/job/env_global_objects_scope.cpp
@@ -179,7 +179,7 @@ EnvGlobalObjectsScope::~EnvGlobalObjectsScope() {
 
 const std::shared_ptr<const ParallelDesc>& EnvGlobalObjectsScope::MutParallelDesc4Device(
     const Device& device) {
-  CHECK(thread_id_ == std::this_thread::get_id());
+//  CHECK(thread_id_ == std::this_thread::get_id());
   {
     const auto& iter = device2parallel_desc_.find(device);
     if (iter != device2parallel_desc_.end()) { return iter->second; }


### PR DESCRIPTION
使用vscode/pycharm进行debug时，debugger会自动读取 LocalTensor 的属性，其中有两处会引发 fatal 。在https://github.com/Oneflow-Inc/oneflow/issues/5146 中有其他人提出过。

1. 当LocalTensor不是flow.buffer时，读取_tensor_buffer_shapes_and_dtypes会crash（log1），是否应该判断一下此LocalTensor的类型是否为flow.buffer； @lixinqi 
2. 使用 pydev 进行debug 时，`env_global_objects_scope.cpp`中`CHECK(thread_id_ == std::this_thread::get_id());`会失败(log2)；使用PDB没有这个问题。
3. 另外，我注意到`CHECK(thread_id_ == std::this_thread::get_id());`后面几行用大括号包起来，是个什么用法？ @poohRui 

目前注释掉两行暂时解决问题，希望大佬帮助把这两个问题给fix。

**log1**

```
(Pdb) p of_out._tensor_buffer_shapes_and_dtypes
F0618 14:30:49.351991 886763 data_type.h:224] 2 10
*** Check failure stack trace: ***
    @     0x7f4bfd944978  google::LogMessage::Fail()
    @     0x7f4bfd9448b3  google::LogMessage::SendToLog()
    @     0x7f4bfd9441e4  google::LogMessage::Flush()
    @     0x7f4bfd9477d2  google::LogMessageFatal::~LogMessageFatal()
    @     0x7f4bf7b49caf  oneflow::CheckDataType<>()
    @     0x7f4bf7b44265  oneflow::Blob::dptr<>()
    @     0x7f4bf7b2f8eb  oneflow::one::(anonymous namespace)::(anonymous namespace)::GetTensorBufferShapesAndDTypes()
    @     0x7f4bf7b5e57c  _ZNO8pybind116detail15argument_loaderIJRKSt10shared_ptrIN7oneflow3one14MirroredTensorEEEE9call_implISt5tupleIJSt6vectorINS3_5ShapeESaISD_EESC_IPKNS3_5DTypeESaISI_EEEERPFSL_S8_EJLm0EENS0_9void_typeEEET_OT0_NS0_14index_sequenceIJXspT1_EEEEOT2_
    @     0x7f4bf7b584cb  _ZNO8pybind116detail15argument_loaderIJRKSt10shared_ptrIN7oneflow3one14MirroredTensorEEEE4callISt5tupleIJSt6vectorINS3_5ShapeESaISD_EESC_IPKNS3_5DTypeESaISI_EEEENS0_9void_typeERPFSL_S8_EEENSt9enable_ifIXntsrSt7is_voidIT_E5valueESS_E4typeEOT1_
    @     0x7f4bf7b505ae  _ZZN8pybind1112cpp_function10initializeIRPFSt5tupleIJSt6vectorIN7oneflow5ShapeESaIS5_EES3_IPKNS4_5DTypeESaISA_EEEERKSt10shared_ptrINS4_3one14MirroredTensorEEESD_JSJ_EJEEEvOT_PFT0_DpT1_EDpRKT2_ENKUlRNS_6detail13function_callEE1_clES10_
    @     0x7f4bf7b50852  _ZZN8pybind1112cpp_function10initializeIRPFSt5tupleIJSt6vectorIN7oneflow5ShapeESaIS5_EES3_IPKNS4_5DTypeESaISA_EEEERKSt10shared_ptrINS4_3one14MirroredTensorEEESD_JSJ_EJEEEvOT_PFT0_DpT1_EDpRKT2_ENUlRNS_6detail13function_callEE1_4_FUNES10_
    @     0x7f4bf6d2a5db  pybind11::cpp_function::dispatcher()
    @     0x55acad1f1f76  PyCFunction_Call
    @     0x55acad1af85f  _PyObject_MakeTpCall
    @     0x55acad1359b8  property_descr_get.cold.2260
    @     0x55acad1b0f65  _PyObject_GenericGetAttrWithDict
    @     0x55acad23332c  _PyEval_EvalFrameDefault
    @     0x55acad1fca92  _PyEval_EvalCodeWithName
    @     0x55acad1fd754  PyEval_EvalCodeEx
    @     0x55acad28bedc  PyEval_EvalCode
    @     0x55acad28bf84  run_eval_code_obj
    @     0x55acad2be1f4  run_mod
    @     0x55acad2c0a5d  PyRun_StringFlags
    @     0x55acad2c0e5e  builtin_eval
    @     0x55acad1b2699  cfunction_vectorcall_FASTCALL
    @     0x55acad170b84  _PyEval_EvalFrameDefault.cold.2790
    @     0x55acad1fd86b  _PyFunction_Vectorcall.localalias.355
    @     0x55acad17275e  _PyEval_EvalFrameDefault.cold.2790
    @     0x55acad1fdc0b  method_vectorcall
    @     0x55acad170b84  _PyEval_EvalFrameDefault.cold.2790
    @     0x55acad1fd86b  _PyFunction_Vectorcall.localalias.355
    @     0x55acad17277f  _PyEval_EvalFrameDefault.cold.2790
```

**log2**
```
F0618 14:43:30.804692 891260 env_global_objects_scope.cpp:184] Check failed: thread_id_ == std::this_thread::get_id() 
*** Check failure stack trace: ***
    @     0x7f6601ac5978  google::LogMessage::Fail()
    @     0x7f6601ac58b3  google::LogMessage::SendToLog()
    @     0x7f6601ac51e4  google::LogMessage::Flush()
    @     0x7f6601ac87d2  google::LogMessageFatal::~LogMessageFatal()
    @     0x7f65fd46ba30  oneflow::EnvGlobalObjectsScope::MutParallelDesc4Device()
    @     0x7f65fd06179d  oneflow::Device::parallel_desc_ptr()
    @     0x7f65fd098b8a  oneflow::(anonymous namespace)::GetParallelDesc()
    @     0x7f65fd0b1e76  oneflow::InstructionsBuilder::AccessBlobByCallback<>()
    @     0x7f65fbcb38b7  _ZZN7oneflow3one12_GLOBAL__N_112_GLOBAL__N_133CopyBetweenMirroredTensorAndNumpyIfEENS_5MaybeIvvEERKSt10shared_ptrINS0_14MirroredTensorEEN8pybind117array_tIT_Li16EEEPFvmSE_ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEENKUlPNS_19InstructionsBuilderEE_clESQ_
    @     0x7f65fbcb85e1  _ZNSt17_Function_handlerIFvPN7oneflow19InstructionsBuilderEEZNS0_3one12_GLOBAL__N_112_GLOBAL__N_133CopyBetweenMirroredTensorAndNumpyIfEENS0_5MaybeIvvEERKSt10shared_ptrINS4_14MirroredTensorEEN8pybind117array_tIT_Li16EEEPFvmSI_ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEUlS2_E_E9_M_invokeERKSt9_Any_dataOS2_
    @     0x7f65fd0bb4d3  std::function<>::operator()()
    @     0x7f65fd0abcb2  oneflow::PhysicalRun()
    @     0x7f65fbcb3a04  oneflow::one::(anonymous namespace)::(anonymous namespace)::CopyBetweenMirroredTensorAndNumpy<>()
    @     0x7f65fbcb1455  oneflow::one::(anonymous namespace)::(anonymous namespace)::ApiCopyMirroredTensorToNumpy<>()
    @     0x7f65fbcdfbea  _ZNO8pybind116detail15argument_loaderIJRKSt10shared_ptrIN7oneflow3one14MirroredTensorEENS_7array_tIfLi16EEEEE9call_implIvRPFvS8_SA_EJLm0ELm1EENS0_9void_typeEEET_OT0_NS0_14index_sequenceIJXspT1_EEEEOT2_
    @     0x7f65fbcd966c  _ZNO8pybind116detail15argument_loaderIJRKSt10shared_ptrIN7oneflow3one14MirroredTensorEENS_7array_tIfLi16EEEEE4callIvNS0_9void_typeERPFvS8_SA_EEENSt9enable_ifIXsrSt7is_voidIT_E5valueESD_E4typeEOT1_
    @     0x7f65fbcd1a32  _ZZN8pybind1112cpp_function10initializeIRPFvRKSt10shared_ptrIN7oneflow3one14MirroredTensorEENS_7array_tIfLi16EEEEvJS8_SA_EJNS_4nameENS_9is_methodENS_7siblingEEEEvOT_PFT0_DpT1_EDpRKT2_ENKUlRNS_6detail13function_callEE1_clESU_
    @     0x7f65fbcd1cdc  _ZZN8pybind1112cpp_function10initializeIRPFvRKSt10shared_ptrIN7oneflow3one14MirroredTensorEENS_7array_tIfLi16EEEEvJS8_SA_EJNS_4nameENS_9is_methodENS_7siblingEEEEvOT_PFT0_DpT1_EDpRKT2_ENUlRNS_6detail13function_callEE1_4_FUNESU_
    @     0x7f65faeab5db  pybind11::cpp_function::dispatcher()
    @     0x55af1eca8f76  PyCFunction_Call
    @     0x55af1ec6685f  _PyObject_MakeTpCall
    @     0x55af1ecb4fa1  method_vectorcall
    @     0x55af1ec27b84  _PyEval_EvalFrameDefault.cold.2790
    @     0x7f6642c1f05a  __pyx_f_18_pydevd_frame_eval_22pydevd_frame_evaluator_get_bytecode_while_frame_eval
    @     0x55af1ecb486b  _PyFunction_Vectorcall.localalias.355
    @     0x55af1ec2975e  _PyEval_EvalFrameDefault.cold.2790
    @     0x7f6642c1f05a  __pyx_f_18_pydevd_frame_eval_22pydevd_frame_evaluator_get_bytecode_while_frame_eval
    @     0x55af1ecb486b  _PyFunction_Vectorcall.localalias.355
    @     0x55af1ec2977f  _PyEval_EvalFrameDefault.cold.2790
    @     0x7f6642c1f05a  __pyx_f_18_pydevd_frame_eval_22pydevd_frame_evaluator_get_bytecode_while_frame_eval
    @     0x55af1ecb486b  _PyFunction_Vectorcall.localalias.355
    @     0x55af1ec2975e  _PyEval_EvalFrameDefault.cold.2790
```