### PR TITLE
replace ##__LINE__ in ONEFLOW_API_PYBIND11_MODULE by OF_PP_CAT 

### DIFF
--- a/oneflow/api/python/of_api_registry.h
+++ b/oneflow/api/python/of_api_registry.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <map>
 #include <vector>
 #include <functional>
+#include "oneflow/core/common/preprocessor.h"
 
 namespace oneflow {
 
@@ -37,16 +38,17 @@ class OneflowModuleRegistry {
 
 }  // namespace oneflow
 
-#define ONEFLOW_API_PYBIND11_MODULE(module_path, m)                                                \
-  static void OneflowApiPythonModule##__LINE__(pybind11::module&);                                 \
-  namespace {                                                                                      \
-  struct OfApiRegistryInit {                                                                       \
-    OfApiRegistryInit() {                                                                          \
-      ::oneflow::OneflowModuleRegistry().Register(module_path, &OneflowApiPythonModule##__LINE__); \
-    }                                                                                              \
-  };                                                                                               \
-  OfApiRegistryInit of_api_registry_init;                                                          \
-  }                                                                                                \
-  static void OneflowApiPythonModule##__LINE__(pybind11::module& m)
+#define ONEFLOW_API_PYBIND11_MODULE(module_path, m)                                              \
+  static void OF_PP_CAT(OneflowApiPythonModule, __LINE__)(pybind11::module&);                    \
+  namespace {                                                                                    \
+  struct OfApiRegistryInit {                                                                     \
+    OfApiRegistryInit() {                                                                        \
+      ::oneflow::OneflowModuleRegistry().Register(module_path,                                   \
+                                                  &OF_PP_CAT(OneflowApiPythonModule, __LINE__)); \
+    }                                                                                            \
+  };                                                                                             \
+  OfApiRegistryInit of_api_registry_init;                                                        \
+  }                                                                                              \
+  static void OF_PP_CAT(OneflowApiPythonModule, __LINE__)(pybind11::module& m)
 
 #endif  // ONEFLOW_API_PYTHON_UTIL_OF_API_REGISTRY_H_

--- a/oneflow/api/python/of_api_registry.h
+++ b/oneflow/api/python/of_api_registry.h
@@ -49,6 +49,6 @@ class OneflowModuleRegistry {
   };                                                                                             \
   OfApiRegistryInit of_api_registry_init;                                                        \
   }                                                                                              \
-  static void OF_PP_CAT(OneflowApiPythonModule, __LINE__)(pybind11::module& m)
+  static void OF_PP_CAT(OneflowApiPythonModule, __LINE__)(pybind11::module & m)
 
 #endif  // ONEFLOW_API_PYTHON_UTIL_OF_API_REGISTRY_H_


### PR DESCRIPTION
宏定义内的 `abc##__LINE__` 不会被预处理成 `abc35` 等。 https://stackoverflow.com/questions/35087781/using-line-in-a-macro-definition