### PR TITLE
Output op use sbp in blob_conf

### DIFF
--- a/oneflow/core/operator/output_op.cpp
+++ b/oneflow/core/operator/output_op.cpp
@@ -81,6 +81,8 @@ Maybe<void> OutputOp::GetSbpSignatures(cfg::SbpSignatureList* sbp_sig_list) cons
   } else if (sbp_parallel.has_split_parallel()) {
     int64_t split_axis = sbp_parallel.split_parallel().axis();
     SbpSignatureBuilder().Split("in", split_axis).Split("out", split_axis).Build(sbp);
+  } else {
+    UNIMPLEMENTED_THEN_RETURN();
   }
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/output_op.cpp
+++ b/oneflow/core/operator/output_op.cpp
@@ -66,9 +66,6 @@ Maybe<void> OutputOp::InferOutBlobDescs(
 }
 
 Maybe<void> OutputOp::GetSbpSignatures(cfg::SbpSignatureList* sbp_sig_list) const {
-  JUST(InterfaceOpUtil::GetOutputLikeOpSbpSignature(op_conf().output_conf().blob_conf(),
-                                                    input_bns(), output_bns(),
-                                                    sbp_sig_list->mutable_sbp_signature()->Add()));
   cfg::SbpSignature* sbp = sbp_sig_list->mutable_sbp_signature()->Add();
   CHECK_EQ_OR_RETURN(JUST(GetOpParallelDesc())->hierarchy()->NumAxes(), 1)
       << "Only support 1d sbp now.";


### PR DESCRIPTION
解决自动并行决策 OutputOp 的 Sbp 后，被 OpGraph 从 BlobConf 中覆盖，导致产生了 B->P boxing 的 bug。