### PR TITLE
Replace reshape conf in grad acc pass

### DIFF
--- a/oneflow/core/common/shape.cpp
+++ b/oneflow/core/common/shape.cpp
@@ -122,8 +122,7 @@ void Shape::Set(int64_t index, int64_t val) {
   CHECK_GE(index, 0);
   CHECK_LT(index, this->NumAxes()) << " Shape: " << DebugStr() << " visit index: " << index
                                    << " > num_axes: " << this->NumAxes();
-  // NOTE(chengcheng): ONLY support set dim 0 need infer axis as -1
-  CHECK(val >= 0 || (index == 0 && val == -1));
+  CHECK_GE(val, 0);
   dim_vec_.at(index) = val;
   UpdateElemCnt();
 }

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -679,41 +679,18 @@ class ReshapeFunctor {
     }
     size_t x_count = x->shape()->Count(0);
     MutableAttrMap attrs;
-
-    if (LazyMode::is_enabled()) {
-      // NOTE(chengcheng):
-      //  in nn.Graph GradientAccumulation, the reshape conf in JobBuild and after insert acc/unpack
-      //  maybe NOT equal because of dim 0 scaled, so need set dim 0 as -1 for dynamic infer.
-      Shape remark_infer_shape = shape;
-      if (need_infer_axis >= 0) {
-        CHECK_EQ_OR_RETURN(x_count % count, 0);
-        CHECK_GE_OR_RETURN(x_count, count);
-        remark_infer_shape.Set(need_infer_axis, x_count / count);
-        CHECK_EQ_OR_RETURN(remark_infer_shape.Count(0), x_count)
-            << "\n Shape " << shape.ToString() << " is invalid for input shape "
-            << x->shape()->ToString();
-      }
-      if (remark_infer_shape.NumAxes() > 0 && x->shape()->NumAxes() > 0
-          && remark_infer_shape.At(0) == x->shape()->At(0)) {
-        // NOTE(chengcheng):
-        //  dim 0 no changed, so set -1 for dynamic infer
-        remark_infer_shape.Set(0, -1);
-      }
-      JUST(attrs.SetAttr<Shape>("shape", remark_infer_shape));
+    if (need_infer_axis == -1) {
+      CHECK_EQ_OR_RETURN(shape.Count(0), x_count)
+          << "\n Shape " << shape.ToString() << " is invalid for input shape "
+          << x->shape()->ToString();
+      JUST(attrs.SetAttr<Shape>("shape", shape));
     } else {
-      if (need_infer_axis == -1) {
-        CHECK_EQ_OR_RETURN(shape.Count(0), x_count)
-            << "\n Shape " << shape.ToString() << " is invalid for input shape "
-            << x->shape()->ToString();
-        JUST(attrs.SetAttr<Shape>("shape", shape));
-      } else {
-        Shape infered_shape = shape;
-        infered_shape.Set(need_infer_axis, x_count / count);
-        CHECK_EQ_OR_RETURN(infered_shape.Count(0), x_count)
-            << "\n Shape " << shape.ToString() << " is invalid for input shape "
-            << x->shape()->ToString();
-        JUST(attrs.SetAttr<Shape>("shape", infered_shape));
-      }
+      Shape infered_shape = shape;
+      infered_shape.Set(need_infer_axis, x_count / count);
+      CHECK_EQ_OR_RETURN(infered_shape.Count(0), x_count)
+          << "\n Shape " << shape.ToString() << " is invalid for input shape "
+          << x->shape()->ToString();
+      JUST(attrs.SetAttr<Shape>("shape", infered_shape));
     }
     return OpInterpUtil::Dispatch<Tensor>(*op_, {x}, attrs);
   }

--- a/oneflow/core/job_rewriter/gradient_accumulation_rewrite_pass.cpp
+++ b/oneflow/core/job_rewriter/gradient_accumulation_rewrite_pass.cpp
@@ -159,6 +159,26 @@ Maybe<void> GradientAccumulationRewritePass::Apply(Job* job, JobPassCtx* ctx) co
                                                               return_pack_op.output("out", 0));
       CHECK_EQ(return_in_lbn, old_val);
       return Maybe<void>::Ok();
+    } else if (op_conf.has_user_conf() && op_conf.user_conf().op_type_name() == "reshape") {
+      const LogicalBlobId in_lbi = node->op().BnInOp2Lbi(node->op().SoleIbn());
+      const LogicalBlobId out_lbi = node->op().BnInOp2Lbi(node->op().SoleObn());
+      const Shape& in_shape = node->LogicalBlobDesc4Lbi(in_lbi).shape();
+      const Shape& out_shape = node->LogicalBlobDesc4Lbi(out_lbi).shape();
+      if (in_shape.NumAxes() > 0 && out_shape.NumAxes() > 0 && in_shape.At(0) == out_shape.At(0)) {
+        // NOTE(chengcheng):
+        //  in nn.Graph GradientAccumulation, the reshape conf in JobBuild and after insert
+        //  acc/unpack maybe NOT equal because of dim 0 scaled, so need set dim 0 as -1 for
+        //  dynamic infer.
+        OperatorConf* new_reshape_op_conf = GetOperatorConf4Modify(op_conf);
+        AttrValue* attr_val = &(*new_reshape_op_conf->mutable_user_conf()->mutable_attr())["shape"];
+        CHECK(attr_val->has_at_shape());
+        ShapeProto* shape_conf = attr_val->mutable_at_shape();
+        CHECK_GT(shape_conf->dim_size(), 0);
+        shape_conf->set_dim(0, -1);
+        LOG(INFO) << " Replace ReshapeOpConf from: " << op_conf.DebugString() << " to "
+                  << new_reshape_op_conf->DebugString() << " for dynamic infer by insert unpack.";
+      }
+      return Maybe<void>::Ok();
     } else {
       return Maybe<void>::Ok();
     }


### PR DESCRIPTION
根据 后江 @hjchen2 的 idea，将 Reshape 的改动从 ReshapeFunctor 里的特判，移动到了 GradientAccumulationPass 中，有诸多好处：

- 取消了对 LazyMode 的特判；
- 维持了 Shape 原有的语义；
- 将 Grad Acc 对 Reshape 的改动保持在了 Grad Acc Pass 里