### PR TITLE
Auto parallel/greedy search

### DIFF
--- a/oneflow/core/auto_parallel/algorithm_util.cpp
+++ b/oneflow/core/auto_parallel/algorithm_util.cpp
@@ -24,7 +24,7 @@ namespace auto_parallel {
 // equality. For example, we have v[0] < v[1] = v[2] < v[3] We do not know v[1] is before or after
 // v[2] with comp(v[1], v[2]). But if we transfer it to order order[0] < order[1] < order[2] <
 // order[3] We know the strict order.
-void InverseOrder(std::vector<int32_t>& order, std::vector<int32_t>& InvOrder) {
+void InverseOrder(const std::vector<int32_t>& order, std::vector<int32_t>& InvOrder) {
   InvOrder.resize(order.size());
   for (int32_t i = 0; i < order.size(); i++) { InvOrder[order[i]] = i; }
 }

--- a/oneflow/core/auto_parallel/algorithm_util.h
+++ b/oneflow/core/auto_parallel/algorithm_util.h
@@ -46,7 +46,7 @@ void CheckAndRemoveFrom(std::vector<T>& v, T& t) {
 
 // Inverse function, which transfer a vector to an unorder_map.
 template<class T>
-void InverseFunction(std::vector<T>& v, std::unordered_map<T, int32_t>& InverseMap) {
+void InverseFunction(const std::vector<T>& v, std::unordered_map<T, int32_t>& InverseMap) {
   InverseMap.clear();
   for (int32_t i = 0; i < v.size(); i++) { InverseMap[v[i]] = i; }
 }
@@ -57,7 +57,7 @@ void InverseFunction(std::vector<T>& v, std::unordered_map<T, int32_t>& InverseM
 // We could define the comparison, then we have
 // comp(v[order[i]], v[order[j]]) == true for all i<j.
 template<class T, class Compare>
-void DecideOrder(std::vector<T>& v, std::vector<int32_t>& order, Compare comp) {
+void DecideOrder(const T& v, std::vector<int32_t>& order, Compare comp) {
   // Initialize order
   order.resize(v.size());
   for (int32_t i = 0; i < v.size(); i++) { order[i] = i; }
@@ -70,7 +70,7 @@ void DecideOrder(std::vector<T>& v, std::vector<int32_t>& order, Compare comp) {
 // equality. For example, we have v[0] < v[1] = v[2] < v[3] We do not know v[1] is before or after
 // v[2] with comp(v[1], v[2]). But if we transfer it to order order[0] < order[1] < order[2] <
 // order[3] We know the strict order.
-void InverseOrder(std::vector<int32_t>& order, std::vector<int32_t>& InvOrder);
+void InverseOrder(const std::vector<int32_t>& order, std::vector<int32_t>& InvOrder);
 
 }  // namespace auto_parallel
 }  // namespace oneflow

--- a/oneflow/core/auto_parallel/sbp_constructor.cpp
+++ b/oneflow/core/auto_parallel/sbp_constructor.cpp
@@ -54,7 +54,7 @@ Maybe<void> SbpConstructor::FindBestSbpSignature() {
   LOG(INFO) << "Initial cost: " << ori_cost;
   int elimination_num = sbp_graph_.NodeAndEdgeEliminations();
   LOG(INFO) << "Elimination number: " << elimination_num;
-  sbp_graph_.GreedyStrategy(false);
+  sbp_graph_.GreedyStrategy(5);
   sbp_graph_.FinalizeSbp();
 
   double final_cost = sbp_graph_.ComputeCost();

--- a/oneflow/core/auto_parallel/sbp_graph.h
+++ b/oneflow/core/auto_parallel/sbp_graph.h
@@ -484,7 +484,10 @@ double SbpGraph<SbpSignature>::GreedyStrategy(int32_t nbh_num) {
   int32_t step = 0;
   // 1 ring neighborhood buffer
   std::vector<int32_t> nbh_1ring(nbh_num);
+  // 2 ring neighborhood buffer
   std::vector<int32_t> nbh_2ring;
+  std::vector<bool> node_tags(NodeList.size(), false);
+  std::vector<int32_t> nbh_1ring_buffer;
 
 
   while (head != tail && step < NodeList.size()) {
@@ -533,7 +536,8 @@ double SbpGraph<SbpSignature>::GreedyStrategy(int32_t nbh_num) {
         // If changes occur
         if (OrgSbpSignatureId[nbh_id] != NodeList[nbh_1ring[nbh_id]]->FinalSbpSignatureId) {
           // schedule to visit the neighborhood of that changing node
-          NodeList[nbh_1ring[nbh_id]]->OneRingNeighborhood(nbh_2ring);
+          NodeList[nbh_1ring[nbh_id]]->NRingNeighborhood(2, nbh_2ring, nbh_1ring_buffer, NodeList,
+                                                         node_tags);
           for (int32_t nbh_NodeListId : nbh_2ring) {
             // Put them into the pre-visited node list
             if (!PreVisitTags[nbh_NodeListId]) {

--- a/oneflow/core/graph/op_graph.cpp
+++ b/oneflow/core/graph/op_graph.cpp
@@ -563,6 +563,7 @@ void OpGraph::PrintSBPGraphDebugInfo() {
   auto_parallel::DecideOrder(NodeList, order, [&](OpNode* a, OpNode* b) {
     return a->op().op_name().compare(b->op().op_name()) > 0;
   });
+  std::vector<int32_t> str_order;
 
   // test debug
   std::cout << "Finish deciding order" << std::endl;
@@ -570,8 +571,13 @@ void OpGraph::PrintSBPGraphDebugInfo() {
   for (int32_t i = 0; i < NodeList.size(); i++) {
     OpNode* op_node = NodeList[order[i]];
     std::cout << op_node->op().op_name() << " (^_^):" << std::endl;
+    // Sort before printing
+    const auto& op_input_bns = op_node->op().input_bns();
+    auto comp = [](const std::string& a, const std::string& b) { return a.compare(b) > 0; };
+    auto_parallel::DecideOrder(op_input_bns, str_order, comp);
     // Print out SBP information for input operator
-    for (const auto& ibn : op_node->op().input_bns()) {
+    for (int32_t j : str_order) {
+      const auto& ibn = op_input_bns[j];
       auto producer_node = op_node->MutSrcNode4Ibn(ibn);
       std::cout << "Pre Op:" << producer_node->op().op_name() << ": " << ibn;
       const auto& this_sbp_parallel = op_node->SbpParallel4BnInOp(ibn);
@@ -583,13 +589,17 @@ void OpGraph::PrintSBPGraphDebugInfo() {
                 << op_node->LogicalBlobDesc4Lbi(op_node->op().BnInOp2Lbi(ibn)).shape().elem_cnt();
       std::cout << std::endl;
     }
+    // Sort before printing
+    const auto& op_output_bns = op_node->op().output_bns();
+    auto_parallel::DecideOrder(op_output_bns, str_order, comp);
     // Print out SBP information for output blobs
-    for (const auto& ibn : op_node->op().output_bns()) {
-      std::cout << "Out Op:" << ibn;
-      const auto& this_sbp_parallel = op_node->SbpParallel4BnInOp(ibn);
+    for (int32_t j : str_order) {
+      const auto& obn = op_output_bns[j];
+      std::cout << "Out Op:" << obn;
+      const auto& this_sbp_parallel = op_node->SbpParallel4BnInOp(obn);
       std::cout << ", " << SbpParallelToString(this_sbp_parallel);
       std::cout << ", "
-                << op_node->LogicalBlobDesc4Lbi(op_node->op().BnInOp2Lbi(ibn)).shape().elem_cnt();
+                << op_node->LogicalBlobDesc4Lbi(op_node->op().BnInOp2Lbi(obn)).shape().elem_cnt();
       std::cout << std::endl;
     }
   }

--- a/oneflow/core/job/compiler.cpp
+++ b/oneflow/core/job/compiler.cpp
@@ -51,6 +51,8 @@ void Compiler::Compile(Job* job, Plan* plan, bool need_job_complete) const {
 
   // Step2: new Global<OpGraph> and set log configs.
   Global<OpGraph>::New(*job);
+  // Print Auto Parallel SBP
+  Global<OpGraph>::Get()->PrintSBPGraphDebugInfo();
   const JobDesc& job_desc = GlobalJobDesc();
   if (Global<ResourceDesc, ForSession>::Get()->enable_debug_mode()
       || Global<ResourceDesc, ForSession>::Get()->enable_dry_run()) {

--- a/oneflow/core/job/compiler.cpp
+++ b/oneflow/core/job/compiler.cpp
@@ -51,8 +51,6 @@ void Compiler::Compile(Job* job, Plan* plan, bool need_job_complete) const {
 
   // Step2: new Global<OpGraph> and set log configs.
   Global<OpGraph>::New(*job);
-  // Print Auto Parallel SBP
-  Global<OpGraph>::Get()->PrintSBPGraphDebugInfo();
   const JobDesc& job_desc = GlobalJobDesc();
   if (Global<ResourceDesc, ForSession>::Get()->enable_debug_mode()
       || Global<ResourceDesc, ForSession>::Get()->enable_dry_run()) {


### PR DESCRIPTION
1. Reduce searching complexity by adjusting greedy searches. 
2. Decide order with the names of blobs while printing.