### PR TITLE
nn.Graph support host eager tensor to gpu

### DIFF
--- a/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
@@ -535,7 +535,6 @@ Maybe<void> LazyInterpreterApplyImplForCopyUserOpExpr(const UserOpExpr& op_expr,
   CHECK_EQ_OR_RETURN(inputs.size(), 1);
   CHECK_EQ_OR_RETURN(op_expr.input_size(), 1);
   const std::shared_ptr<Tensor>& input_tensor = inputs.at(0);
-  CHECK_OR_RETURN(input_tensor->is_lazy());
   std::string input_lbn = TensorNameScope::Global()->Lookup(input_tensor);
   if (input_lbn.empty()) {
     JUST(AddFreeEagerTensorToVariableOp(input_tensor));

--- a/python/oneflow/nn/modules/to.py
+++ b/python/oneflow/nn/modules/to.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 import oneflow as flow
 from oneflow.framework.tensor import register_tensor_op
+import oneflow._oneflow_internal.lazy_mode as lazy_mode
 
 
 def _tensor_to(input, device, dtype, copy=False):
@@ -55,7 +56,7 @@ def _consistent_tensor_to(input, device_type, dtype, copy=False):
     if device_type == input.placement.device_type and dtype == input.dtype:
         return input if not copy else input.clone()
 
-    if input.is_lazy:
+    if lazy_mode.is_enabled():
         return _lazy_consistent_tensor_to(input, device_type, dtype)
     else:
         return _eager_consistent_tensor_to(input, device_type, dtype)


### PR DESCRIPTION
- [x] 支持 nn.Graph 内部创建的 FreeEagerTensor 后面接 .to("cuda")
- [x] 支持 CPU 上的 Eager Variable Tensor 在 nn.Graph 内部 .to("cuda") 和 .to_consistent("cuda")
