### PR TITLE
Fix fuse_conv_bn bug

### DIFF
--- a/python/oneflow/fx/passes/quantization_ops/fuse_conv_bn.py
+++ b/python/oneflow/fx/passes/quantization_ops/fuse_conv_bn.py
@@ -1,6 +1,22 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 import oneflow as flow
 
 __all__ = ["QConvBN"]
+
 
 class QConvBN(flow.nn.Module):
     def __init__(
@@ -11,7 +27,7 @@ class QConvBN(flow.nn.Module):
         quantization_scheme="symmetric",
         quantization_formula="google",
         per_layer_quantization=True,
-        momentum = 0.95,
+        momentum=0.95,
     ):
         super().__init__()
         self.quantization_bit = quantization_bit
@@ -21,9 +37,14 @@ class QConvBN(flow.nn.Module):
         self.conv_module = conv_module
         self.bn_module = bn_module
 
-        self.moving_min_max_observer = flow.nn.MovingAverageMinMaxObserver(training=self.training, quantization_formula=quantization_formula,
-                                                                       stop_update_after_iters=1, quantization_bit=quantization_bit,
-                                                                       quantization_scheme=quantization_scheme, momentum=momentum)
+        self.moving_min_max_observer = flow.nn.MovingAverageMinMaxObserver(
+            training=self.training,
+            quantization_formula=quantization_formula,
+            stop_update_after_iters=1,
+            quantization_bit=quantization_bit,
+            quantization_scheme=quantization_scheme,
+            momentum=momentum,
+        )
 
         self.min_max_observer = flow.nn.MinMaxObserver(
             quantization_formula=quantization_formula,
@@ -31,7 +52,7 @@ class QConvBN(flow.nn.Module):
             quantization_scheme=quantization_scheme,
             per_layer_quantization=per_layer_quantization,
         )
-        
+
         self.fake_quantization = flow.nn.FakeQuantization(
             quantization_formula=quantization_formula,
             quantization_bit=quantization_bit,
@@ -59,10 +80,11 @@ class QConvBN(flow.nn.Module):
                 bias = -gamma_ * mean
 
         return weight, bias
-    
 
     def forward(self, x):
-        scale, zero_point = self.moving_min_max_observer(x, flow.tensor([0], dtype=flow.int64).to(x.device.type))
+        scale, zero_point = self.moving_min_max_observer(
+            x, flow.tensor([0], dtype=flow.int64).to(x.device.type)
+        )
         x = self.fake_quantization(x, scale, zero_point)
         if self.training:
             y = flow.nn.functional.conv2d(
@@ -78,18 +100,19 @@ class QConvBN(flow.nn.Module):
             y = y.view(self.conv_module.out_channels, -1)  # CNHW -> C,NHW
             mean = y.mean(1)
             var = y.var(1)
-            self.bn_module.running_mean = (
-                self.bn_module.momentum * self.bn_module.running_mean
-                + (1 - self.bn_module.momentum) * mean
-            )
-            self.bn_module.running_var = (
-                self.bn_module.momentum * self.bn_module.running_var
-                + (1 - self.bn_module.momentum) * var
-            )
+            with flow.no_grad():
+                self.bn_module.running_mean = (
+                    self.bn_module.momentum * self.bn_module.running_mean
+                    + (1 - self.bn_module.momentum) * mean
+                )
+                self.bn_module.running_var = (
+                    self.bn_module.momentum * self.bn_module.running_var
+                    + (1 - self.bn_module.momentum) * var
+                )
         else:
             mean = flow.tensor(self.bn_module.running_mean)
             var = flow.tensor(self.bn_module.running_var)
-        
+
         std = flow.sqrt(var + self.bn_module.eps)
         weight, bias = self.fold_bn(mean, std)
 
@@ -104,4 +127,3 @@ class QConvBN(flow.nn.Module):
             groups=self.conv_module.groups,
         )
         return res
- 


### PR DESCRIPTION
用 #5939 的代码跑量化训练时会发现显存泄漏的问题，发现显存 2M 2M 的在增加，而单独跑 eager 训练就没有问题：

```python
import oneflow as flow
import oneflow.nn as nn


class SimpleNet(nn.Module):

    def __init__(self, num_classes=10):
        super(SimpleNet, self).__init__()
        self.features = nn.Sequential(
            nn.Conv2d(3, 64, kernel_size=3, stride=8, padding=2),
            nn.BatchNorm2d(64),
        )


    def forward(self, x):
        conv_features = self.features(x)
        return conv_features

if __name__ == "__main__":
    net = SimpleNet().to("cuda:0")
    for _ in range(500):
        for _ in range(500):
            x = flow.randn(1, 3, 32, 32, requires_grad=True).to("cuda")
            y = net(x).sum()
            y.backward()
```

问题的原因是 QConvBN 中对 running_mean 和 running_var 的更新没有用 flow.no_grad 包围，一旦 input 的 requires_grad 为 True 时，mean 和 var 的 requires_grad 就也为 True，导致更新后 running_mean 和 running_var 的 requires_grad 就也为 True。

然而 running_mean/var 的后向图中，会捕获之前的 running_mean/var，导致每一次迭代计算的 running_mean/var 都在 FunctionNode 中被捕获无法释放。造成的显存泄漏。

```python
self.bn_module.running_mean = (
                  self.bn_module.momentum * self.bn_module.running_mean
                  + (1 - self.bn_module.momentum) * mean
)
```