### PR TITLE
Fix make of_format fail in ubuntu

### DIFF
--- a/ci/check/run_license_format.py
+++ b/ci/check/run_license_format.py
@@ -32,7 +32,7 @@ def get_txt(path: str):
 
 
 def check_file(path):
-    with open(path) as f:
+    with open(path, "r", encoding="utf-8") as f:
         content = f.read()
         txt = get_txt(path)
         if "import doctest" in content and "raise_on_error=True" not in content:


### PR DESCRIPTION
Fix python open utf-8 file fail problem in Ubuntu when runing make of_format