### PR TITLE
use clang tidy appimage in ci

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -51,11 +51,11 @@ jobs:
             -DBUILD_TESTING=ON
           cmake --build . -j$(nproc) --target of_git_version oneflow_deps generate_functional of_cfgobj generate_py_cfg
       - name: Run Maybe-related checks by clang-tidy
+        # use clang as compiler for correct compiler flags
         run: |
           cd build
           rm CMakeCache.txt
           cmake .. -C ../cmake/caches/international/cpu.cmake \
-            # use clang as compiler for correct compiler flags
             -DCMAKE_C_COMPILER=clang-12 \
             -DCMAKE_CXX_COMPILER=clang++-12 \
             -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -39,15 +39,13 @@ jobs:
           sudo apt-get install -y libopenblas-dev nasm python3-pip ninja-build
       - name: Download OneFlow custom clang-tidy
         run: |
-          wget https://github.com/oneflow-inc/llvm-project/releases/download/latest/clang-tidy
+          wget https://github.com/Oneflow-Inc/llvm-project/releases/download/latest/clang-tidy-489012f-x86_64.AppImage
           wget https://raw.githubusercontent.com/oneflow-inc/llvm-project/maybe/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
-          chmod +x clang-tidy run-clang-tidy.py
+          chmod +x clang-tidy-489012f-x86_64.AppImage run-clang-tidy.py
       - name: Build third party libs and generate files
         run: |
           mkdir build
           cd build
-          # clang-tidy has builtin includes, but doesn't work here
-          # https://clang.llvm.org/docs/LibTooling.html#builtin-includes
           cmake .. -C ../cmake/caches/international/cpu.cmake \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON
@@ -57,14 +55,11 @@ jobs:
           cd build
           rm CMakeCache.txt
           cmake .. -C ../cmake/caches/international/cpu.cmake \
-            -DCMAKE_C_COMPILER=clang-12 \
-            -DCMAKE_CXX_COMPILER=clang++-12 \
-            -DCMAKE_CXX_FLAGS="-isystem /usr/lib/llvm-12/lib/clang/12.0.1/include/" \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           cd ..
-          ./run-clang-tidy.py -clang-tidy-binary ./clang-tidy -p build -quiet
+          ./run-clang-tidy.py -clang-tidy-binary ./clang-tidy-489012f-x86_64.AppImage -p build -quiet
 
   hosted:
     name: CPU-only

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -55,6 +55,9 @@ jobs:
           cd build
           rm CMakeCache.txt
           cmake .. -C ../cmake/caches/international/cpu.cmake \
+            # use clang as compiler for correct compiler flags
+            -DCMAKE_C_COMPILER=clang-12 \
+            -DCMAKE_CXX_COMPILER=clang++-12 \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON

--- a/oneflow/user/kernels/conv_cudnn_kernels.cpp
+++ b/oneflow/user/kernels/conv_cudnn_kernels.cpp
@@ -162,7 +162,7 @@ class ConvGpuKernel final : public user_op::OpKernel {
           GetBiasCudnnTensorDesc<NDims>(data_format, filters, GetDataType<T>::value));
     }
 
-    return std::move(state);
+    return state;
   }
 
  private:


### PR DESCRIPTION
打包 clang-tidy 的 AppImage，把头文件包含进 AppImage 里，避免 ci 中遇到的找不到头文件的错误