### PR TITLE
Add env ONEFLOW_KERNEL_DISABLE_BLOB_ACCESS_CHECKER

### DIFF
--- a/oneflow/core/kernel/acc_tick_kernel.h
+++ b/oneflow/core/kernel/acc_tick_kernel.h
@@ -30,7 +30,6 @@ class AccTickKernel final : public KernelIf<device_type> {
  private:
   void ForwardDataContent(const KernelCtx& ctx,
                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {}
-  const PbMessage& GetCustomizedOpConf() const override { return this->op_conf().acc_tick_conf(); }
 };
 
 }  // namespace oneflow

--- a/oneflow/core/kernel/device_tick_kernel.h
+++ b/oneflow/core/kernel/device_tick_kernel.h
@@ -30,9 +30,6 @@ class DeviceTickKernel final : public KernelIf<device_type> {
  private:
   void ForwardDataContent(const KernelCtx& ctx,
                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {}
-  const PbMessage& GetCustomizedOpConf() const override {
-    return this->op_conf().device_tick_conf();
-  }
 };
 
 }  // namespace oneflow

--- a/oneflow/core/kernel/dst_subset_tick_kernel.cpp
+++ b/oneflow/core/kernel/dst_subset_tick_kernel.cpp
@@ -27,9 +27,6 @@ class DstSubsetTickKernel final : public KernelIf<DeviceType::kCPU> {
  private:
   void ForwardDataContent(const KernelCtx& ctx,
                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {}
-  const PbMessage& GetCustomizedOpConf() const override {
-    return this->op_conf().dst_subset_tick_conf();
-  }
 };
 
 REGISTER_KERNEL(OperatorConf::kDstSubsetTickConf, DstSubsetTickKernel);

--- a/oneflow/core/kernel/kernel.h
+++ b/oneflow/core/kernel/kernel.h
@@ -111,26 +111,16 @@ class Kernel {
                              std::function<Blob*(const std::string&)> BnInOp2Blob) const;
   virtual void ForwardShape(const KernelCtx& ctx,
                             std::function<Blob*(const std::string&)> BnInOp2Blob) const;
-  void NaiveForwardShape(std::function<Blob*(const std::string&)>& BnInOp2Blob) const;
   // TODO(niuchong) : rename ForwardDataContent to ForwardBody
   virtual void ForwardDataContent(const KernelCtx& ctx,
                                   std::function<Blob*(const std::string&)> BnInOp2Blob) const = 0;
   virtual bool IsStateless() const { return false; }
-  virtual const PbMessage& GetCustomizedOpConf() const {
-    UNIMPLEMENTED();
-    return *(const PbMessage*)nullptr;
-  }
-  virtual const PbMessage& GetCustomizedKernelConf() const {
-    UNIMPLEMENTED();
-    return *(const PbMessage*)nullptr;
-  }
-  void CheckSameDim0ValidNum(const PbRpf<std::string>& bns,
-                             const std::function<Blob*(const std::string&)>& BnInOp2Blob) const;
 
  private:
   const JobDesc* job_desc_;
   RuntimeBlobShapeInferHelper* shape_infer_helper_;
   KernelConf kernel_conf_;
+  bool blob_access_checker_disabled_;
 };
 
 template<DeviceType device_type>

--- a/oneflow/core/kernel/sink_tick_kernel.h
+++ b/oneflow/core/kernel/sink_tick_kernel.h
@@ -29,7 +29,6 @@ class SinkTickKernel final : public KernelIf<DeviceType::kCPU> {
  private:
   void ForwardDataContent(const KernelCtx& ctx,
                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {}
-  const PbMessage& GetCustomizedOpConf() const override { return this->op_conf().sink_tick_conf(); }
 };
 
 }  // namespace oneflow

--- a/oneflow/core/kernel/source_tick_kernel.h
+++ b/oneflow/core/kernel/source_tick_kernel.h
@@ -29,9 +29,6 @@ class SourceTickKernel final : public KernelIf<DeviceType::kCPU> {
  private:
   void ForwardDataContent(const KernelCtx& ctx,
                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {}
-  const PbMessage& GetCustomizedOpConf() const override {
-    return this->op_conf().source_tick_conf();
-  }
 };
 
 }  // namespace oneflow

--- a/oneflow/core/kernel/src_subset_tick_kernel.cpp
+++ b/oneflow/core/kernel/src_subset_tick_kernel.cpp
@@ -27,9 +27,6 @@ class SrcSubsetTickKernel final : public KernelIf<DeviceType::kCPU> {
  private:
   void ForwardDataContent(const KernelCtx& ctx,
                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {}
-  const PbMessage& GetCustomizedOpConf() const override {
-    return this->op_conf().src_subset_tick_conf();
-  }
 };
 
 REGISTER_KERNEL(OperatorConf::kSrcSubsetTickConf, SrcSubsetTickKernel);

--- a/oneflow/core/kernel/tick_kernel.h
+++ b/oneflow/core/kernel/tick_kernel.h
@@ -30,7 +30,6 @@ class TickKernel final : public KernelIf<device_type> {
  private:
   void ForwardDataContent(const KernelCtx& ctx,
                           std::function<Blob*(const std::string&)> BnInOp2Blob) const override {}
-  const PbMessage& GetCustomizedOpConf() const override { return this->op_conf().tick_conf(); }
 };
 
 }  // namespace oneflow


### PR DESCRIPTION
* 添加环境变量 `ONEFLOW_KERNEL_DISABLE_BLOB_ACCESS_CHECKER` ，开启后仅用 blob_access_checker，因为blob_access_checker 偏向于正确性保证，某些场景关闭可以提高kernel开销
* 空 blob 跳过执行的检查仅在包含 dynamic blob 的情况下执行
* 删除一些无用代码