### PR TITLE
Fix batchnorm momentum notion

### DIFF
--- a/python/oneflow/nn/modules/batchnorm.py
+++ b/python/oneflow/nn/modules/batchnorm.py
@@ -115,10 +115,10 @@ class _BatchNorm(_NormBase):
             variance = x.var(dim=reduce_axis, unbiased=False, keepdim=False)
             if self.training and self.track_running_stats:
                 running_mean = (
-                    self.momentum * self.running_mean + (1 - self.momentum) * mean
+                    (1 - self.momentum) * self.running_mean + self.momentum * mean
                 )
                 running_var = (
-                    self.momentum * self.running_var + (1 - self.momentum) * variance
+                    (1 - self.momentum) * self.running_var + self.momentum * variance
                 )
                 self.__setattr__("running_mean", running_mean)
                 self.__setattr__("running_var", running_var)
@@ -172,7 +172,7 @@ class _BatchNorm(_NormBase):
                 self.bias,
                 axis=1,
                 epsilon=self.eps,
-                momentum=self.momentum,
+                momentum=1 - self.momentum,
                 is_training=is_training,
             )
 


### PR DESCRIPTION
[pytorch BatchNorm2d 文档](https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html) 中对 momentum 参数的定义

![image](https://user-images.githubusercontent.com/7133477/130841570-bc95fce6-ec5d-427a-b3a1-88029bcf7d13.png)

[cudnn BatchNormalization 文档](https://docs.nvidia.com/deeplearning/cudnn/api/index.html#cudnnBatchNormalizationForwardTrainingEx) 中对 momentum 的定义

![image](https://user-images.githubusercontent.com/7133477/130841950-07206469-96b4-48e4-90f6-7ddcd32dff7e.png)

oneflow 中 Normalization op kernel 调用 cudnn 接口的地方

```c++
      OF_CUDNN_CHECK(cudnnBatchNormalizationForwardTrainingEx(
          ctx->device_ctx()->cudnn_handle(), CUDNN_BATCHNORM_SPATIAL_PERSISTENT,
          CUDNN_BATCHNORM_OPS_BN, sp_alpha, sp_beta, desc_helper.xy_desc(), x->dptr(), nullptr,
          nullptr, desc_helper.xy_desc(), y->mut_dptr(), desc_helper.param_desc(), gamma->dptr(),
          beta->dptr(), 1.0 - momentum, moving_mean ? moving_mean->mut_dptr() : NULL,
          moving_variance ? moving_variance->mut_dptr() : NULL, epsilon, mean->mut_dptr(),
          inv_variance->mut_dptr(), nullptr, workspace->mut_dptr(), workspace->shape().elem_cnt(),
          nullptr, 0));
```

- pytorch BatchNorm2d momentum 默认值 0.1，指每次更新 running stat，new stat 影响只占 10%
- cudnn BatchNormalizationForward 接口中的 `exponentialAverageFactor` 参数与 pytorch BatchNorm2d momentum 一致
- 原来 oneflow.layers.batch_normalization 接口中的 momentum 与上述两者相反，默认值 0.9，所以在调用 cudnn 传参时需要 `1 - momentum`

本 pr 修复了 oneflow BatchNorm2d module 中，求 running_mean/running_variance 的公式，和调用 oneflow 原有 function batch_normalization 时传入的 momentum 不对的问题。

问题是 python/oneflow/test/modules/test_batchnorm.py 单元测试为什么没能发现这个问题？需检查原因。