### PR TITLE
fix concat bug

### DIFF
--- a/oneflow/core/autograd/gradient_funcs/concat.cpp
+++ b/oneflow/core/autograd/gradient_funcs/concat.cpp
@@ -65,11 +65,17 @@ Maybe<void> Concat::Apply(const ConcatCaptureState* ctx, const TensorTuple& out_
   in_grads->resize(ctx->input_num);
   TensorTuple like(ctx->input_num);
   for (int i = 0; i < ctx->input_num; ++i) { like[i] = ctx->SavedTensors().at(i); }
-  const auto& results = JUST(functional::SplitLike(out_grads.at(0), like, ctx->axis));
-  CHECK_EQ_OR_RETURN(results->size(), ctx->input_num);
+  if(ctx->input_num==1){
+    const auto& result = out_grads.at(0);
+    CHECK_EQ_OR_RETURN(1, ctx->input_num);
+    in_grads->at(0) = result;
+  }else{
+    const auto& results = JUST(functional::SplitLike(out_grads.at(0), like, ctx->axis));
+    CHECK_EQ_OR_RETURN(results->size(), ctx->input_num);
 
-  for (int i = 0; i < ctx->input_num; ++i)
-    if (ctx->requires_grad.at(i)) { in_grads->at(i) = results->at(i); }
+    for (int i = 0; i < ctx->input_num; ++i)
+      if (ctx->requires_grad.at(i)) { in_grads->at(i) = results->at(i); }
+    }
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/autograd/gradient_funcs/concat.cpp
+++ b/oneflow/core/autograd/gradient_funcs/concat.cpp
@@ -65,15 +65,15 @@ Maybe<void> Concat::Apply(const ConcatCaptureState* ctx, const TensorTuple& out_
   in_grads->resize(ctx->input_num);
   TensorTuple like(ctx->input_num);
   for (int i = 0; i < ctx->input_num; ++i) { like[i] = ctx->SavedTensors().at(i); }
-  if(ctx->input_num==1){
+  if (ctx->input_num == 1) {
     in_grads->at(0) = out_grads.at(0);
-  }else{
+  } else {
     const auto& results = JUST(functional::SplitLike(out_grads.at(0), like, ctx->axis));
     CHECK_EQ_OR_RETURN(results->size(), ctx->input_num);
 
     for (int i = 0; i < ctx->input_num; ++i)
       if (ctx->requires_grad.at(i)) { in_grads->at(i) = results->at(i); }
-    }
+  }
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/autograd/gradient_funcs/concat.cpp
+++ b/oneflow/core/autograd/gradient_funcs/concat.cpp
@@ -66,9 +66,7 @@ Maybe<void> Concat::Apply(const ConcatCaptureState* ctx, const TensorTuple& out_
   TensorTuple like(ctx->input_num);
   for (int i = 0; i < ctx->input_num; ++i) { like[i] = ctx->SavedTensors().at(i); }
   if(ctx->input_num==1){
-    const auto& result = out_grads.at(0);
-    CHECK_EQ_OR_RETURN(1, ctx->input_num);
-    in_grads->at(0) = result;
+    in_grads->at(0) = out_grads.at(0);
   }else{
     const auto& results = JUST(functional::SplitLike(out_grads.at(0), like, ctx->axis));
     CHECK_EQ_OR_RETURN(results->size(), ctx->input_num);

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -464,21 +464,23 @@ class ConcatFunctor {
     JUST(attrs.SetAttr<int64_t>("axis", axis));
     JUST(attrs.SetAttr<int64_t>("max_dim_size", max_dim_size));
     TensorTuple outputs;
-    for (int i = 0; i < inputs.size(); i += kMaxInputCount) {
-      size_t size = (i + kMaxInputCount) < inputs.size() ? kMaxInputCount : inputs.size() - i;
-      TensorTuple partial_inputs(size);
-      if(size==1){
-        partial_inputs[0] = inputs[0];
+    if(inputs.size()==1){
+      TensorTuple input_tuple(1);
+      input_tuple[0] = inputs[0];
         outputs.emplace_back(
-            JUST(OpInterpUtil::Dispatch<Tensor>(*op_, partial_inputs, attrs)));
-      }else{
+            JUST(OpInterpUtil::Dispatch<Tensor>(*op_, input_tuple, attrs)));
+    }else{
+      for (int i = 0; i < inputs.size(); i += kMaxInputCount) {
+        size_t size = (i + kMaxInputCount) < inputs.size() ? kMaxInputCount : inputs.size() - i;
+        TensorTuple partial_inputs(size);
         for (int j = 0; j < size; ++j) { 
           partial_inputs[j] = inputs[i + j]; 
         }
         outputs.emplace_back(
             JUST(OpInterpUtil::Dispatch<Tensor>(*ops_.at(size - 1), partial_inputs, attrs)));
-        }
+      }
     }
+    
     if (outputs.size() == 1) { return outputs.at(0); }
     return this->operator()(outputs, axis);
   }

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -435,7 +435,6 @@ class ConcatFunctor {
     }
   }
   Maybe<Tensor> operator()(const TensorTuple& inputs, const int64_t& dim) const {
-    if (inputs.size() == 1) { return inputs.at(0); }
     int64_t axis = dim;
     int64_t ndim = inputs[0]->ndim();
     int64_t max_dim_size = 0;

--- a/oneflow/user/ops/concat_op.cpp
+++ b/oneflow/user/ops/concat_op.cpp
@@ -108,7 +108,7 @@ Maybe<void> InferDataType(user_op::InferContext* ctx) {
 }  // namespace
 
 REGISTER_USER_OP("concat")
-    .InputWithMinimum("in", 2)
+    .InputWithMinimum("in", 1)
     .Output("out")
     .Attr<int64_t>("axis")
     .Attr<int64_t>("max_dim_size")

--- a/python/oneflow/test/modules/test_concat.py
+++ b/python/oneflow/test/modules/test_concat.py
@@ -156,6 +156,12 @@ class TestModule(flow.unittest.TestCase):
         dim = random(0, 4).to(int).value()
         z = torch.cat((x, y), dim=dim)
         return z
+    
+    @autotest(n=10, check_graph=False)
+    def test_cat_one_tensor(test_case):
+        device = random_device()
+        x = random_pytorch_tensor(4, 2, 3, random(0, 3)).to(device)
+        return torch.cat((x,), 0)
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_concat.py
+++ b/python/oneflow/test/modules/test_concat.py
@@ -158,7 +158,7 @@ class TestModule(flow.unittest.TestCase):
         return z
     
     @autotest(n=10, check_graph=False)
-    def test_cat_one_tensor(test_case):
+    def test_cat_only_one_tensor(test_case):
         device = random_device()
         x = random_pytorch_tensor(4, 2, 3, random(0, 3)).to(device)
         return torch.cat((x,), 0)

--- a/python/oneflow/test/modules/test_concat.py
+++ b/python/oneflow/test/modules/test_concat.py
@@ -156,7 +156,7 @@ class TestModule(flow.unittest.TestCase):
         dim = random(0, 4).to(int).value()
         z = torch.cat((x, y), dim=dim)
         return z
-    
+
     @autotest(n=10, check_graph=False)
     def test_cat_only_one_tensor(test_case):
         device = random_device()


### PR DESCRIPTION
#### fix bug in issue:https://github.com/Oneflow-Inc/oneflow/issues/7074

- 修复前，输入input tensor数量为1时直接返回原tensor；
- 修复后，不直接返回tensor，而是返回copy后的tensor；

#### sample codes:
![image](https://user-images.githubusercontent.com/28823622/147067816-6dfeecd8-5488-4179-9efb-20092b5c9b2a.png)