### PR TITLE
fix clang tidy diff options and file format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -761,4 +761,4 @@ jobs:
             -DBUILD_TESTING=ON \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           cd ..
-          git diff -U0 ${{ github.event.pull_request.base.sha }} | ./clang-tidy-diff.py -clang-tidy-binary ./clang-tidy-489012f-x86_64.AppImage -path build -allow-enabling-alpha-checkers -j $(nproc) -p1 -extra-arg="-Xclang" -extra-arg="-analyzer-config" -extra-arg="-Xclang" -extra-arg="aggressive-binary-operation-simplification=true -warnings-as-errors=*,-maybe-glog-fatal"
+          git diff -U0 ${{ github.event.pull_request.base.sha }} | ./clang-tidy-diff.py -clang-tidy-binary ./clang-tidy-489012f-x86_64.AppImage -path build -allow-enabling-alpha-checkers -j $(nproc) -p1 -extra-arg="-Xclang" -extra-arg="-analyzer-config" -extra-arg="-Xclang" -extra-arg="aggressive-binary-operation-simplification=true" -warnings-as-errors="*,-maybe-glog-fatal,-clang-analyzer-alpha.*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -762,3 +762,20 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           cd ..
           git diff -U0 ${{ github.event.pull_request.base.sha }} | ./clang-tidy-diff.py -clang-tidy-binary ./clang-tidy-489012f-x86_64.AppImage -path build -allow-enabling-alpha-checkers -j $(nproc) -p1 -extra-arg="-Xclang" -extra-arg="-analyzer-config" -extra-arg="-Xclang" -extra-arg="aggressive-binary-operation-simplification=true" -warnings-as-errors="*,-maybe-glog-fatal,-clang-analyzer-alpha.*"
+      - name: Remove automerge
+        if: failure() && cancelled() == false && contains(github.event.pull_request.labels.*.name, 'automerge')
+        uses: actions/github-script@v4
+        with:
+          script: |
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'automerge'
+            })
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'CI failed, removing label automerge'
+            })

--- a/ci/check/run_clang_tidy.py
+++ b/ci/check/run_clang_tidy.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     assert downloaded is not None
     ret_code = loop.run_until_complete(
         run_command(
-            f"cd .. && git diff -U0 master | {downloaded[1]} -clang-tidy-binary {downloaded[0]} -path {args.build_dir} -j $(nproc) -p1  -allow-enabling-alpha-checkers -extra-arg=-Xclang -extra-arg=-analyzer-config -extra-arg=-Xclang -extra-arg=aggressive-binary-operation-simplification=true -warnings-as-errors=*,-maybe-glog-fatal"
+            f"cd .. && git diff -U0 master | {downloaded[1]} -clang-tidy-binary {downloaded[0]} -path {args.build_dir} -j $(nproc) -p1  -allow-enabling-alpha-checkers -extra-arg=-Xclang -extra-arg=-analyzer-config -extra-arg=-Xclang -extra-arg=aggressive-binary-operation-simplification=true -warnings-as-errors=*,-maybe-glog-fatal,-clang-analyzer-alpha.*"
         )
     )
     exit(ret_code)

--- a/oneflow/api/python/rpc/ccl.cpp
+++ b/oneflow/api/python/rpc/ccl.cpp
@@ -29,6 +29,7 @@ namespace {
 Maybe<py::bytes> CpuBroadcast(py::bytes* in, int64_t root) {
   const auto& rank_group = JUST(RankGroup::DefaultRankGroup());
   const auto& parallel_desc = JUST(RankGroup::GetDefaultParallelDesc(DeviceType::kCPU, rank_group));
+  int x;
   Py_ssize_t length;
   char* buffer;
   if (GlobalProcessCtx::Rank() == root) {

--- a/oneflow/api/python/rpc/ccl.cpp
+++ b/oneflow/api/python/rpc/ccl.cpp
@@ -29,7 +29,6 @@ namespace {
 Maybe<py::bytes> CpuBroadcast(py::bytes* in, int64_t root) {
   const auto& rank_group = JUST(RankGroup::DefaultRankGroup());
   const auto& parallel_desc = JUST(RankGroup::GetDefaultParallelDesc(DeviceType::kCPU, rank_group));
-  int x;
   Py_ssize_t length;
   char* buffer;
   if (GlobalProcessCtx::Rank() == root) {


### PR DESCRIPTION
修复 .github/workflows/test.yml 里引号加错了位置的 bug，增加 -clang-analyzer-alpha.*

修复 ci/check/run_clang_tidy.py 的文件格式（dos2unix）