### PR TITLE
default mem chain merge false

### DIFF
--- a/oneflow/core/job/resource.proto
+++ b/oneflow/core/job/resource.proto
@@ -47,7 +47,8 @@ message Resource {
   optional int64 thread_local_cache_max_size = 17 [default = 67108864]; // 64M
   optional bool enable_debug_mode = 18 [default = false];
   optional bool enable_tensor_float_32_compute = 20 [default = true];
-  optional bool enable_mem_chain_merge = 21 [default = true];
+  // NOTE(chengcheng): mem chain merge has an implicit correctness bug under boundary conditions.
+  optional bool enable_mem_chain_merge = 21 [default = false];
   
   optional CollectiveBoxingConf collective_boxing_conf = 19;
 


### PR DESCRIPTION
将 MemoryChain 的 merge 的默认开关置为 false。因为有隐含的正确性问题。同时在绝大多数情况下，这个开关没有收益只有风险。（这个开关有意义的情形，是没有 grad acc 的 模型并行 且 使用 SliceBoxing隔断 的场景）

后续完善的 merge 实现将由

- #6287 

实现