### PR TITLE
Output arg modifier return maybe part_0

### DIFF
--- a/oneflow/core/framework/user_op_registry.h
+++ b/oneflow/core/framework/user_op_registry.h
@@ -52,7 +52,8 @@ using InputArgModifyFn = std::function<void(GetInputArgModifier, const UserOpCon
 using OutputArgModifier = OutputBlobModifier;
 using GetOutputArgModifier =
     std::function<OutputArgModifier*(const std::string& out_arg_name, int32_t out_arg_index)>;
-using OutputArgModifyFn = std::function<void(GetOutputArgModifier, const UserOpConfWrapper&)>;
+using OutputArgModifyFn =
+    std::function<Maybe<void>(GetOutputArgModifier, const UserOpConfWrapper&)>;
 using OutputBlobTimeShapeInferFn = std::function<Maybe<void>(InferOutputBlobTimeShapeFnContext*)>;
 using ParallelDistributionInferFn = std::function<Maybe<void>(InferParallelDistributionFnContext*)>;
 

--- a/oneflow/core/operator/acc_tick_op.cpp
+++ b/oneflow/core/operator/acc_tick_op.cpp
@@ -27,11 +27,12 @@ Maybe<void> InferBlobDescs(const std::function<BlobDesc*(const std::string&)>& G
 
 }  // namespace
 
-void AccTickOp::InitFromOpConf() {
+Maybe<void> AccTickOp::InitFromOpConf() {
   CHECK(op_conf().has_acc_tick_conf());
 
   EnrollInputBn("one", false);
   EnrollOutputBn("acc", false);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> AccTickOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/acc_tick_op.h
+++ b/oneflow/core/operator/acc_tick_op.h
@@ -26,7 +26,7 @@ class AccTickOp final : public Operator {
   AccTickOp() = default;
   ~AccTickOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,

--- a/oneflow/core/operator/assign_op.cpp
+++ b/oneflow/core/operator/assign_op.cpp
@@ -23,7 +23,7 @@ class AssignOp final : public Operator {
   AssignOp() = default;
   ~AssignOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;
@@ -37,10 +37,11 @@ class AssignOp final : public Operator {
       cfg::SbpSignatureList* sbp_sig_list) const override;
 };
 
-void AssignOp::InitFromOpConf() {
+Maybe<void> AssignOp::InitFromOpConf() {
   CHECK(op_conf().has_assign_conf());
   EnrollInputBn("ref")->set_is_mutable(true);
   EnrollInputBn("value");
+  return Maybe<void>::Ok();
 }
 
 std::string DebugString(const BlobDesc& blob_desc) {

--- a/oneflow/core/operator/boxing_identity_op.cpp
+++ b/oneflow/core/operator/boxing_identity_op.cpp
@@ -25,7 +25,7 @@ class BoxingIdentityOp : public Operator {
   BoxingIdentityOp() = default;
   ~BoxingIdentityOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override {
@@ -40,9 +40,10 @@ class BoxingIdentityOp : public Operator {
   LogicalBlobId lbi4obn(const std::string& output_bn) const override;
 };
 
-void BoxingIdentityOp::InitFromOpConf() {
+Maybe<void> BoxingIdentityOp::InitFromOpConf() {
   EnrollInputBn("in", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 LogicalBlobId BoxingIdentityOp::lbi4ibn(const std::string& input_bn) const {

--- a/oneflow/core/operator/boxing_op.cpp
+++ b/oneflow/core/operator/boxing_op.cpp
@@ -42,7 +42,7 @@ void BoxingOp::VirtualGenKernelConf(
   EraseEmptyBnInVec(GetBlobDesc4BnInOp, op_attribute->mutable_output_bns());
 }
 
-void BoxingOp::InitFromOpConf() {
+Maybe<void> BoxingOp::InitFromOpConf() {
   CHECK(op_conf().has_boxing_conf());
   const BoxingOpConf& boxing_conf = op_conf().boxing_conf();
 
@@ -56,6 +56,7 @@ void BoxingOp::InitFromOpConf() {
   for (int32_t i = 0; i < boxing_conf.out_num(); ++i) {
     EnrollOutputBn("out_" + std::to_string(i), false);
   }
+  return Maybe<void>::Ok();
 }
 
 LogicalBlobId BoxingOp::lbi4ibn(const std::string& input_bn) const {

--- a/oneflow/core/operator/boxing_op.h
+++ b/oneflow/core/operator/boxing_op.h
@@ -26,7 +26,7 @@ class BoxingOp final : public Operator {
   BoxingOp() = default;
   ~BoxingOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/boxing_zeros_op.cpp
+++ b/oneflow/core/operator/boxing_zeros_op.cpp
@@ -24,7 +24,7 @@ class BoxingZerosOp : public Operator {
   BoxingZerosOp() = default;
   ~BoxingZerosOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override {
@@ -39,7 +39,10 @@ class BoxingZerosOp : public Operator {
   LogicalBlobId lbi4obn(const std::string& output_bn) const override;
 };
 
-void BoxingZerosOp::InitFromOpConf() { EnrollOutputBn("out", false); }
+Maybe<void> BoxingZerosOp::InitFromOpConf() {
+  EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
+}
 
 LogicalBlobId BoxingZerosOp::lbi4ibn(const std::string& input_bn) const {
   return this->op_conf().boxing_zeros_conf().lbi();

--- a/oneflow/core/operator/broadcast_to_compatible_with_op.cpp
+++ b/oneflow/core/operator/broadcast_to_compatible_with_op.cpp
@@ -58,11 +58,12 @@ class BroadcastToCompatibleWithOp final : public Operator {
   BroadcastToCompatibleWithOp() = default;
   ~BroadcastToCompatibleWithOp() override = default;
 
-  void InitFromOpConf() {
+  Maybe<void> InitFromOpConf() {
     CHECK(op_conf().has_broadcast_to_compatible_with_conf());
     EnrollInputBn("x");
     EnrollRepeatedInputBn("compatible", false);
     EnrollOutputBn("y");
+    return Maybe<void>::Ok();
   }
 
   Maybe<void> InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/callback_notify_op.cpp
+++ b/oneflow/core/operator/callback_notify_op.cpp
@@ -18,9 +18,10 @@ limitations under the License.
 
 namespace oneflow {
 
-void CallbackNotifyOp::InitFromOpConf() {
+Maybe<void> CallbackNotifyOp::InitFromOpConf() {
   CHECK(op_conf().has_callback_notify_conf());
   EnrollInputBn("in", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/callback_notify_op.h
+++ b/oneflow/core/operator/callback_notify_op.h
@@ -26,7 +26,7 @@ class CallbackNotifyOp final : public Operator {
   CallbackNotifyOp() = default;
   ~CallbackNotifyOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/case_op.cpp
+++ b/oneflow/core/operator/case_op.cpp
@@ -18,9 +18,10 @@ limitations under the License.
 
 namespace oneflow {
 
-void CaseOp::InitFromOpConf() {
+Maybe<void> CaseOp::InitFromOpConf() {
   EnrollInputBn("in", false);
   EnrollRepeatedOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/case_op.h
+++ b/oneflow/core/operator/case_op.h
@@ -26,7 +26,7 @@ class CaseOp final : public Operator {
   CaseOp() = default;
   ~CaseOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/collective_boxing_ops.cpp
+++ b/oneflow/core/operator/collective_boxing_ops.cpp
@@ -27,11 +27,12 @@ class CollectiveBoxingGenericOp : public Operator {
   ~CollectiveBoxingGenericOp() override = default;
 
  private:
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     CHECK(op_conf().has_collective_boxing_generic_conf());
     const RankDesc& rank_desc = op_conf().collective_boxing_generic_conf().rank_desc();
     if (GenericOpHasInput(rank_desc)) { EnrollInputBn("in", false); }
     if (GenericOpHasOutput(rank_desc)) { EnrollOutputBn("out", false); }
+    return Maybe<void>::Ok();
   }
 
   LogicalBlobId lbi4ibn(const std::string& input_bn) const override {

--- a/oneflow/core/operator/collective_boxing_pack_op.cpp
+++ b/oneflow/core/operator/collective_boxing_pack_op.cpp
@@ -25,7 +25,7 @@ class CollectiveBoxingPackOp : public Operator {
   CollectiveBoxingPackOp() = default;
   ~CollectiveBoxingPackOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
@@ -41,9 +41,10 @@ class CollectiveBoxingPackOp : public Operator {
   LogicalBlobId lbi4obn(const std::string& output_bn) const override;
 };
 
-void CollectiveBoxingPackOp::InitFromOpConf() {
+Maybe<void> CollectiveBoxingPackOp::InitFromOpConf() {
   EnrollInputBn("in", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 LogicalBlobId CollectiveBoxingPackOp::lbi4ibn(const std::string& input_bn) const {

--- a/oneflow/core/operator/collective_boxing_unpack_op.cpp
+++ b/oneflow/core/operator/collective_boxing_unpack_op.cpp
@@ -25,7 +25,7 @@ class CollectiveBoxingUnpackOp : public Operator {
   CollectiveBoxingUnpackOp() = default;
   ~CollectiveBoxingUnpackOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
@@ -41,9 +41,10 @@ class CollectiveBoxingUnpackOp : public Operator {
   LogicalBlobId lbi4obn(const std::string& output_bn) const override;
 };
 
-void CollectiveBoxingUnpackOp::InitFromOpConf() {
+Maybe<void> CollectiveBoxingUnpackOp::InitFromOpConf() {
   EnrollInputBn("in", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 LogicalBlobId CollectiveBoxingUnpackOp::lbi4ibn(const std::string& input_bn) const {

--- a/oneflow/core/operator/constant_like_op.cpp
+++ b/oneflow/core/operator/constant_like_op.cpp
@@ -36,10 +36,11 @@ class ConstantLikeOp final : public Operator {
   ConstantLikeOp() = default;
   ~ConstantLikeOp() = default;
 
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     CHECK(op_conf().has_constant_like_conf());
     EnrollInputBn("like", false);
     EnrollOutputBn("out", false);
+    return Maybe<void>::Ok();
   }
 
   Maybe<void> InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/copy_comm_net_op.cpp
+++ b/oneflow/core/operator/copy_comm_net_op.cpp
@@ -17,9 +17,10 @@ limitations under the License.
 
 namespace oneflow {
 
-void CopyCommNetOp::InitFromOpConf() {
+Maybe<void> CopyCommNetOp::InitFromOpConf() {
   EnrollInputBn("in", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 LogicalBlobId CopyCommNetOp::lbi4obn(const std::string& output_bn) const {

--- a/oneflow/core/operator/copy_comm_net_op.h
+++ b/oneflow/core/operator/copy_comm_net_op.h
@@ -26,7 +26,7 @@ class CopyCommNetOp final : public Operator {
   CopyCommNetOp() = default;
   ~CopyCommNetOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override {

--- a/oneflow/core/operator/copy_hd_op.cpp
+++ b/oneflow/core/operator/copy_hd_op.cpp
@@ -23,7 +23,7 @@ class CopyHdOp final : public Operator {
   CopyHdOp() = default;
   ~CopyHdOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override {
@@ -50,9 +50,10 @@ class CopyHdOp final : public Operator {
   LogicalBlobId lbi4obn(const std::string& output_bn) const override;
 };
 
-void CopyHdOp::InitFromOpConf() {
+Maybe<void> CopyHdOp::InitFromOpConf() {
   EnrollInputBn("in", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> CopyHdOp::InferOutBlobDescs(

--- a/oneflow/core/operator/cwise_op.cpp
+++ b/oneflow/core/operator/cwise_op.cpp
@@ -17,10 +17,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void CWiseOp::InitFromOpConf() {
+Maybe<void> CWiseOp::InitFromOpConf() {
   EnrollRepeatedInputBn("in");
   EnrollOutputBn("out")->set_mutable_inplace_ibn("in_0");
   VirtualInitFromOpConf();
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> CWiseOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/cwise_op.h
+++ b/oneflow/core/operator/cwise_op.h
@@ -26,7 +26,7 @@ class CWiseOp : public Operator {
   CWiseOp() = default;
   virtual ~CWiseOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,

--- a/oneflow/core/operator/decode_random_op.cpp
+++ b/oneflow/core/operator/decode_random_op.cpp
@@ -17,10 +17,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void DecodeRandomOp::InitFromOpConf() {
+Maybe<void> DecodeRandomOp::InitFromOpConf() {
   CHECK(op_conf().has_decode_random_conf());
   if (op_conf().decode_random_conf().has_tick()) { EnrollInputBn("tick", false); }
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 void DecodeRandomOp::VirtualGenKernelConf(

--- a/oneflow/core/operator/decode_random_op.h
+++ b/oneflow/core/operator/decode_random_op.h
@@ -26,7 +26,7 @@ class DecodeRandomOp final : public Operator {
   DecodeRandomOp() = default;
   ~DecodeRandomOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,

--- a/oneflow/core/operator/device_tick_op.cpp
+++ b/oneflow/core/operator/device_tick_op.cpp
@@ -18,10 +18,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void DeviceTickOp::InitFromOpConf() {
+Maybe<void> DeviceTickOp::InitFromOpConf() {
   CHECK(op_conf().has_device_tick_conf());
   EnrollRepeatedInputBn("tick", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/device_tick_op.h
+++ b/oneflow/core/operator/device_tick_op.h
@@ -26,7 +26,7 @@ class DeviceTickOp final : public Operator {
   DeviceTickOp() = default;
   ~DeviceTickOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/distribute_add_op.cpp
+++ b/oneflow/core/operator/distribute_add_op.cpp
@@ -27,7 +27,7 @@ class DistributeAddOp final : public Operator {
   DistributeAddOp() = default;
   ~DistributeAddOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
@@ -45,11 +45,12 @@ class DistributeAddOp final : public Operator {
       const ParallelDesc& parallel_desc) const override;
 };
 
-void DistributeAddOp::InitFromOpConf() {
+Maybe<void> DistributeAddOp::InitFromOpConf() {
   CHECK(op_conf().has_distribute_add_conf());
 
   EnrollRepeatedInputBn("in");
   EnrollOutputBn("out");
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> DistributeAddOp::InferBlobParallelDesc() {

--- a/oneflow/core/operator/distribute_clone_op.cpp
+++ b/oneflow/core/operator/distribute_clone_op.cpp
@@ -27,7 +27,7 @@ class DistributeCloneOp final : public Operator {
   DistributeCloneOp() = default;
   ~DistributeCloneOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
  private:
   Maybe<void> InferBlobParallelDesc() override;
@@ -44,13 +44,14 @@ class DistributeCloneOp final : public Operator {
       const ParallelContext* parallel_ctx) const override;
 };
 
-void DistributeCloneOp::InitFromOpConf() {
+Maybe<void> DistributeCloneOp::InitFromOpConf() {
   CHECK(op_conf().has_distribute_clone_conf());
 
   EnrollInputBn("in");
   EnrollRepeatedOutputBnWithSetter("out", [&](OutputBlobModifier* ob_modifier) {
     ob_modifier->set_is_mutable(op_conf().distribute_clone_conf().is_variable_ref());
   });
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> DistributeCloneOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/distribute_concat_op.cpp
+++ b/oneflow/core/operator/distribute_concat_op.cpp
@@ -27,7 +27,7 @@ class DistributeConcatOp final : public Operator {
   DistributeConcatOp() = default;
   ~DistributeConcatOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
@@ -51,11 +51,12 @@ class DistributeConcatOp final : public Operator {
   int32_t FixAxis(const int32_t axis, const int64_t num_axes) const;
 };
 
-void DistributeConcatOp::InitFromOpConf() {
+Maybe<void> DistributeConcatOp::InitFromOpConf() {
   CHECK(op_conf().has_distribute_concat_conf());
 
   EnrollRepeatedInputBn("in");
   EnrollOutputBn("out");
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> DistributeConcatOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/distribute_split_op.cpp
+++ b/oneflow/core/operator/distribute_split_op.cpp
@@ -27,7 +27,7 @@ class DistributeSplitOp final : public Operator {
   DistributeSplitOp() = default;
   ~DistributeSplitOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
  private:
   Maybe<void> InferBlobParallelDesc() override;
@@ -50,13 +50,14 @@ class DistributeSplitOp final : public Operator {
   int32_t FixAxis(const int32_t axis, const int64_t num_axes) const;
 };
 
-void DistributeSplitOp::InitFromOpConf() {
+Maybe<void> DistributeSplitOp::InitFromOpConf() {
   CHECK(op_conf().has_distribute_split_conf());
   EnrollInputBn("in");
   EnrollRepeatedOutputBnWithSetter("out", [&](OutputBlobModifier* ob_modifier) {
     ob_modifier->set_header_infered_before_compute(false);
     ob_modifier->set_is_mutable(op_conf().distribute_split_conf().is_variable_ref());
   });
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> DistributeSplitOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/dst_subset_tick_op.cpp
+++ b/oneflow/core/operator/dst_subset_tick_op.cpp
@@ -36,7 +36,7 @@ class DstSubsetTickOp final : public Operator {
   DstSubsetTickOp() = default;
   ~DstSubsetTickOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;
@@ -48,10 +48,11 @@ class DstSubsetTickOp final : public Operator {
   Maybe<void> GetSbpSignatures(cfg::SbpSignatureList* sbp_sig_list) const override;
 };
 
-void DstSubsetTickOp::InitFromOpConf() {
+Maybe<void> DstSubsetTickOp::InitFromOpConf() {
   CHECK(op_conf().has_dst_subset_tick_conf());
   EnrollRepeatedInputBn("in", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> DstSubsetTickOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/dynamic_reshape_op.cpp
+++ b/oneflow/core/operator/dynamic_reshape_op.cpp
@@ -19,10 +19,11 @@ namespace oneflow {
 
 class DynamicReshapeOp final : public Operator {
  public:
-  void InitFromOpConf() {
+  Maybe<void> InitFromOpConf() {
     CHECK(op_conf().has_dynamic_reshape_conf());
     EnrollInputBn("in");
     EnrollOutputBn("out")->set_const_inplace_ibn("in");
+    return Maybe<void>::Ok();
   }
 
   Maybe<void> InferLogicalOutBlobDescs(
@@ -116,11 +117,12 @@ REGISTER_OP(OperatorConf::kDynamicReshapeConf, DynamicReshapeOp);
 
 class DynamicReshapeLikeOp final : public Operator {
  public:
-  void InitFromOpConf() {
+  Maybe<void> InitFromOpConf() {
     CHECK(op_conf().has_dynamic_reshape_like_conf());
     EnrollInputBn("x");
     EnrollOutputBn("y");
     EnrollInputBn("like", false);
+    return Maybe<void>::Ok();
   }
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,

--- a/oneflow/core/operator/esac_op.cpp
+++ b/oneflow/core/operator/esac_op.cpp
@@ -18,9 +18,10 @@ limitations under the License.
 
 namespace oneflow {
 
-void EsacOp::InitFromOpConf() {
+Maybe<void> EsacOp::InitFromOpConf() {
   EnrollRepeatedInputBn("in", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/esac_op.h
+++ b/oneflow/core/operator/esac_op.h
@@ -26,7 +26,7 @@ class EsacOp final : public Operator {
   EsacOp() = default;
   ~EsacOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/foreign_input_op.cpp
+++ b/oneflow/core/operator/foreign_input_op.cpp
@@ -36,10 +36,11 @@ Maybe<void> InferBlobDescs(const OperatorConf& op_conf,
 
 }  // namespace
 
-void ForeignInputOp::InitFromOpConf() {
+Maybe<void> ForeignInputOp::InitFromOpConf() {
   CHECK(op_conf().has_foreign_input_conf());
   if (op_conf().foreign_input_conf().has_tick()) { EnrollInputBn("tick", false); }
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> ForeignInputOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/foreign_input_op.h
+++ b/oneflow/core/operator/foreign_input_op.h
@@ -26,7 +26,7 @@ class ForeignInputOp final : public Operator {
   ForeignInputOp() : Operator() {}
   ~ForeignInputOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/foreign_output_op.cpp
+++ b/oneflow/core/operator/foreign_output_op.cpp
@@ -18,9 +18,10 @@ limitations under the License.
 
 namespace oneflow {
 
-void ForeignOutputOp::InitFromOpConf() {
+Maybe<void> ForeignOutputOp::InitFromOpConf() {
   CHECK(op_conf().has_foreign_output_conf());
   EnrollInputBn("in");
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> ForeignOutputOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/foreign_output_op.h
+++ b/oneflow/core/operator/foreign_output_op.h
@@ -26,7 +26,7 @@ class ForeignOutputOp final : public Operator {
   ForeignOutputOp() = default;
   ~ForeignOutputOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/foreign_watch_op.cpp
+++ b/oneflow/core/operator/foreign_watch_op.cpp
@@ -18,9 +18,10 @@ limitations under the License.
 
 namespace oneflow {
 
-void ForeignWatchOp::InitFromOpConf() {
+Maybe<void> ForeignWatchOp::InitFromOpConf() {
   CHECK(op_conf().has_foreign_watch_conf());
   EnrollInputBn("in");
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> ForeignWatchOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/foreign_watch_op.h
+++ b/oneflow/core/operator/foreign_watch_op.h
@@ -26,7 +26,7 @@ class ForeignWatchOp final : public Operator {
   ForeignWatchOp() = default;
   ~ForeignWatchOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/identity_op.cpp
+++ b/oneflow/core/operator/identity_op.cpp
@@ -36,9 +36,10 @@ class IdentityOpTpl final : public Operator {
   IdentityOpTpl() = default;
   ~IdentityOpTpl() override = default;
 
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     EnrollInputBn("in");
     EnrollOutputBn("out")->set_const_inplace_ibn("in");
+    return Maybe<void>::Ok();
   }
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
@@ -75,9 +76,10 @@ class MirroredCastOp : public Operator {
   MirroredCastOp() = default;
   virtual ~MirroredCastOp() override = default;
 
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     EnrollInputBn("in");
     EnrollOutputBn("out")->set_const_inplace_ibn("in");
+    return Maybe<void>::Ok();
   }
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,

--- a/oneflow/core/operator/image_decoder_random_crop_resize_op.cpp
+++ b/oneflow/core/operator/image_decoder_random_crop_resize_op.cpp
@@ -51,10 +51,11 @@ class ImageDecoderRandomCropResizeOp final : public Operator {
   ~ImageDecoderRandomCropResizeOp() override = default;
 
  private:
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     EnrollInputBn("in", false);
     EnrollOutputBn("out", false);
     EnrollTmpBn("tmp");
+    return Maybe<void>::Ok();
   }
 
   Maybe<void> InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/input_op.cpp
+++ b/oneflow/core/operator/input_op.cpp
@@ -20,12 +20,13 @@ limitations under the License.
 
 namespace oneflow {
 
-void InputOp::InitFromOpConf() {
+Maybe<void> InputOp::InitFromOpConf() {
   CHECK(op_conf().has_input_conf());
   if (op_conf().input_conf().has_tick()) { EnrollInputBn("tick", false); }
   OutputBlobModifier* modifier = EnrollOutputBn("out", false);
   modifier->set_is_mutable(true);
   modifier->set_header_infered_before_compute(false);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> InputOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/input_op.h
+++ b/oneflow/core/operator/input_op.h
@@ -26,7 +26,7 @@ class InputOp final : public Operator {
   InputOp() : Operator() {}
   ~InputOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
       const ParallelContext* parallel_ctx) const override;

--- a/oneflow/core/operator/learning_rate_schedule_op.cpp
+++ b/oneflow/core/operator/learning_rate_schedule_op.cpp
@@ -23,7 +23,7 @@ class LearningRateScheduleOp final : public Operator {
   LearningRateScheduleOp() = default;
   ~LearningRateScheduleOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   virtual Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const;
@@ -37,10 +37,11 @@ class LearningRateScheduleOp final : public Operator {
       cfg::SbpSignatureList* sbp_sig_list) const override;
 };
 
-void LearningRateScheduleOp::InitFromOpConf() {
+Maybe<void> LearningRateScheduleOp::InitFromOpConf() {
   CHECK(op_conf().has_learning_rate_schedule_conf());
   EnrollInputBn("train_step");
   EnrollOutputBn("out");
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/model_init_op.cpp
+++ b/oneflow/core/operator/model_init_op.cpp
@@ -19,7 +19,7 @@ namespace oneflow {
 
 class ModelInitOp : public Operator {
  public:
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   virtual Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
@@ -34,10 +34,11 @@ class ModelInitOp : public Operator {
       cfg::SbpSignatureList* sbp_sig_list) const override;
 };
 
-void ModelInitOp::InitFromOpConf() {
+Maybe<void> ModelInitOp::InitFromOpConf() {
   CHECK(op_conf().has_model_init_conf());
   if (op_conf().model_init_conf().has_tick()) { EnrollInputBn("tick", false); }
   EnrollRepeatedOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/model_io_v2_op.cpp
+++ b/oneflow/core/operator/model_io_v2_op.cpp
@@ -21,11 +21,12 @@ namespace oneflow {
 
 class ModelInitV2Op : public Operator {
  public:
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     CHECK(op_conf().has_model_init_v2_conf());
     FOR_RANGE(int64_t, i, 0, op_conf().model_init_v2_conf().ref_size()) {
       EnrollInputBn(GenRepeatedBn("ref", i), false)->set_is_mutable(true);
     }
+    return Maybe<void>::Ok();
   }
 
   Maybe<void> InferLogicalOutBlobDescs(
@@ -59,12 +60,13 @@ REGISTER_OP(OperatorConf::kModelInitV2Conf, ModelInitV2Op);
 
 class ModelLoadV2Op : public Operator {
  public:
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     CHECK(op_conf().has_model_load_v2_conf());
     EnrollInputBn("path", false);
     FOR_RANGE(int64_t, i, 0, op_conf().model_load_v2_conf().ref_size()) {
       EnrollInputBn(GenRepeatedBn("ref", i), false)->set_is_mutable(true);
     }
+    return Maybe<void>::Ok();
   }
 
   Maybe<void> InferLogicalOutBlobDescs(
@@ -109,10 +111,11 @@ class ModelSaveV2Op final : public Operator {
   ModelSaveV2Op() = default;
   ~ModelSaveV2Op() override = default;
 
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     CHECK(op_conf().has_model_save_v2_conf());
     EnrollInputBn("path", false);
     EnrollRepeatedInputBn("in", false);
+    return Maybe<void>::Ok();
   }
 
   Maybe<void> InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/model_load_op.cpp
+++ b/oneflow/core/operator/model_load_op.cpp
@@ -19,7 +19,7 @@ namespace oneflow {
 
 class ModelLoadOp : public Operator {
  public:
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   virtual Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
@@ -34,10 +34,11 @@ class ModelLoadOp : public Operator {
       cfg::SbpSignatureList* sbp_sig_list) const override;
 };
 
-void ModelLoadOp::InitFromOpConf() {
+Maybe<void> ModelLoadOp::InitFromOpConf() {
   CHECK(op_conf().has_model_load_conf());
   EnrollInputBn("path", false);
   EnrollRepeatedOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/model_save_op.cpp
+++ b/oneflow/core/operator/model_save_op.cpp
@@ -23,7 +23,7 @@ class ModelSaveOp final : public Operator {
   ModelSaveOp() = default;
   ~ModelSaveOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override {
@@ -64,10 +64,11 @@ class ModelSaveOp final : public Operator {
   }
 };
 
-void ModelSaveOp::InitFromOpConf() {
+Maybe<void> ModelSaveOp::InitFromOpConf() {
   CHECK(op_conf().has_model_save_conf());
   EnrollInputBn("path", false);
   EnrollRepeatedInputBn("in", false);
+  return Maybe<void>::Ok();
 }
 
 REGISTER_CPU_OP(OperatorConf::kModelSaveConf, ModelSaveOp);

--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -45,9 +45,9 @@ class Operator {
   virtual ~Operator() = default;
 
   //
-  void Init(const OperatorConf& op_conf);
-  void Init(std::shared_ptr<const OperatorConf> op_conf);
-  virtual void InitFromOpConf() = 0;
+  Maybe<void> Init(const OperatorConf& op_conf);
+  Maybe<void> Init(std::shared_ptr<const OperatorConf> op_conf);
+  virtual Maybe<void> InitFromOpConf() = 0;
 
   // bn_in_op <-> lbi
   const LogicalBlobId& BnInOp2Lbi(const std::string& bn_in_op) const;

--- a/oneflow/core/operator/output_op.cpp
+++ b/oneflow/core/operator/output_op.cpp
@@ -19,10 +19,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void OutputOp::InitFromOpConf() {
+Maybe<void> OutputOp::InitFromOpConf() {
   CHECK(op_conf().has_output_conf());
   EnrollInputBn("in");
   EnrollOutputBn("out")->set_is_mutable(true);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> OutputOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/output_op.h
+++ b/oneflow/core/operator/output_op.h
@@ -26,7 +26,7 @@ class OutputOp final : public Operator {
   OutputOp() = default;
   ~OutputOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
       const ParallelContext* parallel_ctx) const override;

--- a/oneflow/core/operator/reentrant_lock_op.cpp
+++ b/oneflow/core/operator/reentrant_lock_op.cpp
@@ -18,10 +18,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void ReentrantLockOp::InitFromOpConf() {
+Maybe<void> ReentrantLockOp::InitFromOpConf() {
   EnrollInputBn("start", false);
   if (op_conf().reentrant_lock_conf().has_end()) { EnrollInputBn("end", false); }
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/reentrant_lock_op.h
+++ b/oneflow/core/operator/reentrant_lock_op.h
@@ -26,7 +26,7 @@ class ReentrantLockOp final : public Operator {
   ReentrantLockOp() = default;
   ~ReentrantLockOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/return_op.cpp
+++ b/oneflow/core/operator/return_op.cpp
@@ -19,10 +19,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void ReturnOp::InitFromOpConf() {
+Maybe<void> ReturnOp::InitFromOpConf() {
   CHECK(op_conf().has_return_conf());
   EnrollInputBn("in");
   EnrollOutputBn("out")->set_is_mutable(true);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/return_op.h
+++ b/oneflow/core/operator/return_op.h
@@ -26,7 +26,7 @@ class ReturnOp final : public Operator {
   ReturnOp() = default;
   ~ReturnOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/scalar_op_base.cpp
+++ b/oneflow/core/operator/scalar_op_base.cpp
@@ -18,11 +18,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void ScalarOpBase::InitFromOpConf() {
+Maybe<void> ScalarOpBase::InitFromOpConf() {
   EnrollInputBn("in");
   EnrollInputBn("scalar");
   EnrollOutputBn("out")->set_mutable_inplace_ibn("in");
-  ;
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> ScalarOpBase::InferOutBlobDescs(

--- a/oneflow/core/operator/scalar_op_base.h
+++ b/oneflow/core/operator/scalar_op_base.h
@@ -26,7 +26,7 @@ class ScalarOpBase : public Operator {
   ScalarOpBase() = default;
   ~ScalarOpBase() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
       const ParallelContext* parallel_ctx) const override;

--- a/oneflow/core/operator/shape_elem_cnt_op.cpp
+++ b/oneflow/core/operator/shape_elem_cnt_op.cpp
@@ -49,9 +49,10 @@ HashSet<int32_t> GetInclusiveAxes(const ShapeElemCntOpConf& conf, int32_t num_ax
 
 }  // namespace
 
-void ShapeElemCntOp::InitFromOpConf() {
+Maybe<void> ShapeElemCntOp::InitFromOpConf() {
   EnrollInputBn("x", false);
   EnrollOutputBn("y", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/shape_elem_cnt_op.h
+++ b/oneflow/core/operator/shape_elem_cnt_op.h
@@ -26,7 +26,7 @@ class ShapeElemCntOp final : public Operator {
   ShapeElemCntOp() = default;
   ~ShapeElemCntOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/sink_tick_op.cpp
+++ b/oneflow/core/operator/sink_tick_op.cpp
@@ -18,10 +18,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void SinkTickOp::InitFromOpConf() {
+Maybe<void> SinkTickOp::InitFromOpConf() {
   CHECK(op_conf().has_sink_tick_conf());
   EnrollRepeatedInputBn("tick", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/sink_tick_op.h
+++ b/oneflow/core/operator/sink_tick_op.h
@@ -26,7 +26,7 @@ class SinkTickOp final : public Operator {
   SinkTickOp() = default;
   ~SinkTickOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/slice_boxing_op.cpp
+++ b/oneflow/core/operator/slice_boxing_op.cpp
@@ -25,7 +25,7 @@ class SliceBoxingOp : public Operator {
   SliceBoxingOp() = default;
   ~SliceBoxingOp() override = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override {
@@ -74,10 +74,11 @@ class SliceBoxingAddOp final : public SliceBoxingOp {
   Symbol<OperatorConf> GetOpConfWithoutOpNameAndLbn() const override;
 };
 
-void SliceBoxingOp::InitFromOpConf() {
+Maybe<void> SliceBoxingOp::InitFromOpConf() {
   EnrollRepeatedInputBn("in", GetCustomizedBoxingConf().in_slice_size(), false);
   EnrollOutputBn("out");
   VirtualInitFromOpConf();
+  return Maybe<void>::Ok();
 }
 
 LogicalBlobId SliceBoxingOp::lbi4ibn(const std::string& input_bn) const {

--- a/oneflow/core/operator/source_tick_op.cpp
+++ b/oneflow/core/operator/source_tick_op.cpp
@@ -18,10 +18,11 @@ limitations under the License.
 
 namespace oneflow {
 
-void SourceTickOp::InitFromOpConf() {
+Maybe<void> SourceTickOp::InitFromOpConf() {
   CHECK(op_conf().has_source_tick_conf());
   CHECK(op_conf().ctrl_in_op_name().empty());
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> SourceTickOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/source_tick_op.h
+++ b/oneflow/core/operator/source_tick_op.h
@@ -26,7 +26,7 @@ class SourceTickOp final : public Operator {
   SourceTickOp() = default;
   ~SourceTickOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/src_subset_tick_op.cpp
+++ b/oneflow/core/operator/src_subset_tick_op.cpp
@@ -25,7 +25,7 @@ class SrcSubsetTickOp final : public Operator {
   SrcSubsetTickOp() = default;
   ~SrcSubsetTickOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;
@@ -37,10 +37,11 @@ class SrcSubsetTickOp final : public Operator {
   Maybe<void> GetSbpSignatures(cfg::SbpSignatureList* sbp_sig_list) const override;
 };
 
-void SrcSubsetTickOp::InitFromOpConf() {
+Maybe<void> SrcSubsetTickOp::InitFromOpConf() {
   CHECK(op_conf().has_src_subset_tick_conf());
   EnrollRepeatedInputBn("in", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/sync_dynamic_resize_op.cpp
+++ b/oneflow/core/operator/sync_dynamic_resize_op.cpp
@@ -41,10 +41,11 @@ class SyncDynamicResizeOp : public Operator {
   SyncDynamicResizeOp() = default;
   ~SyncDynamicResizeOp() override = default;
 
-  void InitFromOpConf() override {
+  Maybe<void> InitFromOpConf() override {
     EnrollInputBn("in");
     EnrollInputBn("size", false);
     EnrollOutputBn("out")->set_header_infered_before_compute(false);
+    return Maybe<void>::Ok();
   }
 
   Maybe<void> InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/tick_op.cpp
+++ b/oneflow/core/operator/tick_op.cpp
@@ -29,10 +29,11 @@ Maybe<void> InferBlobDescs(const std::function<BlobDesc*(const std::string&)>& B
 
 }  // namespace
 
-void TickOp::InitFromOpConf() {
+Maybe<void> TickOp::InitFromOpConf() {
   CHECK(op_conf().has_tick_conf());
   EnrollRepeatedInputBn("tick", false);
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> TickOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/tick_op.h
+++ b/oneflow/core/operator/tick_op.h
@@ -26,7 +26,7 @@ class TickOp final : public Operator {
   TickOp() = default;
   ~TickOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/core/operator/user_op.cpp
+++ b/oneflow/core/operator/user_op.cpp
@@ -484,7 +484,7 @@ class UserOpInferParallelDistributionFnContext
       parallel_distribution_infer_hint4ibn_fn_;
 };
 
-void UserOp::InitFromOpConf() {
+Maybe<void> UserOp::InitFromOpConf() {
   CHECK(op_conf().has_user_conf());
   for (const auto& pair : op_conf().user_conf().input()) {
     EnrollRepeatedInputBn(pair.first, pair.second.s_size());
@@ -524,9 +524,10 @@ void UserOp::InitFromOpConf() {
         }
         return nullptr;
       };
-      val_->output_arg_modify_fn(GetOutputArgModifierFn, *user_op_conf_);
+      JUST(val_->output_arg_modify_fn(GetOutputArgModifierFn, *user_op_conf_));
     }
   }
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> UserOp::InferInternalBlobDescs(

--- a/oneflow/core/operator/user_op.h
+++ b/oneflow/core/operator/user_op.h
@@ -29,7 +29,7 @@ class UserOp final : public Operator {
 
   using ArgVec = std::vector<std::pair<std::string, int32_t>>;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferInternalBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
       const ParallelContext* parallel_ctx, const JobDesc* job_desc) const override;

--- a/oneflow/core/operator/variable_op.cpp
+++ b/oneflow/core/operator/variable_op.cpp
@@ -41,11 +41,12 @@ Maybe<void> ParseParallelDistributionFromConf(const VariableOpConf& conf,
 
 }  // namespace
 
-void VariableOp::InitFromOpConf() {
+Maybe<void> VariableOp::InitFromOpConf() {
   CHECK(op_conf().has_variable_conf());
   if (op_conf().variable_conf().has_tick()) { EnrollInputBn("tick", false); }
   bool is_trainable = op_conf().variable_conf().trainable();
   EnrollOutputBn("out", is_trainable)->set_is_mutable(true);
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> VariableOp::InferLogicalOutBlobDescs(

--- a/oneflow/core/operator/variable_op.h
+++ b/oneflow/core/operator/variable_op.h
@@ -26,7 +26,7 @@ class VariableOp final : public Operator {
   VariableOp() : Operator() {}
   ~VariableOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& GetBlobDesc4BnInOp,
       const ParallelContext* parallel_ctx) const override;

--- a/oneflow/core/operator/wait_and_send_ids_op.cpp
+++ b/oneflow/core/operator/wait_and_send_ids_op.cpp
@@ -18,9 +18,10 @@ limitations under the License.
 
 namespace oneflow {
 
-void WaitAndSendIdsOp::InitFromOpConf() {
+Maybe<void> WaitAndSendIdsOp::InitFromOpConf() {
   CHECK(op_conf().has_wait_and_send_ids_conf());
   EnrollOutputBn("out", false);
+  return Maybe<void>::Ok();
 }
 
 namespace {

--- a/oneflow/core/operator/wait_and_send_ids_op.h
+++ b/oneflow/core/operator/wait_and_send_ids_op.h
@@ -26,7 +26,7 @@ class WaitAndSendIdsOp final : public Operator {
   WaitAndSendIdsOp() = default;
   ~WaitAndSendIdsOp() = default;
 
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,
       const ParallelDesc& parallel_desc) const override;

--- a/oneflow/user/kernels/stateful_local_opkernel.cpp
+++ b/oneflow/user/kernels/stateful_local_opkernel.cpp
@@ -313,7 +313,7 @@ Maybe<void> InitTensorTupleIndexes4Bns(const std::shared_ptr<const OperatorConf>
       auto* map = arg_modifier_signature.mutable_obn2output_blob_modifier();
       return &map->at(obn);
     };
-    op_reg_val->output_arg_modify_fn(GetOutputArgModifierFn, op_conf_wrapper);
+    JUST(op_reg_val->output_arg_modify_fn(GetOutputArgModifierFn, op_conf_wrapper));
   }
 
   for (int i = 0; i < indexed_input_pairs.size(); i++) {

--- a/oneflow/user/ops/coco_reader_op.cpp
+++ b/oneflow/user/ops/coco_reader_op.cpp
@@ -93,32 +93,32 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("COCOReader")
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
                              const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* image_modifier = GetOutputArgModifierFn("image", 0);
-      CHECK(image_modifier != nullptr);
+      CHECK_OR_RETURN(image_modifier != nullptr);
       image_modifier->set_header_infered_before_compute(false);
 
       user_op::OutputArgModifier* image_id_modifier = GetOutputArgModifierFn("image_id", 0);
-      CHECK(image_id_modifier != nullptr);
+      CHECK_OR_RETURN(image_id_modifier != nullptr);
       image_id_modifier->set_header_infered_before_compute(false);
 
       user_op::OutputArgModifier* image_size_modifier = GetOutputArgModifierFn("image_size", 0);
-      CHECK(image_size_modifier != nullptr);
+      CHECK_OR_RETURN(image_size_modifier != nullptr);
       image_size_modifier->set_header_infered_before_compute(false);
 
       user_op::OutputArgModifier* gt_bbox_modifier = GetOutputArgModifierFn("gt_bbox", 0);
-      CHECK(gt_bbox_modifier != nullptr);
+      CHECK_OR_RETURN(gt_bbox_modifier != nullptr);
       gt_bbox_modifier->set_header_infered_before_compute(false);
 
       user_op::OutputArgModifier* gt_label_modifier = GetOutputArgModifierFn("gt_label", 0);
-      CHECK(gt_label_modifier != nullptr);
+      CHECK_OR_RETURN(gt_label_modifier != nullptr);
       gt_label_modifier->set_header_infered_before_compute(false);
 
       user_op::OutputArgModifier* gt_segm_modifier = GetOutputArgModifierFn("gt_segm", 0);
-      CHECK(gt_segm_modifier != nullptr);
+      CHECK_OR_RETURN(gt_segm_modifier != nullptr);
       gt_segm_modifier->set_header_infered_before_compute(false);
 
       user_op::OutputArgModifier* gt_segm_index_modifier =
           GetOutputArgModifierFn("gt_segm_index", 0);
-      CHECK(gt_segm_index_modifier != nullptr);
+      CHECK_OR_RETURN(gt_segm_index_modifier != nullptr);
       gt_segm_index_modifier->set_header_infered_before_compute(false);
       return Maybe<void>::Ok();
     })

--- a/oneflow/user/ops/coco_reader_op.cpp
+++ b/oneflow/user/ops/coco_reader_op.cpp
@@ -91,7 +91,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("COCOReader")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* image_modifier = GetOutputArgModifierFn("image", 0);
       CHECK(image_modifier != nullptr);
       image_modifier->set_header_infered_before_compute(false);
@@ -120,6 +120,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("COCOReader")
           GetOutputArgModifierFn("gt_segm_index", 0);
       CHECK(gt_segm_index_modifier != nullptr);
       gt_segm_index_modifier->set_header_infered_before_compute(false);
+      return Maybe<void>::Ok();
     })
     .SetDataTypeInferFn([](user_op::InferContext* ctx) -> Maybe<void> {
       user_op::TensorDesc* image_desc = ctx->OutputTensorDesc("image", 0);

--- a/oneflow/user/ops/image_batch_align_op.cpp
+++ b/oneflow/user/ops/image_batch_align_op.cpp
@@ -77,10 +77,11 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("image_batch_align")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("out", 0);
       CHECK(out_modifier != nullptr);
       out_modifier->set_header_infered_before_compute(false);
+      return Maybe<void>::Ok();
     })
     .SetDataTypeInferFn([](user_op::InferContext* ctx) -> Maybe<void> {
       const user_op::TensorDesc* in_desc = ctx->TensorDesc4ArgNameAndIndex("in", 0);

--- a/oneflow/user/ops/image_batch_align_op.cpp
+++ b/oneflow/user/ops/image_batch_align_op.cpp
@@ -79,7 +79,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("image_batch_align")
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
                              const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("out", 0);
-      CHECK(out_modifier != nullptr);
+      CHECK_OR_RETURN(out_modifier != nullptr);
       out_modifier->set_header_infered_before_compute(false);
       return Maybe<void>::Ok();
     })

--- a/oneflow/user/ops/ofrecord_image_classification_reader_op.cpp
+++ b/oneflow/user/ops/ofrecord_image_classification_reader_op.cpp
@@ -63,10 +63,10 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("ofrecord_image_classification_reader")
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
                              const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* image_modifier = GetOutputArgModifierFn("image", 0);
-      CHECK(image_modifier != nullptr);
+      CHECK_OR_RETURN(image_modifier != nullptr);
       image_modifier->set_header_infered_before_compute(false);
       user_op::OutputArgModifier* label_modifier = GetOutputArgModifierFn("label", 0);
-      CHECK(label_modifier != nullptr);
+      CHECK_OR_RETURN(label_modifier != nullptr);
       label_modifier->set_header_infered_before_compute(false);
       return Maybe<void>::Ok();
     })

--- a/oneflow/user/ops/ofrecord_image_classification_reader_op.cpp
+++ b/oneflow/user/ops/ofrecord_image_classification_reader_op.cpp
@@ -61,13 +61,14 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("ofrecord_image_classification_reader")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* image_modifier = GetOutputArgModifierFn("image", 0);
       CHECK(image_modifier != nullptr);
       image_modifier->set_header_infered_before_compute(false);
       user_op::OutputArgModifier* label_modifier = GetOutputArgModifierFn("label", 0);
       CHECK(label_modifier != nullptr);
       label_modifier->set_header_infered_before_compute(false);
+      return Maybe<void>::Ok();
     })
     .SetDataTypeInferFn([](user_op::InferContext* ctx) -> Maybe<void> {
       *ctx->OutputDType("image", 0) = DataType::kTensorBuffer;

--- a/oneflow/user/ops/ofrecord_reader_op.cpp
+++ b/oneflow/user/ops/ofrecord_reader_op.cpp
@@ -51,10 +51,11 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("OFRecordReader")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("out", 0);
       CHECK(out_modifier != nullptr);
       out_modifier->set_header_infered_before_compute(false);
+      return Maybe<void>::Ok();
     })
     .SetDataTypeInferFn([](user_op::InferContext* ctx) -> Maybe<void> {
       *ctx->OutputDType("out", 0) = DataType::kOFRecord;

--- a/oneflow/user/ops/ofrecord_reader_op.cpp
+++ b/oneflow/user/ops/ofrecord_reader_op.cpp
@@ -53,7 +53,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("OFRecordReader")
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
                              const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("out", 0);
-      CHECK(out_modifier != nullptr);
+      CHECK_OR_RETURN(out_modifier != nullptr);
       out_modifier->set_header_infered_before_compute(false);
       return Maybe<void>::Ok();
     })

--- a/oneflow/user/ops/onerec_decoder_op.cpp
+++ b/oneflow/user/ops/onerec_decoder_op.cpp
@@ -56,7 +56,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("onerec_decoder")
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
                              const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("out", 0);
-      CHECK(out_modifier != nullptr);
+      CHECK_OR_RETURN(out_modifier != nullptr);
       out_modifier->set_header_infered_before_compute(false);
       return Maybe<void>::Ok();
     })

--- a/oneflow/user/ops/onerec_decoder_op.cpp
+++ b/oneflow/user/ops/onerec_decoder_op.cpp
@@ -54,10 +54,11 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("onerec_decoder")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("out", 0);
       CHECK(out_modifier != nullptr);
       out_modifier->set_header_infered_before_compute(false);
+      return Maybe<void>::Ok();
     })
     .SetDataTypeInferFn([](user_op::InferContext* ctx) -> Maybe<void> {
       user_op::TensorDesc* in_tensor = ctx->TensorDesc4ArgNameAndIndex("in", 0);

--- a/oneflow/user/ops/ssp_variable_proxy_op.cpp
+++ b/oneflow/user/ops/ssp_variable_proxy_op.cpp
@@ -49,7 +49,7 @@ REGISTER_NO_GRAD_USER_OP("ssp_variable_proxy")
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
                              const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("ref", 0);
-      CHECK(out_modifier != nullptr);
+      CHECK_OR_RETURN(out_modifier != nullptr);
       out_modifier->set_is_mutable(true);
       return Maybe<void>::Ok();
     });

--- a/oneflow/user/ops/ssp_variable_proxy_op.cpp
+++ b/oneflow/user/ops/ssp_variable_proxy_op.cpp
@@ -47,10 +47,11 @@ REGISTER_NO_GRAD_USER_OP("ssp_variable_proxy")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("ref", 0);
       CHECK(out_modifier != nullptr);
       out_modifier->set_is_mutable(true);
+      return Maybe<void>::Ok();
     });
 
 }  // namespace

--- a/oneflow/user/ops/tensor_buffer_ops.cpp
+++ b/oneflow/user/ops/tensor_buffer_ops.cpp
@@ -150,7 +150,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("tensor_buffer_to_list_of_tensors")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       if (conf.attr<bool>("dynamic_out")) {
         FOR_RANGE(int64_t, i, 0, conf.output_size("out")) {
           user_op::OutputArgModifier* out_i_modifier = GetOutputArgModifierFn("out", i);
@@ -158,6 +158,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("tensor_buffer_to_list_of_tensors")
           out_i_modifier->set_header_infered_before_compute(false);
         }
       }
+      return Maybe<void>::Ok();
     })
     .SetGetSbpFn(user_op::GetSbpFnUtil::DefaultBroadcastToBroadcast);
 
@@ -194,7 +195,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("tensor_buffer_to_list_of_tensors_v2")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       if (conf.attr<bool>("dynamic_out")) {
         FOR_RANGE(int64_t, i, 0, conf.output_size("out")) {
           user_op::OutputArgModifier* out_i_modifier = GetOutputArgModifierFn("out", i);
@@ -202,6 +203,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("tensor_buffer_to_list_of_tensors_v2")
           out_i_modifier->set_header_infered_before_compute(false);
         }
       }
+      return Maybe<void>::Ok();
     })
     .SetGetSbpFn(user_op::GetSbpFnUtil::DefaultBroadcastToBroadcast);
 

--- a/oneflow/user/ops/tensor_buffer_ops.cpp
+++ b/oneflow/user/ops/tensor_buffer_ops.cpp
@@ -154,7 +154,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("tensor_buffer_to_list_of_tensors")
       if (conf.attr<bool>("dynamic_out")) {
         FOR_RANGE(int64_t, i, 0, conf.output_size("out")) {
           user_op::OutputArgModifier* out_i_modifier = GetOutputArgModifierFn("out", i);
-          CHECK(out_i_modifier != nullptr);
+          CHECK_OR_RETURN(out_i_modifier != nullptr);
           out_i_modifier->set_header_infered_before_compute(false);
         }
       }
@@ -199,7 +199,7 @@ REGISTER_NO_GRAD_CPU_ONLY_USER_OP("tensor_buffer_to_list_of_tensors_v2")
       if (conf.attr<bool>("dynamic_out")) {
         FOR_RANGE(int64_t, i, 0, conf.output_size("out")) {
           user_op::OutputArgModifier* out_i_modifier = GetOutputArgModifierFn("out", i);
-          CHECK(out_i_modifier != nullptr);
+          CHECK_OR_RETURN(out_i_modifier != nullptr);
           out_i_modifier->set_header_infered_before_compute(false);
         }
       }

--- a/oneflow/user/ops/test_ops.cpp
+++ b/oneflow/user/ops/test_ops.cpp
@@ -254,10 +254,11 @@ REGISTER_USER_OP("TestDynamicSource")
       return Maybe<void>::Ok();
     })
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
-                             const user_op::UserOpConfWrapper& conf) {
+                             const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("out", 0);
       CHECK(out_modifier != nullptr);
       out_modifier->set_header_infered_before_compute(false);
+      return Maybe<void>::Ok();
     });
 
 REGISTER_USER_OP("TestRandomSource")

--- a/oneflow/user/ops/test_ops.cpp
+++ b/oneflow/user/ops/test_ops.cpp
@@ -256,7 +256,7 @@ REGISTER_USER_OP("TestDynamicSource")
     .SetOutputArgModifyFn([](user_op::GetOutputArgModifier GetOutputArgModifierFn,
                              const user_op::UserOpConfWrapper& conf) -> Maybe<void> {
       user_op::OutputArgModifier* out_modifier = GetOutputArgModifierFn("out", 0);
-      CHECK(out_modifier != nullptr);
+      CHECK_OR_RETURN(out_modifier != nullptr);
       out_modifier->set_header_infered_before_compute(false);
       return Maybe<void>::Ok();
     });

--- a/oneflow/xrt/launch_op.cpp
+++ b/oneflow/xrt/launch_op.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 
 namespace oneflow {
 
-void XrtLaunchOp::InitFromOpConf() {
+Maybe<void> XrtLaunchOp::InitFromOpConf() {
   CHECK(op_conf().has_xrt_launch_conf());
   const auto& launch_conf = op_conf().xrt_launch_conf();
   int inputs_num = launch_conf.in().size();
@@ -38,6 +38,7 @@ void XrtLaunchOp::InitFromOpConf() {
     EnrollInputBn(absl::StrCat("in_", i))->set_is_mutable(mutability);
   }
   if (outputs_num > 0) { EnrollRepeatedOutputBn("out"); }
+  return Maybe<void>::Ok();
 }
 
 Maybe<void> XrtLaunchOp::InferLogicalOutBlobDescs(

--- a/oneflow/xrt/launch_op.h
+++ b/oneflow/xrt/launch_op.h
@@ -24,7 +24,7 @@ namespace oneflow {
 
 class XrtLaunchOp : public Operator {
  public:
-  void InitFromOpConf() override;
+  Maybe<void> InitFromOpConf() override;
 
   Maybe<void> InferLogicalOutBlobDescs(
       const std::function<BlobDesc*(const std::string&)>& BlobDesc4BnInOp,


### PR DESCRIPTION
**Output arg modifier return maybe - part_0:**

这次pr是形成 api层到 OutputArgModifer回调函数 完整的 maybe手工栈的第一部分，共两部分。
第二部分在：https://github.com/Oneflow-Inc/oneflow/pull/5451

完整调用链为：
api层 -> f0(如CurJobBuildAndInferCtx_AddAndInferMirroredOp) -> f1(如AddAndInferMirroredOp）-> ConstructOp -> CheckAndConstructOp -> Operator->Init() -> Init() -> InitFromOpConf() -> output_arg_modify_fn

因ConstructOp会传染较多文件，故本次pr从output_arg_modify_fn截止到CheckAndConstructOp,使用了CHECK_JUST中断了手工栈
"""
std::shared_ptr<Operator> CheckAndConstructOp(std::shared_ptr<const OperatorConf> op_conf) { 
       ...
      CHECK_JUST(rptr->Init(op_conf));
       ...
}
"""
第二部分pr形成ConstructOp到api层手工栈。