### PR TITLE
rm nn.Graph.train

### DIFF
--- a/oneflow/python/nn/graph.py
+++ b/oneflow/python/nn/graph.py
@@ -322,7 +322,7 @@ class Block(object):
 class GraphConfig(FunctionConfig):
     def __init__(self):
         super().__init__()
-        self._train(True)
+        self._train(False)
 
     @property
     def proto(self):

--- a/oneflow/python/nn/graph.py
+++ b/oneflow/python/nn/graph.py
@@ -39,7 +39,6 @@ class Graph(object):
         self._optimizers = OrderedDict()
         self._is_compiled = False
         self._state_tensortuple = None
-        self.train(True)
 
     @property
     def name(self):
@@ -63,12 +62,6 @@ class Graph(object):
         self._optimizers[name] = self.OptimizerConfig(
             optimizer, lr_scheduler, grad_clipping_conf, weight_decay_conf
         )
-
-    def train(self, mode: bool = True):
-        self.config._train(mode)
-        for name, block in self._blocks.items():
-            assert block.type == BlockType.MODULE
-            block.origin.train(mode)
 
     def _named_state(self):
         for _, b in self._blocks.items():
@@ -329,6 +322,7 @@ class Block(object):
 class GraphConfig(FunctionConfig):
     def __init__(self):
         super().__init__()
+        self._train(True)
 
     @property
     def proto(self):

--- a/oneflow/python/test/graph/test_graph.py
+++ b/oneflow/python/test/graph/test_graph.py
@@ -114,23 +114,11 @@ class TestGraph(flow.unittest.TestCase):
 
         g = CustomGraph()
 
-        # check set train to True
-        g.train(True)
-        test_case.assertEqual(g.training, True)
-        test_case.assertEqual(g.m.training, True)
-        test_case.assertEqual(g.m.layer.conv1.training, True)
+        # check default training is True
+        test_case.assertEqual(g.config.training, True)
 
         # set graph config
         g.config.enable_fuse_add_to_output(True)
-
-        # check set train to False
-        g.train(False)
-        test_case.assertEqual(g.training, False)
-        test_case.assertEqual(g.training, False)
-        test_case.assertEqual(g.m.training, False)
-        test_case.assertEqual(g.m.layer.conv1.training, False)
-
-        # set graph config
         g.config.enable_fuse_add_to_output(False)
 
         # check _named_state get the right tensor

--- a/oneflow/python/test/graph/test_graph.py
+++ b/oneflow/python/test/graph/test_graph.py
@@ -115,7 +115,7 @@ class TestGraph(flow.unittest.TestCase):
         g = CustomGraph()
 
         # check default training is True
-        test_case.assertEqual(g.config.training, True)
+        test_case.assertEqual(g.config.training, False)
 
         # set graph config
         g.config.enable_fuse_add_to_output(True)


### PR DESCRIPTION
讨论认为把train的控制还都放在nn.Module层面处理，能处理GAN这些部分网络Train、部分网络Predict的情况。

 这里总结下利用Module freeze部分网络的方法：
- nn.Moudle.train(False)，修改Module.training标识，控制batchnorm/dropout等的forward执行逻辑；
- nn.Moudle.requires_grad_(False)，修改Module的parameters，使其不需要grad，变成普通tensor，不为其生成grad；
- optimizer不绑定特定parameter，这样就optimizer就不会更新对应parameter；

这部分对train的控制比较精细、也复杂，所以nn.Graph层面就不做总体控制。后面nn.Graph根据是否add_optimizer判断时训练任务，然后做些检查。