### PR TITLE
remove references to "_C" in API documentation

### DIFF
--- a/python/oneflow/framework/docstr/activation.py
+++ b/python/oneflow/framework/docstr/activation.py
@@ -35,7 +35,7 @@ add_docstr(
 
         >>> x = flow.tensor(np.asarray([[[[1, -2], [3, 4]]]]), dtype=flow.float32)
         >>> alpha = flow.nn.Parameter(flow.tensor([1], dtype=flow.float32).fill_(0.25))
-        >>> print(flow._C.prelu(x, alpha).numpy())
+        >>> print(flow.nn.functional.prelu(x, alpha).numpy())
         [[[[ 1.  -0.5]
            [ 3.   4. ]]]]
    
@@ -139,7 +139,7 @@ add_docstr(
         >>> x = np.array([-0.5, 0, 0.5]).astype(np.float32)
         >>> input = flow.tensor(x)     
           
-        >>> out = flow._C.log_sigmoid(input)
+        >>> out = flow.nn.functional.log_sigmoid(input)
         >>> out
         tensor([-0.9741, -0.6931, -0.4741], dtype=oneflow.float32)
 
@@ -168,7 +168,7 @@ add_docstr(
 
         >>> x = np.array([1, 2, 3]).astype(np.float32)
         >>> input = flow.tensor(x) 
-        >>> out = flow._C.softsign(input)
+        >>> out = flow.nn.functional.softsign(input)
         >>> out
         tensor([0.5000, 0.6667, 0.7500], dtype=oneflow.float32)
  

--- a/python/oneflow/framework/docstr/dropout.py
+++ b/python/oneflow/framework/docstr/dropout.py
@@ -33,9 +33,9 @@ add_docstr(
 
     Description of Parameter misalignment:
 
-    Parameter generator : oneflow._C.dropout have it but torch.nn.functional.dropout do not.
+    Parameter generator : oneflow.nn.functional.dropout have it but torch.nn.functional.dropout do not.
     
-    Parameter training : torch.nn.functional.dropout have it but oneflow._C.dropout do not.
+    Parameter training : torch.nn.functional.dropout have it but oneflow.nn.functional.dropout do not.
 
     Args:      
         p: (float)probability of an element to be zeroed. Default: 0.5        
@@ -63,7 +63,7 @@ add_docstr(
         ...    ]
         ... )
         >>> x = flow.tensor(arr, dtype=flow.float32)
-        >>> y = flow._C.dropout(x, p=0) 
+        >>> y = flow.nn.functional.dropout(x, p=0) 
 
         >>> arr = np.array(
         ...    [
@@ -74,7 +74,7 @@ add_docstr(
         ... )
         >>> x = flow.tensor(arr, dtype=flow.float32)    
         >>> generator = flow.Generator()
-        >>> y = flow._C.dropout(x, 0.5, generator) 
+        >>> y = flow.nn.functional.dropout(x, 0.5, generator) 
       
 
     

--- a/python/oneflow/framework/docstr/onehot.py
+++ b/python/oneflow/framework/docstr/onehot.py
@@ -46,7 +46,7 @@ add_docstr(
         >>> import numpy as np
 
         >>> input=flow.tensor(np.array([0, 3, 1, 2]).astype(np.int32), dtype=flow.int64)
-        >>> out = flow._C.one_hot(input, num_classes=5)
+        >>> out = flow.nn.functional.one_hot(input, num_classes=5)
         >>> out
         tensor([[1, 0, 0, 0, 0],
                 [0, 0, 0, 1, 0],

--- a/python/oneflow/framework/docstr/vision.py
+++ b/python/oneflow/framework/docstr/vision.py
@@ -133,7 +133,7 @@ add_docstr(
         >>> import oneflow as flow
 
         >>> input = flow.tensor(np.arange(1, 5).reshape((1, 1, 2, 2)), dtype=flow.float32)  
-        >>> output = flow._C.upsample(input, height_scale=2.0, width_scale=2.0, align_corners=False, interpolation="nearest")
+        >>> output = flow.nn.functional.upsample(input, height_scale=2.0, width_scale=2.0, align_corners=False, interpolation="nearest")
     
         >>> output
         tensor([[[[1., 1., 2., 2.],


### PR DESCRIPTION
在线上的API文档中，部分样例代码包含了._C.
用nn.functional替换了在文档中出现的_C