### PR TITLE
adjust GILForeignLockHelper order to avoid glog print to stderr

### DIFF
--- a/python/oneflow/__init__.py
+++ b/python/oneflow/__init__.py
@@ -156,7 +156,6 @@ import oneflow.framework.register_python_callback
 
 INVALID_SPLIT_AXIS = oneflow._oneflow_internal.INVALID_SPLIT_AXIS
 register_class_method_util.RegisterMethod4Class()
-oneflow._oneflow_internal.RegisterGILForeignLockHelper()
 import oneflow.framework.env_util as env_util
 import oneflow.framework.scope_util as scope_util
 import oneflow.framework.session_context as session_ctx
@@ -166,6 +165,7 @@ if not env_util.HasAllMultiClientEnvVars():
     env_util.SetDefaultMultiClientEnvVars()
 oneflow._oneflow_internal.SetIsMultiClient(True)
 env_util.api_env_init()
+oneflow._oneflow_internal.RegisterGILForeignLockHelper()
 oneflow._oneflow_internal.InitDefaultConsistentTransportTokenScope()
 session_ctx.OpenDefaultSession(
     MultiClientSession(oneflow._oneflow_internal.NewSessionId())


### PR DESCRIPTION
把注册调整到evn init后，消除这个不正常展示的日志：
```
WARNING: Logging before InitGoogleLogging() is written to STDERR
I1102 11:04:26.252228 40372 global.h:43] DeleteGlobal N7oneflow17ForeignLockHelperE
```