### PR TITLE
NNGraph input/output valid by register tensors

### DIFF
--- a/oneflow/api/python/framework/nn_graph.cpp
+++ b/oneflow/api/python/framework/nn_graph.cpp
@@ -31,13 +31,17 @@ ONEFLOW_API_PYBIND11_MODULE("nn.graph.", m) {
   py::class_<NNGraph, std::shared_ptr<NNGraph>>(m, "CNNGraph")
       .def(py::init<const std::string&>())
       .def_property_readonly("name", &NNGraph::job_name)
-      .def("register_input_op_names",
-           [](NNGraph& graph, const std::vector<std::string>& input_op_names) {
-             return graph.RegisterInputOpNames(input_op_names).GetOrThrow();
-           })
-      .def("register_output_op_names",
-           [](NNGraph& graph, const std::vector<std::string>& output_op_names) {
-             return graph.RegisterOutputOpNames(output_op_names).GetOrThrow();
+      .def(
+          "register_input_op_names_and_tensors",
+          [](NNGraph& graph, const std::vector<std::string>& input_op_names,
+             const std::vector<std::shared_ptr<one::Tensor>>& input_tensors) {
+            return graph.RegisterInputOpNamesAndTensors(input_op_names, input_tensors).GetOrThrow();
+          })
+      .def("register_output_op_names_and_tensors",
+           [](NNGraph& graph, const std::vector<std::string>& output_op_names,
+              const std::vector<std::shared_ptr<one::Tensor>>& output_tensors) {
+             return graph.RegisterOutputOpNamesAndTensors(output_op_names, output_tensors)
+                 .GetOrThrow();
            })
       .def("register_variable_op_names_and_tensors",
            [](NNGraph& graph, const std::vector<std::string>& variable_op_names,

--- a/oneflow/core/eager/lazy_job_instruction_type_test.cpp
+++ b/oneflow/core/eager/lazy_job_instruction_type_test.cpp
@@ -58,12 +58,12 @@ class NoArgNoRetMockNNGraph : public NNGraphIf {
   }
 
   const std::vector<bool>& inputs_valid() const override {
-    static std::vector<std::string> empty;
+    static std::vector<bool> empty;
     return empty;
   }
 
   const std::vector<bool>& outputs_valid() const override {
-    static std::vector<std::string> empty;
+    static std::vector<bool> empty;
     return empty;
   }
 

--- a/oneflow/core/eager/lazy_job_instruction_type_test.cpp
+++ b/oneflow/core/eager/lazy_job_instruction_type_test.cpp
@@ -57,6 +57,16 @@ class NoArgNoRetMockNNGraph : public NNGraphIf {
     return empty;
   }
 
+  const std::vector<bool>& inputs_valid() const override {
+    static std::vector<std::string> empty;
+    return empty;
+  }
+
+  const std::vector<bool>& outputs_valid() const override {
+    static std::vector<std::string> empty;
+    return empty;
+  }
+
  private:
   const std::string job_name_;
 };

--- a/oneflow/core/framework/nn_graph.h
+++ b/oneflow/core/framework/nn_graph.h
@@ -33,12 +33,12 @@ class NNGraph final : public NNGraphIf {
       : name_(name), runtime_inited_(false), is_closed_(false) {}
   ~NNGraph();
 
-  const std::string& job_name() const { return name_; }
+  const std::string& job_name() const override { return name_; }
   const std::vector<std::string>& inputs_op_names() const override;
   const std::vector<std::string>& outputs_op_names() const override;
-  int64_t variable_op_size() const;
   const std::vector<bool>& inputs_valid() const override;
   const std::vector<bool>& outputs_valid() const override;
+  int64_t variable_op_size() const;
 
   Maybe<void> RegisterInputOpNamesAndTensors(
       const std::vector<std::string>& input_op_names,

--- a/oneflow/core/framework/nn_graph.h
+++ b/oneflow/core/framework/nn_graph.h
@@ -34,12 +34,18 @@ class NNGraph final : public NNGraphIf {
   ~NNGraph();
 
   const std::string& job_name() const { return name_; }
-  const std::vector<std::string>& inputs_op_names() const;
-  const std::vector<std::string>& outputs_op_names() const;
+  const std::vector<std::string>& inputs_op_names() const override;
+  const std::vector<std::string>& outputs_op_names() const override;
   int64_t variable_op_size() const;
+  const std::vector<bool>& inputs_valid() const override;
+  const std::vector<bool>& outputs_valid() const override;
 
-  Maybe<void> RegisterInputOpNames(const std::vector<std::string>& input_op_names);
-  Maybe<void> RegisterOutputOpNames(const std::vector<std::string>& output_op_names);
+  Maybe<void> RegisterInputOpNamesAndTensors(
+      const std::vector<std::string>& input_op_names,
+      const std::vector<std::shared_ptr<one::Tensor>>& input_tensors);
+  Maybe<void> RegisterOutputOpNamesAndTensors(
+      const std::vector<std::string>& output_op_names,
+      const std::vector<std::shared_ptr<one::Tensor>>& output_tensors);
   Maybe<void> RegisterVariableOpNamesAndTensors(
       const std::vector<std::string>& variable_op_names,
       const std::vector<std::shared_ptr<one::Tensor>>& variable_tensors);
@@ -56,6 +62,8 @@ class NNGraph final : public NNGraphIf {
   std::string name_;
   std::vector<std::string> input_op_names_;
   std::vector<std::string> output_op_names_;
+  std::vector<bool> input_tensors_valid_;
+  std::vector<bool> output_tensors_valid_;
   HashMap<std::string, Blob*> variable_op_name2eager_blob_;
   HashSet<std::string> variable_op_names_;
   Job job_;

--- a/oneflow/core/framework/nn_graph_if.h
+++ b/oneflow/core/framework/nn_graph_if.h
@@ -28,6 +28,8 @@ class NNGraphIf {
   virtual const std::string& job_name() const = 0;
   virtual const std::vector<std::string>& inputs_op_names() const = 0;
   virtual const std::vector<std::string>& outputs_op_names() const = 0;
+  virtual const std::vector<bool>& inputs_valid() const = 0;
+  virtual const std::vector<bool>& outputs_valid() const = 0;
 
  protected:
   NNGraphIf() = default;

--- a/python/oneflow/nn/graph/graph.py
+++ b/python/oneflow/nn/graph/graph.py
@@ -492,8 +492,12 @@ class Graph(object):
             self._rebuild_outputs(out2name)
 
             # Register input/output/variable/buffer to _c_nn_graph
-            self._c_nn_graph.register_input_op_names(arg_op_names)
-            self._c_nn_graph.register_output_op_names(output_op_names)
+            self._c_nn_graph.register_input_op_names_and_tensors(
+                arg_op_names, convert_to_tensor_tuple(self._flatten_io("input", *args))
+            )
+            self._c_nn_graph.register_output_op_names_and_tensors(
+                output_op_names, self._outputs_tensor_tuple
+            )
             self._c_nn_graph.register_variable_op_names_and_tensors(
                 state_op_names, self._states_tensor_tuple
             )

--- a/python/oneflow/test/graph/test_graph_buffer_limit.py
+++ b/python/oneflow/test/graph/test_graph_buffer_limit.py
@@ -1,0 +1,92 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import time
+import unittest
+import numpy as np
+
+import oneflow as flow
+import oneflow.unittest
+
+
+def _test_graph_buffer_limit(test_case):
+    class StageLayerModule(flow.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear1 = flow.nn.Linear(10, 8, False)
+            self.linear2 = flow.nn.Linear(8, 10, False)
+            flow.nn.init.constant_(self.linear1.weight, 0.023)
+            flow.nn.init.constant_(self.linear2.weight, 1.23)
+
+        def forward(self, x):
+            out0 = self.linear1(x)
+            out0 = out0 + 1.0
+            out0 = out0 * 2.0
+            out1 = self.linear2(out0)
+            return out1
+
+    P0 = flow.placement("cuda", {0: [0]})
+    P1 = flow.placement("cuda", {0: [1]})
+    PT = flow.placement("cuda", {0: [0, 1]})
+    B = flow.sbp.broadcast
+
+    class PipelineModule(flow.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_0 = StageLayerModule()
+            self.layer_1 = StageLayerModule()
+            self.layer_0.to_consistent(P0, B)
+            self.layer_1.to_consistent(P1, B)
+
+        def forward(self, x):
+            # stage 0
+            in0 = x.to_consistent(P0, B)
+            out0 = self.layer_0(in0)
+            # stage 1
+            in1 = out0.to_consistent(P1, B)
+            out1 = self.layer_1(in1)
+            return out1
+
+    pp_m = PipelineModule()
+    pp_m.eval()
+
+    class PipelineGraph(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.pp_m = pp_m
+
+        def build(self, x):
+            return self.pp_m(x)
+
+    pp_g = PipelineGraph()
+
+    for i in range(500):
+        x = flow.randn(16, 10)
+        x = x.to_consistent(P0, B)
+        out = pp_g(x)
+        # print(out.to_local().mean())
+
+
+@unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+@flow.unittest.skip_unless_1n2d()
+class TestGraphPipelineBufferLimit(oneflow.unittest.TestCase):
+    def test_graph_buffer_limit(test_case):
+        _test_graph_buffer_limit(test_case)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
用于同时解决：
1. nn.Graph 非对称 Consistent Input/Output Tensor 在每个 rank 上有无分量 决定 是否 send Push/Pull CB 的 问题。
2. nn.Graph 检查每个 step 输入 tensor 的 meta 信息与编译时的 tensor meta 一致


- [x] nn.Graph register_input/output_op_names -> register_input/output_op_names_and_tensors
- [x] NNGraphIf 提供 input/output_valid 接口，用于表示每个 input/output tensor 有无在本 rank 上的分量
- [x] RunLazyJobInstructionType::Compute 给 BufferMgr Send JobInstance 的 Push/Pull CB 时，根据 io valid 过滤跳过无分量的 op
~~- [ ] 每次 RunLazyNNGraph 检查 input tensor meta 信息合法~~ #6243 
- [x] 非对称 超过 buffer size 的 nn.Graph 单测通过