### PR TITLE
CopyBetweenMirroredTensorAndNumpy  support storage_offset

### DIFF
--- a/oneflow/api/python/ofblob/ofblob.e.h
+++ b/oneflow/api/python/ofblob/ofblob.e.h
@@ -48,6 +48,26 @@ struct OfBlob_CopyBuffer {
     of_blob->AutoMemCopyTo<T>(buf_ptr, size);
     return Maybe<void>::Ok();
   }
+
+  template<typename T>
+  static Maybe<void> From(uint64_t of_blob_ptr, int64_t storage_offset,
+                          const NumPyArrayPtr& array) {
+    T* buf_ptr = (T*)array.data();
+    size_t size = array.size();
+    auto* of_blob = reinterpret_cast<OfBlob*>(of_blob_ptr);
+    of_blob->AutoMemCopyFrom<T>(buf_ptr, storage_offset, size);
+    return Maybe<void>::Ok();
+  }
+
+  template<typename T>
+  static Maybe<void> To(uint64_t of_blob_ptr, int64_t storage_offset, const NumPyArrayPtr& array) {
+    T* buf_ptr = (T*)array.data();
+    size_t size = array.size();
+    auto* of_blob = reinterpret_cast<OfBlob*>(of_blob_ptr);
+    of_blob->AutoMemCopyTo<T>(buf_ptr, storage_offset, size);
+    return Maybe<void>::Ok();
+  }
+
 };
 
 }  // namespace oneflow

--- a/oneflow/api/python/utils/tensor_utils.h
+++ b/oneflow/api/python/utils/tensor_utils.h
@@ -41,12 +41,15 @@ Maybe<void> EagerMirroredTensorZeros(const std::shared_ptr<Tensor>& t);
 template<typename T>
 inline Maybe<void> CopyBetweenMirroredTensorAndNumpy(
     const std::shared_ptr<Tensor>& t, PyObject* array,
-    Maybe<void> (*Copy)(uint64_t, const NumPyArrayPtr&), const std::string& modifier,
+    Maybe<void> (*Copy)(uint64_t, int64_t, const NumPyArrayPtr&), const std::string& modifier,
     bool block_host_until_done) {
   std::shared_ptr<MirroredTensor> tensor;
   CHECK_OR_RETURN(t->is_eager()) << "eager tensors supported only";
+  int64_t storage_offset = 0;
   if (t->is_local()) {
     tensor = JUST(t->AsMirroredTensor());
+    // view op could generate none-zero storage_offset
+    storage_offset = JUST(tensor->eager_blob_object())->storage_offset();
   } else {
     const Symbol<ConsistentTensorMeta>& tensor_meta = JUST(t->consistent_tensor_meta());
     const Symbol<cfg::NdSbp>& nd_sbp = tensor_meta->nd_sbp();
@@ -64,7 +67,9 @@ inline Maybe<void> CopyBetweenMirroredTensorAndNumpy(
   if (block_host_until_done) {
     NumPyArrayPtr array_ptr(array);
     const auto& Callback = std::make_shared<std::function<void(uint64_t)>>(
-        [array_ptr, Copy](uint64_t ofblob_ptr) { CHECK_JUST(Copy(ofblob_ptr, array_ptr)); });
+        [array_ptr, storage_offset, Copy](uint64_t ofblob_ptr) {
+          CHECK_JUST(Copy(ofblob_ptr, storage_offset, array_ptr));
+        });
     bool is_printed = false;
     JUST(SpinCounter::SpinWait(
         1,
@@ -89,7 +94,9 @@ inline Maybe<void> CopyBetweenMirroredTensorAndNumpy(
     JUST(PhysicalRun([&](InstructionsBuilder* builder) -> Maybe<void> {
       return builder->AccessBlobByCallback(
           tensor,
-          [array_ptr, Copy](uint64_t ofblob_ptr) { CHECK_JUST(Copy(ofblob_ptr, array_ptr)); },
+          [array_ptr, storage_offset, Copy](uint64_t ofblob_ptr) {
+            CHECK_JUST(Copy(ofblob_ptr, storage_offset, array_ptr));
+          },
           modifier);
     }));
   }


### PR DESCRIPTION
支持stride/view机制后，tensor <-> numpy互转时需要支持storage_offset信息，不然在某些情况（如slice、narrow等）下，view之后的tensor.numpy()会得到错误的结果。**此pr给tensor <-> numpy互转提供了storage_offset的支持，以便在上述情况下得到正确的结果**