### PR TITLE
support inpersistent state in a naive way

### DIFF
--- a/oneflow/core/framework/op_kernel.h
+++ b/oneflow/core/framework/op_kernel.h
@@ -279,6 +279,7 @@ class OpKernel {
   virtual std::shared_ptr<OpKernelState> CreateOpKernelState(KernelInitContext* ctx) const {
     return std::shared_ptr<OpKernelState>();
   }
+  virtual bool IsStatePersistentInEager() const { return true; }
 
   virtual void Compute(KernelComputeContext* ctx, OpKernelState*) const { Compute(ctx); }
   virtual void Compute(KernelComputeContext*) const { LOG(INFO) << "UNIMPLEMENTED"; }

--- a/oneflow/user/kernels/slice_kernel.cpp
+++ b/oneflow/user/kernels/slice_kernel.cpp
@@ -322,6 +322,8 @@ class LogicalSliceKernel final : public user_op::OpKernel {
     return CreateSliceState(ctx, "x");
   }
 
+  bool IsStatePersistentInEager() const override { return false; }
+
  private:
   void Compute(user_op::KernelComputeContext* ctx, user_op::OpKernelState* state) const override {
     user_op::Tensor* y_tensor = ctx->Tensor4ArgNameAndIndex("y", 0);
@@ -360,6 +362,8 @@ class LogicalSliceAssignKernel final : public user_op::OpKernel {
     }
     return CreateSliceState(ctx, "ref");
   }
+
+  bool IsStatePersistentInEager() const override { return false; }
 
  private:
   void Compute(user_op::KernelComputeContext* ctx, user_op::OpKernelState* state) const override {

--- a/oneflow/user/kernels/stateful_local_opkernel.h
+++ b/oneflow/user/kernels/stateful_local_opkernel.h
@@ -433,11 +433,10 @@ class StatefulLocalOpKernel final {
   user_op::TensorDescInferFn TensorDescInferFn() const;
   user_op::DataTypeInferFn DataTypeInferFn() const;
 
-  void TryInitOpKernelState(
+  std::shared_ptr<user_op::OpKernelState> TryInitOpKernelState(
       const user_op::OpKernel* op_kernel, DeviceCtx* device_ctx,
       const EagerBlobObjectListPtr& inputs, const EagerBlobObjectListPtr& outputs,
-      const std::shared_ptr<const ConsistentTensorInferResult>& consistent_tensor_infer_result,
-      user_op::OpKernelState** state);
+      const std::shared_ptr<const ConsistentTensorInferResult>& consistent_tensor_infer_result);
 
   vm::EagerBlobObject* mut_temp_blob_object();
 

--- a/python/oneflow/test/modules/test_stateful_kernel_with_inpersistent_state.py
+++ b/python/oneflow/test/modules/test_stateful_kernel_with_inpersistent_state.py
@@ -1,0 +1,38 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+import numpy as np
+import oneflow as flow
+import oneflow.unittest
+
+@flow.unittest.skip_unless_1n2d()
+class TestStatefulKernelWithInpersistentState(flow.unittest.TestCase):
+    def test_stateful_kernel_with_inpersistent_state(test_case):
+        x = flow.arange(4).reshape(2, 2)
+        x = x.to_consistent(flow.env.all_device_placement('cuda'), flow.sbp.split(0))
+        y = flow._C.logical_slice(x, [0, 0], [3, 1], [1, 1])
+        y_np = np.array([[0], [2], [0]])
+        test_case.assertTrue(np.array_equal(y.to_consistent(sbp=flow.sbp.broadcast).to_local().numpy(), y_np))
+        x = x.to_consistent(sbp=flow.sbp.split(1))
+        y = flow._C.logical_slice(x, [0, 0], [3, 1], [1, 1])
+        test_case.assertTrue(np.array_equal(y.to_consistent(sbp=flow.sbp.broadcast).to_local().numpy(), y_np))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
背景：https://github.com/Oneflow-Inc/OneTeam/issues/629 

这个 pr 只能暂时避免 tensor 切片赋值操作出错的问题，不是 https://github.com/Oneflow-Inc/OneTeam/issues/629 的最终解决方案（因为 state 是否是 persistent 还依赖于 op expr 的调用方式，不应该只把 IsStatePersistentInEager() 这个信息实现在 kernel 层）