### PR TITLE
Fix BUG of reshape op infer -1

### DIFF
--- a/oneflow/user/ops/reshape_op.cpp
+++ b/oneflow/user/ops/reshape_op.cpp
@@ -99,7 +99,11 @@ Maybe<void> TensorDescInferFn(user_op::InferContext* ctx) {
   }
   const auto& nd_sbp = ctx->NdSbp4ArgNameAndIndex("out", 0);
   *out_shape = *JUST(GetPhysicalShape(shape, nd_sbp, ctx->parallel_desc(), ctx->parallel_ctx()));
-  CHECK_EQ_OR_RETURN(out_shape->elem_cnt(), in_shape.elem_cnt());
+  CHECK_EQ_OR_RETURN(out_shape->elem_cnt(), in_shape.elem_cnt())
+      << " Reshape infer ERROR! in op_name: " << ctx->op_name()
+      << " input shape is : " << in_shape.ToString()
+      << " , output shape is : " << out_shape->ToString()
+      << " , And reshape shape conf is : " << ctx->Attr<Shape>("shape").ToString();
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
修复 Reshape Op 推导 infer -1 的 BUG。

之前的代码仅考虑了 -1 来自用户配置，而忽略了系统添加的 reshape op 包含 -1 的情形；所以必须老老实实的推导 reshape 的 -1 值为多少。而不是特判仅和 dim 0 相同 。

（在 BERT grad acc 多卡时会报错）