### PR TITLE
Fix inplace op circle reference bug

### DIFF
--- a/oneflow/api/python/functional/python_functions.cpp
+++ b/oneflow/api/python/functional/python_functions.cpp
@@ -84,26 +84,6 @@ py::object PyAdd(py::args py_args, py::kwargs py_kwargs) {
       if (*a->shape() == *b->shape()) {
         return functional::Add(a, b, inplace);
       } else {
-        if (inplace) {
-          // Check whether b can expand to a
-          const auto& a_shape = a->shape();
-          const auto& b_shape = b->shape();
-          CHECK_GE_OR_RETURN(a_shape->NumAxes(), b_shape->NumAxes())
-              << "Invalid shape to do inplace BroadcastAdd.";
-          int shift = a_shape->NumAxes() - b_shape->NumAxes();
-          for (int i = a_shape->NumAxes() - 1; i >= 0; --i) {
-            int index = i - shift;
-            if (index >= 0) {
-              int dim_a = a_shape->At(i);
-              int dim_b = b_shape->At(index);
-              CHECK_OR_RETURN(dim_a == dim_b || (dim_a > 0 && dim_b == 1))
-                  << "Invalid expand shape " << a_shape->ToString();
-            } else {
-              CHECK_GT_OR_RETURN(a_shape->At(i), 0)
-                  << "Invalid expand shape " << a_shape->ToString();
-            }
-          }
-        }
         return functional::BroadcastAdd(a, b, inplace);
       }
     }

--- a/oneflow/core/framework/op_expr_grad_function.h
+++ b/oneflow/core/framework/op_expr_grad_function.h
@@ -56,7 +56,7 @@ class OpExprGradFunction : public OpExprGradFunctionIf {
                         const OpExprInterpContext& interp_ctx) const override {
     StateT* state = dynamic_cast<StateT*>(ctx);
     CHECK_NOTNULL_OR_RETURN(state);
-    // Only catures detach tensor for calculating grad and set right requires_grad
+    // Only captures detached tensor for calculating grad and set right requires_grad
     // for higher order derivative
     TensorTuple detach_inputs(inputs.size());
     for (int i = 0; i < inputs.size(); ++i) {

--- a/oneflow/core/framework/op_expr_grad_function.h
+++ b/oneflow/core/framework/op_expr_grad_function.h
@@ -56,11 +56,19 @@ class OpExprGradFunction : public OpExprGradFunctionIf {
                         const OpExprInterpContext& interp_ctx) const override {
     StateT* state = dynamic_cast<StateT*>(ctx);
     CHECK_NOTNULL_OR_RETURN(state);
+    // Only catures detach tensor for calculating grad and set right requires_grad
+    // for higher order derivative
+    TensorTuple detach_inputs(inputs.size());
+    for (int i = 0; i < inputs.size(); ++i) {
+      detach_inputs.at(i) = JUST(inputs.at(i)->detach());
+      detach_inputs.at(i)->set_requires_grad(inputs.at(i)->requires_grad());
+    }
     TensorTuple detach_outputs(outputs.size());
     for (int i = 0; i < outputs.size(); ++i) {
       detach_outputs.at(i) = JUST(outputs.at(i)->detach());
+      detach_outputs.at(i)->set_requires_grad(outputs.at(i)->requires_grad());
     }
-    return Capture(state, inputs, detach_outputs, interp_ctx);
+    return Capture(state, detach_inputs, detach_outputs, interp_ctx);
   }
 
   Maybe<void> ApplyIf(const OpExprInterpState* ctx, const TensorTuple& out_grads,

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -37,7 +37,7 @@
   bind_python: False
 
 - name: "broadcast_add"
-  signature: "Tensor BroadcastAdd(Tensor x, Tensor y)"
+  signature: "Tensor BroadcastAdd(Tensor x, Tensor y, *, Bool inplace=False)"
   bind_python: False
 
 - name: "sub_scalar_by_tensor"

--- a/oneflow/core/functional/impl/binary_functor.cpp
+++ b/oneflow/core/functional/impl/binary_functor.cpp
@@ -66,7 +66,7 @@ class PowFunctor : public BinaryFunctor {
   }
 };
 
-class BroadcastAddFunctor : public InplaceableBinaryFunctor {
+class BroadcastAddFunctor : public InplaceableBroadcastBinaryFunctor {
  public:
   BroadcastAddFunctor() {
     op_ = CHECK_JUST(one::OpBuilder("broadcast_add").Input("x").Input("y").Output("z").Build());

--- a/oneflow/core/functional/impl/binary_functor.cpp
+++ b/oneflow/core/functional/impl/binary_functor.cpp
@@ -66,7 +66,7 @@ class PowFunctor : public BinaryFunctor {
   }
 };
 
-class BroadcastAddFunctor : public BinaryFunctor {
+class BroadcastAddFunctor : public InplaceableBinaryFunctor {
  public:
   BroadcastAddFunctor() {
     op_ = CHECK_JUST(one::OpBuilder("broadcast_add").Input("x").Input("y").Output("z").Build());

--- a/oneflow/core/functional/impl/binary_functor.h
+++ b/oneflow/core/functional/impl/binary_functor.h
@@ -64,6 +64,47 @@ class InplaceableBinaryFunctor {
   std::shared_ptr<OpExpr> op_;
 };
 
+class InplaceableBroadcastBinaryFunctor {
+ public:
+  Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
+                           const std::shared_ptr<one::Tensor>& y, bool inplace) const {
+    if (inplace) {
+      JUST(CheckInplaceValid(x));
+      // Check whether y can expand to x
+      const auto& x_shape = x->shape();
+      const auto& y_shape = y->shape();
+      CHECK_GE_OR_RETURN(x_shape->NumAxes(), y_shape->NumAxes())
+          << "Invalid shape to do inplace broadcast operator.";
+      int shift = x_shape->NumAxes() - y_shape->NumAxes();
+      for (int i = x_shape->NumAxes() - 1; i >= 0; --i) {
+        int index = i - shift;
+        if (index >= 0) {
+          int dim_a = x_shape->At(i);
+          int dim_b = y_shape->At(index);
+          CHECK_OR_RETURN(dim_a == dim_b || (dim_a > 0 && dim_b == 1))
+              << "Can't expand " << y_shape->ToString() << "to" << x_shape->ToString();
+        } else {
+          CHECK_GT_OR_RETURN(x_shape->At(i), 0)
+              << "Can't expand " << y_shape->ToString() << "to" << x_shape->ToString();
+        }
+      }
+
+      std::shared_ptr<TensorTuple> outputs = std::make_shared<TensorTuple>(1);
+      outputs->at(0) = x;
+      JUST(OpInterpUtil::Dispatch(*op_, {x, y}, outputs.get()));
+      return outputs->at(0);
+    } else {
+      return OpInterpUtil::Dispatch<Tensor>(*op_, {x, y});
+    }
+  }
+
+ protected:
+  InplaceableBroadcastBinaryFunctor() = default;
+  virtual ~InplaceableBroadcastBinaryFunctor() = default;
+
+  std::shared_ptr<OpExpr> op_;
+};
+
 }  // namespace impl
 
 }  // namespace functional

--- a/oneflow/core/functional/impl/binary_functor.h
+++ b/oneflow/core/functional/impl/binary_functor.h
@@ -82,10 +82,10 @@ class InplaceableBroadcastBinaryFunctor {
           int dim_a = x_shape->At(i);
           int dim_b = y_shape->At(index);
           CHECK_OR_RETURN(dim_a == dim_b || (dim_a > 0 && dim_b == 1))
-              << "Can't expand " << y_shape->ToString() << "to" << x_shape->ToString();
+              << "Can't expand " << y_shape->ToString() << " to " << x_shape->ToString();
         } else {
           CHECK_GT_OR_RETURN(x_shape->At(i), 0)
-              << "Can't expand " << y_shape->ToString() << "to" << x_shape->ToString();
+              << "Can't expand " << y_shape->ToString() << " to " << x_shape->ToString();
         }
       }
 

--- a/python/oneflow/nn/modules/linear.py
+++ b/python/oneflow/nn/modules/linear.py
@@ -95,11 +95,8 @@ class Linear(Module):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
-        self.use_bias = bias
         self.weight = flow.nn.Parameter(flow.Tensor(out_features, in_features))
-        self.bias = None
-        if bias:
-            self.bias = flow.nn.Parameter(flow.Tensor(out_features))
+        self.bias = flow.nn.Parameter(flow.Tensor(out_features)) if bias else None
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
@@ -111,11 +108,8 @@ class Linear(Module):
 
     def forward(self, x):
         res = flow.F.matmul(x, self.weight, transpose_a=False, transpose_b=True)
-        if self.use_bias:
-            # TODO(zwx): Inplace add is not supported yet with consistent tensor,
-            # use non-inplace version before inplace broadcast add has been implemented.
-            # res += self.bias
-            res = res + self.bias
+        if self.bias is not None:
+            res += self.bias
         return res
 
     def extra_repr(self) -> str:


### PR DESCRIPTION
解决  https://github.com/Oneflow-Inc/oneflow/pull/5551#issuecomment-898860540 提出的问题。

例子中：

```python
import oneflow as flow
for i in range(1000):
    a = flow.ones((256*256, 1024), requires_grad=True).to("cuda")
    b = flow.ones((1024), requires_grad=True).to("cuda")
    a += b
```

由于a是requires_grad=True又调用了inplace op，后向图中形成了循环引用 `a -> FunctionNode -> ctx -> a`。

在后向图构建过程中只用捕获 tensor.detach() 参与后向计算就可以了，同时保留requires_grad以保证高阶导正确。后面就可以正常做BroadcastAdd了。