### PR TITLE
Fix ddp all_reduce bug

### DIFF
--- a/python/oneflow/nn/parallel/ddp.py
+++ b/python/oneflow/nn/parallel/ddp.py
@@ -16,8 +16,8 @@ limitations under the License.
 from collections import OrderedDict
 
 import oneflow as flow
-from oneflow.ops.builtin_ops import BuiltinOp as builtin_op
 from oneflow.framework.tensor_tuple_util import convert_to_tensor_tuple
+from oneflow.ops.builtin_ops import BuiltinOp as builtin_op
 
 
 def allreduce_fn(ddp_state_for_reversed_params, param):
@@ -53,7 +53,7 @@ def DistributedDataParallel(
             x.requires_grad_(requires_grad)
 
     ddp_state_for_reversed_params = OrderedDict(
-        reversed([(x, [False, False]) for x in module.parameters()])
+        reversed([(x, [False, False]) for x in module.parameters() if x.requires_grad])
     )
     module._ddp_state_for_reversed_params = ddp_state_for_reversed_params
     for param in module.parameters():


### PR DESCRIPTION
修复 oneflow-face ddp 训练时遇到的 bug：https://github.com/Oneflow-Inc/OneTeam/issues/578#issuecomment-919370524

最小复现代码为：

<details>
<summary> 复现代码 </summary>

```python
import oneflow as flow
from oneflow.nn.parallel import DistributedDataParallel as ddp

train_x = [
    flow.tensor([[1, 2], [2, 3]], dtype=flow.float32),
    flow.tensor([[4, 6], [3, 1]], dtype=flow.float32),
]
train_y = [
    flow.tensor([[8], [13]], dtype=flow.float32),
    flow.tensor([[26], [9]], dtype=flow.float32),
]


class Model(flow.nn.Module):
    def __init__(self):
        super().__init__()
        self.lr = 0.01
        self.iter_count = 500
        self.w = flow.nn.Parameter(flow.tensor([[0], [0]], dtype=flow.float32))
        self.bn = flow.nn.BatchNorm2d(27)
        self.bn.weight.requires_grad = False

    def forward(self, x):
        x = flow.matmul(x, self.w)
        return x


m = Model().to("cuda")
m = ddp(m)
loss = flow.nn.MSELoss(reduction="sum")
optimizer = flow.optim.SGD(m.parameters(), m.lr)

for i in range(0, m.iter_count):
    rank = flow.env.get_rank()
    x = train_x[rank].to("cuda")
    y = train_y[rank].to("cuda")

    y_pred = m(x)
    l = loss(y_pred, y)
    #  if (i + 1) % 50 == 0:
    #      print(f"{i+1}/{m.iter_count} loss:{l}")

    l.backward()
    for name, param in m.named_parameters():
        print(f"{name}: {param}")
        print(f"{name}.grad: {param.grad}")
        print()
    exit(0)
    optimizer.step()
    optimizer.zero_grad()

print(f"\nw:{m.w}")
```

</details>

问题的原因是部分 Parameter.requires_grad 为 False，导致 all_reduce 时到这个 Parameter 中断了，在它上面声明的 Parameter 都无法 all_reduce 了。解决的办法是只把 requires_grad = True 的参数放入 all_reduce 列表中就可以了。