### PR TITLE
consistent_tensor_infer_cache: fix memory leak

### DIFF
--- a/oneflow/core/framework/consistent_tensor_infer_cache.cpp
+++ b/oneflow/core/framework/consistent_tensor_infer_cache.cpp
@@ -217,8 +217,8 @@ Maybe<void> CheckIsDeviceSupportedByOp(const ParallelDesc& parallel_desc,
     // The inferred results can be retrieved by op->NdSbp4BnInOp(obn).
     JUST(op->InferNdSbpSignatureIf(nd_sbp_constraints, *parallel_desc, NdSbpInferHint4Ibn));
   }
-  auto* result =
-      new ConsistentTensorInferResult(user_op_expr.input_size(), user_op_expr.output_size());
+  auto result = std::make_unique<ConsistentTensorInferResult>(user_op_expr.input_size(),
+                                                              user_op_expr.output_size());
   auto* input_metas = result->mut_input_tensor_metas();
   for (int32_t i = 0; i < user_op_expr.input_size(); ++i) {
     const auto& old_consistent_tensor_meta =
@@ -240,7 +240,7 @@ Maybe<void> CheckIsDeviceSupportedByOp(const ParallelDesc& parallel_desc,
     ConsistentTensorMeta tensor_meta(shape, data_type, nd_sbp, parallel_desc);
     output_metas->at(i) = SymbolOf(tensor_meta);
   }
-  return std::shared_ptr<const ConsistentTensorInferResult>(result);
+  return std::shared_ptr<const ConsistentTensorInferResult>(std::move(result));
 }
 
 /* static */ Maybe<const ConsistentTensorInferResult> ConsistentTensorInferCache::Infer(


### PR DESCRIPTION
detected by clang static analyzer:
```
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:227:36: warning: Potential leak of memory pointed to by 'result' [clang-analyzer-cplusplus.NewDeleteLeaks]
    const auto& nd_sbp = SymbolOf(*JUST(op->NdSbp4BnInOp(ibn)));
                                   ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:277:40: note: expanded from macro 'JUST'
      auto* stack_frame = maybe.error()->add_stack_frame();       \
                                       ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:278:3: note: Taking true branch
  if (iter == cache_.end()) {
  ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:280:5: note: Taking false branch
    CHECK_OR_RETURN(static_cast<bool>(user_op_expr));
    ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:323:3: note: expanded from macro 'CHECK_OR_RETURN'
  if (!(expr))                                                                     \
  ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:281:44: note: Calling 'ConsistentTensorInferCache::Infer'
    const auto& output_tensor_metas = JUST(Infer(*user_op_expr, infer_args));
                                           ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:275:52: note: expanded from macro 'JUST'
    auto&& maybe = __MaybeErrorStackCheckWrapper__(__VA_ARGS__);  \
                                                   ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:261:46: note: expanded from macro '__MaybeErrorStackCheckWrapper__'
#define __MaybeErrorStackCheckWrapper__(...) __VA_ARGS__
                                             ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:186:3: note: Assuming the condition is true
  CHECK_GT_OR_RETURN(infer_args.input_consistent_tensor_metas().size(), 0);
  ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:334:19: note: expanded from macro 'CHECK_GT_OR_RETURN'
  CHECK_OR_RETURN((lhs) > (rhs)) << "(" << (lhs) << " vs " << (rhs) << ") "
                  ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:323:9: note: expanded from macro 'CHECK_OR_RETURN'
  if (!(expr))                                                                     \
        ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:186:3: note: Taking false branch
  CHECK_GT_OR_RETURN(infer_args.input_consistent_tensor_metas().size(), 0);
  ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:334:3: note: expanded from macro 'CHECK_GT_OR_RETURN'
  CHECK_OR_RETURN((lhs) > (rhs)) << "(" << (lhs) << " vs " << (rhs) << ") "
  ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:323:3: note: expanded from macro 'CHECK_OR_RETURN'
  if (!(expr))                                                                     \
  ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:189:3: note: Taking false branch
  JUST(CheckInputParallelDescIdentical(infer_args));
  ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:190:3: note: Taking false branch
  JUST(CheckIsDeviceSupportedByOp(*parallel_desc, user_op_expr.op_type_name()));
  ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:195:5: note: Assuming the condition is false
    JUST(user_op_expr.InferLogicalShapeAndDType(
    ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:9: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
        ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:195:5: note: Taking false branch
    JUST(user_op_expr.InferLogicalShapeAndDType(
    ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:200:20: note: Taking false branch
  const auto& op = JUST(MakeOp(user_op_expr, infer_args.attrs(), parallel_desc->device_tag()));
                   ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:201:3: note: Assuming the condition is false
  JUST(op->FillOpParallelDesc(parallel_desc.shared_from_symbol()));
  ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:9: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
        ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:201:3: note: Taking false branch
  JUST(op->FillOpParallelDesc(parallel_desc.shared_from_symbol()));
  ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:205:5: note: Taking false branch
    JUST(infer_args.MakeNdSbpConstraints(user_op_expr, &nd_sbp_constraints));
    ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:207:5: note: Taking false branch
    JUST(infer_args.MakeInputBlobDescs(user_op_expr, &blob_descs));
    ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:209:5: note: Taking false branch
    JUST(infer_args.MakeNdSbpInferHints(user_op_expr, blob_descs, &pd_infer_hints));
    ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:218:5: note: Assuming the condition is false
    JUST(op->InferNdSbpSignatureIf(nd_sbp_constraints, *parallel_desc, NdSbpInferHint4Ibn));
    ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:9: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
        ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:218:5: note: Taking false branch
    JUST(op->InferNdSbpSignatureIf(nd_sbp_constraints, *parallel_desc, NdSbpInferHint4Ibn));
    ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:221:7: note: Memory is allocated
      new ConsistentTensorInferResult(user_op_expr.input_size(), user_op_expr.output_size());
      ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:223:23: note: Assuming the condition is true
  for (int32_t i = 0; i < user_op_expr.input_size(); ++i) {
                      ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:223:3: note: Loop condition is true.  Entering loop body
  for (int32_t i = 0; i < user_op_expr.input_size(); ++i) {
  ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:227:36: note: Assuming the condition is true
    const auto& nd_sbp = SymbolOf(*JUST(op->NdSbp4BnInOp(ibn)));
                                   ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:9: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
        ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:227:36: note: Taking true branch
    const auto& nd_sbp = SymbolOf(*JUST(op->NdSbp4BnInOp(ibn)));
                                   ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:276:5: note: expanded from macro 'JUST'
    if (!maybe.IsOk()) {                                          \
    ^
/home/twice/project/oneflow/oneflow/core/framework/consistent_tensor_infer_cache.cpp:227:36: note: Potential leak of memory pointed to by 'result'
    const auto& nd_sbp = SymbolOf(*JUST(op->NdSbp4BnInOp(ibn)));
                                   ^
/home/twice/project/oneflow/oneflow/core/common/maybe.h:277:40: note: expanded from macro 'JUST'
      auto* stack_frame = maybe.error()->add_stack_frame();       \
                                       ^
```