### PR TITLE
delete interpolate int type

### DIFF
--- a/oneflow/user/kernels/upsample_bicubic2d_kernel.cpp
+++ b/oneflow/user/kernels/upsample_bicubic2d_kernel.cpp
@@ -178,6 +178,5 @@ class UpsampleBicubic2dGradCPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPLE_BICUBIC_CPU_KERNEL(float)
 REGISTER_UPSAMPLE_BICUBIC_CPU_KERNEL(double)
-REGISTER_UPSAMPLE_BICUBIC_CPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_bicubic2d_kernel.cu
+++ b/oneflow/user/kernels/upsample_bicubic2d_kernel.cu
@@ -217,6 +217,5 @@ class UpsampleBicubic2dGradGPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPLE_BICUBIC_GPU_KERNEL(float)
 REGISTER_UPSAMPLE_BICUBIC_GPU_KERNEL(double)
-REGISTER_UPSAMPLE_BICUBIC_GPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_bilinear_2d_kernel.cpp
+++ b/oneflow/user/kernels/upsample_bilinear_2d_kernel.cpp
@@ -167,6 +167,5 @@ class UpsampleBilinear2DGradCPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPLE_BILINEAR_2D_CPU_KERNEL(float)
 REGISTER_UPSAMPLE_BILINEAR_2D_CPU_KERNEL(double)
-REGISTER_UPSAMPLE_BILINEAR_2D_CPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_bilinear_2d_kernel.cu
+++ b/oneflow/user/kernels/upsample_bilinear_2d_kernel.cu
@@ -169,6 +169,5 @@ class UpsampleBilinear2DGradGPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPLE_BILINEAR_2D_GPU_KERNEL(float)
 REGISTER_UPSAMPLE_BILINEAR_2D_GPU_KERNEL(double)
-REGISTER_UPSAMPLE_BILINEAR_2D_GPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_kernel.h
+++ b/oneflow/user/kernels/upsample_kernel.h
@@ -138,7 +138,7 @@ OF_DEVICE_FUNC T cubic_convolution2(const T x, const T A) {
 
 template<typename T>
 OF_DEVICE_FUNC void get_cubic_upsample_coefficients(T coeffs[4], const T t) {
-  float A = -0.75;
+  T A = -0.75;
 
   T x1 = t;
   coeffs[0] = cubic_convolution2<T>(x1 + 1.0, A);

--- a/oneflow/user/kernels/upsample_linear_1d_kernel.cpp
+++ b/oneflow/user/kernels/upsample_linear_1d_kernel.cpp
@@ -143,6 +143,5 @@ class UpsampleLinearGrad1DCPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPLELINEAR1D_CPU_KERNEL(float)
 REGISTER_UPSAMPLELINEAR1D_CPU_KERNEL(double)
-REGISTER_UPSAMPLELINEAR1D_CPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_linear_1d_kernel.cu
+++ b/oneflow/user/kernels/upsample_linear_1d_kernel.cu
@@ -146,6 +146,5 @@ class UpsampleLinearGrad1DGPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPLELINEAR1D_GPU_KERNEL(float)
 REGISTER_UPSAMPLELINEAR1D_GPU_KERNEL(double)
-REGISTER_UPSAMPLELINEAR1D_GPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_nearest_kernel.cpp
+++ b/oneflow/user/kernels/upsample_nearest_kernel.cpp
@@ -198,7 +198,6 @@ class UpsampleNearestGrad1DCPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPNEAREST1D_CPU_KERNEL(float)
 REGISTER_UPSAMPNEAREST1D_CPU_KERNEL(double)
-REGISTER_UPSAMPNEAREST1D_CPU_KERNEL(int)
 
 template<typename T>
 class UpsampleNearest2DCPUKernel final : public user_op::OpKernel {
@@ -291,7 +290,6 @@ class UpsampleNearest2DGradCPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPLE_NEAREST_2D_CPU_KERNEL(float)
 REGISTER_UPSAMPLE_NEAREST_2D_CPU_KERNEL(double)
-REGISTER_UPSAMPLE_NEAREST_2D_CPU_KERNEL(int)
 
 template<typename T>
 class UpsampleNearest3DCPUKernel final : public user_op::OpKernel {
@@ -364,6 +362,5 @@ class UpsampleNearestGrad3DCPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPNEAREST3D_CPU_KERNEL(float)
 REGISTER_UPSAMPNEAREST3D_CPU_KERNEL(double)
-REGISTER_UPSAMPNEAREST3D_CPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_nearest_kernel.cu
+++ b/oneflow/user/kernels/upsample_nearest_kernel.cu
@@ -194,7 +194,6 @@ class UpsampleNearestGrad1DGPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPNEAREST1D_GPU_KERNEL(float)
 REGISTER_UPSAMPNEAREST1D_GPU_KERNEL(double)
-REGISTER_UPSAMPNEAREST1D_GPU_KERNEL(int)
 
 template<typename T>
 class UpsampleNearest2DGPUKernel final : public user_op::OpKernel {
@@ -282,7 +281,6 @@ class UpsampleNearest2DGradGPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPLE_NEAREST_2D_GPU_KERNEL(float)
 REGISTER_UPSAMPLE_NEAREST_2D_GPU_KERNEL(double)
-REGISTER_UPSAMPLE_NEAREST_2D_GPU_KERNEL(int)
 
 template<typename T>
 class UpsampleNearest3DGPUKernel final : public user_op::OpKernel {
@@ -355,6 +353,5 @@ class UpsampleNearestGrad3DGPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPNEAREST3D_GPU_KERNEL(float)
 REGISTER_UPSAMPNEAREST3D_GPU_KERNEL(double)
-REGISTER_UPSAMPNEAREST3D_GPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_trilinear_3d_kernel.cpp
+++ b/oneflow/user/kernels/upsample_trilinear_3d_kernel.cpp
@@ -213,6 +213,5 @@ class UpsampleTrilinearGrad3DCPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPTRILINEAR3D_CPU_KERNEL(float)
 REGISTER_UPSAMPTRILINEAR3D_CPU_KERNEL(double)
-REGISTER_UPSAMPTRILINEAR3D_CPU_KERNEL(int)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/upsample_trilinear_3d_kernel.cu
+++ b/oneflow/user/kernels/upsample_trilinear_3d_kernel.cu
@@ -216,6 +216,5 @@ class UpsampleTrilinearGrad3DGPUKernel final : public user_op::OpKernel {
 
 REGISTER_UPSAMPTRILINEAR3D_GPU_KERNEL(float)
 REGISTER_UPSAMPTRILINEAR3D_GPU_KERNEL(double)
-REGISTER_UPSAMPTRILINEAR3D_GPU_KERNEL(int)
 
 }  // namespace oneflow


### PR DESCRIPTION
去掉插值方法中注册的int类型，和Pytorch对齐。