### PR TITLE
make flow._C.local_all_reduce sync lanuched

### DIFF
--- a/oneflow/core/functional/impl/comm_functor.cpp
+++ b/oneflow/core/functional/impl/comm_functor.cpp
@@ -156,7 +156,7 @@ class LocalAllReduceFunctor {
                          .Input("in")
                          .Output("out")
                          .Attr("parallel_conf", PbMessage2TxtString(parallel_conf))
-                         .Attr<bool>("async_launch", true)
+                         .Attr<bool>("async_launch", false)
                          .Build());
       rank_group2op_expr[rank_group] = op_expr;
     } else {


### PR DESCRIPTION
暂时把 flow._C.local_all_reduce 设置成 sync launched，这样子不会出现两卡结果不一致的问题，等待 allocator per stream 功能实现之后恢复