### PR TITLE
fix tensor.uniform_

### DIFF
--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -482,6 +482,12 @@ def _triu(self, diagonal=0):
 
 
 def _uniform(self, a=0, b=1):
+    if isinstance(a, Tensor):
+        assert a.ndim == 0 and a.nelement() == 1  , "a must be a integer or scalar tensor!"
+        a = a.numpy().item()
+    if isinstance(b, Tensor):
+        assert b.ndim == 0 and b.nelement() == 1  , "a must be a integer or scalar tensor!"
+        b = b.numpy().item()
     initializer_conf = flow.random_uniform_initializer(
         minval=a, maxval=b, dtype=self.dtype
     )


### PR DESCRIPTION
Fix @doombeaker 跑一个demo时发现的bug：Tensor.uniform_方法不支持scalar tensor作为上下界。

torch
```python
>>> import torch
>>> x1 = torch.tensor(-0.2)
>>> x2 = torch.tensor(0.2)
>>> y = torch.empty(1).uniform_(x1, x2)
>>> y
tensor([-0.0980])
```
oneflow fix前会报错：
```python
>>> import oneflow as flow
>>> x1 = flow.tensor(-0.2)
>>> x2 = flow.tensor(0.2)
>>> y = flow.empty(1).uniform_(x1, x2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/luyang/Oneflow/oneflow/python/oneflow/framework/tensor.py", line 486, in _uniform
    minval=a, maxval=b, dtype=self.dtype
  File "/home/luyang/Oneflow/oneflow/python/oneflow/ops/initializer_util.py", line 352, in random_uniform_initializer
    setattr(initializer.random_uniform_conf, "min", float(minval))
TypeError: float() argument must be a string or a number, not 'oneflow._oneflow_internal.Tensor'
>>>
```

fix后：
```python
>>> import oneflow as flow
>>> x1 = flow.tensor(-0.2)
>>> x2 = flow.tensor(0.2)
>>> y = flow.empty(1).uniform_(x1, x2)
>>> tensor([0.0564], dtype=oneflow.float32)
```
