### PR TITLE
Add new autotest for some ops

### DIFF
--- a/oneflow/python/test/modules/test_addmm.py
+++ b/oneflow/python/test/modules/test_addmm.py
@@ -63,29 +63,36 @@ class TestAddmm(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest
+    @autotest()
     def test_flow_addmm_with_random_data(test_case):
-        m = random(1, 6)
-        n = random(1, 6)
+        m = random(1, 6).to(int)
+        n = random(1, 6).to(int)
         device = random_device()
         input = random_pytorch_tensor(ndim=2, dim0=m, dim1=m).to(device)
         mat1 = random_pytorch_tensor(ndim=2, dim0=m, dim1=n).to(device)
         mat2 = random_pytorch_tensor(ndim=2, dim0=n, dim1=m).to(device)
         y = torch.addmm(
-            input, mat1, mat2, beta=random() | nothing(), alpha=random() | nothing(),
+            input,
+            mat1,
+            mat2,
+            beta=random().to(float) | nothing(),
+            alpha=random().to(float) | nothing(),
         )
         return y
 
-    @autotest
+    @autotest()
     def test_tensor_addmm_with_random_data(test_case):
-        m = random(1, 6)
-        n = random(1, 6)
+        m = random(1, 6).to(int)
+        n = random(1, 6).to(int)
         device = random_device()
         input = random_pytorch_tensor(ndim=2, dim0=m, dim1=m).to(device)
         mat1 = random_pytorch_tensor(ndim=2, dim0=m, dim1=n).to(device)
         mat2 = random_pytorch_tensor(ndim=2, dim0=n, dim1=m).to(device)
         y = input.addmm(
-            mat1, mat2, beta=random() | nothing(), alpha=random() | nothing(),
+            mat1,
+            mat2,
+            beta=random().to(float) | nothing(),
+            alpha=random().to(float) | nothing(),
         )
         return y
 

--- a/oneflow/python/test/modules/test_ceil.py
+++ b/oneflow/python/test/modules/test_ceil.py
@@ -48,14 +48,14 @@ class TestCeilModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest
+    @autotest()
     def test_flow_ceil_with_random_data(test_case):
         device = random_device()
         x = random_pytorch_tensor().to(device)
         y = torch.ceil(x)
         return y
 
-    @autotest
+    @autotest()
     def test_tensor_ceil_with_random_data(test_case):
         device = random_device()
         x = random_pytorch_tensor().to(device)

--- a/oneflow/python/test/modules/test_ceil.py
+++ b/oneflow/python/test/modules/test_ceil.py
@@ -17,9 +17,11 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
+import torch
 
 import oneflow.experimental as flow
 from test_util import GenArgList
+from automated_test_util import *
 
 
 def _test_ceil_impl(test_case, device, shape):
@@ -45,6 +47,19 @@ class TestCeilModule(flow.unittest.TestCase):
 
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
+
+    @autotest
+    def test_flow_ceil_with_random_data(test_case):
+        device = random_device()
+        x = random_pytorch_tensor().to(device)
+        y = torch.ceil(x)
+        return y
+
+    @autotest
+    def test_tensor_ceil_with_random_data(test_case):
+        device = random_device()
+        x = random_pytorch_tensor().to(device)
+        return x.ceil()
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_clamp.py
+++ b/oneflow/python/test/modules/test_clamp.py
@@ -17,9 +17,11 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
+import torch
 
 import oneflow.experimental as flow
 from test_util import GenArgList
+from automated_test_util import *
 
 
 def _test_clamp(test_case, shape, device):
@@ -101,6 +103,23 @@ class TestClampModule(flow.unittest.TestCase):
         arg_dict["device"] = ["cpu", "cuda"]
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
+
+    @autotest
+    def test_flow_clamp_with_random_data(test_case):
+        device = random_device()
+        x = random_pytorch_tensor().to(device)
+        y = torch.clamp(
+            x, min=random(0.1, 0.3) | nothing(), max=random(0.5, 0.8) | nothing()
+        )
+        return y
+
+    @autotest
+    def test_tensor_clamp_with_random_data(test_case):
+        device = random_device()
+        x = random_pytorch_tensor().to(device)
+        return x.clamp(
+            x, min=random(0.1, 0.3) | nothing(), max=random(0.5, 0.8) | nothing()
+        )
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_clamp.py
+++ b/oneflow/python/test/modules/test_clamp.py
@@ -17,11 +17,9 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
-import torch
 
 import oneflow.experimental as flow
 from test_util import GenArgList
-from automated_test_util import *
 
 
 def _test_clamp(test_case, shape, device):
@@ -103,23 +101,6 @@ class TestClampModule(flow.unittest.TestCase):
         arg_dict["device"] = ["cpu", "cuda"]
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
-
-    @autotest
-    def test_flow_clamp_with_random_data(test_case):
-        device = random_device()
-        x = random_pytorch_tensor().to(device)
-        y = torch.clamp(
-            x, min=random(0.1, 0.3) | nothing(), max=random(0.5, 0.8) | nothing()
-        )
-        return y
-
-    @autotest
-    def test_tensor_clamp_with_random_data(test_case):
-        device = random_device()
-        x = random_pytorch_tensor().to(device)
-        return x.clamp(
-            x, min=random(0.1, 0.3) | nothing(), max=random(0.5, 0.8) | nothing()
-        )
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_expm1.py
+++ b/oneflow/python/test/modules/test_expm1.py
@@ -50,18 +50,18 @@ class TestExpm1Module(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest
+    @autotest()
     def test_flow_expm1_with_random_data(test_case):
         device = random_device()
         x = random_pytorch_tensor().to(device)
         y = torch.expm1(x)
         return y
 
-    @autotest
+    @autotest()
     def test_tensor_expm1_with_random_data(test_case):
         device = random_device()
         x = random_pytorch_tensor().to(device)
-        return input.expm1(x)
+        return x.expm1()
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_expm1.py
+++ b/oneflow/python/test/modules/test_expm1.py
@@ -17,11 +17,11 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
+import torch
 
 import oneflow.experimental as flow
 from test_util import GenArgList
-
-flow.enable_eager_execution()
+from automated_test_util import *
 
 
 def _test_expm1_impl(test_case, device, shape):
@@ -49,6 +49,19 @@ class TestExpm1Module(flow.unittest.TestCase):
 
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
+
+    @autotest
+    def test_flow_expm1_with_random_data(test_case):
+        device = random_device()
+        x = random_pytorch_tensor().to(device)
+        y = torch.expm1(x)
+        return y
+
+    @autotest
+    def test_tensor_expm1_with_random_data(test_case):
+        device = random_device()
+        x = random_pytorch_tensor().to(device)
+        return input.expm1(x)
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_l1loss.py
+++ b/oneflow/python/test/modules/test_l1loss.py
@@ -17,9 +17,11 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
+import torch
 
 import oneflow.experimental as flow
 from test_util import GenArgList
+from automated_test_util import *
 
 
 def _np_l1loss(np_input, np_target):
@@ -86,6 +88,26 @@ class TestL1LossModule(flow.unittest.TestCase):
         arg_dict["reduction"] = ["none", "sum", "mean"]
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
+
+    @autotest()
+    def test_l1loss_module_with_random_data(test_case):
+        k = random(1, 6).to(int)
+        dim0 = random(1, 10).to(int)
+        dim1 = random(1, 10).to(int)
+        dim2 = random(1, 10).to(int)
+        dim3 = random(1, 10).to(int)
+        dim4 = random(1, 10).to(int)
+        reduction = oneof("none", "sum", "mean")
+        loss = torch.nn.L1Loss(
+            reduction=reduction | nothing()
+        )
+        loss.train(random())
+        device = random_device()
+        loss.to(device)
+        input = random_pytorch_tensor(ndim=k, dim0=dim0, dim1=dim1, dim2=dim2, dim3=dim3, dim4=dim4).to(device)
+        target = random_pytorch_tensor(ndim=k, dim0=dim0, dim1=dim1, dim2=dim2, dim3=dim3, dim4=dim4).to(device)
+        y = loss(input, target)
+        return y
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_squeeze.py
+++ b/oneflow/python/test/modules/test_squeeze.py
@@ -17,6 +17,7 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
+import torch
 
 import oneflow.experimental as flow
 from test_util import GenArgList
@@ -99,25 +100,21 @@ class TestSqueeze(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
+    @autotest()
     def test_flow_squeeze_with_random_data(test_case):
-        for device in ["cpu", "cuda"]:
-            test_flow_against_pytorch(
-                test_case,
-                "squeeze",
-                extra_annotations={"dim": int,},
-                extra_generators={"dim": random(0, 6)},
-                device=device,
-            )
+        k = random().to(int)
+        device = random_device()
+        input = random_pytorch_tensor(ndim=k, dim0=1, dim1=1).to(device)
+        y = torch.squeeze(input, dim=1)
+        return y
 
+    @autotest()
     def test_flow_tensor_squeeze_with_random_data(test_case):
-        for device in ["cpu", "cuda"]:
-            test_tensor_against_pytorch(
-                test_case,
-                "squeeze",
-                extra_annotations={"dim": int},
-                extra_generators={"dim": random(0, 6)},
-                device=device,
-            )
+        k = random().to(int)
+        device = random_device()
+        input = random_pytorch_tensor(ndim=k, dim0=1, dim1=1).to(device)
+        y = input.squeeze(dim=1)
+        return y
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_transpose.py
+++ b/oneflow/python/test/modules/test_transpose.py
@@ -17,9 +17,11 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
+import torch
 
 import oneflow.experimental as flow
 from test_util import GenArgList
+from automated_test_util import *
 
 
 def _test_transpose(test_case, device):
@@ -87,6 +89,24 @@ class TestTranspose(flow.unittest.TestCase):
         arg_dict["device"] = ["cpu", "cuda"]
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
+
+    @autotest()
+    def test_flow_transpose_with_random_data(test_case):
+        k = random().to(int)
+        device = random_device()
+        input = random_pytorch_tensor(ndim=k).to(device)
+        y = torch.transpose(
+            input, dim0=random(0, k).to(int), dim1=random(0, k).to(int)
+        )
+        return y
+
+    @autotest()
+    def test_flow_tensor_transpose_with_random_data(test_case):
+        k = random().to(int)
+        device = random_device()
+        input = random_pytorch_tensor(ndim=k).to(device)
+        y = input.transpose(dim0=random(0, k).to(int), dim1=random(0, k).to(int))
+        return y
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test/modules/test_unsqueeze.py
+++ b/oneflow/python/test/modules/test_unsqueeze.py
@@ -17,9 +17,11 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
+import torch
 
 import oneflow.experimental as flow
 from test_util import GenArgList
+from automated_test_util import *
 
 
 def _test_unsqueeze(test_case, device):
@@ -68,6 +70,22 @@ class TestUnsqueeze(flow.unittest.TestCase):
         arg_dict["device"] = ["cpu", "cuda"]
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
+
+    @autotest()
+    def test_flow_unsqueeze_with_random_data(test_case):
+        k = random().to(int)
+        device = random_device()
+        input = random_pytorch_tensor(ndim=k).to(device)
+        y = torch.unsqueeze(input, dim=random(0, k).to(int))
+        return y
+
+    @autotest()
+    def test_flow_tensor_squeeze_with_random_data(test_case):
+        k = random().to(int)
+        device = random_device()
+        input = random_pytorch_tensor(ndim=k).to(device)
+        y = input.unsqueeze(dim=random(0, k).to(int))
+        return y
 
 
 if __name__ == "__main__":

--- a/oneflow/python/test_utils/automated_test_util/generators.py
+++ b/oneflow/python/test_utils/automated_test_util/generators.py
@@ -629,6 +629,7 @@ __all__ = [
     "random_or_nothing",
     "constant",
     "nothing",
+    "oneof",
     "test_module_against_pytorch",
     "test_flow_against_pytorch",
     "test_tensor_against_pytorch",


### PR DESCRIPTION
在以下op应用新版单元测试接口：

- [x] oneflow.experimental.ceil
- [x] oneflow.experimental.Tensor.ceil
- [x] oneflow.experimental.expm1
- [x] oneflow.experimental.Tensor.expm1
- [ ] oneflow.experimental.clamp
- [ ] oneflow.experimental.Tensor.clamp
- [x] oneflow.experimental.addmm
- [x] oneflow.experimental.Tensor.addmm
- [x] oneflow.experimental.nn.L1Loss
- [x] oneflow.experimental.squeeze
- [x] oneflow.experimental.Tensor.squeeze
- [x] oneflow.experimental.transpose
- [x] oneflow.experimental.Tensor.transpose

其中 squeeze 接口
oneflow dim 参数类型为 `Optional[Sequence[int]]` 
PyTorch dim 参数类型为 `Optional[int]`
