### PR TITLE
async construct tensor from numpy array

### DIFF
--- a/oneflow/api/python/utils/tensor_utils.h
+++ b/oneflow/api/python/utils/tensor_utils.h
@@ -75,6 +75,15 @@ inline Maybe<void> CopyBetweenMirroredTensorAndNumpy(const std::shared_ptr<Tenso
           is_printed = true;
         }
       }));
+  // JUST(PhysicalRun([&](InstructionsBuilder* builder) -> Maybe<void> {
+  //   //   JUST(builder->AccessBlobByCallback(
+  //     //       tensor,
+  //       //       [array, Copy](uint64_t ofblob_ptr) {
+  //         //         CHECK_JUST(Copy(ofblob_ptr, array));
+  //           //       },
+  //             //       modifier));
+  //               //   return Maybe<void>::Ok();
+  //                 // }));
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
Oneflow-Inc/OneTeam/issues/677
从np array 构建tensor时，改为异步拷贝数据并进行性能的比较
目前简单地测试了一下CPU,GPU上oneflow同步，异步和torch的性能，可以看出异步copy的性能提升比较大。测试代码如下：
（以下为CPU测试代码和测试结果）
```
import oneflowas flow
import numpy as np
import time

loop = 100

data = np.random.rand(100, 100, 100, 10)

start = time.time()
for i in range(loop):
    x = flow.tensor(data, device='cpu')

print("test case: oneflow, device=cpu, shape=(100,100,100,10), loop=", loop, ", time=", time.time() - start)
```

测试结果：

```
test oneflow sync
test case: oneflow, device=cpu, shape=(100,100,100,10), loop= 100 , time= 7.112638711929321
test case: oneflow, device=cpu, shape=(100,100,100,10), loop= 100 , time= 7.445601224899292
test case: oneflow, device=cpu, shape=(100,100,100,10), loop= 100 , time= 7.653692007064819

test oneflow async:
test case: oneflow, device=cpu, shape=(100,100,100,10), loop= 100 , time= 1.6982994079589844
test case: oneflow, device=cpu, shape=(100,100,100,10), loop= 100 , time= 1.5714929103851318
test case: oneflow, device=cpu, shape=(100,100,100,10), loop= 100 , time= 1.5994224548339844

test torch: 
test case: torch, device=cpu, shape=(100,100,100,10), loop= 100 , time= 1.6106979846954346
test case: torch, device=cpu, shape=(100,100,100,10), loop= 100 , time= 1.540008783340454
test case: torch, device=cpu, shape=(100,100,100,10), loop= 100 , time= 1.64304518699646
```
以下是GPU测试代码和测试结果：
```
import torch
import numpy as np
import time

loop = 100

data = np.random.rand(100, 100, 100, 10)
torch.tensor(data, device="cuda").cpu().numpy()

start = time.time()
for i in range(loop):
    x = torch.tensor(data, device='cuda')

print("test case: torch, device=cuda, shape=(100,100,100,10), loop=", loop, ", time=", time.time() - start)
```
```
GPU tests:
test oneflow sync:
test case: oneflow, device=cuda, shape=(100,100,100,10), loop= 100 , time= 2.850877523422241
test case: oneflow, device=cuda, shape=(100,100,100,10), loop= 100 , time= 3.249467372894287
test case: oneflow, device=cuda, shape=(100,100,100,10), loop= 100 , time= 3.2295963764190674

test oneflow async:
test case: oneflow, device=cuda, shape=(100,100,100,10), loop= 100 , time= 0.0029370784759521484
test case: oneflow, device=cuda, shape=(100,100,100,10), loop= 100 , time= 0.005952119827270508
test case: oneflow, device=cuda, shape=(100,100,100,10), loop= 100 , time= 0.0030112266540527344

test torch: 
test case: torch, device=cuda, shape=(100,100,100,10), loop= 100 , time= 0.9699256420135498
test case: torch, device=cuda, shape=(100,100,100,10), loop= 100 , time= 1.233154535293579
test case: torch, device=cuda, shape=(100,100,100,10), loop= 100 , time= 1.2271559238433838
```