### PR TITLE
fix default stride value

### DIFF
--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -638,7 +638,7 @@
 
 - name: "max_pool1d"
   signature:
-    'TensorTuple (Tensor x, Int32List[1] kernel_size, Int32List[1] stride=1, 
+    'TensorTuple (Tensor x, Int32List[1] kernel_size, Int32List[1] stride=None, 
                   Int32List[1] padding=0, Int32List[1] dilation=1, 
                   Bool return_indices=True, Bool ceil_mode=False, 
                   String data_format="channels_first") => Maxpool1D'
@@ -646,7 +646,7 @@
 
 - name: "max_pool2d"
   signature:
-    'TensorTuple (Tensor x, Int32List[2] kernel_size, Int32List[2] stride=1, 
+    'TensorTuple (Tensor x, Int32List[2] kernel_size, Int32List[2] stride=None, 
                   Int32List[2] padding=0, Int32List[2] dilation=1, 
                   Bool return_indices=True, Bool ceil_mode=False, 
                   String data_format="channels_first") => Maxpool2D'
@@ -654,7 +654,7 @@
 
 - name: "max_pool3d"
   signature:
-    'TensorTuple (Tensor x, Int32List[3] kernel_size, Int32List[3] stride=1, 
+    'TensorTuple (Tensor x, Int32List[3] kernel_size, Int32List[3] stride=None, 
                   Int32List[3] padding=0, Int32List[3] dilation=1, 
                   Bool return_indices=True, Bool ceil_mode=False, 
                   String data_format="channels_first") => Maxpool3D'
@@ -996,21 +996,21 @@
 
 - name: "avg_pool1d"
   signature:
-    'Tensor (Tensor x, Int32List[1] kernel_size, Int32List[1] stride=1, 
+    'Tensor (Tensor x, Int32List[1] kernel_size, Int32List[1] stride=None, 
              Int32List[1] padding=0, Bool ceil_mode=False, Bool count_include_pad=True,
              Int64 divisor_override=0, String data_format="channels_first") => Avgpool1D'
   bind_python: True
 
 - name: "avg_pool2d"
   signature:
-    'Tensor (Tensor x, Int32List[2] kernel_size, Int32List[2] stride=1, 
+    'Tensor (Tensor x, Int32List[2] kernel_size, Int32List[2] stride=None, 
              Int32List[2] padding=0, Bool ceil_mode=False, Bool count_include_pad=True,
              Int64 divisor_override=0, String data_format="channels_first") => Avgpool2D'
   bind_python: True
 
 - name: "avg_pool3d"
   signature:
-    'Tensor (Tensor x, Int32List[3] kernel_size, Int32List[3] stride=1, 
+    'Tensor (Tensor x, Int32List[3] kernel_size, Int32List[3] stride=None, 
              Int32List[3] padding=0, Bool ceil_mode=False, Bool count_include_pad=True,
              Int64 divisor_override=0, String data_format="channels_first") => Avgpool3D'
   bind_python: True

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -638,7 +638,7 @@
 
 - name: "max_pool1d"
   signature:
-    'TensorTuple (Tensor x, Int32List[1] kernel_size, Int32List[1] stride=None, 
+    'TensorTuple (Tensor input, Int32List[1] kernel_size, Int32List[1] stride=None, 
                   Int32List[1] padding=0, Int32List[1] dilation=1, 
                   Bool return_indices=True, Bool ceil_mode=False, 
                   String data_format="channels_first") => Maxpool1D'
@@ -646,7 +646,7 @@
 
 - name: "max_pool2d"
   signature:
-    'TensorTuple (Tensor x, Int32List[2] kernel_size, Int32List[2] stride=None, 
+    'TensorTuple (Tensor input, Int32List[2] kernel_size, Int32List[2] stride=None, 
                   Int32List[2] padding=0, Int32List[2] dilation=1, 
                   Bool return_indices=True, Bool ceil_mode=False, 
                   String data_format="channels_first") => Maxpool2D'
@@ -654,7 +654,7 @@
 
 - name: "max_pool3d"
   signature:
-    'TensorTuple (Tensor x, Int32List[3] kernel_size, Int32List[3] stride=None, 
+    'TensorTuple (Tensor input, Int32List[3] kernel_size, Int32List[3] stride=None, 
                   Int32List[3] padding=0, Int32List[3] dilation=1, 
                   Bool return_indices=True, Bool ceil_mode=False, 
                   String data_format="channels_first") => Maxpool3D'
@@ -996,21 +996,21 @@
 
 - name: "avg_pool1d"
   signature:
-    'Tensor (Tensor x, Int32List[1] kernel_size, Int32List[1] stride=None, 
+    'Tensor (Tensor input, Int32List[1] kernel_size, Int32List[1] stride=None, 
              Int32List[1] padding=0, Bool ceil_mode=False, Bool count_include_pad=True,
              Int64 divisor_override=0, String data_format="channels_first") => Avgpool1D'
   bind_python: True
 
 - name: "avg_pool2d"
   signature:
-    'Tensor (Tensor x, Int32List[2] kernel_size, Int32List[2] stride=None, 
+    'Tensor (Tensor input, Int32List[2] kernel_size, Int32List[2] stride=None, 
              Int32List[2] padding=0, Bool ceil_mode=False, Bool count_include_pad=True,
              Int64 divisor_override=0, String data_format="channels_first") => Avgpool2D'
   bind_python: True
 
 - name: "avg_pool3d"
   signature:
-    'Tensor (Tensor x, Int32List[3] kernel_size, Int32List[3] stride=None, 
+    'Tensor (Tensor input, Int32List[3] kernel_size, Int32List[3] stride=None, 
              Int32List[3] padding=0, Bool ceil_mode=False, Bool count_include_pad=True,
              Int64 divisor_override=0, String data_format="channels_first") => Avgpool3D'
   bind_python: True

--- a/python/oneflow/nn/functional/functional_maxpool.py
+++ b/python/oneflow/nn/functional/functional_maxpool.py
@@ -20,7 +20,7 @@ import oneflow
 def max_pool1d(
     x,
     kernel_size,
-    stride=1,
+    stride=None,
     padding=0,
     dilation=1,
     return_indices=False,
@@ -46,7 +46,7 @@ def max_pool1d(
 def max_pool2d(
     x,
     kernel_size,
-    stride=1,
+    stride=None,
     padding=0,
     dilation=1,
     return_indices=False,
@@ -72,7 +72,7 @@ def max_pool2d(
 def max_pool3d(
     x,
     kernel_size,
-    stride=1,
+    stride=None,
     padding=0,
     dilation=1,
     return_indices=False,

--- a/python/oneflow/test/modules/test_avgpool.py
+++ b/python/oneflow/test/modules/test_avgpool.py
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import unittest
+import numpy as np
 
 import oneflow as flow
+from oneflow.test_utils.automated_test_util.generators import constant, random_bool
 import oneflow.unittest
 from automated_test_util import *
 
@@ -74,6 +76,55 @@ class TestAvgPoolingModule(flow.unittest.TestCase):
             ndim=5, dim2=random(20, 22), dim3=random(20, 22), dim4=random(20, 22)
         ).to(device)
         y = m(x)
+        return y
+
+
+@flow.unittest.skip_unless_1n1d()
+class TestAvgPoolingFunctional(flow.unittest.TestCase):
+    @autotest(n=100)
+    def test_avgpool1d_functional(test_case):
+        device = random_device()
+        x = random_pytorch_tensor(ndim=3, dim2=random(20, 22)).to(device)
+        y = torch.nn.functional.avg_pool1d(
+            x,
+            kernel_size=random(1, 6).to(int),
+            stride=random(1, 3).to(int) | nothing(),
+            padding=random(1, 3).to(int),
+            ceil_mode=random_bool(),
+            count_include_pad=random_bool(),
+        )
+        return y
+
+    @autotest(n=100)
+    def test_avgpool2d_functional(test_case):
+        device = random_device()
+        x = random_pytorch_tensor(ndim=4, dim2=random(20, 22), dim3=random(20, 22)).to(
+            device
+        )
+        y = torch.nn.functional.avg_pool2d(
+            x,
+            kernel_size=random(1, 6).to(int),
+            stride=random(1, 3).to(int) | nothing(),
+            padding=random(1, 3).to(int),
+            ceil_mode=random_bool(),
+            count_include_pad=random_bool(),
+        )
+        return y
+
+    @autotest(n=100)
+    def test_avgpool3d_functional(test_case):
+        device = random_device()
+        x = random_pytorch_tensor(
+            ndim=5, dim2=random(20, 22), dim3=random(20, 22), dim4=random(20, 22)
+        ).to(device)
+        y = torch.nn.functional.avg_pool3d(
+            x,
+            kernel_size=random(1, 6).to(int),
+            stride=random(1, 3).to(int) | nothing(),
+            padding=random(1, 3).to(int),
+            ceil_mode=random_bool(),
+            count_include_pad=random_bool(),
+        )
         return y
 
 

--- a/python/oneflow/test/modules/test_avgpool.py
+++ b/python/oneflow/test/modules/test_avgpool.py
@@ -23,7 +23,7 @@ from automated_test_util import *
 
 @flow.unittest.skip_unless_1n1d()
 class TestAvgPoolingModule(flow.unittest.TestCase):
-    @autotest(n=100)
+    @autotest()
     def test_avgpool1d_with_random_data(test_case):
         m = torch.nn.AvgPool1d(
             kernel_size=random(4, 6),
@@ -39,7 +39,7 @@ class TestAvgPoolingModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(n=100)
+    @autotest()
     def test_avgpool2d_with_random_data(test_case):
         m = torch.nn.AvgPool2d(
             kernel_size=random(4, 6),
@@ -58,7 +58,7 @@ class TestAvgPoolingModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(n=100)
+    @autotest()
     def test_avgpool3d_with_random_data(test_case):
         m = torch.nn.AvgPool3d(
             kernel_size=random(4, 6),
@@ -80,7 +80,7 @@ class TestAvgPoolingModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAvgPoolingFunctional(flow.unittest.TestCase):
-    @autotest(n=100)
+    @autotest()
     def test_avgpool1d_functional(test_case):
         device = random_device()
         x = random_pytorch_tensor(ndim=3, dim2=random(20, 22)).to(device)
@@ -94,7 +94,7 @@ class TestAvgPoolingFunctional(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(n=100)
+    @autotest()
     def test_avgpool2d_functional(test_case):
         device = random_device()
         x = random_pytorch_tensor(ndim=4, dim2=random(20, 22), dim3=random(20, 22)).to(
@@ -110,7 +110,7 @@ class TestAvgPoolingFunctional(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(n=100)
+    @autotest()
     def test_avgpool3d_functional(test_case):
         device = random_device()
         x = random_pytorch_tensor(

--- a/python/oneflow/test/modules/test_avgpool.py
+++ b/python/oneflow/test/modules/test_avgpool.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import unittest
-import numpy as np
 
 import oneflow as flow
 from oneflow.test_utils.automated_test_util.generators import constant, random_bool

--- a/python/oneflow/test/modules/test_maxpool.py
+++ b/python/oneflow/test/modules/test_maxpool.py
@@ -28,7 +28,7 @@ def unpack_indices(dual_object):
 
 @flow.unittest.skip_unless_1n1d()
 class TestMaxPooling(flow.unittest.TestCase):
-    @autotest(n=100, auto_backward=False)
+    @autotest(auto_backward=False)
     def test_maxpool1d_with_random_data(test_case):
         return_indices = random().to(bool).value()
         m = torch.nn.MaxPool1d(
@@ -50,7 +50,7 @@ class TestMaxPooling(flow.unittest.TestCase):
         else:
             return y, y.sum().backward()
 
-    @autotest(n=100, auto_backward=False)
+    @autotest(auto_backward=False)
     def test_maxpool2d_with_random_data(test_case):
         return_indices = random().to(bool).value()
         m = torch.nn.MaxPool2d(
@@ -74,7 +74,7 @@ class TestMaxPooling(flow.unittest.TestCase):
         else:
             return y, y.sum().backward()
 
-    @autotest(n=100, auto_backward=False)
+    @autotest(auto_backward=False)
     def test_maxpool3d_with_random_data(test_case):
         return_indices = random().to(bool).value()
         m = torch.nn.MaxPool3d(
@@ -101,7 +101,7 @@ class TestMaxPooling(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestMaxPoolingFunctional(flow.unittest.TestCase):
-    @autotest(n=100, auto_backward=False)
+    @autotest(auto_backward=False)
     def test_maxpool1d_with_random_data(test_case):
         return_indices = random().to(bool).value()
         device = random_device()
@@ -121,7 +121,7 @@ class TestMaxPoolingFunctional(flow.unittest.TestCase):
         else:
             return y, y.sum().backward()
 
-    @autotest(n=100, auto_backward=False)
+    @autotest(auto_backward=False)
     def test_maxpool2d_with_random_data(test_case):
         return_indices = random().to(bool).value()
         device = random_device()
@@ -143,7 +143,7 @@ class TestMaxPoolingFunctional(flow.unittest.TestCase):
         else:
             return y, y.sum().backward()
 
-    @autotest(n=100, auto_backward=False)
+    @autotest(auto_backward=False)
     def test_maxpool3d_with_random_data(test_case):
         return_indices = random().to(bool).value()
         device = random_device()

--- a/python/oneflow/test/modules/test_maxpool.py
+++ b/python/oneflow/test/modules/test_maxpool.py
@@ -99,5 +99,72 @@ class TestMaxPooling(flow.unittest.TestCase):
             return y, y.sum().backward()
 
 
+@flow.unittest.skip_unless_1n1d()
+class TestMaxPoolingFunctional(flow.unittest.TestCase):
+    @autotest(n=100, auto_backward=False)
+    def test_maxpool1d_with_random_data(test_case):
+        return_indices = random().to(bool).value()
+        device = random_device()
+        x = random_pytorch_tensor(ndim=3, dim2=random(20, 22)).to(device)
+        y = torch.nn.functional.max_pool1d(
+            x,
+            kernel_size=random(4, 6).to(int),
+            stride=random(1, 3).to(int) | nothing(),
+            padding=random(1, 3).to(int) | nothing(),
+            dilation=random(2, 4).to(int) | nothing(),
+            ceil_mode=random().to(bool),
+            return_indices=return_indices,
+        )
+
+        if return_indices:
+            return unpack_indices(y)
+        else:
+            return y, y.sum().backward()
+
+    @autotest(n=100, auto_backward=False)
+    def test_maxpool2d_with_random_data(test_case):
+        return_indices = random().to(bool).value()
+        device = random_device()
+        x = random_pytorch_tensor(ndim=4, dim2=random(20, 22), dim3=random(20, 22)).to(
+            device
+        )
+        y = torch.nn.functional.max_pool2d(
+            x,
+            kernel_size=random(4, 6).to(int),
+            stride=random(1, 3).to(int) | nothing(),
+            padding=random(1, 3).to(int) | nothing(),
+            dilation=random(2, 4).to(int) | nothing(),
+            ceil_mode=random().to(bool),
+            return_indices=return_indices,
+        )
+
+        if return_indices:
+            return unpack_indices(y)
+        else:
+            return y, y.sum().backward()
+
+    @autotest(n=100, auto_backward=False)
+    def test_maxpool3d_with_random_data(test_case):
+        return_indices = random().to(bool).value()
+        device = random_device()
+        x = random_pytorch_tensor(
+            ndim=5, dim2=random(20, 22), dim3=random(20, 22), dim4=random(20, 22)
+        ).to(device)
+        y = torch.nn.functional.max_pool3d(
+            x,
+            kernel_size=random(4, 6).to(int),
+            stride=random(1, 3).to(int) | nothing(),
+            padding=random(1, 3).to(int) | nothing(),
+            dilation=random(2, 4).to(int) | nothing(),
+            ceil_mode=random().to(bool),
+            return_indices=return_indices,
+        )
+
+        if return_indices:
+            return unpack_indices(y)
+        else:
+            return y, y.sum().backward()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/functional/generator.py
+++ b/tools/functional/generator.py
@@ -222,16 +222,17 @@ class Argument:
         sp = self._name.find("=")
         if sp != -1:
             self._default_value = _normalize(self._name[sp + 1 :])
-            if self._type.endswith("List"):
-                _value_list = [
-                    self._default_value for i in range(self._size)
-                ]  # For int32List[2] = 1, _value_list will be [1, 1]
-                self._default_cpp_value = (
-                    "{" + ", ".join(_value_list) + "}"
-                )  # [1, 1] -> "{1, 1}"
-            elif self._default_value == "None":
+            if self._default_value == "None":
                 self._optional = True
                 self._default_cpp_value = ""
+            elif self._type.endswith("List"):
+                if self._default_value != "None":
+                    _value_list = [
+                        self._default_value for i in range(self._size)
+                    ]  # For int32List[2] = 2, _value_list will be ["2", "2"]
+                    self._default_cpp_value = (
+                        "{" + ", ".join(_value_list) + "}"
+                    )  # ["2", "2"] -> "{2, 2}"
             elif self._default_value in value_aliases:
                 self._default_cpp_value = value_aliases[self._default_value]
             else:


### PR DESCRIPTION
修复pool系列的初始值设定

当stride没有给定值的时候，pytorch会给他设置为kernelsize的值