### PR TITLE
Fix from_numpy in stride

### DIFF
--- a/python/oneflow/test/modules/test_from_numpy.py
+++ b/python/oneflow/test/modules/test_from_numpy.py
@@ -28,6 +28,9 @@ class TestFromNumpy(flow.unittest.TestCase):
         np_arr = np.random.randn(3, 4, 5)
         tensor = flow.from_numpy(np_arr)
         test_case.assertTrue(np.array_equal(np_arr, tensor.numpy()))
+        test_case.assertEqual(tensor.size(), (3, 4, 5))
+        test_case.assertEqual(tensor.stride(), (20, 5, 1))
+        test_case.assertEqual(tensor.storage_offset(), 0)
 
         np_arr[1:2, 2:3, 3:4] = random.random()
         test_case.assertTrue(np.array_equal(np_arr, tensor.numpy()))


### PR DESCRIPTION
Numpy 的 strides 是以 byte 来计数的，在传递的时候应该再做一下处理。已增加回归测试。