### PR TITLE
Multi-Client LogicalRun degenerate to PhysicalRun

### DIFF
--- a/oneflow/core/vm/id_generator.cpp
+++ b/oneflow/core/vm/id_generator.cpp
@@ -16,16 +16,28 @@ limitations under the License.
 #include "oneflow/core/vm/id_generator.h"
 #include "oneflow/core/vm/id_util.h"
 #include "oneflow/core/control/global_process_ctx.h"
+#include "oneflow/api/python/env/env.h"
 
 namespace oneflow {
 namespace vm {
 
 Maybe<int64_t> LogicalIdGenerator::NewSymbolId() {
+  if (JUST(IsMultiClient())) {
+    // NOTE(chengcheng): in Multi-Client LogicalIdGenerator will degenerate directly to
+    //   PhysicalIdGenerator, because each rank will generate id ONLY from itself, NOT the master.
+    return IdUtil::NewPhysicalSymbolId(GlobalProcessCtx::Rank());
+  }
   CHECK_OR_RETURN(GlobalProcessCtx::IsThisProcessMaster());
   return IdUtil::NewLogicalSymbolId();
 }
 
 Maybe<int64_t> LogicalIdGenerator::NewObjectId() {
+  if (JUST(IsMultiClient())) {
+    // NOTE(chengcheng): in Multi-Client LogicalIdGenerator will degenerate directly to
+    //   PhysicalIdGenerator, because each rank will generate id ONLY from itself, NOT the master.
+    return IdUtil::NewPhysicalObjectId(GlobalProcessCtx::Rank());
+  }
+
   CHECK_OR_RETURN(GlobalProcessCtx::IsThisProcessMaster());
   return IdUtil::NewLogicalObjectId();
 }


### PR DESCRIPTION
在 Multi-Client 下，虚拟机 VM 的 指令： LogicalRun 会直接退化成 PhysicalRun，因为每个 rank 都 **只会收到和处理本 rank 的指令**，不会再有 rank 之间的 指令级别的同步（对应之前 Single-Client 下的 ClusterInstruction）

补充： 

- VM 的  IdGenerator 的 Logical 版本也会退化为 Physical 版本