### PR TITLE
delete proxy enviroment variables before init

### DIFF
--- a/python/oneflow/__init__.py
+++ b/python/oneflow/__init__.py
@@ -72,6 +72,7 @@ import oneflow.framework.scope_util as scope_util
 import oneflow.framework.session_context as session_ctx
 from oneflow.framework.multi_client_session import MultiClientSession
 
+env_util.DeleteProxyEnvVars()
 if not env_util.HasAllMultiClientEnvVars():
     env_util.SetDefaultMultiClientEnvVars()
 oneflow._oneflow_internal.SetIsMultiClient(True)

--- a/python/oneflow/framework/env_util.py
+++ b/python/oneflow/framework/env_util.py
@@ -323,6 +323,13 @@ def _FindFreePort():
         return s.getsockname()[1]
 
 
+# proxy will interfere bootstrap
+def DeleteProxyEnvVars():
+    for proxy_env in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "all_proxy", "ALL_PROXY"]:
+        if proxy_env in os.environ:
+            del os.environ[proxy_env]
+
+
 def HasAllMultiClientEnvVars():
     env_var_names = ["MASTER_ADDR", "MASTER_PORT", "WORLD_SIZE", "RANK", "LOCAL_RANK"]
     has_all_env_vars = all([os.getenv(x) for x in env_var_names])


### PR DESCRIPTION
在 init oneflow 之前从 os.environ 里删掉代理相关的环境变量，避免设置代理后在多进程启动时死锁