### PR TITLE
set CMAKE_BUILD_TYPE to Release if undefined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Minimum CMake required
 cmake_minimum_required(VERSION 3.14.0)
 
+if (NOT CMAKE_BUILD_TYPE)
+  message(STATUS "No build type selected, default to Release")
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type (default Release)" FORCE)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(FATAL_ERROR "Expected CMAKE_BUILD_TYPE is Debug, Release, RelWithDebInfo or MinSizeRel, got ${CMAKE_BUILD_TYPE}")
 endif()


### PR DESCRIPTION
修复 https://github.com/Oneflow-Inc/oneflow/pull/5656 带来的问题，在不设置 CMAKE_BUILD_TYPE 时将它设置成 Release