### PR TITLE
fix wrong raii usage in nccl_executor_backend.cu 

### DIFF
--- a/oneflow/core/job/collective_boxing/nccl_executor_backend.cu
+++ b/oneflow/core/job/collective_boxing/nccl_executor_backend.cu
@@ -126,7 +126,7 @@ class CommRank final {
 
   ~CommRank() {
     if (nccl_comm_ != nullptr) {
-      CudaCurrentDeviceGuard(device_id_);
+      CudaCurrentDeviceGuard guard(device_id_);
       OF_NCCL_CHECK(ncclCommDestroy(nccl_comm_));
     }
   }
@@ -136,7 +136,7 @@ class CommRank final {
   ncclComm_t nccl_comm() const { return nccl_comm_; }
 
   void InitRank(ncclUniqueId unique_id, int32_t global_rank_count) {
-    CudaCurrentDeviceGuard(device_id_);
+    CudaCurrentDeviceGuard guard(device_id_);
     OF_NCCL_CHECK(ncclCommInitRank(&nccl_comm_, global_rank_count, unique_id, global_rank_));
   }
 


### PR DESCRIPTION
用 clang 编译 gpu 版 oneflow 时根据编译日志发现的问题，`CudaCurrentDeviceGuard(device_id_);` 实际是一个 c 风格的类型转换，会构造出一个立即被销毁的 CudaCurrentDeviceGuard 临时对象，所以实际上没有起到作用