### PR TITLE
container_util: fix VectorAt, remove useless MutMapAt

### DIFF
--- a/oneflow/core/common/container_util.h
+++ b/oneflow/core/common/container_util.h
@@ -23,16 +23,6 @@ limitations under the License.
 namespace oneflow {
 
 template<typename MapT, typename KeyT>
-scalar_or_const_ref_t<typename MapT::mapped_type> MapAtOrDefault(const MapT& map, const KeyT& key) {
-  const auto& iter = map.find(key);
-  if (iter == map.end()) {
-    static typename MapT::mapped_type default_val;
-    return default_val;
-  }
-  return iter->second;
-}
-
-template<typename MapT, typename KeyT>
 Maybe<scalar_or_const_ref_t<typename MapT::mapped_type>> MapAt(const MapT& map, const KeyT& key) {
   const auto& iter = map.find(key);
   CHECK_OR_RETURN(iter != map.end());
@@ -40,41 +30,38 @@ Maybe<scalar_or_const_ref_t<typename MapT::mapped_type>> MapAt(const MapT& map, 
 }
 
 template<typename MapT, typename KeyT>
-Maybe<typename MapT::mapped_type*> MutMapAt(MapT* map, const KeyT& key) {
+Maybe<typename MapT::mapped_type*> MapAt(MapT* map, const KeyT& key) {
   const auto& iter = map->find(key);
   CHECK_OR_RETURN(iter != map->end());
   return &iter->second;
 }
 
-template<typename MapT, typename KeyT>
-Maybe<typename MapT::mapped_type*> MapAt(MapT* map, const KeyT& key) {
-  return MutMapAt(map, key);
-}
-
 template<typename VecT>
-Maybe<scalar_or_const_ref_t<typename VecT::value_type>> VectorAt(const VecT& vec, int64_t index) {
-  CHECK_GE_OR_RETURN(index, 0);
+Maybe<scalar_or_const_ref_t<typename VecT::value_type>> VectorAt(const VecT& vec, typename VecT::size_type index) {
   CHECK_LT_OR_RETURN(index, vec.size());
-  return vec.at(index);
+  return vec[index];
 }
 
 template<typename VecT>
-Maybe<typename VecT::value_type*> VectorAt(VecT* vec, int64_t index) {
-  CHECK_GE_OR_RETURN(index, 0);
+Maybe<typename VecT::value_type*> VectorAt(VecT* vec, typename VecT::size_type index) {
   CHECK_LT_OR_RETURN(index, vec->size());
-  return &vec->at(index);
+  return &vec[index];
 }
 
 template<typename T>
-std::string Join(const T& vec, const std::string& glue) {
-  std::string str;
-  bool not_first = false;
-  for (const auto& elem : vec) {
-    if (not_first) { str += glue; }
-    str += elem;
-    not_first = true;
-  }
-  return str;
+std::string Join(const T& con, const std::string& delimiter) {
+    std::ostringstream os;
+    auto b = begin(con), e = end(con);
+
+    if (b != e) {
+        std::copy(b, prev(e), std::ostream_iterator<typename T::value_type>(os, delimiter));
+        b = prev(e);
+    }
+    if (b != e) {
+        os << *b;
+    }
+
+    return os.str();
 }
 
 }  // namespace oneflow

--- a/oneflow/core/common/container_util.h
+++ b/oneflow/core/common/container_util.h
@@ -21,13 +21,12 @@ limitations under the License.
 #include "oneflow/core/common/maybe.h"
 
 namespace oneflow {
-  
+
 template<typename MapT, typename KeyT, typename U>
-scalar_or_const_ref_t<typename MapT::mapped_type> MapAt(const MapT& map, const KeyT& key, const U& default_val) {
+scalar_or_const_ref_t<typename MapT::mapped_type> MapAt(const MapT& map, const KeyT& key,
+                                                        const U& default_val) {
   const auto& iter = map.find(key);
-  if (iter == map.end()) {
-    return default_val;
-  }
+  if (iter == map.end()) { return default_val; }
   return iter->second;
 }
 

--- a/oneflow/core/common/container_util.h
+++ b/oneflow/core/common/container_util.h
@@ -21,6 +21,15 @@ limitations under the License.
 #include "oneflow/core/common/maybe.h"
 
 namespace oneflow {
+  
+template<typename MapT, typename KeyT, typename U>
+scalar_or_const_ref_t<typename MapT::mapped_type> MapAt(const MapT& map, const KeyT& key, const U& default_val) {
+  const auto& iter = map.find(key);
+  if (iter == map.end()) {
+    return default_val;
+  }
+  return iter->second;
+}
 
 template<typename MapT, typename KeyT>
 Maybe<scalar_or_const_ref_t<typename MapT::mapped_type>> MapAt(const MapT& map, const KeyT& key) {

--- a/oneflow/core/common/container_util.h
+++ b/oneflow/core/common/container_util.h
@@ -37,7 +37,8 @@ Maybe<typename MapT::mapped_type*> MapAt(MapT* map, const KeyT& key) {
 }
 
 template<typename VecT>
-Maybe<scalar_or_const_ref_t<typename VecT::value_type>> VectorAt(const VecT& vec, typename VecT::size_type index) {
+Maybe<scalar_or_const_ref_t<typename VecT::value_type>> VectorAt(const VecT& vec,
+                                                                 typename VecT::size_type index) {
   CHECK_LT_OR_RETURN(index, vec.size());
   return vec[index];
 }
@@ -50,18 +51,16 @@ Maybe<typename VecT::value_type*> VectorAt(VecT* vec, typename VecT::size_type i
 
 template<typename T>
 std::string Join(const T& con, const std::string& delimiter) {
-    std::ostringstream os;
-    auto b = begin(con), e = end(con);
+  std::ostringstream os;
+  auto b = begin(con), e = end(con);
 
-    if (b != e) {
-        std::copy(b, prev(e), std::ostream_iterator<typename T::value_type>(os, delimiter));
-        b = prev(e);
-    }
-    if (b != e) {
-        os << *b;
-    }
+  if (b != e) {
+    std::copy(b, prev(e), std::ostream_iterator<typename T::value_type>(os, delimiter));
+    b = prev(e);
+  }
+  if (b != e) { os << *b; }
 
-    return os.str();
+  return os.str();
 }
 
 }  // namespace oneflow

--- a/oneflow/core/framework/placement_sbp_util.cpp
+++ b/oneflow/core/framework/placement_sbp_util.cpp
@@ -592,14 +592,14 @@ Maybe<std::unordered_map<int64_t, Symbol<ParallelDesc>>> CalcBroadcastGroup(
         const auto& src_process_ids = node_iter->second;
         int64_t src_process_index = (node_id2counter[node_id]++) % src_process_ids.size();
         int64_t src_process_id = src_process_ids.at(src_process_index);
-        JUST(MutMapAt(&process_id2group, src_process_id))->push_back(process_id);
+        JUST(MapAt(&process_id2group, src_process_id))->push_back(process_id);
       }
     }
   }
   // put remainder process ids into src groups.
   for (int i = 0; i < remainder_process_ids.size(); ++i) {
     int64_t src_process_id = src_process_ids.at(i % src_process_ids.size());
-    JUST(MutMapAt(&process_id2group, src_process_id))->push_back(remainder_process_ids.at(i));
+    JUST(MapAt(&process_id2group, src_process_id))->push_back(remainder_process_ids.at(i));
   }
   const auto& map = std::make_shared<std::unordered_map<int64_t, Symbol<ParallelDesc>>>();
   for (const auto& pair : process_id2group) {


### PR DESCRIPTION
- fix `MapAtOrDefault`: let users provide the default value to prevent unintended behaviors
- remove `MutMapAt`: because there is no `MutVectorAt`
- fix `VectorAt`: 
  - use `VecT::size_type` instead of `int64_t`, so we can eliminate the check `index < 0`.
  - call to `at()` is useless here, we call `operator[]` directly.
- a better version of `Join`