### PR TITLE
Fix tick and device_tick

### DIFF
--- a/oneflow/core/graph_impl/tick_compute_task_node.cpp
+++ b/oneflow/core/graph_impl/tick_compute_task_node.cpp
@@ -59,7 +59,14 @@ void TickCompTaskNode::BuildExecGphAndRegst() {
   node->InferBlobDescs(parallel_ctx());
 }
 
-REGISTER_TICK_TASK_STREAM_INDEX_GETTER(TaskType::kTick);
+#define REGISTER_TICK_TOCK_TASK_STREAM_INDEX_GETTER(device_type)         \
+  REGISTER_TASK_STREAM_INDEX_GETTER(                                     \
+      device_type, TaskType::kTick,                                      \
+      ([](StreamIndexGenerator* generator) -> StreamId::stream_index_t { \
+        return generator->GenerateNamed("TICK");                         \
+      }));
+
+OF_PP_FOR_EACH_TUPLE(REGISTER_TICK_TOCK_TASK_STREAM_INDEX_GETTER, DEVICE_TYPE_SEQ)
 
 REGISTER_SYSTEM_OP_COMP_TASK_NODE_TYPE(OperatorConf::kTickConf, TickCompTaskNode);
 


### PR DESCRIPTION
本 pr 为了验证 @lixinqi 对目前 Graph 可能误用 device_tick 导致性能降低的猜想。

修改 tick 的 stream 注册逻辑使其也可放置在 cuda 设备上，无论是 tick 是放置在 cpu 还是 cuda 上，都会放在一个名字为 “TICK” 的 stream 中。

device_tick 与它的消费者保持在相同的 stream 上即可。

device_tick 的作用是减少 tick 朝 src op 发消息时的开销。tick 和 src op 在不同的 stream 上，所以每次都通过 callback 来发送消息，device_tick 相当于可以把同一条 stream 上的 src op 的消息聚合起来，因为此时只需要 tick 向 device_tick 发送异步消息，而 device_tick -> src op 的消息由于在同一条 stream 上，所以是同步的。

按照上面的设定，目前在 op graph 阶段的 pass 需求为 src op 插入 tick 时，都应该插入 tick 而不是 device tick，之前因为 tick 不能放置在 cuda 设备上，有一些插入 tick 的地方被改成了插入 device_tick，实际上我们不应该在 op graph pass 中插入 device_tick，因为此时还是逻辑计算图。