### PR TITLE
Dev eliminate gcc warnings

### DIFF
--- a/oneflow/core/framework/op_interpreter/boxing/symmetric_nd_sbp_boxing.cpp
+++ b/oneflow/core/framework/op_interpreter/boxing/symmetric_nd_sbp_boxing.cpp
@@ -71,7 +71,6 @@ Maybe<void> CheckSymmetricNdSbpBoxing(Symbol<PlacedNdSbp> in, Symbol<PlacedNdSbp
 
 Maybe<one::Tensor> SymmetricNdSbpBoxing(const std::shared_ptr<one::Tensor>& input,
                                         Symbol<PlacedNdSbp> in, Symbol<PlacedNdSbp> out) {
-  const auto& in_nd_sbp = in->nd_sbp();
   const auto& out_nd_sbp = out->nd_sbp();
   const auto& in_parallel_desc = in->placement();
   const auto& out_parallel_desc = out->placement();

--- a/oneflow/core/job/session_global_objects_scope.cpp
+++ b/oneflow/core/job/session_global_objects_scope.cpp
@@ -91,7 +91,7 @@ AvailableMemDesc GetDryRunAvailableMemDesc() {
 
   AvailableMemDesc ret;
   AvailableMemDescOfMachine machine_amd_i;
-  for (int64_t i : Global<ResourceDesc, ForSession>::Get()->process_ranks()) {
+  for (int64_t i = 0; i < Global<ResourceDesc, ForSession>::Get()->process_ranks().size(); ++i) {
     *ret.add_machine_amd() = this_machine_mem_desc;
   }
   return ret;

--- a/oneflow/core/kernel/user_kernel.cpp
+++ b/oneflow/core/kernel/user_kernel.cpp
@@ -637,9 +637,8 @@ const std::shared_ptr<user_op::OpKernelState>& UserKernel::GetOpKernelState() co
 
 void UserKernel::ForwardUserKernel(const std::function<Blob*(const std::string&)>& BnInOp2Blob,
                                    user_op::OpKernelState* opkernel_state) const {
-  const bool updated = ctx_->UpdateTensorWithCorrBlob(BnInOp2Blob);
-
 #ifdef WITH_CUDA_GRAPHS
+  const bool updated = ctx_->UpdateTensorWithCorrBlob(BnInOp2Blob);
   bool current_scope_capturing = false;
   if (cuda_graph_exec_) {
     if (!cuda_graph_ctx_->IsGraphCapturing()) {

--- a/oneflow/core/kernel/user_kernel.cpp
+++ b/oneflow/core/kernel/user_kernel.cpp
@@ -637,8 +637,9 @@ const std::shared_ptr<user_op::OpKernelState>& UserKernel::GetOpKernelState() co
 
 void UserKernel::ForwardUserKernel(const std::function<Blob*(const std::string&)>& BnInOp2Blob,
                                    user_op::OpKernelState* opkernel_state) const {
-#ifdef WITH_CUDA_GRAPHS
   const bool updated = ctx_->UpdateTensorWithCorrBlob(BnInOp2Blob);
+
+#ifdef WITH_CUDA_GRAPHS
   bool current_scope_capturing = false;
   if (cuda_graph_exec_) {
     if (!cuda_graph_ctx_->IsGraphCapturing()) {

--- a/oneflow/user/kernels/nvtx_range_kernel.cu
+++ b/oneflow/user/kernels/nvtx_range_kernel.cu
@@ -59,7 +59,6 @@ class NvtxStartKernel final : public user_op::OpKernel {
  private:
   using user_op::OpKernel::Compute;
   void Compute(user_op::KernelComputeContext* ctx, user_op::OpKernelState* state) const override {
-    auto* kernel_state = dynamic_cast<NvtxOpKernelState*>(state);
     const user_op::Tensor* in = ctx->Tensor4ArgNameAndIndex("in", 0);
     user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
     const ShapeView& in_shape = in->shape();
@@ -69,6 +68,7 @@ class NvtxStartKernel final : public user_op::OpKernel {
     Memcpy<DeviceType::kGPU>(ctx->device_ctx(), out->mut_dptr<void>(), in->dptr<void>(),
                              in_shape.elem_cnt() * GetSizeOfDataType(in_data_type));
 #ifdef OF_ENABLE_PROFILER
+    auto* kernel_state = dynamic_cast<NvtxOpKernelState*>(state);
     const std::string mark_prefix = ctx->Attr<std::string>("mark_prefix");
     const std::string mark = mark_prefix + "-" + std::to_string(kernel_state->counter());
     nvtxRangeId_t range_id = nvtxRangeStartA(mark.c_str());
@@ -101,7 +101,6 @@ class NvtxEndKernel final : public user_op::OpKernel {
  private:
   using user_op::OpKernel::Compute;
   void Compute(user_op::KernelComputeContext* ctx, user_op::OpKernelState* state) const override {
-    auto* kernel_state = dynamic_cast<NvtxOpKernelState*>(state);
     const user_op::Tensor* in = ctx->Tensor4ArgNameAndIndex("in", 0);
     user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
     const ShapeView& in_shape = in->shape();
@@ -109,6 +108,7 @@ class NvtxEndKernel final : public user_op::OpKernel {
     const DataType in_data_type = in->data_type();
     CHECK_EQ(out->data_type(), in_data_type);
 #ifdef OF_ENABLE_PROFILER
+    auto* kernel_state = dynamic_cast<NvtxOpKernelState*>(state);
     const std::string mark_prefix = ctx->Attr<std::string>("mark_prefix");
     const std::string mark = mark_prefix + "-" + std::to_string(kernel_state->counter());
     auto it = mark2range_id.find(mark.c_str());

--- a/oneflow/user/ops/narrow_op.cpp
+++ b/oneflow/user/ops/narrow_op.cpp
@@ -47,7 +47,6 @@ REGISTER_USER_OP("narrow")
     .SetGetSbpFn([](user_op::SbpContext* ctx) -> Maybe<void> {
       const user_op::TensorDesc& in_tensor = ctx->LogicalTensorDesc4InputArgNameAndIndex("in", 0);
       const int64_t& dim = ctx->Attr<int64_t>("dim");
-      const int64_t& start = ctx->Attr<int64_t>("start");
       const int64_t& length = ctx->Attr<int64_t>("length");
       FOR_RANGE(int64_t, i, 0, in_tensor.shape().NumAxes()) {
         if (i != dim) {

--- a/oneflow/user/ops/prelu_op.cpp
+++ b/oneflow/user/ops/prelu_op.cpp
@@ -72,8 +72,6 @@ REGISTER_USER_OP("prelu_grad")
     })
     .SetGetSbpFn([](user_op::SbpContext* ctx) -> Maybe<void> {
       const user_op::TensorDesc& x_tensor = ctx->LogicalTensorDesc4InputArgNameAndIndex("x", 0);
-      const user_op::TensorDesc& alpha_tensor =
-          ctx->LogicalTensorDesc4InputArgNameAndIndex("alpha", 0);
       ctx->NewBuilder()
           .Split(user_op::OpArg("dy", 0), 0)
           .Split(user_op::OpArg("x", 0), 0)


### PR DESCRIPTION
- 此pr修复了5条oneflow编译时gcc给出的warning
```shell
/home/luyang/Oneflow/oneflow/oneflow/user/kernels/nvtx_range_kernel.cu(62): warning: variable "kernel_state" was declared but never referenced

/home/luyang/Oneflow/oneflow/oneflow/user/kernels/nvtx_range_kernel.cu(104): warning: variable "kernel_state" was declared but never referenced


/home/luyang/Oneflow/oneflow/oneflow/core/framework/op_interpreter/boxing/symmetric_nd_sbp_boxing.cpp: In function ‘oneflow::Maybe<oneflow::one::Tensor> oneflow::SymmetricNdSbpBoxing(const std::shared_ptr<oneflow::one::Tensor>&, oneflow::Symbol<oneflow::PlacedNdSbp>, oneflow::Symbol<oneflow::PlacedNdSbp>)’:
/home/luyang/Oneflow/oneflow/oneflow/core/framework/op_interpreter/boxing/symmetric_nd_sbp_boxing.cpp:74:15: warning: unused variable ‘in_nd_sbp’ [-Wunused-variable]
   const auto& in_nd_sbp = in->nd_sbp();
               ^~~~~~~~~

/home/luyang/Oneflow/oneflow/oneflow/core/job/session_global_objects_scope.cpp: In function ‘oneflow::AvailableMemDesc oneflow::{anonymous}::GetDryRunAvailableMemDesc()’:
/home/luyang/Oneflow/oneflow/oneflow/core/job/session_global_objects_scope.cpp:94:16: warning: unused variable ‘i’ [-Wunused-variable]
   for (int64_t i : Global<ResourceDesc, ForSession>::Get()->process_ranks()) {
                ^


/home/luyang/Oneflow/oneflow/oneflow/user/ops/narrow_op.cpp: In lambda function:
/home/luyang/Oneflow/oneflow/oneflow/user/ops/narrow_op.cpp:50:22: warning: unused variable ‘start’ [-Wunused-variable]
       const int64_t& start = ctx->Attr<int64_t>("start");
                      ^~~~~

/home/luyang/Oneflow/oneflow/oneflow/user/ops/prelu_op.cpp: In lambda function:
/home/luyang/Oneflow/oneflow/oneflow/user/ops/prelu_op.cpp:75:34: warning: unused variable ‘alpha_tensor’ [-Wunused-variable]
       const user_op::TensorDesc& alpha_tensor =
                                  ^~~~~~~~~~~~
```