### PR TITLE
Move default third party dir into build dir

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous runs of outdated commit
+        if: github.ref != 'refs/heads/master'
         uses: styfle/cancel-workflow-action@0.9.0
         with:
           access_token: ${{ github.token }}

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -81,8 +81,9 @@ jobs:
         run: |
           set -x
           mkdir -p build-third_party
+          mkdir -p third_party_install
           cd build-third_party
-          cmake .. ${{ env.cmake_flags }} -DTHIRD_PARTY=ON -DONEFLOW=OFF
+          cmake .. ${{ env.cmake_flags }} -DTHIRD_PARTY=ON -DONEFLOW=OFF -DTHIRD_PARTY_DIR=$(realpath ../third_party_install)
           make -j $(nproc)
         shell: bash
       - name: Build (of_ccobj)
@@ -90,7 +91,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake .. ${{ env.cmake_flags }} -DTHIRD_PARTY=OFF -DONEFLOW=ON
+          cmake .. ${{ env.cmake_flags }} -DTHIRD_PARTY=OFF -DONEFLOW=ON -DTHIRD_PARTY_DIR=$(realpath ../third_party_install)
           make -j ${{ matrix.make_concurrency }} of_ccobj
         shell: bash
       - name: Build (oneflow_internal)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,17 +81,17 @@ if (OF_SOFTMAX_USE_FAST_MATH)
 endif()
 if (RPC_BACKEND MATCHES "GRPC")
   add_definitions(-DRPC_BACKEND_GRPC)
-  message("-- RPC backend enabled: gRPC")
+  message(STATUS "RPC backend enabled: gRPC")
   set(SUPPORTED_RPC_BACKEND_FOUND 1)
 endif()
 add_definitions(-DRPC_BACKEND_LOCAL)
-message("-- RPC backend enabled: local")
+message(STATUS "RPC backend enabled: local")
 enable_testing()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party"
-  CACHE PATH "Where the third party headers and libs are put")
+set(THIRD_PARTY_DIR "${PROJECT_BINARY_DIR}/third_party_install"
+  CACHE PATH "Where to install third party headers and libs")
 
 set(THIRD_PARTY_SUBMODULE_DIR "${PROJECT_SOURCE_DIR}/build/third_party"
   CACHE PATH "Where the third party submodules are")
@@ -168,10 +168,10 @@ if (BUILD_CUDA)
   foreach(CUDA_NVCC_GENCODE ${CUDA_NVCC_GENCODES})
     list(APPEND CUDA_NVCC_FLAGS -gencode ${CUDA_NVCC_GENCODE})
   endforeach()
-  message("-- CUDA_NVCC_FLAGS: " ${CUDA_NVCC_FLAGS})
+  message(STATUS "CUDA_NVCC_FLAGS: " ${CUDA_NVCC_FLAGS})
 endif()
 
-message("-- CMAKE_CXX_COMPILER_VERSION: " ${CMAKE_CXX_COMPILER_VERSION})
+message(STATUS "CMAKE_CXX_COMPILER_VERSION: " ${CMAKE_CXX_COMPILER_VERSION})
 
 if (THIRD_PARTY)
   add_custom_target(prepare_oneflow_third_party ALL DEPENDS ${oneflow_third_party_dependencies})


### PR DESCRIPTION
因为经过各种优化，third party 的编译已经相当快了，所以没有复用 third party 的编译结果的需求了，现在将默认第三方库的路径移入 build 下