### PR TITLE
[WIP] Add DTR feature

### DIFF
--- a/oneflow/core/framework/op_interpreter.h
+++ b/oneflow/core/framework/op_interpreter.h
@@ -139,6 +139,15 @@ class EagerMirroredInterpreter : public EagerInterpreter {
   FOR_EACH_BUILTIN_OPS(DECLARE_OVERRIDE_APPLY_FUNC);
 };
 
+class DTREagerMirroredInterpreter : public EagerMirroredInterpreter {
+ public:
+  DTREagerMirroredInterpreter() : EagerMirroredInterpreter() {}
+  ~DTREagerMirroredInterpreter() = default;
+
+ private:
+  FOR_EACH_BUILTIN_OPS(DECLARE_OVERRIDE_APPLY_FUNC);
+};
+
 #undef DECLARE_OVERRIDE_APPLY_FUNC
 #undef DECLARE_PURE_VIRTUAL_APPLY_FUNC
 #undef DECLARE_NORMAL_APPLY_FUNC

--- a/oneflow/core/framework/op_interpreter/op_interpreter_util.cpp
+++ b/oneflow/core/framework/op_interpreter/op_interpreter_util.cpp
@@ -30,8 +30,11 @@ namespace one {
 namespace {
 
 std::shared_ptr<AutogradInterpreter> BuildEagerInterpreter(const bool& is_mirrored) {
+  bool enable_dtr = true;
   std::shared_ptr<OpExprInterpreter> internal;
-  if (is_mirrored) {
+  if (enable_dtr) {
+    internal = std::make_shared<DTREagerMirroredInterpreter>();
+  } else if (is_mirrored) {
     internal = std::make_shared<EagerMirroredInterpreter>();
   } else {
     internal = std::make_shared<EagerConsistentInterpreter>();

--- a/oneflow/core/framework/tensor_impl.h
+++ b/oneflow/core/framework/tensor_impl.h
@@ -86,6 +86,7 @@ class TensorImpl {
 };
 
 class EagerMirroredTensorImpl;
+class DTREagerMirroredTensorImpl;
 class MirroredTensorImpl : public TensorImpl {
  public:
   virtual ~MirroredTensorImpl() = default;
@@ -113,6 +114,7 @@ class MirroredTensorImpl : public TensorImpl {
 };
 
 class MirroredTensor;
+class DTRMirroredTensor;
 
 class ConsistentTensorImpl : public TensorImpl {
  public:
@@ -175,7 +177,7 @@ class LazyMirroredTensorImpl final : public MirroredTensorImpl {
   Maybe<MirroredTensorImpl> detach() const override;
 };
 
-class EagerMirroredTensorImpl final : public MirroredTensorImpl {
+class EagerMirroredTensorImpl : public MirroredTensorImpl {
  public:
   OF_DISALLOW_COPY_AND_MOVE(EagerMirroredTensorImpl);
   EagerMirroredTensorImpl();
@@ -213,12 +215,26 @@ class EagerMirroredTensorImpl final : public MirroredTensorImpl {
       const std::shared_ptr<TensorStorage>& tensor_storage);
   Maybe<EagerMirroredTensorImpl*> mut_eager_mirrored_tensor_impl() override { return this; }
 
- private:
+ protected:
   Maybe<void> UpdateTensorStorage();
   Maybe<void> set_eager_blob_object(std::shared_ptr<vm::EagerBlobObject> eager_blob_object);
 
   std::shared_ptr<TensorStorage> tensor_storage_;
   std::shared_ptr<vm::EagerBlobObject> eager_blob_object_;
+};
+
+class DTREagerMirroredTensorImpl final : public EagerMirroredTensorImpl {
+public:
+  OF_DISALLOW_COPY_AND_MOVE(DTREagerMirroredTensorImpl);
+  DTREagerMirroredTensorImpl() {}
+  DTREagerMirroredTensorImpl(const std::shared_ptr<const MirroredTensorMeta>& tensor_meta,
+                          const std::shared_ptr<AutogradMeta>& autograd_meta) : EagerMirroredTensorImpl(tensor_meta, autograd_meta) {}
+  DTREagerMirroredTensorImpl(const std::shared_ptr<const MirroredTensorMeta>& tensor_meta,
+                          bool requires_grad, bool is_leaf) : EagerMirroredTensorImpl(tensor_meta, requires_grad, is_leaf) {}
+  DTREagerMirroredTensorImpl(const std::shared_ptr<const MirroredTensorMeta>& tensor_meta,
+                          const std::shared_ptr<TensorStorage> tensor_storage, bool requires_grad,
+                          bool is_leaf) : EagerMirroredTensorImpl(tensor_meta, tensor_storage, requires_grad, is_leaf) {}
+  ~DTREagerMirroredTensorImpl() {std::cout << "DTREagerMirroredTensorImpl is being deleted." << std::endl;}
 };
 
 class LazyConsistentTensorImpl final : public ConsistentTensorImpl {

--- a/test_b.py
+++ b/test_b.py
@@ -1,0 +1,9 @@
+import oneflow.experimental as flow
+flow.enable_eager_execution()
+
+x = flow.tensor([0])
+y = flow.tensor([1])
+
+z = x + y
+
+print(z)


### PR DESCRIPTION
为 oneflow eager 模式注入亚线性显存优化的逻辑，即在动态计算图上通过 tensor 的自动重计算，保证训练过程中显存占用始终小于某一阈值，为机器显存受限时训练大模型和使用更大的 batch size 提供可能。DTR 策略来自 ICLR 2021 文章：[Dynamic Tensor Rematerialization](https://arxiv.org/pdf/2006.09616.pdf)

理想用法：为用户提供接口进入 DTR 模式。随后系统根据当前计算需求及显存的占用情况自动释放和重计算位于 memory pool 中的 tensors。

希望在尽量少改动 oneflow 原始框架的基础上完成以上任务。

TODO:
- [ ] 为 DTR tensor 建立独立的 Tensor 类型、Implementation、Interpreter；
- [ ] 为 DTRTensor 加入如 compute_time, size, last_access_time, compute_path 等特有属性；
- [ ] 实现手动释放指定的 DTR tensor；
- [ ] 在 Interpreter 中注入 DTR 逻辑。

