### PR TITLE
Feat: memory shared between EagerTensor with VariableRegst

### DIFF
--- a/oneflow/core/framework/nn_graph.cpp
+++ b/oneflow/core/framework/nn_graph.cpp
@@ -66,7 +66,10 @@ Maybe<void> NNGraph::RegisterVariableOpNamesAndTensors(
     } else {
       var_blob = JUST(var->eager_blob_object())->mut_blob();
     }
-    CHECK_OR_RETURN(variable_op_name2eager_blob_.emplace(variable_op_names.at(i), var_blob).second);
+    const std::string& var_name = variable_op_names.at(i);
+    CHECK_OR_RETURN(!var_name.empty());
+    CHECK_OR_RETURN(variable_op_name2eager_blob_.emplace(var_name, var_blob).second);
+    CHECK_OR_RETURN(variable_op_names_.insert(var_name).second);
   }
   return Maybe<void>::Ok();
 }
@@ -85,6 +88,7 @@ Maybe<void> NNGraph::CompileAndInitRuntime() {
     double start = GetCurTime();
     // TODO(chengcheng): new memory reused by chunk
     Compiler().Compile(&job_, &plan_, /* need_job_complete */ true);
+    PlanUtil::GenMemBlockAndChunkWithVariableOpNames4Plan(&plan_, variable_op_names_);
 
     LOG(INFO) << "\njob_id: " << job_ctx->job_id() << " , job_name: " << name_
               << " , compile time: " << (GetCurTime() - start) / 1000000000.0 << " seconds.\n";
@@ -93,7 +97,7 @@ Maybe<void> NNGraph::CompileAndInitRuntime() {
     }
     // TODO(chengcheng): test collective boxing for multi-job.
     PlanUtil::GenCollectiveBoxingPlan(&job_, &plan_);
-    PlanUtil::SetForceInplaceMemBlock(&plan_);
+    // PlanUtil::SetForceInplaceMemBlock(&plan_); NOTE(chengcheng): only for ssp.
     PlanUtil::DumpCtrlRegstInfoToPlan(&plan_);
   }
   if (GlobalProcessCtx::WorldSize() > 1) {

--- a/oneflow/core/framework/nn_graph.cpp
+++ b/oneflow/core/framework/nn_graph.cpp
@@ -114,7 +114,7 @@ Maybe<void> NNGraph::CompileAndInitRuntime() {
   PlanUtil::PopulateOpAttibute(&plan_, plan_.job_id2op_attribute_ref_table());
 
   NewRuntimeBuffers();
-  runtime_.reset(new Runtime(plan_, GetMaxVal<size_t>(), false));
+  runtime_.reset(new Runtime(plan_, GetMaxVal<size_t>(), false, variable_op_name2eager_blob_));
   runtime_inited_ = true;
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/framework/nn_graph.h
+++ b/oneflow/core/framework/nn_graph.h
@@ -52,6 +52,7 @@ class NNGraph final : public NNGraphIf {
   std::vector<std::string> input_op_names_;
   std::vector<std::string> output_op_names_;
   HashMap<std::string, Blob*> variable_op_name2eager_blob_;
+  HashSet<std::string> variable_op_names_;
   Job job_;
   Plan plan_;
   // TODO(chengcheng): temp impl using runtime now, need reimplement for dynamic multi nn.Graph.

--- a/oneflow/core/job/compiler.cpp
+++ b/oneflow/core/job/compiler.cpp
@@ -108,7 +108,6 @@ void Compiler::Compile(Job* job, Plan* plan, bool need_job_complete) const {
   // NOTE(chengcheng): infer mem blob id & set inplace & add ctrl
   IntraJobMemSharingUtil::InferMemBlockId4MemReusedRegst(plan, IsReachable);
   PlanUtil::SetUniqueMemBlockId4UnreusedMemRegst(plan);
-  PlanUtil::GenMemBlockAndChunk4Plan(plan);
   Global<OpGraph>::Delete();
 }
 

--- a/oneflow/core/job/improver.cpp
+++ b/oneflow/core/job/improver.cpp
@@ -286,7 +286,7 @@ void GenMemBlockAndChunk4Plan(Plan* plan) {
       mem_block.add_job_id(job_id);
       mem_block.set_machine_id(machine_id);
       *(mem_block.mutable_mem_case()) =
-          MemoryCaseUtil::GetHostPinnedMemoryCaseForRegstSeparatedHeader(regst_desc->mem_case());
+          MemoryCaseUtil::GetHostMemoryCaseForRegstSeparatedHeader(regst_desc->mem_case());
       mem_block.set_enable_reuse_mem(false);
       mem_block.set_mem_size(regst_separated_size);
       mem_block.set_thrd_id_hint(thrd_id);

--- a/oneflow/core/job/inter_job_mem_sharing_util.cpp
+++ b/oneflow/core/job/inter_job_mem_sharing_util.cpp
@@ -275,7 +275,7 @@ void MergeSharedMemBlockR2L(RegstDescProto* lhs, RegstDescProto* rhs,
     int64_t merged_header_id = lhs->separated_header_mem_block_id();
     int64_t erased_header_id = rhs->separated_header_mem_block_id();
     MemoryCase header_mem_case =
-        MemoryCaseUtil::GetHostPinnedMemoryCaseForRegstSeparatedHeader(lhs->mem_case());
+        MemoryCaseUtil::GetHostMemoryCaseForRegstSeparatedHeader(lhs->mem_case());
     MemBlockProto* merged_header_block =
         CheckValidAndGetMemBlock(merged_header_id, separated_header_mem_size, header_mem_case);
     MemBlockProto* erased_header_block =

--- a/oneflow/core/job/oneflow.cpp
+++ b/oneflow/core/job/oneflow.cpp
@@ -210,6 +210,7 @@ Maybe<void> CompileCurJobOnMaster(Job* job, Plan* plan, bool need_job_complete) 
   if (GlobalProcessCtx::IsThisProcessMaster()) {
     double start = GetCurTime();
     Compiler().Compile(job, plan, need_job_complete);
+    PlanUtil::GenMemBlockAndChunk4Plan(plan);
 
     LOG(INFO) << "\njob_id: " << job_desc.job_id() << " , job_name: " << job_desc.job_name()
               << " , compile time: " << (GetCurTime() - start) / 1000000000.0 << " seconds.\n";

--- a/oneflow/core/job/oneflow.cpp
+++ b/oneflow/core/job/oneflow.cpp
@@ -1025,7 +1025,9 @@ Maybe<void> Oneflow::Init(const oneflow::JobSet& job_set) {
     LOG(ERROR) << "this is dry run, exiting";
     exit(0);
   }
-  runtime_.reset(new Runtime(plan_, GetMaxVal<size_t>(), false));
+
+  HashMap<std::string, Blob*> variable_op_name2eager_blob;
+  runtime_.reset(new Runtime(plan_, GetMaxVal<size_t>(), false, variable_op_name2eager_blob));
   OF_PROFILER_RANGE_POP();  // new Runtime
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/job/plan_util.cpp
+++ b/oneflow/core/job/plan_util.cpp
@@ -63,9 +63,31 @@ void PlanUtil::SetUniqueMemBlockId4UnreusedMemRegst(Plan* plan) {
 }
 
 void PlanUtil::GenMemBlockAndChunk4Plan(Plan* plan) {
+  HashSet<std::string> variable_op_names;
+  PlanUtil::GenMemBlockAndChunkWithVariableOpNames4Plan(plan, variable_op_names);
+}
+
+void PlanUtil::GenMemBlockAndChunkWithVariableOpNames4Plan(
+    Plan* plan, const HashSet<std::string>& variable_op_names) {
   HashMap<int64_t, MemBlockProto> mem_block_id2mem_block;
   // mzuid = memory zone unique id
   HashMap<int64_t, ChunkProto> mzuid2chunk;
+
+  auto IsVariableRegst = [&](const TaskProto* task, std::string* name) -> bool {
+    if (variable_op_names.empty()) { return false; }
+    if (task->exec_sequence().exec_node_size() != 1) { return false; }
+    const auto& op_conf =
+        GetOpAttribute(plan, task->job_id(), task->exec_sequence().exec_node(0).kernel_conf())
+            .op_conf();
+    if (op_conf.has_variable_conf()) {
+      const std::string& var_name = op_conf.name();
+      if (variable_op_names.find(var_name) != variable_op_names.end()) {
+        *name = var_name;
+        return true;
+      }
+    }
+    return false;
+  };
 
   auto GenMemBlock4RegstIfNeed = [&](RegstDescProto* regst_desc, const TaskProto* task) {
     const int64_t job_id = task->job_id();
@@ -77,9 +99,24 @@ void PlanUtil::GenMemBlockAndChunk4Plan(Plan* plan) {
     CHECK_NE(mem_block_offset, -1);
     CHECK_EQ(regst_desc->separated_header_mem_block_id(), -1);
 
+    std::string var_name;
+    bool is_variable_regst = IsVariableRegst(task, &var_name);
+    if (is_variable_regst) {
+      CHECK(!var_name.empty());
+      CHECK_EQ(regst_desc->register_num(), 1);
+      CHECK_EQ(regst_desc->min_register_num(), 1);
+      CHECK_EQ(regst_desc->max_register_num(), 1);
+      regst_desc->set_variable_op_name(var_name);
+    }
+
     RtRegstDesc rt_regst_desc(*regst_desc);
     int64_t regst_main_size = rt_regst_desc.TotalMainByteSize4AllRegst();
     int64_t regst_separated_size = rt_regst_desc.TotalSeparatedHeaderByteSize4AllRegst();
+
+    if (is_variable_regst) {
+      CHECK_GT(regst_separated_size,
+               0);  // NOTE(chengcheng): variable regst header ALWAYS separated
+    }
 
     if (mem_block_id2mem_block.find(mem_block_id) == mem_block_id2mem_block.end()) {
       MemBlockProto mem_block;
@@ -90,9 +127,14 @@ void PlanUtil::GenMemBlockAndChunk4Plan(Plan* plan) {
       mem_block.set_enable_reuse_mem(regst_desc->enable_reuse_mem());
       mem_block.set_mem_size(regst_main_size + mem_block_offset);
       mem_block.set_thrd_id_hint(thrd_id);
+      if (is_variable_regst) {
+        mem_block.set_variable_op_name(var_name);
+        mem_block.set_is_separated_header(false);
+      }
       CHECK(mem_block_id2mem_block.emplace(mem_block.mem_block_id(), mem_block).second);
     } else {
       MemBlockProto* mem_block = &(mem_block_id2mem_block.at(mem_block_id));
+      CHECK(!mem_block->has_variable_op_name());  // variable regst mem block is unique.
       CHECK_EQ(mem_block->job_id(0), job_id);
       CHECK_EQ(mem_block->machine_id(), machine_id);
       CHECK(mem_block->mem_case() == regst_desc->mem_case());
@@ -108,10 +150,14 @@ void PlanUtil::GenMemBlockAndChunk4Plan(Plan* plan) {
       mem_block.add_job_id(job_id);
       mem_block.set_machine_id(machine_id);
       *(mem_block.mutable_mem_case()) =
-          MemoryCaseUtil::GetHostPinnedMemoryCaseForRegstSeparatedHeader(regst_desc->mem_case());
+          MemoryCaseUtil::GetHostMemoryCaseForRegstSeparatedHeader(regst_desc->mem_case());
       mem_block.set_enable_reuse_mem(false);
       mem_block.set_mem_size(regst_separated_size);
       mem_block.set_thrd_id_hint(thrd_id);
+      if (is_variable_regst) {
+        mem_block.set_variable_op_name(var_name);
+        mem_block.set_is_separated_header(true);
+      }
       CHECK(mem_block_id2mem_block.emplace(mem_block.mem_block_id(), mem_block).second);
     }
   };
@@ -211,7 +257,7 @@ void PlanUtil::CleanUselessMemBlockAndCheckValid(Plan* plan) {
         CHECK_EQ(header_mem_block.mem_size(), separated_header_mem_size);
         CHECK_EQ(task.machine_id(), header_mem_block.machine_id());
         CHECK(header_mem_block.mem_case()
-              == MemoryCaseUtil::GetHostPinnedMemoryCaseForRegstSeparatedHeader(regst.mem_case()));
+              == MemoryCaseUtil::GetHostMemoryCaseForRegstSeparatedHeader(regst.mem_case()));
         CHECK(header_mem_block.enable_reuse_mem() == false);
         const auto& header_block_job_ids = mem_block_id2job_ids[header_block_id];
         CHECK(header_block_job_ids.find(task.job_id()) != header_block_job_ids.end());

--- a/oneflow/core/job/plan_util.cpp
+++ b/oneflow/core/job/plan_util.cpp
@@ -79,14 +79,11 @@ void PlanUtil::GenMemBlockAndChunkWithVariableOpNames4Plan(
     const auto& op_conf =
         GetOpAttribute(plan, task->job_id(), task->exec_sequence().exec_node(0).kernel_conf())
             .op_conf();
-    if (op_conf.has_variable_conf()) {
-      const std::string& var_name = op_conf.name();
-      if (variable_op_names.find(var_name) != variable_op_names.end()) {
-        *name = var_name;
-        return true;
-      }
-    }
-    return false;
+    if (!op_conf.has_variable_conf()) { return false; }
+    const std::string& var_name = op_conf.name();
+    if (variable_op_names.find(var_name) == variable_op_names.end()) { return false; }
+    *name = var_name;
+    return true;
   };
 
   auto GenMemBlock4RegstIfNeed = [&](RegstDescProto* regst_desc, const TaskProto* task) {

--- a/oneflow/core/job/plan_util.h
+++ b/oneflow/core/job/plan_util.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <functional>
 #include "oneflow/core/common/protobuf.h"
+#include "oneflow/core/common/util.h"
 #include "oneflow/core/job/plan.pb.h"
 #include "oneflow/core/job/job.pb.h"
 
@@ -28,6 +29,8 @@ struct PlanUtil {
   static std::function<const TaskProto*(int64_t)> MakeGetterTaskProto4TaskId(const Plan& plan);
   static void SetUniqueMemBlockId4UnreusedMemRegst(Plan* plan);
   static void GenMemBlockAndChunk4Plan(Plan* plan);
+  static void GenMemBlockAndChunkWithVariableOpNames4Plan(
+      Plan* plan, const HashSet<std::string>& variable_op_names);
   static void CleanUselessMemBlockAndCheckValid(Plan* plan);
   static void ToDotFile(const Plan& plan, const std::string& filepath);
   static std::function<RegstDescProto*(int64_t)> MakeMutRegstDesc4Id(Plan* plan);

--- a/oneflow/core/job/runtime.cpp
+++ b/oneflow/core/job/runtime.cpp
@@ -126,7 +126,8 @@ void Runtime::NewAllGlobal(const Plan& plan, size_t total_piece_num, bool is_exp
   }
   Global<boxing::collective::CollectiveBoxingExecutor>::New(plan);
   Global<MemoryAllocator>::New();
-  Global<RegstMgr>::New(plan);
+  Global<RegstMgr>::New();
+  Global<RegstMgr>::Get()->AddPlan(plan);
   Global<ActorMsgBus>::New();
   Global<ThreadMgr>::New();
   Global<ThreadMgr>::Get()->AddPlan(plan);

--- a/oneflow/core/job/runtime.cpp
+++ b/oneflow/core/job/runtime.cpp
@@ -63,8 +63,9 @@ bool HasNonCtrlConsumedRegstDescId(const TaskProto& task) {
 
 }  // namespace
 
-Runtime::Runtime(const Plan& plan, size_t total_piece_num, bool is_experiment_phase) {
-  NewAllGlobal(plan, total_piece_num, is_experiment_phase);
+Runtime::Runtime(const Plan& plan, size_t total_piece_num, bool is_experiment_phase,
+                 const HashMap<std::string, Blob*>& variable_op_name2eager_blob) {
+  NewAllGlobal(plan, total_piece_num, is_experiment_phase, variable_op_name2eager_blob);
   std::vector<const TaskProto*> source_tasks;
   std::vector<const TaskProto*> other_tasks;
   int64_t this_machine_task_num = 0;
@@ -95,7 +96,8 @@ Runtime::~Runtime() {
   DeleteAllGlobal();
 }
 
-void Runtime::NewAllGlobal(const Plan& plan, size_t total_piece_num, bool is_experiment_phase) {
+void Runtime::NewAllGlobal(const Plan& plan, size_t total_piece_num, bool is_experiment_phase,
+                           const HashMap<std::string, Blob*>& variable_op_name2eager_blob) {
   Global<RuntimeCtx>::New(total_piece_num, is_experiment_phase);
   if (GlobalProcessCtx::IsThisProcessMaster() && Global<RuntimeCtx>::Get()->NeedCollectActEvent()) {
     Global<ActEventLogger>::New(is_experiment_phase);
@@ -127,7 +129,7 @@ void Runtime::NewAllGlobal(const Plan& plan, size_t total_piece_num, bool is_exp
   Global<boxing::collective::CollectiveBoxingExecutor>::New(plan);
   Global<MemoryAllocator>::New();
   Global<RegstMgr>::New();
-  Global<RegstMgr>::Get()->AddPlan(plan);
+  Global<RegstMgr>::Get()->AddPlan(plan, variable_op_name2eager_blob);
   Global<ActorMsgBus>::New();
   Global<ThreadMgr>::New();
   Global<ThreadMgr>::Get()->AddPlan(plan);

--- a/oneflow/core/job/runtime.h
+++ b/oneflow/core/job/runtime.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "oneflow/core/job/job_desc.h"
 #include "oneflow/core/job/plan.pb.h"
 #include "oneflow/core/job/runtime_context.h"
+#include "oneflow/core/register/blob.h"
 
 namespace oneflow {
 
@@ -28,10 +29,13 @@ class Runtime final {
   Runtime() = delete;
   ~Runtime();
 
-  Runtime(const Plan& plan, size_t total_piece_num, bool is_experiment_phase);
+  // TODO(chengcheng): refactor Runtime interface about variable_op_name2eager_blob
+  Runtime(const Plan& plan, size_t total_piece_num, bool is_experiment_phase,
+          const HashMap<std::string, Blob*>& variable_op_name2eager_blob);
 
  private:
-  void NewAllGlobal(const Plan& plan, size_t total_piece_num, bool is_experiment_phase);
+  void NewAllGlobal(const Plan& plan, size_t total_piece_num, bool is_experiment_phase,
+                    const HashMap<std::string, Blob*>& variable_op_name2eager_blob);
   void DeleteAllGlobal();
 };
 

--- a/oneflow/core/job/runtime_job_descs.cpp
+++ b/oneflow/core/job/runtime_job_descs.cpp
@@ -21,22 +21,12 @@ RuntimeJobDescs::RuntimeJobDescs(const PbMap<int64_t, JobConfigProto>& proto) {
   for (const auto& pair : proto) {
     auto job_desc = std::make_unique<JobDesc>(pair.second, pair.first);
     CHECK(job_id2job_desc_.emplace(pair.first, std::move(job_desc)).second);
-    std::cout << " RuntimeJobDescs::emplace job_id: " << pair.first
-              << " with job_conf: " << pair.second.DebugString();
   }
 }
 
 const JobDesc& RuntimeJobDescs::job_desc(int64_t job_id) const {
   auto it = job_id2job_desc_.find(job_id);
-  if (it == job_id2job_desc_.end()) {
-    std::cout << " ERROR! Cannot find job_id: " << job_id << " in RuntimeJobDescs,"
-              << " And current job_id2job_desc_.size() = " << job_id2job_desc_.size() << "\n\n";
-    for (const auto& pair : job_id2job_desc_) {
-      std::cout << " In RuntimeJobDescs::job_id2job_desc_, job_id : " << pair.first
-                << " job_conf_ : " << pair.second->job_conf().DebugString() << "\n\n";
-    }
-    LOG(FATAL) << " RuntimeJobDescs::Error.";
-  }
+  CHECK(it != job_id2job_desc_.end());
   return *(it->second);
 }
 

--- a/oneflow/core/job/runtime_job_descs.cpp
+++ b/oneflow/core/job/runtime_job_descs.cpp
@@ -21,7 +21,23 @@ RuntimeJobDescs::RuntimeJobDescs(const PbMap<int64_t, JobConfigProto>& proto) {
   for (const auto& pair : proto) {
     auto job_desc = std::make_unique<JobDesc>(pair.second, pair.first);
     CHECK(job_id2job_desc_.emplace(pair.first, std::move(job_desc)).second);
+    std::cout << " RuntimeJobDescs::emplace job_id: " << pair.first
+              << " with job_conf: " << pair.second.DebugString();
   }
+}
+
+const JobDesc& RuntimeJobDescs::job_desc(int64_t job_id) const {
+  auto it = job_id2job_desc_.find(job_id);
+  if (it == job_id2job_desc_.end()) {
+    std::cout << " ERROR! Cannot find job_id: " << job_id << " in RuntimeJobDescs,"
+              << " And current job_id2job_desc_.size() = " << job_id2job_desc_.size() << "\n\n";
+    for (const auto& pair : job_id2job_desc_) {
+      std::cout << " In RuntimeJobDescs::job_id2job_desc_, job_id : " << pair.first
+                << " job_conf_ : " << pair.second->job_conf().DebugString() << "\n\n";
+    }
+    LOG(FATAL) << " RuntimeJobDescs::Error.";
+  }
+  return *(it->second);
 }
 
 }  // namespace oneflow

--- a/oneflow/core/job/runtime_job_descs.h
+++ b/oneflow/core/job/runtime_job_descs.h
@@ -24,7 +24,7 @@ namespace oneflow {
 class RuntimeJobDescs final {
  public:
   explicit RuntimeJobDescs(const PbMap<int64_t, JobConfigProto>& proto);
-  const JobDesc& job_desc(int64_t job_id) const { return *job_id2job_desc_.at(job_id); }
+  const JobDesc& job_desc(int64_t job_id) const;
 
  private:
   HashMap<int64_t, std::unique_ptr<JobDesc>> job_id2job_desc_;

--- a/oneflow/core/memory/memory_block.proto
+++ b/oneflow/core/memory/memory_block.proto
@@ -14,6 +14,9 @@ message MemBlockProto {
   required int64 mem_size = 8;
   // NOTE(chengcheng): thrd id hint is used by packed separated block group order.
   optional int64 thrd_id_hint = 9 [default = -1];
+  // NOTE(chengcheng): mark this block memory is shared with EagerParameter.
+  optional string variable_op_name = 10 [default = ""];
+  optional bool is_separated_header = 11 [default = false];
 }
 
 message ChunkProto {

--- a/oneflow/core/memory/memory_case_util.cpp
+++ b/oneflow/core/memory/memory_case_util.cpp
@@ -37,12 +37,13 @@ bool MemoryCaseUtil::GetCommonMemoryCase(const MemoryCase& a, const MemoryCase& 
   }
 }
 
-MemoryCase MemoryCaseUtil::GetHostPinnedMemoryCaseForRegstSeparatedHeader(
-    const MemoryCase& mem_case) {
-  CHECK(mem_case.has_device_cuda_mem());
+MemoryCase MemoryCaseUtil::GetHostMemoryCaseForRegstSeparatedHeader(const MemoryCase& mem_case) {
   MemoryCase ret;
-  ret.mutable_host_mem()->mutable_cuda_pinned_mem()->set_device_id(
-      mem_case.device_cuda_mem().device_id());
+  ret.mutable_host_mem();
+  if (mem_case.has_device_cuda_mem()) {
+    ret.mutable_host_mem()->mutable_cuda_pinned_mem()->set_device_id(
+        mem_case.device_cuda_mem().device_id());
+  }
   return ret;
 }
 

--- a/oneflow/core/memory/memory_case_util.h
+++ b/oneflow/core/memory/memory_case_util.h
@@ -42,7 +42,7 @@ inline bool operator==(const MemoryCase& lhs, const MemoryCase& rhs) {
 struct MemoryCaseUtil {
   static bool GetCommonMemoryCase(const MemoryCase& a, const MemoryCase& b, MemoryCase* common);
 
-  static MemoryCase GetHostPinnedMemoryCaseForRegstSeparatedHeader(const MemoryCase& mem_case);
+  static MemoryCase GetHostMemoryCaseForRegstSeparatedHeader(const MemoryCase& mem_case);
 
   static int64_t GenMemZoneUniqueId(int64_t machine_id, const MemoryCase& mem_case);
 

--- a/oneflow/core/register/register_desc.proto
+++ b/oneflow/core/register/register_desc.proto
@@ -44,4 +44,6 @@ message RegstDescProto {
     int64 hint_inplace_consumed_regst_desc_id = 14 [default = -1];
     int64 force_inplace_consumed_regst_desc_id = 15 [default = -1];
   }
+  // NOTE(chengcheng): mark this regst memory is shared with EagerParameter.
+  optional string variable_op_name = 16 [default = ""];
 }

--- a/oneflow/core/register/register_manager.cpp
+++ b/oneflow/core/register/register_manager.cpp
@@ -54,7 +54,6 @@ void RegstMgr::AddPlan(const Plan& plan,
 
   HashSet<int64_t> all_block_ids;
   HashMap<int64_t, PackedChunkInfo> zone_id2packed_chunk;
-  HashMap<int64_t, MemBlockProto*> mem_block_id2proto;
   for (const MemBlockProto& mem_block : plan.block_chunk_list().mem_block()) {
     if (mem_block.machine_id() != this_machine_id) { continue; }
     if (mem_block.mem_size() == 0) { continue; }

--- a/oneflow/core/register/register_manager.cpp
+++ b/oneflow/core/register/register_manager.cpp
@@ -39,7 +39,8 @@ struct PackedChunkInfo {
 
 }  // namespace
 
-void RegstMgr::AddPlan(const Plan& plan, HashMap<std::string, Blob*> variable_op_name2eager_blob) {
+void RegstMgr::AddPlan(const Plan& plan,
+                       const HashMap<std::string, Blob*>& variable_op_name2eager_blob) {
   int64_t this_machine_id = GlobalProcessCtx::Rank();
 
   // TODO(chengcheng): create chunk mgr for reuse memory between plans.

--- a/oneflow/core/register/register_manager.cpp
+++ b/oneflow/core/register/register_manager.cpp
@@ -39,29 +39,59 @@ struct PackedChunkInfo {
 
 }  // namespace
 
-RegstMgr::RegstMgr(const Plan& plan) {
+Maybe<void> RegstMgr::AddPlan(const Plan& plan,
+                              HashMap<std::string, Blob*> variable_op_name2eager_blob) {
   int64_t this_machine_id = GlobalProcessCtx::Rank();
 
+  // TODO(chengcheng): create chunk mgr for reuse memory between plans.
   HashMap<int64_t, char*> chunk_id2ptr;
   for (const ChunkProto& chunk : plan.block_chunk_list().chunk()) {
     if (chunk.machine_id() != this_machine_id) { continue; }
     if (chunk.mem_size() == 0) { continue; }
     char* chunk_ptr = Global<MemoryAllocator>::Get()->Allocate(chunk.mem_case(), chunk.mem_size());
-    CHECK(chunk_id2ptr.emplace(chunk.chunk_id(), chunk_ptr).second);
+    CHECK_OR_RETURN(chunk_id2ptr.emplace(chunk.chunk_id(), chunk_ptr).second);
   }
 
   HashSet<int64_t> all_block_ids;
   HashMap<int64_t, PackedChunkInfo> zone_id2packed_chunk;
+  HashMap<int64_t, MemBlockProto*> mem_block_id2proto;
   for (const MemBlockProto& mem_block : plan.block_chunk_list().mem_block()) {
     if (mem_block.machine_id() != this_machine_id) { continue; }
     if (mem_block.mem_size() == 0) { continue; }
     const int64_t mem_block_id = mem_block.mem_block_id();
-    CHECK(all_block_ids.insert(mem_block_id).second);
+    CHECK_OR_RETURN(all_block_ids.insert(mem_block_id).second);
+
     if (mem_block.has_chunk_id()) {
-      CHECK(mem_block.has_chunk_offset());
-      CHECK(chunk_id2ptr.find(mem_block.chunk_id()) != chunk_id2ptr.end());
+      CHECK_OR_RETURN(mem_block.has_chunk_offset());
+      CHECK_OR_RETURN(chunk_id2ptr.find(mem_block.chunk_id()) != chunk_id2ptr.end());
       char* mem_block_ptr = chunk_id2ptr.at(mem_block.chunk_id()) + mem_block.chunk_offset();
-      CHECK(mem_block_id2ptr_.emplace(mem_block_id, mem_block_ptr).second);
+      CHECK_OR_RETURN(mem_block_id2ptr_.emplace(mem_block_id, mem_block_ptr).second);
+      CHECK_OR_RETURN(!mem_block.has_variable_op_name());
+    } else if (mem_block.has_variable_op_name()) {
+      // NOTE(chengcheng): bind mem_block_ptr to variable blob header_ptr and body_ptr
+      CHECK_OR_RETURN(!mem_block.enable_reuse_mem());
+      const std::string& var_name = mem_block.variable_op_name();
+      CHECK_OR_RETURN(!var_name.empty());
+      auto it = variable_op_name2eager_blob.find(var_name);
+      CHECK_OR_RETURN(it != variable_op_name2eager_blob.end())
+          << " CANNOT find variable op name: " << var_name;
+      CHECK_OR_RETURN(mem_block.has_is_separated_header());
+      Blob* var_blob = it->second;
+      CHECK_OR_RETURN(var_blob) << " variable op name: " << var_name
+                                << " in rank: " << this_machine_id << " CANNNOT NULL.";
+      if (mem_block.is_separated_header()) {
+        CHECK_GE_OR_RETURN(var_blob->blob_desc().AlignedByteSizeOfBlobHeader(),
+                           mem_block.mem_size());
+        CHECK_GE_OR_RETURN(mem_block.mem_size(), var_blob->blob_desc().ByteSizeOfBlobHeader());
+        CHECK_OR_RETURN(mem_block_id2ptr_.emplace(mem_block_id, var_blob->mut_header_ptr()).second);
+        CHECK_OR_RETURN(mem_block.mem_case().has_host_mem());
+      } else {
+        CHECK_GE_OR_RETURN(var_blob->blob_desc().AlignedByteSizeOfBlobBody(), mem_block.mem_size());
+        CHECK_GE_OR_RETURN(mem_block.mem_size(), var_blob->blob_desc().ByteSizeOfBlobBody());
+        CHECK_OR_RETURN(
+            mem_block_id2ptr_.emplace(mem_block_id, var_blob->ForceMutDptr<char>()).second);
+        CHECK_OR_RETURN(mem_block.mem_case() == var_blob->mem_case());
+      }
     } else {
       int64_t zone_id = MemoryCaseUtil::GenMemZoneId(mem_block.mem_case());
       if (zone_id2packed_chunk.find(zone_id) == zone_id2packed_chunk.end()) {
@@ -70,7 +100,7 @@ RegstMgr::RegstMgr(const Plan& plan) {
       PackedChunkInfo* packed_chunk = &(zone_id2packed_chunk.at(zone_id));
       packed_chunk->blocks.push_back(&mem_block);
       packed_chunk->size += mem_block.mem_size();
-      CHECK(packed_chunk->mem_case == mem_block.mem_case());
+      CHECK_OR_RETURN(packed_chunk->mem_case == mem_block.mem_case());
     }
   }
 
@@ -89,14 +119,14 @@ RegstMgr::RegstMgr(const Plan& plan) {
               });
     int64_t offset = 0;
     for (const MemBlockProto* block : packed_chunk->blocks) {
-      CHECK(mem_block_id2ptr_.emplace(block->mem_block_id(), ptr + offset).second);
+      CHECK_OR_RETURN(mem_block_id2ptr_.emplace(block->mem_block_id(), ptr + offset).second);
       offset += block->mem_size();
     }
-    CHECK_EQ(offset, packed_chunk->size);
+    CHECK_EQ_OR_RETURN(offset, packed_chunk->size);
   }
 
   for (int64_t mem_block_id : all_block_ids) {
-    CHECK(mem_block_id2ptr_.find(mem_block_id) != mem_block_id2ptr_.end());
+    CHECK_OR_RETURN(mem_block_id2ptr_.find(mem_block_id) != mem_block_id2ptr_.end());
   }
 
   for (const TaskProto& task : plan.task()) {
@@ -104,15 +134,21 @@ RegstMgr::RegstMgr(const Plan& plan) {
     for (const auto& pair : task.produced_regst_desc()) {
       const RegstDescProto& regst_desc = pair.second;
       const int64_t regst_desc_id = regst_desc.regst_desc_id();
-      CHECK(regst_desc_id2rt_regst_desc_
-                .emplace(regst_desc_id, std::make_unique<const RtRegstDesc>(regst_desc))
-                .second);
-      CHECK(regst_desc_id2parallel_ctx_.emplace(regst_desc_id, task.parallel_ctx()).second);
+      CHECK_OR_RETURN(regst_desc_id2rt_regst_desc_
+                          .emplace(regst_desc_id, std::make_unique<const RtRegstDesc>(regst_desc))
+                          .second);
+      CHECK_OR_RETURN(
+          regst_desc_id2parallel_ctx_.emplace(regst_desc_id, task.parallel_ctx()).second);
     }
   }
   for (const auto& pair : plan.ctrl_regst_desc_info().ctrl_regst_desc_id2producer_task_id()) {
-    CHECK(ctrl_regst_desc_id2producer_task_id_.emplace(pair.first, pair.second).second);
+    CHECK_OR_RETURN(ctrl_regst_desc_id2producer_task_id_.emplace(pair.first, pair.second).second);
   }
+}
+
+Maybe<void> RegstMgr::AddPlan(const Plan& plan) {
+  HashMap<std::string, Blob*> variable_op_name2eager_blob;
+  JUST(AddPlan(plan, variable_op_name2eager_blob));
 }
 
 void RegstMgr::NewRegsts(const RegstDescProto& regst_desc_proto,

--- a/oneflow/core/register/register_manager.h
+++ b/oneflow/core/register/register_manager.h
@@ -32,9 +32,11 @@ namespace oneflow {
 class RegstMgr final {
  public:
   OF_DISALLOW_COPY_AND_MOVE(RegstMgr);
-  RegstMgr() = delete;
+  RegstMgr() = default;
   ~RegstMgr() = default;
 
+  Maybe<void> AddPlan(const Plan& plan, HashMap<std::string, Blob*> variable_op_name2eager_blob);
+  Maybe<void> AddPlan(const Plan& plan);
   void NewRegsts(const RegstDescProto& regst_desc_proto, std::function<void(Regst*)> OneRegstDone);
   const RtRegstDesc& RegstDesc4RegstDescId(int64_t regst_desc_id) const;
   bool HasRegstDescId(int64_t regst_desc_id) const;
@@ -43,11 +45,9 @@ class RegstMgr final {
   Blob* Blob4LbiAndParallelId(const LogicalBlobId& lbi, const int64_t parallel_id);
 
  private:
-  friend class Global<RegstMgr>;
-
-  explicit RegstMgr(const Plan& plan);
   void NewBlobsInOneRegst(const std::vector<LbiBlobDescPair>& lbis, Regst*, const RtRegstDesc*,
                           char* main_mem_ptr, char* separated_header_mem_ptr);
+
   HashMap<int64_t, std::unique_ptr<const RtRegstDesc>> regst_desc_id2rt_regst_desc_;
   HashMap<LogicalBlobId, HashMap<int64_t, Blob*>> lbi2parallel_id2blob_;
   HashMap<int64_t, char*> mem_block_id2ptr_;

--- a/oneflow/core/register/register_manager.h
+++ b/oneflow/core/register/register_manager.h
@@ -35,8 +35,8 @@ class RegstMgr final {
   RegstMgr() = default;
   ~RegstMgr() = default;
 
-  Maybe<void> AddPlan(const Plan& plan, HashMap<std::string, Blob*> variable_op_name2eager_blob);
-  Maybe<void> AddPlan(const Plan& plan);
+  void AddPlan(const Plan& plan, HashMap<std::string, Blob*> variable_op_name2eager_blob);
+  void AddPlan(const Plan& plan);
   void NewRegsts(const RegstDescProto& regst_desc_proto, std::function<void(Regst*)> OneRegstDone);
   const RtRegstDesc& RegstDesc4RegstDescId(int64_t regst_desc_id) const;
   bool HasRegstDescId(int64_t regst_desc_id) const;

--- a/oneflow/core/register/register_manager.h
+++ b/oneflow/core/register/register_manager.h
@@ -35,7 +35,7 @@ class RegstMgr final {
   RegstMgr() = default;
   ~RegstMgr() = default;
 
-  void AddPlan(const Plan& plan, HashMap<std::string, Blob*> variable_op_name2eager_blob);
+  void AddPlan(const Plan& plan, const HashMap<std::string, Blob*>& variable_op_name2eager_blob);
   void AddPlan(const Plan& plan);
   void NewRegsts(const RegstDescProto& regst_desc_proto, std::function<void(Regst*)> OneRegstDone);
   const RtRegstDesc& RegstDesc4RegstDescId(int64_t regst_desc_id) const;

--- a/oneflow/core/register/runtime_register_desc.h
+++ b/oneflow/core/register/runtime_register_desc.h
@@ -65,6 +65,8 @@ class RtRegstDesc {
   std::unique_ptr<Shape> data_regst_time_shape_;
   std::vector<std::unique_ptr<const BlobDesc>> sorted_blob_desc_vec_;
   std::vector<LogicalBlobId> sorted_lbi_vec_;
+
+  bool has_separated_header_;
 };
 
 }  // namespace oneflow

--- a/python/oneflow/test/graph/test_graph_linear.py
+++ b/python/oneflow/test/graph/test_graph_linear.py
@@ -20,42 +20,49 @@ import oneflow as flow
 import oneflow.unittest
 
 
+def _test_linear_graph(test_case, device):
+    linear = flow.nn.Linear(3, 8, False)
+    linear = linear.to(device)
+    input_arr = np.array(
+        [
+            [-0.94630778, -0.83378579, -0.87060891],
+            [2.0289922, -0.28708987, -2.18369248],
+            [0.35217619, -0.67095644, -1.58943879],
+            [0.08086036, -1.81075924, 1.20752494],
+            [0.8901075, -0.49976737, -1.07153746],
+            [-0.44872912, -1.07275683, 0.06256855],
+            [-0.22556897, 0.74798368, 0.90416439],
+            [0.48339456, -2.32742195, -0.59321527],
+        ],
+        dtype=np.float32,
+    )
+    np_weight = np.ones((3, 8)).astype(np.float32)
+    np_weight.fill(2.3)
+    x = flow.tensor(input_arr, device=device)
+    flow.nn.init.constant_(linear.weight, 2.3)
+    of_eager_out = linear(x)
+    np_out = np.matmul(input_arr, np_weight)
+    test_case.assertTrue(np.allclose(of_eager_out.numpy(), np_out, 1e-05, 1e-05))
+
+    class LinearGraph(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.my_linear = linear
+
+        def build(self, x):
+            return self.my_linear(x)
+
+    linear_g = LinearGraph()
+    of_lazy_out = linear_g(x)
+    test_case.assertTrue(np.array_equal(of_lazy_out.numpy(), of_eager_out.numpy()))
+
+
 class TestLinearGraph(oneflow.unittest.TestCase):
-    def test_linear_graph(test_case):
-        linear = flow.nn.Linear(3, 8, False)
-        # linear = linear.to(device)
-        input_arr = np.array(
-            [
-                [-0.94630778, -0.83378579, -0.87060891],
-                [2.0289922, -0.28708987, -2.18369248],
-                [0.35217619, -0.67095644, -1.58943879],
-                [0.08086036, -1.81075924, 1.20752494],
-                [0.8901075, -0.49976737, -1.07153746],
-                [-0.44872912, -1.07275683, 0.06256855],
-                [-0.22556897, 0.74798368, 0.90416439],
-                [0.48339456, -2.32742195, -0.59321527],
-            ],
-            dtype=np.float32,
-        )
-        np_weight = np.ones((3, 8)).astype(np.float32)
-        np_weight.fill(2.3)
-        x = flow.tensor(input_arr)  # , device=flow.device(device))
-        flow.nn.init.constant_(linear.weight, 2.3)
-        of_eager_out = linear(x)
-        np_out = np.matmul(input_arr, np_weight)
-        test_case.assertTrue(np.allclose(of_eager_out.numpy(), np_out, 1e-05, 1e-05))
+    def test_linear_graph_gpu(test_case):
+        _test_linear_graph(test_case, flow.device("cuda"))
 
-        class LinearGraph(flow.nn.Graph):
-            def __init__(self):
-                super().__init__()
-                self.my_linear = linear
-
-            def build(self, x):
-                return self.my_linear(x)
-
-        linear_g = LinearGraph()
-        of_lazy_out = linear_g(x)
-        test_case.assertTrue(np.array_equal(of_lazy_out.numpy(), of_eager_out.numpy()))
+    def test_linear_graph_cpu(test_case):
+        _test_linear_graph(test_case, flow.device("cpu"))
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/graph/test_graph_linear.py
+++ b/python/oneflow/test/graph/test_graph_linear.py
@@ -44,8 +44,6 @@ class TestLinearGraph(oneflow.unittest.TestCase):
         of_eager_out = linear(x)
         np_out = np.matmul(input_arr, np_weight)
         test_case.assertTrue(np.allclose(of_eager_out.numpy(), np_out, 1e-05, 1e-05))
-        print("of_eager_out: ", of_eager_out)
-        print("np_out: ", np_out)
 
         class LinearGraph(flow.nn.Graph):
             def __init__(self):
@@ -57,9 +55,6 @@ class TestLinearGraph(oneflow.unittest.TestCase):
 
         linear_g = LinearGraph()
         of_lazy_out = linear_g(x)
-        print("of_lazy_out: ", of_lazy_out)
-        # print(f"type of lazy y: {type(y_lazy)}")
-        # print(f"lazy y shape: {y_lazy.shape}, data: {y_lazy}")
         test_case.assertTrue(np.array_equal(of_lazy_out.numpy(), of_eager_out.numpy()))
 
 

--- a/python/oneflow/test/graph/test_graph_linear.py
+++ b/python/oneflow/test/graph/test_graph_linear.py
@@ -1,0 +1,67 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+import numpy as np
+
+import oneflow as flow
+import oneflow.unittest
+
+
+class TestLinearGraph(oneflow.unittest.TestCase):
+    def test_linear_graph(test_case):
+        linear = flow.nn.Linear(3, 8, False)
+        # linear = linear.to(device)
+        input_arr = np.array(
+            [
+                [-0.94630778, -0.83378579, -0.87060891],
+                [2.0289922, -0.28708987, -2.18369248],
+                [0.35217619, -0.67095644, -1.58943879],
+                [0.08086036, -1.81075924, 1.20752494],
+                [0.8901075, -0.49976737, -1.07153746],
+                [-0.44872912, -1.07275683, 0.06256855],
+                [-0.22556897, 0.74798368, 0.90416439],
+                [0.48339456, -2.32742195, -0.59321527],
+            ],
+            dtype=np.float32,
+        )
+        np_weight = np.ones((3, 8)).astype(np.float32)
+        np_weight.fill(2.3)
+        x = flow.tensor(input_arr)  # , device=flow.device(device))
+        flow.nn.init.constant_(linear.weight, 2.3)
+        of_eager_out = linear(x)
+        np_out = np.matmul(input_arr, np_weight)
+        test_case.assertTrue(np.allclose(of_eager_out.numpy(), np_out, 1e-05, 1e-05))
+        print("of_eager_out: ", of_eager_out)
+        print("np_out: ", np_out)
+
+        class LinearGraph(flow.nn.Graph):
+            def __init__(self):
+                super().__init__()
+                self.my_linear = linear
+
+            def build(self, x):
+                return self.my_linear(x)
+
+        linear_g = LinearGraph()
+        of_lazy_out = linear_g(x)
+        print("of_lazy_out: ", of_lazy_out)
+        # print(f"type of lazy y: {type(y_lazy)}")
+        # print(f"lazy y shape: {y_lazy.shape}, data: {y_lazy}")
+        test_case.assertTrue(np.array_equal(of_lazy_out.numpy(), of_eager_out.numpy()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
支持 EagerTensor（Parameters 和 Buffers）中的 EagerBlobObject 和 Lazy 编译好的 Variable 的  Regst 内存共享

- [x] RegstMgr 支持 AddPlan
- [x] 在 MemBlobProto 中新增 VariableOpName 等信息
- [x] 在 RegstDescProto 中新增 VariableOpName 等信息
- [x] 新增 RuntimeRegstDesc 推导自己的是否有 Separated Header 的规则
- [x] 重写了 MemoryCaseUtil 中根据 Blob body 的 MemCase 推导对应的 header MemCase 的逻辑
- [x] PlanUtil 生成 MemBlock 的 逻辑从 Compiler 内 移到 外面； 提供参数 VariableOpNames 供生成特定的 MemBlock（用于和 EagerBlobObject 内存共享的 Block）； 新增检查逻辑
- [x] RegstMgr 支持 MemBlock 和 EagerBlobObject 内存共享，并增加检查逻辑
- [x] Runtime 支持 NNGraph 传参 variable_op_name2eager_blob
- [x] 提供 Lazy Linear 的 nn.Graph 单测，并测试通过