### PR TITLE
fix segfault in clang plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,6 @@ jobs:
           set -x
           echo "CC=clang-12" >> $GITHUB_ENV
           echo "CXX=clang++-12" >> $GITHUB_ENV
-          echo "ONEFLOW_MAYBE_CHECK_ONLY_FN=${PWD}/oneflow/" >> $GITHUB_ENV
-          echo "ONEFLOW_MAYBE_CHECK_SKIP_FN=.cfg.cpp;oneflow/core/kernel/kernel_util;oneflow/core/kernel/new_kernel_util" >> $GITHUB_ENV
       - name: Build Clang plug-in
         run: |
           cd tools/clang-plugin
@@ -126,41 +124,28 @@ jobs:
           clang_plugin_path="${PWD}/lib/libCheckUnusedMaybe.so"
           ldd ${clang_plugin_path}
           echo "clang_plugin_path=${clang_plugin_path}" >> $GITHUB_ENV
-      - name: Build (CMake configure)
+      - name: Build (third party)
         run: |
           mkdir build
           cd build
+          # -w to suppress all warnings
           cmake .. -C ../cmake/caches/international/cpu.cmake \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=Debug \
             -DBUILD_TESTING=ON \
-            -DCMAKE_CXX_FLAGS="-fplugin=${{ env.clang_plugin_path }}"
-      - name: Build (third party)
-        run: |
-          ulimit -c
-          ulimit -c unlimited
-          ulimit -c
-          cd build
-          cmake --build . -j$(nproc) --target oneflow_deps
+            -DTHIRD_PARTY=ON \
+            -DONEFLOW=OFF \
+            -DCMAKE_CXX_FLAGS="-w"
+          cmake --build . -j$(nproc)
       - name: Check unused Maybe (by building OneFlow with Clang plug-in)
         run: |
-          ulimit -c
-          ulimit -c unlimited
-          ulimit -c
           cd build
+          cmake .. -C ../cmake/caches/international/cpu.cmake \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_TESTING=ON \
+            -DTHIRD_PARTY=OFF \
+            -DONEFLOW=ON \
+            -DCMAKE_CXX_FLAGS="-w -fplugin=${{ env.clang_plugin_path }}"
           cmake --build . -j$(nproc)
-      - name: Tar core
-        if: always()
-        continue-on-error: true
-        run: |
-          set -ex
-          tar -cvf build_core.tar ${PWD}/build/**/core.*
-      - name: Upload core
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: core-build-oneflow-with-clang-plugin
-          path: |
-            build.tar
 
   wait_for_gpu_slot:
     name: Wait for GPU slots

--- a/tools/clang-plugin/.clang-format
+++ b/tools/clang-plugin/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/tools/clang-plugin/CheckUnusedMaybe/CheckUnusedMaybe.cpp
+++ b/tools/clang-plugin/CheckUnusedMaybe/CheckUnusedMaybe.cpp
@@ -11,50 +11,65 @@
 
 using namespace clang;
 
-class CheckUnusedMaybeVisitor : public RecursiveASTVisitor<CheckUnusedMaybeVisitor> {
- public:
-  explicit CheckUnusedMaybeVisitor(ASTContext* Context) : Context(Context) {
+class CheckUnusedMaybeVisitor
+    : public RecursiveASTVisitor<CheckUnusedMaybeVisitor> {
+public:
+  explicit CheckUnusedMaybeVisitor(ASTContext *Context) : Context(Context) {
     {
-      auto skip_filenames_env = llvm::StringRef(std::getenv("ONEFLOW_MAYBE_CHECK_SKIP_FN"));
+      auto skip_filenames_env =
+          llvm::StringRef(std::getenv("ONEFLOW_MAYBE_CHECK_SKIP_FN"));
       if (!skip_filenames_env.empty()) {
         skip_filenames_env.split(skip_filenames, ";");
-        for (const auto& x : skip_filenames) { llvm::outs() << "skip: " << x << "\n"; }
+        for (const auto &x : skip_filenames) {
+          llvm::outs() << "skip: " << x << "\n";
+        }
       }
     }
     {
-      auto only_filenames_env = llvm::StringRef(std::getenv("ONEFLOW_MAYBE_CHECK_ONLY_FN"));
+      auto only_filenames_env =
+          llvm::StringRef(std::getenv("ONEFLOW_MAYBE_CHECK_ONLY_FN"));
       if (!only_filenames_env.empty()) {
         only_filenames_env.split(only_filenames, ";");
-        for (const auto& x : only_filenames) { llvm::outs() << "only: " << x << "\n"; }
+        for (const auto &x : only_filenames) {
+          llvm::outs() << "only: " << x << "\n";
+        }
       }
     }
   }
 
-  virtual bool VisitCompoundStmt(CompoundStmt* stmt) {
+  virtual bool VisitCompoundStmt(CompoundStmt *stmt) {
     if (!only_filenames.empty()) {
       bool skip = true;
-      for (const auto& x : only_filenames) {
-        if (Context->getSourceManager().getFilename(stmt->getBeginLoc()).contains(x)) {
+      for (const auto &x : only_filenames) {
+        if (Context->getSourceManager()
+                .getFilename(stmt->getBeginLoc())
+                .contains(x)) {
           skip = false;
         }
       }
-      if (skip) { return true; }
+      if (skip) {
+        return true;
+      }
     }
 
-    for (const auto& x : skip_filenames) {
-      if (Context->getSourceManager().getFilename(stmt->getBeginLoc()).contains(x)) { return true; }
+    for (const auto &x : skip_filenames) {
+      if (Context->getSourceManager()
+              .getFilename(stmt->getBeginLoc())
+              .contains(x)) {
+        return true;
+      }
     }
 
-    for (const auto& x : stmt->children()) {
+    for (const auto &x : stmt->children()) {
       std::string typeStr;
-      if (ExprWithCleanups* expr = dyn_cast<ExprWithCleanups>(x)) {
+      if (ExprWithCleanups *expr = dyn_cast<ExprWithCleanups>(x)) {
         typeStr = expr->getType().getAsString();
       }
-      if (CallExpr* call = dyn_cast<CallExpr>(x)) {
+      if (CallExpr *call = dyn_cast<CallExpr>(x)) {
         llvm::CrashRecoveryContext CRC;
         CRC.RunSafely([&call, &typeStr, this]() {
           QualType returnType;
-          if (auto* callee = call->getDirectCallee()) {
+          if (auto *callee = call->getDirectCallee()) {
             returnType = callee->getReturnType();
           } else {
             returnType = call->getCallReturnType(*this->Context);
@@ -64,44 +79,50 @@ class CheckUnusedMaybeVisitor : public RecursiveASTVisitor<CheckUnusedMaybeVisit
           }
         });
       }
-      if (typeStr.substr(0, 12) == "class Maybe<" || typeStr.substr(0, 6) == "Maybe<") {
-        DiagnosticsEngine& DE = Context->getDiagnostics();
-        unsigned DiagID = DE.getCustomDiagID(DiagnosticsEngine::Error,
-                                             "This function returns Maybe but the return "
-                                             "value is ignored. Wrap it with JUST(..)?");
+      if (typeStr.substr(0, 12) == "class Maybe<" ||
+          typeStr.substr(0, 6) == "Maybe<") {
+        DiagnosticsEngine &DE = Context->getDiagnostics();
+        unsigned DiagID =
+            DE.getCustomDiagID(DiagnosticsEngine::Error,
+                               "This function returns Maybe but the return "
+                               "value is ignored. Wrap it with JUST(..)?");
         auto DB = DE.Report(x->getBeginLoc(), DiagID);
-        DB.AddSourceRange(clang::CharSourceRange::getCharRange(x->getSourceRange()));
+        DB.AddSourceRange(
+            clang::CharSourceRange::getCharRange(x->getSourceRange()));
       }
     }
     return true;
   }
 
- private:
-  ASTContext* Context;
+private:
+  ASTContext *Context;
   llvm::SmallVector<llvm::StringRef, 10> skip_filenames;
   llvm::SmallVector<llvm::StringRef, 10> only_filenames;
 };
 
 class CheckUnusedMaybeConsumer : public clang::ASTConsumer {
- public:
-  explicit CheckUnusedMaybeConsumer(ASTContext* Context) : Visitor(Context) {}
+public:
+  explicit CheckUnusedMaybeConsumer(ASTContext *Context) : Visitor(Context) {}
 
-  void HandleTranslationUnit(clang::ASTContext& Context) override {
+  void HandleTranslationUnit(clang::ASTContext &Context) override {
     Visitor.TraverseDecl(Context.getTranslationUnitDecl());
   }
 
- private:
+private:
   CheckUnusedMaybeVisitor Visitor;
 };
 
 class CheckUnusedMaybeAction : public clang::PluginASTAction {
- public:
-  virtual std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& Compiler,
-                                                                llvm::StringRef InFile) override {
-    return std::make_unique<CheckUnusedMaybeConsumer>(&Compiler.getASTContext());
+public:
+  virtual std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &Compiler,
+                    llvm::StringRef InFile) override {
+    return std::make_unique<CheckUnusedMaybeConsumer>(
+        &Compiler.getASTContext());
   }
 
-  bool ParseArgs(const CompilerInstance& CI, const std::vector<std::string>& args) override {
+  bool ParseArgs(const CompilerInstance &CI,
+                 const std::vector<std::string> &args) override {
     return true;
   }
 
@@ -109,5 +130,5 @@ class CheckUnusedMaybeAction : public clang::PluginASTAction {
   ActionType getActionType() override { return AddAfterMainAction; }
 };
 
-static FrontendPluginRegistry::Add<CheckUnusedMaybeAction> X("check-unused-maybe",
-                                                             "Check unused maybe");
+static FrontendPluginRegistry::Add<CheckUnusedMaybeAction>
+    X("check-unused-maybe", "Check unused maybe");


### PR DESCRIPTION
1. 只在 `!returnType.isNull() && returnType->isClassType()` 成立时调用 `getAsString()`，避免 segfault
2. 不设置 ONEFLOW_MAYBE_CHECK_ONLY_FN 和 ONEFLOW_MAYBE_CHECK_SKIP_FN（没有必要了），改为只在编译 oneflow 本体时设置 plugin