### PR TITLE
consistent_tensor_to_api

### DIFF
--- a/oneflow/api/python/symbol/placement_symbol.cpp
+++ b/oneflow/api/python/symbol/placement_symbol.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "oneflow/api/python/of_api_registry.h"
 #include "oneflow/core/control/global_process_ctx.h"
 #include "oneflow/core/common/symbol.h"
+#include "oneflow/core/common/container_util.h"
 #include "oneflow/core/framework/instructions_builder.h"
 #include "oneflow/core/framework/parallel_conf_util.h"
 #include "oneflow/core/job/parallel_desc.h"
@@ -198,7 +199,7 @@ struct PlacementSymbolExportUtil {
     static const HashMap<std::string, std::string> type2device_tag{{"cpu", "cpu"}, {"cuda", "gpu"}};
     std::shared_ptr<cfg::ParallelConf> parallel_conf =
         std::make_shared<cfg::ParallelConf>(*parallel_desc->cfg_parallel_conf());
-    parallel_conf->set_device_tag(type2device_tag.at(device_type));
+    parallel_conf->set_device_tag(JUST(MapAt(type2device_tag, device_type)));
     std::shared_ptr<ParallelDesc> out_parallel_desc;
     JUST(LogicalRun(
         [&out_parallel_desc, &parallel_conf](InstructionsBuilder* builder) -> Maybe<void> {

--- a/python/oneflow/nn/modules/to.py
+++ b/python/oneflow/nn/modules/to.py
@@ -50,8 +50,7 @@ def ConsistentTo(input, device):
     input_local_tesnor = input.to_local()
     device = flow.device(device)
     output_local_tesnor = To(False)(input_local_tesnor, device, None)
-    ret = output_local_tesnor.to_consistent(out_placement, sbp)
-    return ret
+    return output_local_tesnor.to_consistent(out_placement, sbp)
 
 
 @register_tensor_op("to")

--- a/python/oneflow/nn/modules/to.py
+++ b/python/oneflow/nn/modules/to.py
@@ -90,6 +90,7 @@ def to_op(input, *args, **kwargs):
     device = kwargs.get("device", None)
     dtype = kwargs.get("dtype", None)
     if input.is_consistent:
+        input.check_meta_consistency()
         if len(args) > 0:
             assert args[0] in (
                 "cuda",

--- a/python/oneflow/nn/modules/to.py
+++ b/python/oneflow/nn/modules/to.py
@@ -41,16 +41,16 @@ def ConsistentTo(input, device):
         "cuda",
         "cpu",
     ), 'consistent tensor only support to("cuda") or to("cpu")'
-    if (device == "cuda" and input.is_cuda) or (device == "cpu" and not input.is_cuda):
+    if device == input.placement.device_type:
         return input
     out_placement = flow._oneflow_internal._ReplacePlacementDeviceTag(
         input.placement, device
     )
     sbp = input.sbp
-    input_local_tesnor = input.to_local()
+    input_local_tensor = input.to_local()
     device = flow.device(device)
-    output_local_tesnor = To(False)(input_local_tesnor, device, None)
-    return output_local_tesnor.to_consistent(out_placement, sbp)
+    output_local_tensor = To(False)(input_local_tensor, device, None)
+    return output_local_tensor.to_consistent(out_placement, sbp)
 
 
 @register_tensor_op("to")


### PR DESCRIPTION
ConsistentTensor 支持方法 .to("cpu")：
0号进程演示
```python
>>> import oneflow as flow
>>> import numpy as np
>>> import os
>>> if int(os.environ.get("RANK")) == 0:
...     ndarr = np.asarray([[1, -3, 2], [-3, 7, -4]])
... else:
...     ndarr = np.asarray([[6, -5, 9], [-4, 8, -3]])
...
>>> a = flow.Tensor(ndarr)
>>> b = a.to("cuda")
>>> p = flow.placement("cuda", {0:range(2)})
>>> c = b.to_consistent(p, flow.sbp.split(0))
>>> print(c.to_local())
tensor([[ 1., -3.,  2.],
        [-3.,  7., -4.]], device='cuda:0', dtype=oneflow.float32)
>>> d = c.to("cpu")
>>> print(d.to_local())
tensor([[ 1., -3.,  2.],
        [-3.,  7., -4.]], dtype=oneflow.float32)
>>>
```
1号进程演示：
```python
>>> import oneflow as flow
>>> import numpy as np
>>> import os
>>> if int(os.environ.get("RANK")) == 0:
...     ndarr = np.asarray([[1, -3, 2], [-3, 7, -4]])
... else:
...     ndarr = np.asarray([[6, -5, 9], [-4, 8, -3]])
...
>>> a = flow.Tensor(ndarr)
>>> b = a.to("cuda")
>>> p = flow.placement("cuda", {0:range(2)})
>>> c = b.to_consistent(p, flow.sbp.split(0))
>>> print(c.to_local())
tensor([[ 6., -5.,  9.],
        [-4.,  8., -3.]], device='cuda:1', dtype=oneflow.float32)
>>> d = c.to("cpu")
>>> print(d.to_local())
tensor([[ 6., -5.,  9.],
        [-4.,  8., -3.]], dtype=oneflow.float32)
>>>
```