### PR TITLE
Fix bug of reshape rewrite in Single-Client grad acc

### DIFF
--- a/oneflow/core/job_rewriter/gradient_accumulation_rewrite_pass.cpp
+++ b/oneflow/core/job_rewriter/gradient_accumulation_rewrite_pass.cpp
@@ -159,7 +159,8 @@ Maybe<void> GradientAccumulationRewritePass::Apply(Job* job, JobPassCtx* ctx) co
                                                               return_pack_op.output("out", 0));
       CHECK_EQ(return_in_lbn, old_val);
       return Maybe<void>::Ok();
-    } else if (op_conf.has_user_conf() && op_conf.user_conf().op_type_name() == "reshape") {
+    } else if (is_multi_client && op_conf.has_user_conf()
+               && op_conf.user_conf().op_type_name() == "reshape") {
       const LogicalBlobId in_lbi = node->op().BnInOp2Lbi(node->op().SoleIbn());
       const LogicalBlobId out_lbi = node->op().BnInOp2Lbi(node->op().SoleObn());
       const Shape& in_shape = node->LogicalBlobDesc4Lbi(in_lbi).shape();


### PR DESCRIPTION
- 修复 #6254 引入的 Single-Client 下的 reshape BUG。给 reshape 设置 -1 推导是 nn.Graph 里的需求，不应该传染到老版本 Lazy 里（因为老版本 Lazy 的 shape 推导是支持 job 重写的）