### PR TITLE
raise IndexError in get_canonical_index to support for loop

### DIFF
--- a/oneflow/python/framework/tensor.py
+++ b/oneflow/python/framework/tensor.py
@@ -374,6 +374,8 @@ class Tensor:
         def get_canonical_index(index, length, *, start=0):
             if index < 0:
                 index += length
+            if index > length or index < 0:
+                raise IndexError(f"Index should be in [0, {length}), but got {index}")
             return max(min(index, length), start)
 
         def get_slice_if_int(x):


### PR DESCRIPTION
修复 @tea321000 遇到的 `for x in flow.Tensor(3)` 会报错的问题， https://docs.python.org/3/reference/datamodel.html#object.__getitem__