### PR TITLE
Fix GELU formula and Turn OFF FASTMATH

### DIFF
--- a/oneflow/core/autograd/gradient_funcs/layer_norm.cpp
+++ b/oneflow/core/autograd/gradient_funcs/layer_norm.cpp
@@ -108,19 +108,21 @@ Maybe<void> LayerNorm::Apply(const LayerNormCaptureState* ctx, const TensorTuple
   if (begin_norm_axis < 0) { begin_norm_axis += dy->shape()->NumAxes(); }
 
   std::shared_ptr<Tensor> gamma = saved_tensors.at(ctx->gamma_index);
-  if (!ctx->has_affine) {
-    // Use LayerNormParamGrad(Tensor dy, Tensor gamma, Int64 begin_params_axis, Double epsilon).
-    dy = JUST(functional::LayerNormParamGrad(dy, begin_params_axis, ctx->epsilon));
-  } else {
-    // Use LayerNormAffineParamGrad(Tensor dy, Tensor gamma, Tensor normalized, Int64
-    // begin_params_axis, Double epsilon).
-    std::shared_ptr<Tensor> normalized = saved_tensors.at(ctx->normalized_index);
-    const auto& results = JUST(functional::LayerNormAffineParamGrad(
-        dy, gamma, normalized, begin_params_axis, ctx->epsilon));
-    in_grads->at(1) = results->at(0);  // For gamma.
-    in_grads->at(2) = results->at(1);  // For beta.
-    dy = results->at(2);
-  }
+  
+  // TODO
+  // if (!ctx->has_affine) {
+  //   // Use LayerNormParamGrad(Tensor dy, Tensor gamma, Int64 begin_params_axis, Double epsilon).
+  //   dy = JUST(functional::LayerNormParamGrad(dy, begin_params_axis, ctx->epsilon));
+  // } else {
+  //   // Use LayerNormAffineParamGrad(Tensor dy, Tensor gamma, Tensor normalized, Int64
+  //   // begin_params_axis, Double epsilon).
+  //   std::shared_ptr<Tensor> normalized = saved_tensors.at(ctx->normalized_index);
+  //   const auto& results = JUST(functional::LayerNormAffineParamGrad(
+  //       dy, gamma, normalized, begin_params_axis, ctx->epsilon));
+  //   in_grads->at(1) = results->at(0);  // For gamma.
+  //   in_grads->at(2) = results->at(1);  // For beta.
+  //   dy = results->at(2);
+  // }
 
   if (ctx->x_requires_grad) {
     const auto& x = saved_tensors.at(ctx->x_index);

--- a/oneflow/core/cuda/apex_layernorm.cuh
+++ b/oneflow/core/cuda/apex_layernorm.cuh
@@ -1,0 +1,590 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef ONEFLOW_CORE_CUDA_APEX_LAYER_NORM_H_
+#define ONEFLOW_CORE_CUDA_APEX_LAYER_NORM_H_
+
+#include <cuda.h>
+#include <cub/cub.cuh>
+#include <math_constants.h>
+#include <assert.h>
+
+namespace oneflow {
+
+namespace cuda {
+
+namespace apex_layer_norm {
+
+constexpr int32_t warpSize = 32; 
+
+template <typename T>
+__device__ __forceinline__ T WARP_SHFL(T value, int srcLane, int width=warpSize, unsigned int mask = 0xffffffff)
+{
+  return __shfl_sync(mask, value, srcLane, width);
+}
+
+template <typename T>
+__device__ __forceinline__ T WARP_SHFL_XOR(T value, int laneMask, int width = warpSize, unsigned int mask = 0xffffffff)
+{
+  return __shfl_xor_sync(mask, value, laneMask, width);
+}
+
+template<typename U> __device__
+void cuWelfordOnlineSum(
+    const U curr,
+    U& mu,
+    U& sigma2,
+    U& count)
+{
+    count = count + U(1);
+    U delta = curr - mu;
+    U lmean = mu + delta / count;
+    mu = lmean;
+    U delta2 = curr - lmean;
+    sigma2 = sigma2 + delta * delta2;
+}
+    
+template<typename U> __device__
+void cuChanOnlineSum(
+    const U muB,
+    const U sigma2B,
+    const U countB,
+    U& mu,
+    U& sigma2,
+    U& count)
+{
+    U delta = muB - mu;
+    U nA = count;
+    U nB = countB;
+    count = count + countB;
+    U nX = count;
+    if (nX > U(0)) {
+    nA = nA / nX;
+    nB = nB / nX;
+    mu = nA*mu + nB*muB;
+    sigma2 = sigma2 + sigma2B + delta * delta * nA * nB * nX;
+    } else {
+    mu = U(0);
+    sigma2 = U(0);
+    }
+}
+    
+template<typename T, typename U> __device__
+void cuWelfordMuSigma2(
+    const T* __restrict__ vals,
+    const int n1,
+    const int n2,
+    const int i1,
+    U& mu,
+    U& sigma2,
+    U* buf)
+{
+    // Assumptions:
+    // 1) blockDim.x == warpSize
+    // 2) Tensor is contiguous
+    // 3) 2*blockDim.y*sizeof(U)+blockDim.y*sizeof(int) shared memory available.
+    //
+    // compute variance and mean over n2
+    U count = U(0);
+    mu= U(0);
+    sigma2 = U(0);
+    if (i1 < n1) {
+    // one warp normalizes one n1 index,
+    // synchronization is implicit
+    // initialize with standard Welford algorithm
+    const int numx = blockDim.x * blockDim.y;
+    const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
+    const T* lvals = vals + i1*n2;
+    int l = 4*thrx;
+    for (;  l+3 < n2;  l+=4*numx) {
+        for (int k = 0;  k < 4;  ++k) {
+        U curr = static_cast<U>(lvals[l+k]);
+        cuWelfordOnlineSum<U>(curr,mu,sigma2,count);
+        }
+    }
+    for (;  l < n2;  ++l) {
+        U curr = static_cast<U>(lvals[l]);
+        cuWelfordOnlineSum<U>(curr,mu,sigma2,count);
+    }
+    // intra-warp reductions
+    for (int l = 0;  l <= 4;  ++l) {
+        int srcLaneB = (threadIdx.x+(1<<l))&31;
+        U muB = WARP_SHFL(mu, srcLaneB);
+        U countB = WARP_SHFL(count, srcLaneB);
+        U sigma2B = WARP_SHFL(sigma2, srcLaneB);
+        cuChanOnlineSum<U>(muB,sigma2B,countB,mu,sigma2,count);
+    }
+    // threadIdx.x == 0 has correct values for each warp
+    // inter-warp reductions
+    if (blockDim.y > 1) {
+        U* ubuf = (U*)buf;
+        U* ibuf = (U*)(ubuf + blockDim.y);
+        for (int offset = blockDim.y/2;  offset > 0;  offset /= 2) {
+        // upper half of warps write to shared
+        if (threadIdx.x == 0 && threadIdx.y >= offset && threadIdx.y < 2*offset) {
+            const int wrt_y = threadIdx.y - offset;
+            ubuf[2*wrt_y] = mu;
+            ubuf[2*wrt_y+1] = sigma2;
+            ibuf[wrt_y] = count;
+        }
+        __syncthreads();
+        // lower half merges
+        if (threadIdx.x == 0 && threadIdx.y < offset) {
+            U muB = ubuf[2*threadIdx.y];
+            U sigma2B = ubuf[2*threadIdx.y+1];
+            U countB = ibuf[threadIdx.y];
+            cuChanOnlineSum<U>(muB,sigma2B,countB,mu,sigma2,count);
+        }
+        __syncthreads();
+        }
+        // threadIdx.x = 0 && threadIdx.y == 0 only thread that has correct values
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+        ubuf[0] = mu;
+        ubuf[1] = sigma2;
+        }
+        __syncthreads();
+        mu = ubuf[0];
+        sigma2 = ubuf[1]/U(n2);
+        // don't care about final value of count, we know count == n2
+    } else {
+        mu = WARP_SHFL(mu, 0);
+        sigma2 = WARP_SHFL(sigma2/U(n2), 0);
+    }
+    }
+}
+
+template<typename U> __device__ U rsqrt(U v) {
+    return U(1) / sqrt(v);
+}
+template<> __device__ float rsqrt(float v) {
+    return rsqrtf(v);
+}
+template<> __device__ double rsqrt(double v) {
+    return rsqrt(v);
+}
+
+namespace {
+    template <typename T>
+    struct SharedMemory;
+    
+    template <>
+    struct SharedMemory <float>
+    {
+        __device__ float *getPointer()
+        {
+            extern __shared__ float s_float[];
+            return s_float;
+        }
+    };
+    
+    template <>
+    struct SharedMemory <double>
+    {
+        __device__ double *getPointer()
+        {
+            extern __shared__ double s_double[];
+            return s_double;
+        }
+    };
+}
+
+template<typename T, typename U, typename V> __device__
+void cuApplyLayerNorm_(
+  V* __restrict__ output_vals,
+  U* __restrict__ mean,
+  U* __restrict__ invvar,
+  const T* __restrict__ vals,
+  const int n1,
+  const int n2,
+  const U epsilon,
+  const V* __restrict__ gamma,
+  const V* __restrict__ beta
+  )
+{
+  // Assumptions:
+  // 1) blockDim.x == warpSize
+  // 2) Tensors are contiguous
+  //
+  for (auto i1=blockIdx.y; i1 < n1; i1 += gridDim.y) {
+    SharedMemory<U> shared;
+    U* buf = shared.getPointer();
+    U mu,sigma2;
+    cuWelfordMuSigma2(vals,n1,n2,i1,mu,sigma2,buf);
+    const T* lvals = vals + i1*n2;
+    V* ovals = output_vals + i1*n2;
+    U c_invvar = rsqrt(sigma2 + epsilon);
+    const int numx = blockDim.x * blockDim.y;
+    const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
+    if (gamma != NULL && beta != NULL) {
+      for (int i = thrx;  i < n2;  i+=numx) {
+        U curr = static_cast<U>(lvals[i]);
+        ovals[i] = gamma[i] * static_cast<V>(c_invvar * (curr - mu)) + beta[i];
+      }
+    } else {
+      for (int i = thrx;  i < n2;  i+=numx) {
+        U curr = static_cast<U>(lvals[i]);
+        ovals[i] = static_cast<V>(c_invvar * (curr - mu));
+      }
+    }
+    if (threadIdx.x == 0 && threadIdx.y == 0) {
+      mean[i1] = mu;
+      invvar[i1] = c_invvar;
+    }
+    __syncthreads();
+  }
+}
+
+template<typename T, typename U, typename V=T> __global__
+void cuApplyLayerNorm(
+  V* __restrict__ output_vals,
+  U* __restrict__ mean,
+  U* __restrict__ invvar,
+  const T* __restrict__ vals,
+  const int n1,
+  const int n2,
+  const U epsilon,
+  const V* __restrict__ gamma,
+  const V* __restrict__ beta
+  )
+{
+  cuApplyLayerNorm_<T, U, V>(output_vals, mean, invvar, vals, n1, n2, epsilon, gamma, beta);
+}
+
+
+template<typename T, typename U, typename V> __device__
+void cuLoadWriteStridedInputs(
+    const int i1_block,
+    const int thr_load_row_off,
+    const int thr_load_col_off,
+    const int i2_off,
+    const int row_stride,
+    U* warp_buf1,
+    U* warp_buf2,
+    const T* input,
+    const V* dout,
+    const int i1_end,
+    const int n2,
+    const U* __restrict__ mean,
+    const U* __restrict__ invvar
+    )
+{
+  int i1 = i1_block+thr_load_row_off;
+  if (i1 < i1_end) {
+    U curr_mean = mean[i1];
+    U curr_invvar = invvar[i1];
+    for (int k = 0;  k < blockDim.y;  ++k) {
+      int i2 = i2_off + k;
+      int load_idx = i1*n2+i2;
+      int write_idx = thr_load_row_off*row_stride+thr_load_col_off+k;
+      if (i2<n2) {
+        U curr_input = static_cast<U>(input[load_idx]);
+        U curr_dout = static_cast<U>(dout[load_idx]);
+        warp_buf1[write_idx] = curr_dout;
+        warp_buf2[write_idx] = curr_dout * (curr_input - curr_mean) * curr_invvar;
+      } else {
+        warp_buf1[write_idx] = U(0);
+        warp_buf2[write_idx] = U(0);
+      }
+    }
+  } else {
+    for (int k = 0;  k < blockDim.y;  ++k) {
+      int write_idx = thr_load_row_off*row_stride+thr_load_col_off+k;
+      warp_buf1[write_idx] = U(0);
+      warp_buf2[write_idx] = U(0);
+    }
+  }
+}
+
+template<typename T, typename U, typename V> __device__
+void cuLoadAddStridedInputs(
+    const int i1_block,
+    const int thr_load_row_off,
+    const int thr_load_col_off,
+    const int i2_off,
+    const int row_stride,
+    U* warp_buf1,
+    U* warp_buf2,
+    const T* input,
+    const V* dout,
+    const int i1_end,
+    const int n2,
+    const U* __restrict__ mean,
+    const U* __restrict__ invvar
+    )
+{
+  int i1 = i1_block+thr_load_row_off;
+  if (i1 < i1_end) {
+    U curr_mean = mean[i1];
+    U curr_invvar = invvar[i1];
+    for (int k = 0;  k < blockDim.y;  ++k) {
+      int i2 = i2_off + k;
+      int load_idx = i1*n2+i2;
+      int write_idx = thr_load_row_off*row_stride+thr_load_col_off+k;
+      if (i2<n2) {
+        U curr_input = static_cast<U>(input[load_idx]);
+        U curr_dout = static_cast<U>(dout[load_idx]);
+        warp_buf1[write_idx] += curr_dout;
+        warp_buf2[write_idx] += curr_dout * (curr_input - curr_mean) * curr_invvar;
+      }
+    }
+  }
+}
+
+template<typename T, typename U, typename V> __global__
+void cuComputePartGradGammaBeta(
+    const V* __restrict__ dout,
+    const T* __restrict__ input,
+    const int n1,
+    const int n2,
+    const U* __restrict__ mean,
+    const U* __restrict__ invvar,
+    U epsilon,
+    U* part_grad_gamma,
+    U* part_grad_beta)
+{
+    const int numsegs_n1 = (n1+blockDim.y*blockDim.y-1) / (blockDim.y*blockDim.y);
+    const int segs_per_block = (numsegs_n1 + gridDim.y - 1) / gridDim.y;
+    const int i1_beg = blockIdx.y * segs_per_block * blockDim.y*blockDim.y;
+    const int i1_beg_plus_one = (blockIdx.y+1) * segs_per_block * blockDim.y*blockDim.y;
+    const int i1_end = i1_beg_plus_one < n1 ? i1_beg_plus_one : n1;
+    const int row_stride = blockDim.x+1;
+    const int thr_load_col_off = (threadIdx.x*blockDim.y)&(blockDim.x-1);
+    const int thr_load_row_off = (threadIdx.x*blockDim.y)/blockDim.x + threadIdx.y*blockDim.y;
+    const int i2_off = blockIdx.x * blockDim.x + thr_load_col_off;
+    SharedMemory<U> shared;
+    U* buf = shared.getPointer(); // buf has at least blockDim.x * blockDim.y * blockDim.y + (blockDim.y - 1)*(blockDim.x/blockDim.y) elements
+    U* warp_buf1 = (U*)buf;
+    U* warp_buf2 = warp_buf1 + blockDim.y * blockDim.y * row_stride;
+    // compute partial sums from strided inputs
+    // do this to increase number of loads in flight
+    cuLoadWriteStridedInputs(i1_beg,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,input,dout,i1_end,n2,mean,invvar);
+    for (int i1_block = i1_beg+blockDim.y*blockDim.y;  i1_block < i1_end;  i1_block+=blockDim.y*blockDim.y) {
+      cuLoadAddStridedInputs(i1_block,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,input,dout,i1_end,n2,mean,invvar);
+    }
+    __syncthreads();
+    // inter-warp reductions
+    // sum within each warp
+    U acc1 = U(0);
+    U acc2 = U(0);
+    for (int k = 0;  k < blockDim.y;  ++k) {
+      int row1 = threadIdx.y + k*blockDim.y;
+      int idx1 = row1*row_stride + threadIdx.x;
+      acc1 += warp_buf1[idx1];
+      acc2 += warp_buf2[idx1];
+    }
+    warp_buf1[threadIdx.y*row_stride+threadIdx.x] = acc1;
+    warp_buf2[threadIdx.y*row_stride+threadIdx.x] = acc2;
+    __syncthreads();
+    // sum all warps
+    for (int offset = blockDim.y/2;  offset > 1;  offset /= 2) {
+      if (threadIdx.y < offset) {
+        int row1 = threadIdx.y;
+        int row2 = threadIdx.y + offset;
+        int idx1 = row1*row_stride + threadIdx.x;
+        int idx2 = row2*row_stride + threadIdx.x;
+        warp_buf1[idx1] += warp_buf1[idx2];
+        warp_buf2[idx1] += warp_buf2[idx2];
+      }
+      __syncthreads();
+    }
+    int i2 = blockIdx.x * blockDim.x + threadIdx.x;
+    if (threadIdx.y == 0 && i2 < n2) {
+      int row1 = threadIdx.y;
+      int row2 = threadIdx.y + 1;
+      int idx1 = row1*row_stride + threadIdx.x;
+      int idx2 = row2*row_stride + threadIdx.x;
+      part_grad_beta[blockIdx.y*n2+i2] = warp_buf1[idx1] + warp_buf1[idx2];
+      part_grad_gamma[blockIdx.y*n2+i2] = warp_buf2[idx1] + warp_buf2[idx2];
+    }
+}
+
+template<typename U, typename V> __global__
+void cuComputeGradGammaBeta(
+    const U* part_grad_gamma,
+    const U* part_grad_beta,
+    const int part_size,
+    const int n1,
+    const int n2,
+    V* grad_gamma,
+    V* grad_beta)
+{
+    // sum partial gradients for gamma and beta
+    SharedMemory<U> shared;
+    U* buf = shared.getPointer();
+    int i2 = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i2 < n2) {
+      // each warp does sequential reductions until reduced part_size is num_warps
+      int num_warp_reductions = part_size / blockDim.y;
+      U sum_gamma = U(0);
+      U sum_beta = U(0);
+      const U* part_grad_gamma_ptr = part_grad_gamma + threadIdx.y * num_warp_reductions * n2 + i2;
+      const U* part_grad_beta_ptr = part_grad_beta + threadIdx.y * num_warp_reductions * n2 + i2;
+      for (int warp_offset = 0;  warp_offset < num_warp_reductions;  ++warp_offset) {
+        sum_gamma += part_grad_gamma_ptr[warp_offset*n2];
+        sum_beta += part_grad_beta_ptr[warp_offset*n2];
+      }
+      // inter-warp reductions
+      const int nbsize3 = blockDim.x * blockDim.y / 2;
+      for (int offset = blockDim.y/2;  offset >= 1;  offset /= 2) {
+        // top half write to shared memory
+        if (threadIdx.y >= offset && threadIdx.y < 2*offset) {
+          const int write_idx = (threadIdx.y - offset) * blockDim.x + threadIdx.x;
+          buf[write_idx] = sum_gamma;
+          buf[write_idx+nbsize3] = sum_beta;
+        }
+        __syncthreads();
+        // bottom half sums
+        if (threadIdx.y < offset) {
+          const int read_idx = threadIdx.y * blockDim.x + threadIdx.x;
+          sum_gamma += buf[read_idx];
+          sum_beta += buf[read_idx+nbsize3];
+        }
+        __syncthreads();
+      }
+      // write out fully summed gradients
+      if (threadIdx.y == 0) {
+        grad_gamma[i2] = sum_gamma;
+        grad_beta[i2] = sum_beta;
+      }
+    }
+}
+
+template<typename T, typename U, typename V> __global__
+void cuComputeGradInput(
+    const V* __restrict__ dout,
+    const T* __restrict__ input,
+    const int n1,
+    const int n2,
+    const U* __restrict__ mean,
+    const U* __restrict__ invvar,
+    U epsilon,
+    const V* gamma,
+    T* grad_input)
+{
+  for (auto i1=blockIdx.y; i1 < n1; i1 += gridDim.y) {
+    U sum_loss1 = U(0);
+    U sum_loss2 = U(0);
+    const U c_mean = mean[i1];
+    const U c_invvar = invvar[i1];
+    const T* k_input = input + i1*n2;
+    const V* k_dout = dout + i1*n2;
+    const int numx = blockDim.x * blockDim.y;
+    const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
+    if (gamma != NULL) {
+      int l = 4*thrx;
+      for (;  l+3 < n2;  l+=4*numx) {
+        for (int k = 0;  k < 4;  ++k) {
+          const U c_h = static_cast<U>(k_input[l+k]);
+          const U c_loss = static_cast<U>(k_dout[l+k]);
+          sum_loss1 += c_loss * gamma[l+k];
+          sum_loss2 += c_loss * gamma[l+k] * (c_h - c_mean) * c_invvar;
+        }
+      }
+      for (;  l < n2;  ++l) {
+        const U c_h = static_cast<U>(k_input[l]);
+        const U c_loss = static_cast<U>(k_dout[l]);
+        sum_loss1 += c_loss * gamma[l];
+        sum_loss2 += c_loss * gamma[l] * (c_h - c_mean) * c_invvar;
+      }
+    } else {
+      int l = 4*thrx;
+      for (;  l+3 < n2;  l+=4*numx) {
+        for (int k = 0;  k < 4;  ++k) {
+          const U c_h = static_cast<U>(k_input[l+k]);
+          const U c_loss = static_cast<U>(k_dout[l+k]);
+          sum_loss1 += c_loss;
+          sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
+        }
+      }
+      for (;  l < n2;  ++l) {
+        const U c_h = static_cast<U>(k_input[l]);
+        const U c_loss = static_cast<U>(k_dout[l]);
+        sum_loss1 += c_loss;
+        sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
+      }
+    }
+    // intra-warp reductions
+    for (int mask = blockDim.x/2;  mask > 0;  mask /= 2) {
+      sum_loss1 += WARP_SHFL_XOR(sum_loss1, mask);
+      sum_loss2 += WARP_SHFL_XOR(sum_loss2, mask);
+    }
+    // inter-warp reductions
+    if (blockDim.y > 1) {
+      SharedMemory<U> shared;
+      U* buf = shared.getPointer();
+      for (int offset = blockDim.y/2;  offset > 0;  offset /= 2) {
+        // upper half of warps write to shared
+        if (threadIdx.y >= offset && threadIdx.y < 2*offset) {
+          const int wrt_i = (threadIdx.y - offset) * blockDim.x + threadIdx.x;
+          buf[2*wrt_i] = sum_loss1;
+          buf[2*wrt_i+1] = sum_loss2;
+        }
+        __syncthreads();
+        // lower half merges
+        if (threadIdx.y < offset) {
+          const int read_i = threadIdx.y * blockDim.x + threadIdx.x;
+          sum_loss1 += buf[2*read_i];
+          sum_loss2 += buf[2*read_i+1];
+        }
+        __syncthreads();
+      }
+      if (threadIdx.y == 0) {
+        buf[2*threadIdx.x] = sum_loss1;
+        buf[2*threadIdx.x+1] = sum_loss2;
+      }
+      __syncthreads();
+      if (threadIdx.y !=0) {
+        sum_loss1 = buf[2*threadIdx.x];
+        sum_loss2 = buf[2*threadIdx.x+1];
+      }
+    }
+    // all threads now have the two sums over l
+    U fH = (U)n2;
+    U term1 = (U(1) / fH) * c_invvar;
+    T* k_grad_input = grad_input + i1*n2;
+    if (gamma != NULL) {
+      for (int l = thrx;  l < n2;  l+=numx) {
+        const U c_h = static_cast<U>(k_input[l]);
+        const U c_loss = static_cast<U>(k_dout[l]);
+        U f_grad_input = fH * c_loss * gamma[l];
+        f_grad_input -= sum_loss1;
+        f_grad_input -= (c_h - c_mean) * c_invvar * sum_loss2;
+        f_grad_input *= term1;
+        k_grad_input[l] = static_cast<T>(f_grad_input);
+      }
+    } else {
+      for (int l = thrx;  l < n2;  l+=numx) {
+        const U c_h = static_cast<U>(k_input[l]);
+        const U c_loss = static_cast<U>(k_dout[l]);
+        U f_grad_input = fH * c_loss;
+        f_grad_input -= sum_loss1;
+        f_grad_input -= (c_h - c_mean) * c_invvar * sum_loss2;
+        f_grad_input *= term1;
+        k_grad_input[l] = static_cast<T>(f_grad_input);
+      }
+    }
+    // prevent race where buf is written again before reads are done
+    __syncthreads();
+  }
+}
+
+}  // namespace apex_layer_norm
+
+}  // namespace cuda
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_CUDA_APEX_LAYER_NORM_H_

--- a/oneflow/core/cuda/layer_norm.cuh
+++ b/oneflow/core/cuda/layer_norm.cuh
@@ -63,11 +63,11 @@ __inline__ __device__ T Div(T a, T b);
 
 template<>
 __inline__ __device__ float Div<float>(float a, float b) {
-#ifdef OF_LAYER_NORM_USE_FAST_MATH
-  return __fdividef(a, b);
-#else
+// #ifdef OF_LAYER_NORM_USE_FAST_MATH
+//   return __fdividef(a, b);
+// #else
   return a / b;
-#endif
+// #endif
 }
 
 template<>
@@ -80,11 +80,11 @@ __inline__ __device__ T Rsqrt(T x);
 
 template<>
 __inline__ __device__ float Rsqrt<float>(float x) {
-#ifdef OF_LAYER_NORM_USE_FAST_MATH
-  return __frsqrt_rn(x);
-#else
+// #ifdef OF_LAYER_NORM_USE_FAST_MATH
+//   return __frsqrt_rn(x);
+// #else
   return rsqrt(x);
-#endif
+// #endif
 }
 
 template<>

--- a/oneflow/core/cuda/softmax.cuh
+++ b/oneflow/core/cuda/softmax.cuh
@@ -81,11 +81,11 @@ __inline__ __device__ T Exp(T x);
 
 template<>
 __inline__ __device__ float Exp<float>(float x) {
-#ifdef OF_SOFTMAX_USE_FAST_MATH
-  return __expf(x);
-#else
+// #ifdef OF_SOFTMAX_USE_FAST_MATH
+//   return __expf(x);
+// #else
   return exp(x);
-#endif
+// #endif
 }
 
 template<>
@@ -98,11 +98,11 @@ __inline__ __device__ T Div(T a, T b);
 
 template<>
 __inline__ __device__ float Div<float>(float a, float b) {
-#ifdef OF_SOFTMAX_USE_FAST_MATH
-  return __fdividef(a, b);
-#else
+// #ifdef OF_SOFTMAX_USE_FAST_MATH
+//   return __fdividef(a, b);
+// #else
   return a / b;
-#endif
+// #endif
 }
 
 template<>
@@ -115,11 +115,11 @@ __inline__ __device__ T Log(T x);
 
 template<>
 __inline__ __device__ float Log<float>(float x) {
-#ifdef OF_SOFTMAX_USE_FAST_MATH
-  return __logf(x);
-#else
+// #ifdef OF_SOFTMAX_USE_FAST_MATH
+//   return __logf(x);
+// #else
   return log(x);
-#endif
+// #endif
 }
 template<>
 __inline__ __device__ double Log<double>(double x) {

--- a/oneflow/core/ep/cuda/primitive/unary_functor.cuh
+++ b/oneflow/core/ep/cuda/primitive/unary_functor.cuh
@@ -23,12 +23,11 @@ namespace ep {
 namespace primitive {
 
 template<typename Dst, typename Src>
-struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kGelu, Dst, Src> {
-  OF_DEVICE_FUNC Dst operator()(Src src) const {
-    return static_cast<Src>(0.5) * src
-           * (static_cast<Src>(1.0) + erf(static_cast<Src>(M_SQRT1_2) * src));
-  }
-};
+  struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kGelu, Dst, Src> {
+    OF_DEVICE_FUNC Dst operator()(Src src) const {
+      return src * normcdff(src); 
+    }
+  };
 
 template<>
 struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kGelu, half, half> {

--- a/oneflow/user/kernels/apex_layernorm.cu
+++ b/oneflow/user/kernels/apex_layernorm.cu
@@ -1,0 +1,378 @@
+
+#include "oneflow/core/device/cudnn_util.h"
+#include "oneflow/core/framework/framework.h"
+#include "oneflow/core/ndarray/ndarray_util.h"
+#include "oneflow/core/cuda/atomic.cuh"
+#include <cub/cub.cuh>
+#include "oneflow/core/kernel/cuda_graph_support.h"
+#include "oneflow/core/ep/include/primitive/fill.h"
+#include "oneflow/core/ep/cuda/cuda_stream.h"
+#include "oneflow/core/cuda/apex_layernorm.cuh"
+
+namespace oneflow {
+
+
+template<typename T, typename U>
+class LayerNormGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+ public:
+  LayerNormGpuKernel() = default;
+  ~LayerNormGpuKernel() = default;
+
+ private:
+  using user_op::OpKernel::Compute;
+  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+  void Compute(user_op::KernelComputeContext* ctx) const override {
+    const user_op::Tensor* x = ctx->Tensor4ArgNameAndIndex("x", 0);
+    user_op::Tensor* y = ctx->Tensor4ArgNameAndIndex("y", 0);
+    user_op::Tensor* mean = ctx->Tensor4ArgNameAndIndex("mean", 0);
+    user_op::Tensor* inv_variance = ctx->Tensor4ArgNameAndIndex("inv_variance", 0);
+    user_op::Tensor* normalized =
+        ctx->has_input("gamma", 0) ? ctx->Tensor4ArgNameAndIndex("normalized", 0) : y;
+    const double epsilon = ctx->Attr<double>("epsilon");
+    CHECK_GE(epsilon, CUDNN_BN_MIN_EPSILON);
+    const int64_t num_instances = mean->shape().elem_cnt();
+    const int64_t norm_size = x->shape().elem_cnt() / num_instances;
+    const T* gamma_ptr = nullptr;
+    const T* beta_ptr = nullptr;
+    if (ctx->has_input("gamma", 0)) {
+      const user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
+      gamma_ptr = gamma->dptr<T>();
+      CHECK_EQ(gamma->shape().elem_cnt(), norm_size);
+    }
+    if (ctx->has_input("beta", 0)) { beta_ptr = ctx->Tensor4ArgNameAndIndex("beta", 0)->dptr<T>(); }
+    
+    // int32_t n1 = num_instances; 
+    // int32_t n2 = norm_size;
+    
+    int32_t n1 = num_instances; 
+    int32_t n2 = norm_size;
+
+    const dim3 threads(32,4,1);
+    const uint64_t maxGridY = ctx->stream()->As<ep::CudaStream>()->device_properties().maxGridSize[1];
+    
+    // printf("N1 is: %d \n", n1); 
+    // printf("N2 is: %d \n", n2); 
+
+    // printf("Num instance is: %d \n", num_instances); 
+    // printf("Normsize is: %d \n", norm_size); 
+
+    const dim3 blocks(1, std::min((uint64_t)n1, maxGridY), 1);
+    int nshared =
+        threads.y > 1 ?
+	    threads.y*sizeof(U)+(threads.y/2)*sizeof(U) :
+	    0;
+    cuda::apex_layer_norm::cuApplyLayerNorm<T, U, T><<<blocks, threads, nshared, ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+        y->mut_dptr<T>(), mean->mut_dptr<T>(), inv_variance->mut_dptr<T>(), x->dptr<T>(), n1, n2, U(epsilon), gamma_ptr, beta_ptr);
+  };
+};
+
+#define REGISTER_LAYER_NORM_CUDA_KERNEL(dtype, acc_dtype)                         \
+  REGISTER_USER_KERNEL("layer_norm")                                   \
+      .SetCreateFn<LayerNormGpuKernel<dtype, acc_dtype>>()                        \
+      .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA) \
+                       && (user_op::HobDataType("x", 0) == GetDataType<dtype>::value));
+
+REGISTER_LAYER_NORM_CUDA_KERNEL(float, float)
+// REGISTER_LAYER_NORM_CUDA_KERNEL(double)
+// REGISTER_LAYER_NORM_CUDA_KERNEL(half)
+
+template<typename T, typename U>
+class LayerNormGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+ public:
+  LayerNormGradGpuKernel() = default;
+  ~LayerNormGradGpuKernel() = default;
+
+ private:
+  using user_op::OpKernel::Compute;
+  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+  void Compute(user_op::KernelComputeContext* ctx) const override {
+    const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
+    const user_op::Tensor* x = ctx->Tensor4ArgNameAndIndex("x", 0);
+    const user_op::Tensor* mean = ctx->Tensor4ArgNameAndIndex("mean", 0);
+    const user_op::Tensor* inv_variance = ctx->Tensor4ArgNameAndIndex("inv_variance", 0);
+    user_op::Tensor* dx = ctx->Tensor4ArgNameAndIndex("dx", 0);
+    const int64_t num_instances = mean->shape().elem_cnt();
+    const int64_t norm_size = x->shape().elem_cnt() / num_instances;
+    const T* gamma_ptr = nullptr;
+    if (ctx->has_input("gamma", 0)) {
+      gamma_ptr = ctx->Tensor4ArgNameAndIndex("gamma", 0)->dptr<T>();
+    }
+    // const T* add_to_output_ptr = nullptr;
+    // if (ctx->has_input("_add_to_output", 0)) {
+    //   const user_op::Tensor* add_to_output = ctx->Tensor4ArgNameAndIndex("_add_to_output", 0);
+    //   CHECK_EQ(add_to_output->data_type(), dx->data_type());
+    //   CHECK_EQ(add_to_output->shape(), dx->shape());
+    //   add_to_output_ptr = add_to_output->dptr<T>();
+    // }
+    
+    // compute grad_input
+    const double epsilon = 1e-5; // Not be used. 
+    int32_t n1 = num_instances; 
+    int32_t n2 = norm_size; 
+    const uint64_t maxGridY = ctx->stream()->As<ep::CudaStream>()->device_properties().maxGridSize[1];
+    const dim3 blocks1(1, std::min((uint64_t)n1, maxGridY), 1);
+    const dim3 threads1(32,4,1);
+    int nshared =
+	    threads1.y > 1 ?
+	    threads1.y*threads1.x*sizeof(U) :
+	    0;
+    cuda::apex_layer_norm::cuComputeGradInput<<<blocks1, threads1, nshared, ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+            dy->dptr<T>(),
+            x->dptr<T>(),
+            n1,n2,
+            mean->dptr<T>(),
+            inv_variance->dptr<T>(),
+            U(epsilon),
+            gamma_ptr,
+            dx->mut_dptr<T>());
+
+  };
+};
+
+#define REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(dtype, acc_type)                                        \
+  REGISTER_USER_KERNEL("layer_norm_grad")                                                  \
+      .SetCreateFn<LayerNormGradGpuKernel<dtype, acc_type>>()                                        \
+      .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA)                     \
+                       && (user_op::HobDataType("dy", 0) == GetDataType<dtype>::value))    \
+      .SetInplaceProposalFn(                                                               \
+          [](const user_op::InferContext& ctx,                                             \
+             const user_op::AddInplaceArgPair& AddInplaceArgPairFn) -> Maybe<void> {       \
+            if (ctx.has_input("_add_to_output", 0)) {                                      \
+              OF_RETURN_IF_ERROR(AddInplaceArgPairFn("dx", 0, "_add_to_output", 0, true)); \
+            }                                                                              \
+            return Maybe<void>::Ok();                                                      \
+          });
+
+REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(float, float)
+// REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(double)
+// REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(half)
+
+// template<typename T>
+// class LayerNormParamGradGpuKernel final : public user_op::OpKernel,
+//                                           public user_op::CudaGraphSupport {
+//  public:
+//   LayerNormParamGradGpuKernel() = default;
+//   ~LayerNormParamGradGpuKernel() = default;
+
+//  private:
+//   using user_op::OpKernel::Compute;
+//   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+//   void Compute(user_op::KernelComputeContext* ctx) const override {
+//     using NdUtil = NdarrayUtil<DeviceType::kCUDA, T>;
+//     auto Val = NdUtil::GetValNdarrayBuilder();
+//     auto Var = NdUtil::GetVarNdarrayBuilder();
+//     const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
+//     user_op::Tensor* beta_diff = ctx->Tensor4ArgNameAndIndex("beta_diff", 0);
+//     user_op::Tensor* gamma_diff = ctx->Tensor4ArgNameAndIndex("gamma_diff", 0);
+//     user_op::Tensor* normalized_diff = ctx->Tensor4ArgNameAndIndex("normalized_diff", 0);
+//     user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
+//     const bool has_beta_diff = beta_diff != nullptr;
+//     const bool has_gamma_diff = gamma_diff != nullptr;
+//     const bool has_normalized_diff = normalized_diff != nullptr;
+//     const bool has_gamma = gamma != nullptr;
+//     const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
+//     const int64_t elem_cnt = dy->shape().elem_cnt();
+//     const int64_t m = dy->shape().Count(begin_params_axis);
+//     int max_active_blocks = 0;
+//     OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+//         &max_active_blocks, LayerNormParamGradImpl<T, int64_t>, GetLayerNormParamGradBlockSize(),
+//         GetParamGradDynamicSharedMemorySize<T>(m)));
+//     if (has_gamma_diff && has_beta_diff && has_normalized_diff && max_active_blocks > 0) {
+//       const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
+//       Memset<DeviceType::kCUDA>(ctx->stream(), gamma_diff->mut_dptr<T>(), 0,
+//                                 gamma_diff->shape().elem_cnt() * sizeof(T));
+//       Memset<DeviceType::kCUDA>(ctx->stream(), beta_diff->mut_dptr<T>(), 0,
+//                                 beta_diff->shape().elem_cnt() * sizeof(T));
+//       if (elem_cnt > static_cast<int64_t>(GetMaxVal<int32_t>() / 2)) {
+//         LayerNormParamGradImpl<T, int64_t>
+//             <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
+//                GetParamGradDynamicSharedMemorySize<T>(m),
+//                ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+//                 elem_cnt, m, dy->dptr<T>(), normalized->dptr<T>(), gamma->dptr<T>(),
+//                 gamma_diff->mut_dptr<T>(), beta_diff->mut_dptr<T>(),
+//                 normalized_diff->mut_dptr<T>());
+//       } else {
+//         LayerNormParamGradImpl<T, int32_t>
+//             <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
+//                GetParamGradDynamicSharedMemorySize<T>(m),
+//                ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+//                 static_cast<int32_t>(elem_cnt), static_cast<int32_t>(m), dy->dptr<T>(),
+//                 normalized->dptr<T>(), gamma->dptr<T>(), gamma_diff->mut_dptr<T>(),
+//                 beta_diff->mut_dptr<T>(), normalized_diff->mut_dptr<T>());
+//       }
+//     } else {
+//       if (has_beta_diff) {
+//         user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
+//         CHECK_EQ(m, beta_diff->shape().elem_cnt());
+//         CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//         const int64_t n = dy->shape().elem_cnt() / m;
+//         NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<T>()),
+//                           Val({n, m}, dy->dptr<T>()), Var({n, m}, reduce_buf->mut_dptr<T>()));
+//       }
+//       if (has_gamma_diff) {
+//         const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
+//         user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
+//         CHECK_EQ(m, gamma_diff->shape().elem_cnt());
+//         CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//         const int64_t n = dy->shape().elem_cnt() / m;
+//         NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, reduce_buf->mut_dptr<T>()),
+//                              Val({n, m}, normalized->dptr<T>()), Val({n, m}, dy->dptr<T>()));
+//         NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<T>()),
+//                           Val({n, m}, reduce_buf->dptr<T>()),
+//                           Var({n, m}, reduce_buf->mut_dptr<T>()));
+//       }
+//       if (has_normalized_diff) {
+//         if (has_gamma) {
+//           CHECK_EQ(m, gamma->shape().elem_cnt());
+//           CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//           const int64_t n = dy->shape().elem_cnt() / m;
+//           NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, normalized_diff->mut_dptr<T>()),
+//                                Val({n, m}, dy->dptr<T>()), Val({1, m}, gamma->dptr<T>()));
+//         } else {
+//           Memcpy<DeviceType::kCUDA>(ctx->stream(), normalized_diff->mut_dptr<void>(),
+//                                     dy->dptr<void>(),
+//                                     dy->shape().elem_cnt() * GetSizeOfDataType(dy->data_type()));
+//         }
+//       }
+//     }
+//   };
+// };
+
+// #define REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(dtype)              \
+//   REGISTER_USER_KERNEL("layer_norm_param_grad")                        \
+//       .SetCreateFn<LayerNormParamGradGpuKernel<dtype>>()               \
+//       .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA) \
+//                        && (user_op::HobDataType("dy", 0) == GetDataType<dtype>::value));
+
+// REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(float)
+// REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(double)
+
+// class LayerNormParamGradGpuHalfKernel final : public user_op::OpKernel,
+//                                               public user_op::CudaGraphSupport {
+//  public:
+//   LayerNormParamGradGpuHalfKernel() = default;
+//   ~LayerNormParamGradGpuHalfKernel() = default;
+
+//  private:
+//   using user_op::OpKernel::Compute;
+//   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+//   void Compute(user_op::KernelComputeContext* ctx) const override {
+//     using NdUtil = NdarrayUtil<DeviceType::kCUDA, float16>;
+//     auto Val = NdUtil::GetValNdarrayBuilder();
+//     auto Var = NdUtil::GetVarNdarrayBuilder();
+//     const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
+//     user_op::Tensor* beta_diff = ctx->Tensor4ArgNameAndIndex("beta_diff", 0);
+//     user_op::Tensor* gamma_diff = ctx->Tensor4ArgNameAndIndex("gamma_diff", 0);
+//     user_op::Tensor* normalized_diff = ctx->Tensor4ArgNameAndIndex("normalized_diff", 0);
+//     user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
+//     const bool has_beta_diff = beta_diff != nullptr;
+//     const bool has_gamma_diff = gamma_diff != nullptr;
+//     const bool has_normalized_diff = normalized_diff != nullptr;
+//     const bool has_gamma = gamma != nullptr;
+//     const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
+//     const int64_t elem_cnt = dy->shape().elem_cnt();
+//     const int64_t m = dy->shape().Count(begin_params_axis);
+//     int max_active_blocks = 0;
+//     OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+//         &max_active_blocks, LayerNormParamGradHalfImpl<int64_t>, GetLayerNormParamGradBlockSize(),
+//         GetParamGradDynamicSharedMemorySize<float16>(m)));
+//     if (has_gamma_diff && has_beta_diff && has_normalized_diff && max_active_blocks > 0) {
+//       const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
+//       user_op::Tensor* tmp_buffer = ctx->Tensor4ArgNameAndIndex("tmp_buffer", 0);
+//       const int64_t num_blocks = GetLayerNormParamGradNumBlocks(dy->shape().elem_cnt());
+//       const size_t tmp_diff_size = GetCudaAlignedSize(num_blocks * m * sizeof(float16));
+//       float16* tmp_gamma_diff = tmp_buffer->mut_dptr<float16>();
+//       float16* tmp_beta_diff =
+//           reinterpret_cast<float16*>(tmp_buffer->mut_dptr<char>() + tmp_diff_size);
+//       float16* tmp_reduce_buf =
+//           reinterpret_cast<float16*>(tmp_buffer->mut_dptr<char>() + 2 * tmp_diff_size);
+//       CHECK_GE(tmp_buffer->shape().elem_cnt(), 3 * tmp_diff_size);
+//       if (elem_cnt > static_cast<int64_t>(GetMaxVal<int32_t>() / 2)) {
+//         LayerNormParamGradHalfImpl<int64_t>
+//             <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
+//                GetParamGradDynamicSharedMemorySize<float16>(m),
+//                ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+//                 elem_cnt, m, dy->dptr<half>(), normalized->dptr<half>(), gamma->dptr<half>(),
+//                 reinterpret_cast<half*>(tmp_gamma_diff), reinterpret_cast<half*>(tmp_beta_diff),
+//                 normalized_diff->mut_dptr<half>());
+//       } else {
+//         LayerNormParamGradHalfImpl<int32_t>
+//             <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
+//                GetParamGradDynamicSharedMemorySize<float16>(m),
+//                ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+//                 static_cast<int32_t>(elem_cnt), static_cast<int32_t>(m), dy->dptr<half>(),
+//                 normalized->dptr<half>(), gamma->dptr<half>(),
+//                 reinterpret_cast<half*>(tmp_gamma_diff), reinterpret_cast<half*>(tmp_beta_diff),
+//                 normalized_diff->mut_dptr<half>());
+//       }
+//       NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<float16>()),
+//                         Val({num_blocks, m}, tmp_gamma_diff), Var({num_blocks, m}, tmp_reduce_buf));
+//       NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<float16>()),
+//                         Val({num_blocks, m}, tmp_beta_diff), Var({num_blocks, m}, tmp_reduce_buf));
+//     } else {
+//       if (has_beta_diff) {
+//         user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
+//         CHECK_EQ(m, beta_diff->shape().elem_cnt());
+//         CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//         const int64_t n = dy->shape().elem_cnt() / m;
+//         NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<float16>()),
+//                           Val({n, m}, dy->dptr<float16>()),
+//                           Var({n, m}, reduce_buf->mut_dptr<float16>()));
+//       }
+//       if (has_gamma_diff) {
+//         const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
+//         user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
+//         CHECK_EQ(m, gamma_diff->shape().elem_cnt());
+//         CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//         const int64_t n = dy->shape().elem_cnt() / m;
+//         NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, reduce_buf->mut_dptr<float16>()),
+//                              Val({n, m}, normalized->dptr<float16>()),
+//                              Val({n, m}, dy->dptr<float16>()));
+//         NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<float16>()),
+//                           Val({n, m}, reduce_buf->dptr<float16>()),
+//                           Var({n, m}, reduce_buf->mut_dptr<float16>()));
+//       }
+//       if (has_normalized_diff) {
+//         if (has_gamma) {
+//           CHECK_EQ(m, gamma->shape().elem_cnt());
+//           CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//           const int64_t n = dy->shape().elem_cnt() / m;
+//           NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, normalized_diff->mut_dptr<float16>()),
+//                                Val({n, m}, dy->dptr<float16>()),
+//                                Val({1, m}, gamma->dptr<float16>()));
+//         } else {
+//           Memcpy<DeviceType::kCUDA>(ctx->stream(), normalized_diff->mut_dptr<void>(),
+//                                     dy->dptr<void>(),
+//                                     dy->shape().elem_cnt() * GetSizeOfDataType(dy->data_type()));
+//         }
+//       }
+//     }
+//   }
+// };
+
+// REGISTER_USER_KERNEL("layer_norm_param_grad")
+//     .SetCreateFn<LayerNormParamGradGpuHalfKernel>()
+//     .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA)
+//                      && (user_op::HobDataType("dy", 0) == DataType::kFloat16))
+//     .SetInferTmpSizeFn([](user_op::InferContext* ctx) {
+//       const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
+//       const bool has_gamma_diff = ctx->has_output("gamma_diff", 0);
+//       const bool has_beta_diff = ctx->has_output("beta_diff", 0);
+//       const bool has_normalized_diff = ctx->has_output("normalized_diff", 0);
+//       const auto& dy = ctx->InputTensorDesc("dy", 0);
+//       const int64_t instance_size = dy.shape().Count(begin_params_axis);
+//       size_t tmp_buffer_size = 0;
+//       if (has_gamma_diff && has_beta_diff && has_normalized_diff) {
+//         const size_t tmp_gamma_diff =
+//             GetCudaAlignedSize(GetLayerNormParamGradNumBlocks(dy.shape().elem_cnt()) * instance_size
+//                                * sizeof(float16));
+//         const size_t tmp_beta_diff = tmp_gamma_diff;
+//         const size_t tmp_reduce_buf = tmp_gamma_diff;
+//         tmp_buffer_size = tmp_gamma_diff + tmp_beta_diff + tmp_reduce_buf;
+//       } else {
+//         tmp_buffer_size = 0;
+//       }
+//       return tmp_buffer_size;
+//     });
+
+}  // namespace oneflow

--- a/oneflow/user/kernels/gelu_kernel.cu
+++ b/oneflow/user/kernels/gelu_kernel.cu
@@ -25,12 +25,11 @@ namespace {
 
 template<typename T>
 struct GeluGradFunctor {
-  const T coef = std::sqrt(static_cast<T>(2.0) / std::acos(static_cast<T>(-1.0)));
   OF_DEVICE_FUNC T operator()(T x, T dy) const {
-    return static_cast<T>(0.5)
-           * (static_cast<T>(1.0) + erf(static_cast<T>(M_SQRT1_2) * x)
-              + x * coef * exp(static_cast<T>(-0.5) * x * x))
-           * dy;
+    constexpr T kBeta = M_2_SQRTPI * M_SQRT1_2 * static_cast<T>(0.5);
+    const T cdf = normcdff(x);
+    const T pdf = exp( static_cast<T>(-0.5) * x * x) * kBeta;
+    return dy * (cdf + x * pdf);
   }
 };
 

--- a/oneflow/user/kernels/layer_norm_gpu_kernel.cu
+++ b/oneflow/user/kernels/layer_norm_gpu_kernel.cu
@@ -1,620 +1,620 @@
-/*
-Copyright 2020 The OneFlow Authors. All rights reserved.
+// /*
+// Copyright 2020 The OneFlow Authors. All rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
 
-#include "oneflow/core/device/cudnn_util.h"
-#include "oneflow/core/framework/framework.h"
-#include "oneflow/core/ndarray/ndarray_util.h"
-#include "oneflow/core/cuda/atomic.cuh"
-#include <cub/cub.cuh>
-#include "oneflow/core/kernel/cuda_graph_support.h"
-#include "oneflow/core/ep/include/primitive/fill.h"
-#include "oneflow/core/ep/cuda/cuda_stream.h"
-#include "oneflow/core/cuda/layer_norm.cuh"
+// #include "oneflow/core/device/cudnn_util.h"
+// #include "oneflow/core/framework/framework.h"
+// #include "oneflow/core/ndarray/ndarray_util.h"
+// #include "oneflow/core/cuda/atomic.cuh"
+// #include <cub/cub.cuh>
+// #include "oneflow/core/kernel/cuda_graph_support.h"
+// #include "oneflow/core/ep/include/primitive/fill.h"
+// #include "oneflow/core/ep/cuda/cuda_stream.h"
+// #include "oneflow/core/cuda/layer_norm.cuh"
 
-namespace oneflow {
+// namespace oneflow {
 
-namespace {
+// namespace {
 
-template<typename SRC, typename DST, bool do_scale, bool do_center>
-struct AffineStore {
-  AffineStore(DST* normalized, DST* y, int64_t row_size, const DST* gamma, const DST* beta)
-      : normalized(normalized), y(y), row_size(row_size), gamma(gamma), beta(beta) {}
-  template<int N>
-  __device__ void store(const SRC* src, int64_t row, int64_t col) {
-    cuda::layer_norm::Pack<DST, N> y_pack;
-    cuda::layer_norm::Pack<DST, N> normalized_pack;
-    cuda::layer_norm::Pack<DST, N> gamma_pack;
-    cuda::layer_norm::Pack<DST, N> beta_pack;
-    const int64_t offset = (row * row_size + col) / N;
-    const int64_t gamma_offset = col / N;
-    if (do_scale) {
-      gamma_pack.storage =
-          *(reinterpret_cast<const cuda::layer_norm::PackType<DST, N>*>(gamma) + gamma_offset);
-    } else {
-#pragma unroll
-      for (int i = 0; i < N; ++i) { gamma_pack.elem[i] = 1; }
-    }
-    if (do_center) {
-      beta_pack.storage =
-          *(reinterpret_cast<const cuda::layer_norm::PackType<DST, N>*>(beta) + gamma_offset);
-    } else {
-#pragma unroll
-      for (int i = 0; i < N; ++i) { beta_pack.elem[i] = 0; }
-    }
-#pragma unroll
-    for (int i = 0; i < N; ++i) {
-      DST normalized_i = static_cast<DST>(src[i]);
-      if (do_scale) { normalized_pack.elem[i] = normalized_i; }
-      if (do_scale || do_center) {
-        y_pack.elem[i] = normalized_i * gamma_pack.elem[i] + beta_pack.elem[i];
-      } else {
-        y_pack.elem[i] = normalized_i;
-      }
-    }
-    *(reinterpret_cast<cuda::layer_norm::PackType<DST, N>*>(y) + offset) = y_pack.storage;
-    if (do_scale) {
-      *(reinterpret_cast<cuda::layer_norm::PackType<DST, N>*>(normalized) + offset) =
-          normalized_pack.storage;
-    }
-  }
-  DST* normalized;
-  DST* y;
-  int64_t row_size;
-  const DST* gamma;
-  const DST* beta;
-};
+// template<typename SRC, typename DST, bool do_scale, bool do_center>
+// struct AffineStore {
+//   AffineStore(DST* normalized, DST* y, int64_t row_size, const DST* gamma, const DST* beta)
+//       : normalized(normalized), y(y), row_size(row_size), gamma(gamma), beta(beta) {}
+//   template<int N>
+//   __device__ void store(const SRC* src, int64_t row, int64_t col) {
+//     cuda::layer_norm::Pack<DST, N> y_pack;
+//     cuda::layer_norm::Pack<DST, N> normalized_pack;
+//     cuda::layer_norm::Pack<DST, N> gamma_pack;
+//     cuda::layer_norm::Pack<DST, N> beta_pack;
+//     const int64_t offset = (row * row_size + col) / N;
+//     const int64_t gamma_offset = col / N;
+//     if (do_scale) {
+//       gamma_pack.storage =
+//           *(reinterpret_cast<const cuda::layer_norm::PackType<DST, N>*>(gamma) + gamma_offset);
+//     } else {
+// #pragma unroll
+//       for (int i = 0; i < N; ++i) { gamma_pack.elem[i] = 1; }
+//     }
+//     if (do_center) {
+//       beta_pack.storage =
+//           *(reinterpret_cast<const cuda::layer_norm::PackType<DST, N>*>(beta) + gamma_offset);
+//     } else {
+// #pragma unroll
+//       for (int i = 0; i < N; ++i) { beta_pack.elem[i] = 0; }
+//     }
+// #pragma unroll
+//     for (int i = 0; i < N; ++i) {
+//       DST normalized_i = static_cast<DST>(src[i]);
+//       if (do_scale) { normalized_pack.elem[i] = normalized_i; }
+//       if (do_scale || do_center) {
+//         y_pack.elem[i] = normalized_i * gamma_pack.elem[i] + beta_pack.elem[i];
+//       } else {
+//         y_pack.elem[i] = normalized_i;
+//       }
+//     }
+//     *(reinterpret_cast<cuda::layer_norm::PackType<DST, N>*>(y) + offset) = y_pack.storage;
+//     if (do_scale) {
+//       *(reinterpret_cast<cuda::layer_norm::PackType<DST, N>*>(normalized) + offset) =
+//           normalized_pack.storage;
+//     }
+//   }
+//   DST* normalized;
+//   DST* y;
+//   int64_t row_size;
+//   const DST* gamma;
+//   const DST* beta;
+// };
 
-template<typename SRC, typename DST, bool do_scale>
-struct ScaleLoad {
-  ScaleLoad(const SRC* src, const SRC* gamma, int64_t row_size)
-      : src(src), gamma(gamma), row_size(row_size) {}
-  template<int N>
-  __device__ void load(DST* dst, int64_t row, int64_t col) const {
-    cuda::layer_norm::Pack<SRC, N> src_pack;
-    cuda::layer_norm::Pack<SRC, N> gamma_pack;
-    const int64_t offset = (row * row_size + col) / N;
-    const int64_t gamma_offset = col / N;
-    src_pack.storage = *(reinterpret_cast<const cuda::layer_norm::PackType<SRC, N>*>(src) + offset);
-    if (do_scale) {
-      gamma_pack.storage =
-          *(reinterpret_cast<const cuda::layer_norm::PackType<SRC, N>*>(gamma) + gamma_offset);
-    } else {
-#pragma unroll
-      for (int i = 0; i < N; ++i) { gamma_pack.elem[i] = static_cast<SRC>(1); }
-    }
-#pragma unroll
-    for (int i = 0; i < N; ++i) {
-      dst[i] = static_cast<DST>(src_pack.elem[i] * gamma_pack.elem[i]);
-    }
-  }
-  const SRC* src;
-  const SRC* gamma;
-  int64_t row_size;
-};
+// template<typename SRC, typename DST, bool do_scale>
+// struct ScaleLoad {
+//   ScaleLoad(const SRC* src, const SRC* gamma, int64_t row_size)
+//       : src(src), gamma(gamma), row_size(row_size) {}
+//   template<int N>
+//   __device__ void load(DST* dst, int64_t row, int64_t col) const {
+//     cuda::layer_norm::Pack<SRC, N> src_pack;
+//     cuda::layer_norm::Pack<SRC, N> gamma_pack;
+//     const int64_t offset = (row * row_size + col) / N;
+//     const int64_t gamma_offset = col / N;
+//     src_pack.storage = *(reinterpret_cast<const cuda::layer_norm::PackType<SRC, N>*>(src) + offset);
+//     if (do_scale) {
+//       gamma_pack.storage =
+//           *(reinterpret_cast<const cuda::layer_norm::PackType<SRC, N>*>(gamma) + gamma_offset);
+//     } else {
+// #pragma unroll
+//       for (int i = 0; i < N; ++i) { gamma_pack.elem[i] = static_cast<SRC>(1); }
+//     }
+// #pragma unroll
+//     for (int i = 0; i < N; ++i) {
+//       dst[i] = static_cast<DST>(src_pack.elem[i] * gamma_pack.elem[i]);
+//     }
+//   }
+//   const SRC* src;
+//   const SRC* gamma;
+//   int64_t row_size;
+// };
 
-template<typename SRC, typename DST, bool do_add>
-struct AddStore {
-  AddStore(const DST* add_to_output, DST* dst, int64_t row_size)
-      : add_to_output(add_to_output), dst(dst), row_size(row_size) {}
-  template<int N>
-  __device__ void store(const SRC* src, int64_t row, int64_t col) {
-    cuda::layer_norm::Pack<DST, N> add_to_output_pack;
-    cuda::layer_norm::Pack<DST, N> dst_pack;
-    const int64_t offset = (row * row_size + col) / N;
-    if (do_add) {
-      add_to_output_pack.storage =
-          *(reinterpret_cast<const cuda::layer_norm::PackType<DST, N>*>(add_to_output) + offset);
-    }
-#pragma unroll
-    for (int i = 0; i < N; ++i) {
-      if (do_add) {
-        dst_pack.elem[i] = static_cast<DST>(src[i]) + add_to_output_pack.elem[i];
-      } else {
-        dst_pack.elem[i] = static_cast<DST>(src[i]);
-      }
-    }
-    *(reinterpret_cast<cuda::layer_norm::PackType<DST, N>*>(dst) + offset) = dst_pack.storage;
-  }
-  const DST* add_to_output;
-  DST* dst;
-  int64_t row_size;
-};
+// template<typename SRC, typename DST, bool do_add>
+// struct AddStore {
+//   AddStore(const DST* add_to_output, DST* dst, int64_t row_size)
+//       : add_to_output(add_to_output), dst(dst), row_size(row_size) {}
+//   template<int N>
+//   __device__ void store(const SRC* src, int64_t row, int64_t col) {
+//     cuda::layer_norm::Pack<DST, N> add_to_output_pack;
+//     cuda::layer_norm::Pack<DST, N> dst_pack;
+//     const int64_t offset = (row * row_size + col) / N;
+//     if (do_add) {
+//       add_to_output_pack.storage =
+//           *(reinterpret_cast<const cuda::layer_norm::PackType<DST, N>*>(add_to_output) + offset);
+//     }
+// #pragma unroll
+//     for (int i = 0; i < N; ++i) {
+//       if (do_add) {
+//         dst_pack.elem[i] = static_cast<DST>(src[i]) + add_to_output_pack.elem[i];
+//       } else {
+//         dst_pack.elem[i] = static_cast<DST>(src[i]);
+//       }
+//     }
+//     *(reinterpret_cast<cuda::layer_norm::PackType<DST, N>*>(dst) + offset) = dst_pack.storage;
+//   }
+//   const DST* add_to_output;
+//   DST* dst;
+//   int64_t row_size;
+// };
 
-constexpr int64_t kLayerNormParamGradGpuBlockSize = 512;
+// constexpr int64_t kLayerNormParamGradGpuBlockSize = 512;
 
-int64_t GetLayerNormParamGradBlockSize() { return kLayerNormParamGradGpuBlockSize; }
+// int64_t GetLayerNormParamGradBlockSize() { return kLayerNormParamGradGpuBlockSize; }
 
-int64_t GetLayerNormParamGradNumBlocks(const int64_t elem_cnt) {
-  return std::min(static_cast<int>((elem_cnt + kLayerNormParamGradGpuBlockSize - 1)
-                                   / kLayerNormParamGradGpuBlockSize),
-                  256);
-}
+// int64_t GetLayerNormParamGradNumBlocks(const int64_t elem_cnt) {
+//   return std::min(static_cast<int>((elem_cnt + kLayerNormParamGradGpuBlockSize - 1)
+//                                    / kLayerNormParamGradGpuBlockSize),
+//                   256);
+// }
 
-template<typename T>
-int64_t GetParamGradDynamicSharedMemorySize(const int64_t instance_size) {
-  return 2 * instance_size * sizeof(T);
-}
+// template<typename T>
+// int64_t GetParamGradDynamicSharedMemorySize(const int64_t instance_size) {
+//   return 2 * instance_size * sizeof(T);
+// }
 
-template<>
-int64_t GetParamGradDynamicSharedMemorySize<float16>(const int64_t instance_size) {
-  return 2 * instance_size * sizeof(float);
-}
+// template<>
+// int64_t GetParamGradDynamicSharedMemorySize<float16>(const int64_t instance_size) {
+//   return 2 * instance_size * sizeof(float);
+// }
 
-template<typename T, typename I>
-__global__ void LayerNormParamGradImpl(const I n, const I instance_size, const T* dy,
-                                       const T* normalized, const T* gamma, T* gamma_diff,
-                                       T* beta_diff, T* normalized_diff) {
-  extern __shared__ __align__(sizeof(double)) unsigned char bw_shared_buf[];
-  auto* gamma_diff_sum_buf = reinterpret_cast<T*>(bw_shared_buf);
-  auto* beta_diff_sum_buf = gamma_diff_sum_buf + instance_size;
-  const I tid = threadIdx.x;
-  for (I elem_id = tid; elem_id < instance_size; elem_id += blockDim.x) {
-    gamma_diff_sum_buf[elem_id] = 0;
-    beta_diff_sum_buf[elem_id] = 0;
-  }
-  __syncthreads();
-  CUDA_1D_KERNEL_LOOP_T(I, i, n) {
-    const I elem_id = i % instance_size;
-    T dy_val = dy[i];
-    T normalized_val = normalized[i];
-    cuda::atomic::Add(&gamma_diff_sum_buf[elem_id], dy_val * normalized_val);
-    cuda::atomic::Add(&beta_diff_sum_buf[elem_id], dy_val);
-    T gamma_val = gamma[elem_id];
-    normalized_diff[i] = gamma_val * dy_val;
-  }
-  __syncthreads();
-  for (I elem_id = tid; elem_id < instance_size; elem_id += blockDim.x) {
-    cuda::atomic::Add(gamma_diff + elem_id, gamma_diff_sum_buf[elem_id]);
-    cuda::atomic::Add(beta_diff + elem_id, beta_diff_sum_buf[elem_id]);
-  }
-}
+// template<typename T, typename I>
+// __global__ void LayerNormParamGradImpl(const I n, const I instance_size, const T* dy,
+//                                        const T* normalized, const T* gamma, T* gamma_diff,
+//                                        T* beta_diff, T* normalized_diff) {
+//   extern __shared__ __align__(sizeof(double)) unsigned char bw_shared_buf[];
+//   auto* gamma_diff_sum_buf = reinterpret_cast<T*>(bw_shared_buf);
+//   auto* beta_diff_sum_buf = gamma_diff_sum_buf + instance_size;
+//   const I tid = threadIdx.x;
+//   for (I elem_id = tid; elem_id < instance_size; elem_id += blockDim.x) {
+//     gamma_diff_sum_buf[elem_id] = 0;
+//     beta_diff_sum_buf[elem_id] = 0;
+//   }
+//   __syncthreads();
+//   CUDA_1D_KERNEL_LOOP_T(I, i, n) {
+//     const I elem_id = i % instance_size;
+//     T dy_val = dy[i];
+//     T normalized_val = normalized[i];
+//     cuda::atomic::Add(&gamma_diff_sum_buf[elem_id], dy_val * normalized_val);
+//     cuda::atomic::Add(&beta_diff_sum_buf[elem_id], dy_val);
+//     T gamma_val = gamma[elem_id];
+//     normalized_diff[i] = gamma_val * dy_val;
+//   }
+//   __syncthreads();
+//   for (I elem_id = tid; elem_id < instance_size; elem_id += blockDim.x) {
+//     cuda::atomic::Add(gamma_diff + elem_id, gamma_diff_sum_buf[elem_id]);
+//     cuda::atomic::Add(beta_diff + elem_id, beta_diff_sum_buf[elem_id]);
+//   }
+// }
 
-template<typename I>
-__global__ void LayerNormParamGradHalfImpl(const I n, const I instance_size, const half* dy,
-                                           const half* normalized, const half* gamma,
-                                           half* tmp_gamma_diff, half* tmp_beta_diff,
-                                           half* normalized_diff) {
-  extern __shared__ __align__(sizeof(double)) unsigned char bw_shared_buf[];
-  auto* gamma_diff_sum_buf = reinterpret_cast<float*>(bw_shared_buf);
-  auto* beta_diff_sum_buf = gamma_diff_sum_buf + instance_size;
-  const I tid = threadIdx.x;
-  for (I elem_id = tid; elem_id < instance_size; elem_id += blockDim.x) {
-    gamma_diff_sum_buf[elem_id] = 0;
-    beta_diff_sum_buf[elem_id] = 0;
-  }
-  __syncthreads();
-  CUDA_1D_KERNEL_LOOP_T(I, i, n) {
-    const I elem_id = i % instance_size;
-    half dy_val = dy[i];
-    half normalized_val = normalized[i];
-    cuda::atomic::Add(&gamma_diff_sum_buf[elem_id],
-                      __half2float(dy_val) * __half2float(normalized_val));
-    cuda::atomic::Add(&beta_diff_sum_buf[elem_id], __half2float(dy_val));
-    half gamma_val = gamma[elem_id];
-    normalized_diff[i] = __hmul(gamma_val, dy_val);
-  }
-  __syncthreads();
-  for (I elem_id = tid; elem_id < instance_size; elem_id += blockDim.x) {
-    const I offset = blockIdx.x * instance_size + elem_id;
-    tmp_gamma_diff[offset] = __float2half(gamma_diff_sum_buf[elem_id]);
-    tmp_beta_diff[offset] = __float2half(beta_diff_sum_buf[elem_id]);
-  }
-}
+// template<typename I>
+// __global__ void LayerNormParamGradHalfImpl(const I n, const I instance_size, const half* dy,
+//                                            const half* normalized, const half* gamma,
+//                                            half* tmp_gamma_diff, half* tmp_beta_diff,
+//                                            half* normalized_diff) {
+//   extern __shared__ __align__(sizeof(double)) unsigned char bw_shared_buf[];
+//   auto* gamma_diff_sum_buf = reinterpret_cast<float*>(bw_shared_buf);
+//   auto* beta_diff_sum_buf = gamma_diff_sum_buf + instance_size;
+//   const I tid = threadIdx.x;
+//   for (I elem_id = tid; elem_id < instance_size; elem_id += blockDim.x) {
+//     gamma_diff_sum_buf[elem_id] = 0;
+//     beta_diff_sum_buf[elem_id] = 0;
+//   }
+//   __syncthreads();
+//   CUDA_1D_KERNEL_LOOP_T(I, i, n) {
+//     const I elem_id = i % instance_size;
+//     half dy_val = dy[i];
+//     half normalized_val = normalized[i];
+//     cuda::atomic::Add(&gamma_diff_sum_buf[elem_id],
+//                       __half2float(dy_val) * __half2float(normalized_val));
+//     cuda::atomic::Add(&beta_diff_sum_buf[elem_id], __half2float(dy_val));
+//     half gamma_val = gamma[elem_id];
+//     normalized_diff[i] = __hmul(gamma_val, dy_val);
+//   }
+//   __syncthreads();
+//   for (I elem_id = tid; elem_id < instance_size; elem_id += blockDim.x) {
+//     const I offset = blockIdx.x * instance_size + elem_id;
+//     tmp_gamma_diff[offset] = __float2half(gamma_diff_sum_buf[elem_id]);
+//     tmp_beta_diff[offset] = __float2half(beta_diff_sum_buf[elem_id]);
+//   }
+// }
 
-template<typename T, bool do_scale, bool do_center>
-void LayerNormForwardGpu(ep::Stream* stream, const int64_t num_instances, const int64_t norm_size,
-                         const double epsilon, const T* x_ptr, const T* gamma_ptr,
-                         const T* beta_ptr, T* normalized_ptr, T* y_ptr, user_op::Tensor* mean,
-                         user_op::Tensor* inv_variance) {
-  using ComputeType = typename cuda::layer_norm::DefaultComputeType<T>::type;
-  cuda::layer_norm::DirectLoad<T, ComputeType> load(x_ptr, norm_size);
-  AffineStore<ComputeType, T, do_scale, do_center> store(normalized_ptr, y_ptr, norm_size,
-                                                         gamma_ptr, beta_ptr);
-  cuda::layer_norm::DispatchLayerNorm<decltype(load), decltype(store), ComputeType>(
-      stream->As<ep::CudaStream>()->cuda_stream(), load, store, num_instances, norm_size, epsilon,
-      mean->mut_dptr<ComputeType>(), inv_variance->mut_dptr<ComputeType>());
-}
+// template<typename T, bool do_scale, bool do_center>
+// void LayerNormForwardGpu(ep::Stream* stream, const int64_t num_instances, const int64_t norm_size,
+//                          const double epsilon, const T* x_ptr, const T* gamma_ptr,
+//                          const T* beta_ptr, T* normalized_ptr, T* y_ptr, user_op::Tensor* mean,
+//                          user_op::Tensor* inv_variance) {
+//   using ComputeType = typename cuda::layer_norm::DefaultComputeType<T>::type;
+//   cuda::layer_norm::DirectLoad<T, ComputeType> load(x_ptr, norm_size);
+//   AffineStore<ComputeType, T, do_scale, do_center> store(normalized_ptr, y_ptr, norm_size,
+//                                                          gamma_ptr, beta_ptr);
+//   cuda::layer_norm::DispatchLayerNorm<decltype(load), decltype(store), ComputeType>(
+//       stream->As<ep::CudaStream>()->cuda_stream(), load, store, num_instances, norm_size, epsilon,
+//       mean->mut_dptr<ComputeType>(), inv_variance->mut_dptr<ComputeType>());
+// }
 
-template<typename T>
-void DispatchLayerNormForwardGpu(ep::Stream* stream, const int64_t num_instances,
-                                 const int64_t norm_size, const double epsilon, const T* x_ptr,
-                                 const T* gamma_ptr, const T* beta_ptr, T* normalized_ptr, T* y_ptr,
-                                 user_op::Tensor* mean, user_op::Tensor* inv_variance) {
-  if (gamma_ptr != nullptr && beta_ptr != nullptr) {
-    LayerNormForwardGpu<T, true, true>(stream, num_instances, norm_size, epsilon, x_ptr, gamma_ptr,
-                                       beta_ptr, normalized_ptr, y_ptr, mean, inv_variance);
-  } else if (gamma_ptr != nullptr && beta_ptr == nullptr) {
-    LayerNormForwardGpu<T, true, false>(stream, num_instances, norm_size, epsilon, x_ptr, gamma_ptr,
-                                        beta_ptr, normalized_ptr, y_ptr, mean, inv_variance);
-  } else if (gamma_ptr == nullptr && beta_ptr != nullptr) {
-    LayerNormForwardGpu<T, false, true>(stream, num_instances, norm_size, epsilon, x_ptr, gamma_ptr,
-                                        beta_ptr, normalized_ptr, y_ptr, mean, inv_variance);
-  } else {
-    LayerNormForwardGpu<T, false, false>(stream, num_instances, norm_size, epsilon, x_ptr,
-                                         gamma_ptr, beta_ptr, normalized_ptr, y_ptr, mean,
-                                         inv_variance);
-  }
-}
+// template<typename T>
+// void DispatchLayerNormForwardGpu(ep::Stream* stream, const int64_t num_instances,
+//                                  const int64_t norm_size, const double epsilon, const T* x_ptr,
+//                                  const T* gamma_ptr, const T* beta_ptr, T* normalized_ptr, T* y_ptr,
+//                                  user_op::Tensor* mean, user_op::Tensor* inv_variance) {
+//   if (gamma_ptr != nullptr && beta_ptr != nullptr) {
+//     LayerNormForwardGpu<T, true, true>(stream, num_instances, norm_size, epsilon, x_ptr, gamma_ptr,
+//                                        beta_ptr, normalized_ptr, y_ptr, mean, inv_variance);
+//   } else if (gamma_ptr != nullptr && beta_ptr == nullptr) {
+//     LayerNormForwardGpu<T, true, false>(stream, num_instances, norm_size, epsilon, x_ptr, gamma_ptr,
+//                                         beta_ptr, normalized_ptr, y_ptr, mean, inv_variance);
+//   } else if (gamma_ptr == nullptr && beta_ptr != nullptr) {
+//     LayerNormForwardGpu<T, false, true>(stream, num_instances, norm_size, epsilon, x_ptr, gamma_ptr,
+//                                         beta_ptr, normalized_ptr, y_ptr, mean, inv_variance);
+//   } else {
+//     LayerNormForwardGpu<T, false, false>(stream, num_instances, norm_size, epsilon, x_ptr,
+//                                          gamma_ptr, beta_ptr, normalized_ptr, y_ptr, mean,
+//                                          inv_variance);
+//   }
+// }
 
-template<typename T, bool do_scale, bool do_add>
-void LayerNormBackwardGpu(ep::Stream* stream, const int64_t num_instances, const int64_t norm_size,
-                          const T* dy_ptr, const T* x_ptr, const user_op::Tensor* mean,
-                          const user_op::Tensor* inv_variance, const T* gamma_ptr,
-                          const T* add_to_output_ptr, T* dx_ptr) {
-  using ComputeType = typename cuda::layer_norm::DefaultComputeType<T>::type;
-  cuda::layer_norm::DirectLoad<T, ComputeType> load_x(x_ptr, norm_size);
-  ScaleLoad<T, ComputeType, do_scale> load_scaled_dy(dy_ptr, gamma_ptr, norm_size);
-  AddStore<ComputeType, T, do_add> store(add_to_output_ptr, dx_ptr, norm_size);
-  OF_CUDA_CHECK((cuda::layer_norm::DispatchLayerNormGrad<decltype(load_x), decltype(load_scaled_dy),
-                                                         decltype(store), ComputeType>(
-      stream->As<ep::CudaStream>()->cuda_stream(), load_x, load_scaled_dy, store,
-      mean->dptr<ComputeType>(), inv_variance->dptr<ComputeType>(), num_instances, norm_size)));
-}
+// template<typename T, bool do_scale, bool do_add>
+// void LayerNormBackwardGpu(ep::Stream* stream, const int64_t num_instances, const int64_t norm_size,
+//                           const T* dy_ptr, const T* x_ptr, const user_op::Tensor* mean,
+//                           const user_op::Tensor* inv_variance, const T* gamma_ptr,
+//                           const T* add_to_output_ptr, T* dx_ptr) {
+//   using ComputeType = typename cuda::layer_norm::DefaultComputeType<T>::type;
+//   cuda::layer_norm::DirectLoad<T, ComputeType> load_x(x_ptr, norm_size);
+//   ScaleLoad<T, ComputeType, do_scale> load_scaled_dy(dy_ptr, gamma_ptr, norm_size);
+//   AddStore<ComputeType, T, do_add> store(add_to_output_ptr, dx_ptr, norm_size);
+//   OF_CUDA_CHECK((cuda::layer_norm::DispatchLayerNormGrad<decltype(load_x), decltype(load_scaled_dy),
+//                                                          decltype(store), ComputeType>(
+//       stream->As<ep::CudaStream>()->cuda_stream(), load_x, load_scaled_dy, store,
+//       mean->dptr<ComputeType>(), inv_variance->dptr<ComputeType>(), num_instances, norm_size)));
+// }
 
-template<typename T, bool do_scale>
-void DispatchLayerNormBackwardDoAdd(ep::Stream* stream, const int64_t num_instances,
-                                    const int64_t norm_size, const T* dy_ptr, const T* x_ptr,
-                                    const user_op::Tensor* mean,
-                                    const user_op::Tensor* inv_variance, const T* gamma_ptr,
-                                    const T* add_to_output_ptr, T* dx_ptr) {
-  if (add_to_output_ptr != nullptr) {
-    LayerNormBackwardGpu<T, do_scale, true>(stream, num_instances, norm_size, dy_ptr, x_ptr, mean,
-                                            inv_variance, gamma_ptr, add_to_output_ptr, dx_ptr);
-  } else {
-    LayerNormBackwardGpu<T, do_scale, false>(stream, num_instances, norm_size, dy_ptr, x_ptr, mean,
-                                             inv_variance, gamma_ptr, add_to_output_ptr, dx_ptr);
-  }
-}
+// template<typename T, bool do_scale>
+// void DispatchLayerNormBackwardDoAdd(ep::Stream* stream, const int64_t num_instances,
+//                                     const int64_t norm_size, const T* dy_ptr, const T* x_ptr,
+//                                     const user_op::Tensor* mean,
+//                                     const user_op::Tensor* inv_variance, const T* gamma_ptr,
+//                                     const T* add_to_output_ptr, T* dx_ptr) {
+//   if (add_to_output_ptr != nullptr) {
+//     LayerNormBackwardGpu<T, do_scale, true>(stream, num_instances, norm_size, dy_ptr, x_ptr, mean,
+//                                             inv_variance, gamma_ptr, add_to_output_ptr, dx_ptr);
+//   } else {
+//     LayerNormBackwardGpu<T, do_scale, false>(stream, num_instances, norm_size, dy_ptr, x_ptr, mean,
+//                                              inv_variance, gamma_ptr, add_to_output_ptr, dx_ptr);
+//   }
+// }
 
-template<typename T>
-void LaunchLayerNormBackward(ep::Stream* stream, const int64_t num_instances,
-                             const int64_t norm_size, const T* dy_ptr, const T* x_ptr,
-                             const user_op::Tensor* mean, const user_op::Tensor* inv_variance,
-                             const T* gamma_ptr, const T* add_to_output_ptr, T* dx_ptr) {
-  if (gamma_ptr != nullptr) {
-    DispatchLayerNormBackwardDoAdd<T, true>(stream, num_instances, norm_size, dy_ptr, x_ptr, mean,
-                                            inv_variance, gamma_ptr, add_to_output_ptr, dx_ptr);
-  } else {
-    DispatchLayerNormBackwardDoAdd<T, false>(stream, num_instances, norm_size, dy_ptr, x_ptr, mean,
-                                             inv_variance, gamma_ptr, add_to_output_ptr, dx_ptr);
-  }
-}
+// template<typename T>
+// void LaunchLayerNormBackward(ep::Stream* stream, const int64_t num_instances,
+//                              const int64_t norm_size, const T* dy_ptr, const T* x_ptr,
+//                              const user_op::Tensor* mean, const user_op::Tensor* inv_variance,
+//                              const T* gamma_ptr, const T* add_to_output_ptr, T* dx_ptr) {
+//   if (gamma_ptr != nullptr) {
+//     DispatchLayerNormBackwardDoAdd<T, true>(stream, num_instances, norm_size, dy_ptr, x_ptr, mean,
+//                                             inv_variance, gamma_ptr, add_to_output_ptr, dx_ptr);
+//   } else {
+//     DispatchLayerNormBackwardDoAdd<T, false>(stream, num_instances, norm_size, dy_ptr, x_ptr, mean,
+//                                              inv_variance, gamma_ptr, add_to_output_ptr, dx_ptr);
+//   }
+// }
 
-}  // namespace
+// }  // namespace
 
-template<typename T>
-class LayerNormGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
- public:
-  LayerNormGpuKernel() = default;
-  ~LayerNormGpuKernel() = default;
+// template<typename T>
+// class LayerNormGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+//  public:
+//   LayerNormGpuKernel() = default;
+//   ~LayerNormGpuKernel() = default;
 
- private:
-  using user_op::OpKernel::Compute;
-  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
-  void Compute(user_op::KernelComputeContext* ctx) const override {
-    const user_op::Tensor* x = ctx->Tensor4ArgNameAndIndex("x", 0);
-    user_op::Tensor* y = ctx->Tensor4ArgNameAndIndex("y", 0);
-    user_op::Tensor* mean = ctx->Tensor4ArgNameAndIndex("mean", 0);
-    user_op::Tensor* inv_variance = ctx->Tensor4ArgNameAndIndex("inv_variance", 0);
-    user_op::Tensor* normalized =
-        ctx->has_input("gamma", 0) ? ctx->Tensor4ArgNameAndIndex("normalized", 0) : y;
-    const double epsilon = ctx->Attr<double>("epsilon");
-    CHECK_GE(epsilon, CUDNN_BN_MIN_EPSILON);
-    const int64_t num_instances = mean->shape().elem_cnt();
-    const int64_t norm_size = x->shape().elem_cnt() / num_instances;
-    const T* gamma_ptr = nullptr;
-    const T* beta_ptr = nullptr;
-    if (ctx->has_input("gamma", 0)) {
-      const user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
-      gamma_ptr = gamma->dptr<T>();
-      CHECK_EQ(gamma->shape().elem_cnt(), norm_size);
-    }
-    if (ctx->has_input("beta", 0)) { beta_ptr = ctx->Tensor4ArgNameAndIndex("beta", 0)->dptr<T>(); }
-    DispatchLayerNormForwardGpu<T>(ctx->stream(), num_instances, norm_size, epsilon, x->dptr<T>(),
-                                   gamma_ptr, beta_ptr, normalized->mut_dptr<T>(), y->mut_dptr<T>(),
-                                   mean, inv_variance);
-  };
-};
+//  private:
+//   using user_op::OpKernel::Compute;
+//   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+//   void Compute(user_op::KernelComputeContext* ctx) const override {
+//     const user_op::Tensor* x = ctx->Tensor4ArgNameAndIndex("x", 0);
+//     user_op::Tensor* y = ctx->Tensor4ArgNameAndIndex("y", 0);
+//     user_op::Tensor* mean = ctx->Tensor4ArgNameAndIndex("mean", 0);
+//     user_op::Tensor* inv_variance = ctx->Tensor4ArgNameAndIndex("inv_variance", 0);
+//     user_op::Tensor* normalized =
+//         ctx->has_input("gamma", 0) ? ctx->Tensor4ArgNameAndIndex("normalized", 0) : y;
+//     const double epsilon = ctx->Attr<double>("epsilon");
+//     CHECK_GE(epsilon, CUDNN_BN_MIN_EPSILON);
+//     const int64_t num_instances = mean->shape().elem_cnt();
+//     const int64_t norm_size = x->shape().elem_cnt() / num_instances;
+//     const T* gamma_ptr = nullptr;
+//     const T* beta_ptr = nullptr;
+//     if (ctx->has_input("gamma", 0)) {
+//       const user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
+//       gamma_ptr = gamma->dptr<T>();
+//       CHECK_EQ(gamma->shape().elem_cnt(), norm_size);
+//     }
+//     if (ctx->has_input("beta", 0)) { beta_ptr = ctx->Tensor4ArgNameAndIndex("beta", 0)->dptr<T>(); }
+//     DispatchLayerNormForwardGpu<T>(ctx->stream(), num_instances, norm_size, epsilon, x->dptr<T>(),
+//                                    gamma_ptr, beta_ptr, normalized->mut_dptr<T>(), y->mut_dptr<T>(),
+//                                    mean, inv_variance);
+//   };
+// };
 
-#define REGISTER_LAYER_NORM_CUDA_KERNEL(dtype)                         \
-  REGISTER_USER_KERNEL("layer_norm")                                   \
-      .SetCreateFn<LayerNormGpuKernel<dtype>>()                        \
-      .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA) \
-                       && (user_op::HobDataType("x", 0) == GetDataType<dtype>::value));
+// #define REGISTER_LAYER_NORM_CUDA_KERNEL(dtype)                         \
+//   REGISTER_USER_KERNEL("layer_norm")                                   \
+//       .SetCreateFn<LayerNormGpuKernel<dtype>>()                        \
+//       .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA) \
+//                        && (user_op::HobDataType("x", 0) == GetDataType<dtype>::value));
 
-REGISTER_LAYER_NORM_CUDA_KERNEL(float)
-REGISTER_LAYER_NORM_CUDA_KERNEL(double)
-REGISTER_LAYER_NORM_CUDA_KERNEL(half)
+// REGISTER_LAYER_NORM_CUDA_KERNEL(float)
+// REGISTER_LAYER_NORM_CUDA_KERNEL(double)
+// REGISTER_LAYER_NORM_CUDA_KERNEL(half)
 
-template<typename T>
-class LayerNormGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
- public:
-  LayerNormGradGpuKernel() = default;
-  ~LayerNormGradGpuKernel() = default;
+// template<typename T>
+// class LayerNormGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+//  public:
+//   LayerNormGradGpuKernel() = default;
+//   ~LayerNormGradGpuKernel() = default;
 
- private:
-  using user_op::OpKernel::Compute;
-  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
-  void Compute(user_op::KernelComputeContext* ctx) const override {
-    const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
-    const user_op::Tensor* x = ctx->Tensor4ArgNameAndIndex("x", 0);
-    const user_op::Tensor* mean = ctx->Tensor4ArgNameAndIndex("mean", 0);
-    const user_op::Tensor* inv_variance = ctx->Tensor4ArgNameAndIndex("inv_variance", 0);
-    user_op::Tensor* dx = ctx->Tensor4ArgNameAndIndex("dx", 0);
-    const int64_t num_instances = mean->shape().elem_cnt();
-    const int64_t norm_size = x->shape().elem_cnt() / num_instances;
-    const T* gamma_ptr = nullptr;
-    if (ctx->has_input("gamma", 0)) {
-      gamma_ptr = ctx->Tensor4ArgNameAndIndex("gamma", 0)->dptr<T>();
-    }
-    const T* add_to_output_ptr = nullptr;
-    if (ctx->has_input("_add_to_output", 0)) {
-      const user_op::Tensor* add_to_output = ctx->Tensor4ArgNameAndIndex("_add_to_output", 0);
-      CHECK_EQ(add_to_output->data_type(), dx->data_type());
-      CHECK_EQ(add_to_output->shape(), dx->shape());
-      add_to_output_ptr = add_to_output->dptr<T>();
-    }
-    LaunchLayerNormBackward<T>(ctx->stream(), num_instances, norm_size, dy->dptr<T>(), x->dptr<T>(),
-                               mean, inv_variance, gamma_ptr, add_to_output_ptr, dx->mut_dptr<T>());
-  };
-};
+//  private:
+//   using user_op::OpKernel::Compute;
+//   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+//   void Compute(user_op::KernelComputeContext* ctx) const override {
+//     const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
+//     const user_op::Tensor* x = ctx->Tensor4ArgNameAndIndex("x", 0);
+//     const user_op::Tensor* mean = ctx->Tensor4ArgNameAndIndex("mean", 0);
+//     const user_op::Tensor* inv_variance = ctx->Tensor4ArgNameAndIndex("inv_variance", 0);
+//     user_op::Tensor* dx = ctx->Tensor4ArgNameAndIndex("dx", 0);
+//     const int64_t num_instances = mean->shape().elem_cnt();
+//     const int64_t norm_size = x->shape().elem_cnt() / num_instances;
+//     const T* gamma_ptr = nullptr;
+//     if (ctx->has_input("gamma", 0)) {
+//       gamma_ptr = ctx->Tensor4ArgNameAndIndex("gamma", 0)->dptr<T>();
+//     }
+//     const T* add_to_output_ptr = nullptr;
+//     if (ctx->has_input("_add_to_output", 0)) {
+//       const user_op::Tensor* add_to_output = ctx->Tensor4ArgNameAndIndex("_add_to_output", 0);
+//       CHECK_EQ(add_to_output->data_type(), dx->data_type());
+//       CHECK_EQ(add_to_output->shape(), dx->shape());
+//       add_to_output_ptr = add_to_output->dptr<T>();
+//     }
+//     LaunchLayerNormBackward<T>(ctx->stream(), num_instances, norm_size, dy->dptr<T>(), x->dptr<T>(),
+//                                mean, inv_variance, gamma_ptr, add_to_output_ptr, dx->mut_dptr<T>());
+//   };
+// };
 
-#define REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(dtype)                                        \
-  REGISTER_USER_KERNEL("layer_norm_grad")                                                  \
-      .SetCreateFn<LayerNormGradGpuKernel<dtype>>()                                        \
-      .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA)                     \
-                       && (user_op::HobDataType("dy", 0) == GetDataType<dtype>::value))    \
-      .SetInplaceProposalFn(                                                               \
-          [](const user_op::InferContext& ctx,                                             \
-             const user_op::AddInplaceArgPair& AddInplaceArgPairFn) -> Maybe<void> {       \
-            if (ctx.has_input("_add_to_output", 0)) {                                      \
-              OF_RETURN_IF_ERROR(AddInplaceArgPairFn("dx", 0, "_add_to_output", 0, true)); \
-            }                                                                              \
-            return Maybe<void>::Ok();                                                      \
-          });
+// #define REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(dtype)                                        \
+//   REGISTER_USER_KERNEL("layer_norm_grad")                                                  \
+//       .SetCreateFn<LayerNormGradGpuKernel<dtype>>()                                        \
+//       .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA)                     \
+//                        && (user_op::HobDataType("dy", 0) == GetDataType<dtype>::value))    \
+//       .SetInplaceProposalFn(                                                               \
+//           [](const user_op::InferContext& ctx,                                             \
+//              const user_op::AddInplaceArgPair& AddInplaceArgPairFn) -> Maybe<void> {       \
+//             if (ctx.has_input("_add_to_output", 0)) {                                      \
+//               OF_RETURN_IF_ERROR(AddInplaceArgPairFn("dx", 0, "_add_to_output", 0, true)); \
+//             }                                                                              \
+//             return Maybe<void>::Ok();                                                      \
+//           });
 
-REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(float)
-REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(double)
-REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(half)
+// REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(float)
+// REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(double)
+// REGISTER_LAYER_NORM_GRAD_CUDA_KERNEL(half)
 
-template<typename T>
-class LayerNormParamGradGpuKernel final : public user_op::OpKernel,
-                                          public user_op::CudaGraphSupport {
- public:
-  LayerNormParamGradGpuKernel() = default;
-  ~LayerNormParamGradGpuKernel() = default;
+// template<typename T>
+// class LayerNormParamGradGpuKernel final : public user_op::OpKernel,
+//                                           public user_op::CudaGraphSupport {
+//  public:
+//   LayerNormParamGradGpuKernel() = default;
+//   ~LayerNormParamGradGpuKernel() = default;
 
- private:
-  using user_op::OpKernel::Compute;
-  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
-  void Compute(user_op::KernelComputeContext* ctx) const override {
-    using NdUtil = NdarrayUtil<DeviceType::kCUDA, T>;
-    auto Val = NdUtil::GetValNdarrayBuilder();
-    auto Var = NdUtil::GetVarNdarrayBuilder();
-    const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
-    user_op::Tensor* beta_diff = ctx->Tensor4ArgNameAndIndex("beta_diff", 0);
-    user_op::Tensor* gamma_diff = ctx->Tensor4ArgNameAndIndex("gamma_diff", 0);
-    user_op::Tensor* normalized_diff = ctx->Tensor4ArgNameAndIndex("normalized_diff", 0);
-    user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
-    const bool has_beta_diff = beta_diff != nullptr;
-    const bool has_gamma_diff = gamma_diff != nullptr;
-    const bool has_normalized_diff = normalized_diff != nullptr;
-    const bool has_gamma = gamma != nullptr;
-    const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
-    const int64_t elem_cnt = dy->shape().elem_cnt();
-    const int64_t m = dy->shape().Count(begin_params_axis);
-    int max_active_blocks = 0;
-    OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &max_active_blocks, LayerNormParamGradImpl<T, int64_t>, GetLayerNormParamGradBlockSize(),
-        GetParamGradDynamicSharedMemorySize<T>(m)));
-    if (has_gamma_diff && has_beta_diff && has_normalized_diff && max_active_blocks > 0) {
-      const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
-      Memset<DeviceType::kCUDA>(ctx->stream(), gamma_diff->mut_dptr<T>(), 0,
-                                gamma_diff->shape().elem_cnt() * sizeof(T));
-      Memset<DeviceType::kCUDA>(ctx->stream(), beta_diff->mut_dptr<T>(), 0,
-                                beta_diff->shape().elem_cnt() * sizeof(T));
-      if (elem_cnt > static_cast<int64_t>(GetMaxVal<int32_t>() / 2)) {
-        LayerNormParamGradImpl<T, int64_t>
-            <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
-               GetParamGradDynamicSharedMemorySize<T>(m),
-               ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
-                elem_cnt, m, dy->dptr<T>(), normalized->dptr<T>(), gamma->dptr<T>(),
-                gamma_diff->mut_dptr<T>(), beta_diff->mut_dptr<T>(),
-                normalized_diff->mut_dptr<T>());
-      } else {
-        LayerNormParamGradImpl<T, int32_t>
-            <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
-               GetParamGradDynamicSharedMemorySize<T>(m),
-               ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
-                static_cast<int32_t>(elem_cnt), static_cast<int32_t>(m), dy->dptr<T>(),
-                normalized->dptr<T>(), gamma->dptr<T>(), gamma_diff->mut_dptr<T>(),
-                beta_diff->mut_dptr<T>(), normalized_diff->mut_dptr<T>());
-      }
-    } else {
-      if (has_beta_diff) {
-        user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
-        CHECK_EQ(m, beta_diff->shape().elem_cnt());
-        CHECK_EQ(dy->shape().elem_cnt() % m, 0);
-        const int64_t n = dy->shape().elem_cnt() / m;
-        NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<T>()),
-                          Val({n, m}, dy->dptr<T>()), Var({n, m}, reduce_buf->mut_dptr<T>()));
-      }
-      if (has_gamma_diff) {
-        const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
-        user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
-        CHECK_EQ(m, gamma_diff->shape().elem_cnt());
-        CHECK_EQ(dy->shape().elem_cnt() % m, 0);
-        const int64_t n = dy->shape().elem_cnt() / m;
-        NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, reduce_buf->mut_dptr<T>()),
-                             Val({n, m}, normalized->dptr<T>()), Val({n, m}, dy->dptr<T>()));
-        NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<T>()),
-                          Val({n, m}, reduce_buf->dptr<T>()),
-                          Var({n, m}, reduce_buf->mut_dptr<T>()));
-      }
-      if (has_normalized_diff) {
-        if (has_gamma) {
-          CHECK_EQ(m, gamma->shape().elem_cnt());
-          CHECK_EQ(dy->shape().elem_cnt() % m, 0);
-          const int64_t n = dy->shape().elem_cnt() / m;
-          NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, normalized_diff->mut_dptr<T>()),
-                               Val({n, m}, dy->dptr<T>()), Val({1, m}, gamma->dptr<T>()));
-        } else {
-          Memcpy<DeviceType::kCUDA>(ctx->stream(), normalized_diff->mut_dptr<void>(),
-                                    dy->dptr<void>(),
-                                    dy->shape().elem_cnt() * GetSizeOfDataType(dy->data_type()));
-        }
-      }
-    }
-  };
-};
+//  private:
+//   using user_op::OpKernel::Compute;
+//   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+//   void Compute(user_op::KernelComputeContext* ctx) const override {
+//     using NdUtil = NdarrayUtil<DeviceType::kCUDA, T>;
+//     auto Val = NdUtil::GetValNdarrayBuilder();
+//     auto Var = NdUtil::GetVarNdarrayBuilder();
+//     const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
+//     user_op::Tensor* beta_diff = ctx->Tensor4ArgNameAndIndex("beta_diff", 0);
+//     user_op::Tensor* gamma_diff = ctx->Tensor4ArgNameAndIndex("gamma_diff", 0);
+//     user_op::Tensor* normalized_diff = ctx->Tensor4ArgNameAndIndex("normalized_diff", 0);
+//     user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
+//     const bool has_beta_diff = beta_diff != nullptr;
+//     const bool has_gamma_diff = gamma_diff != nullptr;
+//     const bool has_normalized_diff = normalized_diff != nullptr;
+//     const bool has_gamma = gamma != nullptr;
+//     const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
+//     const int64_t elem_cnt = dy->shape().elem_cnt();
+//     const int64_t m = dy->shape().Count(begin_params_axis);
+//     int max_active_blocks = 0;
+//     OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+//         &max_active_blocks, LayerNormParamGradImpl<T, int64_t>, GetLayerNormParamGradBlockSize(),
+//         GetParamGradDynamicSharedMemorySize<T>(m)));
+//     if (has_gamma_diff && has_beta_diff && has_normalized_diff && max_active_blocks > 0) {
+//       const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
+//       Memset<DeviceType::kCUDA>(ctx->stream(), gamma_diff->mut_dptr<T>(), 0,
+//                                 gamma_diff->shape().elem_cnt() * sizeof(T));
+//       Memset<DeviceType::kCUDA>(ctx->stream(), beta_diff->mut_dptr<T>(), 0,
+//                                 beta_diff->shape().elem_cnt() * sizeof(T));
+//       if (elem_cnt > static_cast<int64_t>(GetMaxVal<int32_t>() / 2)) {
+//         LayerNormParamGradImpl<T, int64_t>
+//             <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
+//                GetParamGradDynamicSharedMemorySize<T>(m),
+//                ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+//                 elem_cnt, m, dy->dptr<T>(), normalized->dptr<T>(), gamma->dptr<T>(),
+//                 gamma_diff->mut_dptr<T>(), beta_diff->mut_dptr<T>(),
+//                 normalized_diff->mut_dptr<T>());
+//       } else {
+//         LayerNormParamGradImpl<T, int32_t>
+//             <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
+//                GetParamGradDynamicSharedMemorySize<T>(m),
+//                ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+//                 static_cast<int32_t>(elem_cnt), static_cast<int32_t>(m), dy->dptr<T>(),
+//                 normalized->dptr<T>(), gamma->dptr<T>(), gamma_diff->mut_dptr<T>(),
+//                 beta_diff->mut_dptr<T>(), normalized_diff->mut_dptr<T>());
+//       }
+//     } else {
+//       if (has_beta_diff) {
+//         user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
+//         CHECK_EQ(m, beta_diff->shape().elem_cnt());
+//         CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//         const int64_t n = dy->shape().elem_cnt() / m;
+//         NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<T>()),
+//                           Val({n, m}, dy->dptr<T>()), Var({n, m}, reduce_buf->mut_dptr<T>()));
+//       }
+//       if (has_gamma_diff) {
+//         const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
+//         user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
+//         CHECK_EQ(m, gamma_diff->shape().elem_cnt());
+//         CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//         const int64_t n = dy->shape().elem_cnt() / m;
+//         NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, reduce_buf->mut_dptr<T>()),
+//                              Val({n, m}, normalized->dptr<T>()), Val({n, m}, dy->dptr<T>()));
+//         NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<T>()),
+//                           Val({n, m}, reduce_buf->dptr<T>()),
+//                           Var({n, m}, reduce_buf->mut_dptr<T>()));
+//       }
+//       if (has_normalized_diff) {
+//         if (has_gamma) {
+//           CHECK_EQ(m, gamma->shape().elem_cnt());
+//           CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//           const int64_t n = dy->shape().elem_cnt() / m;
+//           NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, normalized_diff->mut_dptr<T>()),
+//                                Val({n, m}, dy->dptr<T>()), Val({1, m}, gamma->dptr<T>()));
+//         } else {
+//           Memcpy<DeviceType::kCUDA>(ctx->stream(), normalized_diff->mut_dptr<void>(),
+//                                     dy->dptr<void>(),
+//                                     dy->shape().elem_cnt() * GetSizeOfDataType(dy->data_type()));
+//         }
+//       }
+//     }
+//   };
+// };
 
-#define REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(dtype)              \
-  REGISTER_USER_KERNEL("layer_norm_param_grad")                        \
-      .SetCreateFn<LayerNormParamGradGpuKernel<dtype>>()               \
-      .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA) \
-                       && (user_op::HobDataType("dy", 0) == GetDataType<dtype>::value));
+// #define REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(dtype)              \
+//   REGISTER_USER_KERNEL("layer_norm_param_grad")                        \
+//       .SetCreateFn<LayerNormParamGradGpuKernel<dtype>>()               \
+//       .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA) \
+//                        && (user_op::HobDataType("dy", 0) == GetDataType<dtype>::value));
 
-REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(float)
-REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(double)
+// REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(float)
+// REGISTER_LAYER_NORM_PARAM_GRAD_CUDA_KERNEL(double)
 
-class LayerNormParamGradGpuHalfKernel final : public user_op::OpKernel,
-                                              public user_op::CudaGraphSupport {
- public:
-  LayerNormParamGradGpuHalfKernel() = default;
-  ~LayerNormParamGradGpuHalfKernel() = default;
+// class LayerNormParamGradGpuHalfKernel final : public user_op::OpKernel,
+//                                               public user_op::CudaGraphSupport {
+//  public:
+//   LayerNormParamGradGpuHalfKernel() = default;
+//   ~LayerNormParamGradGpuHalfKernel() = default;
 
- private:
-  using user_op::OpKernel::Compute;
-  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
-  void Compute(user_op::KernelComputeContext* ctx) const override {
-    using NdUtil = NdarrayUtil<DeviceType::kCUDA, float16>;
-    auto Val = NdUtil::GetValNdarrayBuilder();
-    auto Var = NdUtil::GetVarNdarrayBuilder();
-    const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
-    user_op::Tensor* beta_diff = ctx->Tensor4ArgNameAndIndex("beta_diff", 0);
-    user_op::Tensor* gamma_diff = ctx->Tensor4ArgNameAndIndex("gamma_diff", 0);
-    user_op::Tensor* normalized_diff = ctx->Tensor4ArgNameAndIndex("normalized_diff", 0);
-    user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
-    const bool has_beta_diff = beta_diff != nullptr;
-    const bool has_gamma_diff = gamma_diff != nullptr;
-    const bool has_normalized_diff = normalized_diff != nullptr;
-    const bool has_gamma = gamma != nullptr;
-    const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
-    const int64_t elem_cnt = dy->shape().elem_cnt();
-    const int64_t m = dy->shape().Count(begin_params_axis);
-    int max_active_blocks = 0;
-    OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &max_active_blocks, LayerNormParamGradHalfImpl<int64_t>, GetLayerNormParamGradBlockSize(),
-        GetParamGradDynamicSharedMemorySize<float16>(m)));
-    if (has_gamma_diff && has_beta_diff && has_normalized_diff && max_active_blocks > 0) {
-      const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
-      user_op::Tensor* tmp_buffer = ctx->Tensor4ArgNameAndIndex("tmp_buffer", 0);
-      const int64_t num_blocks = GetLayerNormParamGradNumBlocks(dy->shape().elem_cnt());
-      const size_t tmp_diff_size = GetCudaAlignedSize(num_blocks * m * sizeof(float16));
-      float16* tmp_gamma_diff = tmp_buffer->mut_dptr<float16>();
-      float16* tmp_beta_diff =
-          reinterpret_cast<float16*>(tmp_buffer->mut_dptr<char>() + tmp_diff_size);
-      float16* tmp_reduce_buf =
-          reinterpret_cast<float16*>(tmp_buffer->mut_dptr<char>() + 2 * tmp_diff_size);
-      CHECK_GE(tmp_buffer->shape().elem_cnt(), 3 * tmp_diff_size);
-      if (elem_cnt > static_cast<int64_t>(GetMaxVal<int32_t>() / 2)) {
-        LayerNormParamGradHalfImpl<int64_t>
-            <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
-               GetParamGradDynamicSharedMemorySize<float16>(m),
-               ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
-                elem_cnt, m, dy->dptr<half>(), normalized->dptr<half>(), gamma->dptr<half>(),
-                reinterpret_cast<half*>(tmp_gamma_diff), reinterpret_cast<half*>(tmp_beta_diff),
-                normalized_diff->mut_dptr<half>());
-      } else {
-        LayerNormParamGradHalfImpl<int32_t>
-            <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
-               GetParamGradDynamicSharedMemorySize<float16>(m),
-               ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
-                static_cast<int32_t>(elem_cnt), static_cast<int32_t>(m), dy->dptr<half>(),
-                normalized->dptr<half>(), gamma->dptr<half>(),
-                reinterpret_cast<half*>(tmp_gamma_diff), reinterpret_cast<half*>(tmp_beta_diff),
-                normalized_diff->mut_dptr<half>());
-      }
-      NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<float16>()),
-                        Val({num_blocks, m}, tmp_gamma_diff), Var({num_blocks, m}, tmp_reduce_buf));
-      NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<float16>()),
-                        Val({num_blocks, m}, tmp_beta_diff), Var({num_blocks, m}, tmp_reduce_buf));
-    } else {
-      if (has_beta_diff) {
-        user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
-        CHECK_EQ(m, beta_diff->shape().elem_cnt());
-        CHECK_EQ(dy->shape().elem_cnt() % m, 0);
-        const int64_t n = dy->shape().elem_cnt() / m;
-        NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<float16>()),
-                          Val({n, m}, dy->dptr<float16>()),
-                          Var({n, m}, reduce_buf->mut_dptr<float16>()));
-      }
-      if (has_gamma_diff) {
-        const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
-        user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
-        CHECK_EQ(m, gamma_diff->shape().elem_cnt());
-        CHECK_EQ(dy->shape().elem_cnt() % m, 0);
-        const int64_t n = dy->shape().elem_cnt() / m;
-        NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, reduce_buf->mut_dptr<float16>()),
-                             Val({n, m}, normalized->dptr<float16>()),
-                             Val({n, m}, dy->dptr<float16>()));
-        NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<float16>()),
-                          Val({n, m}, reduce_buf->dptr<float16>()),
-                          Var({n, m}, reduce_buf->mut_dptr<float16>()));
-      }
-      if (has_normalized_diff) {
-        if (has_gamma) {
-          CHECK_EQ(m, gamma->shape().elem_cnt());
-          CHECK_EQ(dy->shape().elem_cnt() % m, 0);
-          const int64_t n = dy->shape().elem_cnt() / m;
-          NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, normalized_diff->mut_dptr<float16>()),
-                               Val({n, m}, dy->dptr<float16>()),
-                               Val({1, m}, gamma->dptr<float16>()));
-        } else {
-          Memcpy<DeviceType::kCUDA>(ctx->stream(), normalized_diff->mut_dptr<void>(),
-                                    dy->dptr<void>(),
-                                    dy->shape().elem_cnt() * GetSizeOfDataType(dy->data_type()));
-        }
-      }
-    }
-  }
-};
+//  private:
+//   using user_op::OpKernel::Compute;
+//   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+//   void Compute(user_op::KernelComputeContext* ctx) const override {
+//     using NdUtil = NdarrayUtil<DeviceType::kCUDA, float16>;
+//     auto Val = NdUtil::GetValNdarrayBuilder();
+//     auto Var = NdUtil::GetVarNdarrayBuilder();
+//     const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
+//     user_op::Tensor* beta_diff = ctx->Tensor4ArgNameAndIndex("beta_diff", 0);
+//     user_op::Tensor* gamma_diff = ctx->Tensor4ArgNameAndIndex("gamma_diff", 0);
+//     user_op::Tensor* normalized_diff = ctx->Tensor4ArgNameAndIndex("normalized_diff", 0);
+//     user_op::Tensor* gamma = ctx->Tensor4ArgNameAndIndex("gamma", 0);
+//     const bool has_beta_diff = beta_diff != nullptr;
+//     const bool has_gamma_diff = gamma_diff != nullptr;
+//     const bool has_normalized_diff = normalized_diff != nullptr;
+//     const bool has_gamma = gamma != nullptr;
+//     const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
+//     const int64_t elem_cnt = dy->shape().elem_cnt();
+//     const int64_t m = dy->shape().Count(begin_params_axis);
+//     int max_active_blocks = 0;
+//     OF_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+//         &max_active_blocks, LayerNormParamGradHalfImpl<int64_t>, GetLayerNormParamGradBlockSize(),
+//         GetParamGradDynamicSharedMemorySize<float16>(m)));
+//     if (has_gamma_diff && has_beta_diff && has_normalized_diff && max_active_blocks > 0) {
+//       const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
+//       user_op::Tensor* tmp_buffer = ctx->Tensor4ArgNameAndIndex("tmp_buffer", 0);
+//       const int64_t num_blocks = GetLayerNormParamGradNumBlocks(dy->shape().elem_cnt());
+//       const size_t tmp_diff_size = GetCudaAlignedSize(num_blocks * m * sizeof(float16));
+//       float16* tmp_gamma_diff = tmp_buffer->mut_dptr<float16>();
+//       float16* tmp_beta_diff =
+//           reinterpret_cast<float16*>(tmp_buffer->mut_dptr<char>() + tmp_diff_size);
+//       float16* tmp_reduce_buf =
+//           reinterpret_cast<float16*>(tmp_buffer->mut_dptr<char>() + 2 * tmp_diff_size);
+//       CHECK_GE(tmp_buffer->shape().elem_cnt(), 3 * tmp_diff_size);
+//       if (elem_cnt > static_cast<int64_t>(GetMaxVal<int32_t>() / 2)) {
+//         LayerNormParamGradHalfImpl<int64_t>
+//             <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
+//                GetParamGradDynamicSharedMemorySize<float16>(m),
+//                ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+//                 elem_cnt, m, dy->dptr<half>(), normalized->dptr<half>(), gamma->dptr<half>(),
+//                 reinterpret_cast<half*>(tmp_gamma_diff), reinterpret_cast<half*>(tmp_beta_diff),
+//                 normalized_diff->mut_dptr<half>());
+//       } else {
+//         LayerNormParamGradHalfImpl<int32_t>
+//             <<<GetLayerNormParamGradNumBlocks(elem_cnt), GetLayerNormParamGradBlockSize(),
+//                GetParamGradDynamicSharedMemorySize<float16>(m),
+//                ctx->stream()->As<ep::CudaStream>()->cuda_stream()>>>(
+//                 static_cast<int32_t>(elem_cnt), static_cast<int32_t>(m), dy->dptr<half>(),
+//                 normalized->dptr<half>(), gamma->dptr<half>(),
+//                 reinterpret_cast<half*>(tmp_gamma_diff), reinterpret_cast<half*>(tmp_beta_diff),
+//                 normalized_diff->mut_dptr<half>());
+//       }
+//       NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<float16>()),
+//                         Val({num_blocks, m}, tmp_gamma_diff), Var({num_blocks, m}, tmp_reduce_buf));
+//       NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<float16>()),
+//                         Val({num_blocks, m}, tmp_beta_diff), Var({num_blocks, m}, tmp_reduce_buf));
+//     } else {
+//       if (has_beta_diff) {
+//         user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
+//         CHECK_EQ(m, beta_diff->shape().elem_cnt());
+//         CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//         const int64_t n = dy->shape().elem_cnt() / m;
+//         NdUtil::ReduceSum(ctx->stream(), Var({1, m}, beta_diff->mut_dptr<float16>()),
+//                           Val({n, m}, dy->dptr<float16>()),
+//                           Var({n, m}, reduce_buf->mut_dptr<float16>()));
+//       }
+//       if (has_gamma_diff) {
+//         const user_op::Tensor* normalized = ctx->Tensor4ArgNameAndIndex("normalized", 0);
+//         user_op::Tensor* reduce_buf = ctx->Tensor4ArgNameAndIndex("reduce_buf", 0);
+//         CHECK_EQ(m, gamma_diff->shape().elem_cnt());
+//         CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//         const int64_t n = dy->shape().elem_cnt() / m;
+//         NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, reduce_buf->mut_dptr<float16>()),
+//                              Val({n, m}, normalized->dptr<float16>()),
+//                              Val({n, m}, dy->dptr<float16>()));
+//         NdUtil::ReduceSum(ctx->stream(), Var({1, m}, gamma_diff->mut_dptr<float16>()),
+//                           Val({n, m}, reduce_buf->dptr<float16>()),
+//                           Var({n, m}, reduce_buf->mut_dptr<float16>()));
+//       }
+//       if (has_normalized_diff) {
+//         if (has_gamma) {
+//           CHECK_EQ(m, gamma->shape().elem_cnt());
+//           CHECK_EQ(dy->shape().elem_cnt() % m, 0);
+//           const int64_t n = dy->shape().elem_cnt() / m;
+//           NdUtil::BroadcastMul(ctx->stream(), Var({n, m}, normalized_diff->mut_dptr<float16>()),
+//                                Val({n, m}, dy->dptr<float16>()),
+//                                Val({1, m}, gamma->dptr<float16>()));
+//         } else {
+//           Memcpy<DeviceType::kCUDA>(ctx->stream(), normalized_diff->mut_dptr<void>(),
+//                                     dy->dptr<void>(),
+//                                     dy->shape().elem_cnt() * GetSizeOfDataType(dy->data_type()));
+//         }
+//       }
+//     }
+//   }
+// };
 
-REGISTER_USER_KERNEL("layer_norm_param_grad")
-    .SetCreateFn<LayerNormParamGradGpuHalfKernel>()
-    .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA)
-                     && (user_op::HobDataType("dy", 0) == DataType::kFloat16))
-    .SetInferTmpSizeFn([](user_op::InferContext* ctx) {
-      const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
-      const bool has_gamma_diff = ctx->has_output("gamma_diff", 0);
-      const bool has_beta_diff = ctx->has_output("beta_diff", 0);
-      const bool has_normalized_diff = ctx->has_output("normalized_diff", 0);
-      const auto& dy = ctx->InputTensorDesc("dy", 0);
-      const int64_t instance_size = dy.shape().Count(begin_params_axis);
-      size_t tmp_buffer_size = 0;
-      if (has_gamma_diff && has_beta_diff && has_normalized_diff) {
-        const size_t tmp_gamma_diff =
-            GetCudaAlignedSize(GetLayerNormParamGradNumBlocks(dy.shape().elem_cnt()) * instance_size
-                               * sizeof(float16));
-        const size_t tmp_beta_diff = tmp_gamma_diff;
-        const size_t tmp_reduce_buf = tmp_gamma_diff;
-        tmp_buffer_size = tmp_gamma_diff + tmp_beta_diff + tmp_reduce_buf;
-      } else {
-        tmp_buffer_size = 0;
-      }
-      return tmp_buffer_size;
-    });
-}  // namespace oneflow
+// REGISTER_USER_KERNEL("layer_norm_param_grad")
+//     .SetCreateFn<LayerNormParamGradGpuHalfKernel>()
+//     .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA)
+//                      && (user_op::HobDataType("dy", 0) == DataType::kFloat16))
+//     .SetInferTmpSizeFn([](user_op::InferContext* ctx) {
+//       const int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
+//       const bool has_gamma_diff = ctx->has_output("gamma_diff", 0);
+//       const bool has_beta_diff = ctx->has_output("beta_diff", 0);
+//       const bool has_normalized_diff = ctx->has_output("normalized_diff", 0);
+//       const auto& dy = ctx->InputTensorDesc("dy", 0);
+//       const int64_t instance_size = dy.shape().Count(begin_params_axis);
+//       size_t tmp_buffer_size = 0;
+//       if (has_gamma_diff && has_beta_diff && has_normalized_diff) {
+//         const size_t tmp_gamma_diff =
+//             GetCudaAlignedSize(GetLayerNormParamGradNumBlocks(dy.shape().elem_cnt()) * instance_size
+//                                * sizeof(float16));
+//         const size_t tmp_beta_diff = tmp_gamma_diff;
+//         const size_t tmp_reduce_buf = tmp_gamma_diff;
+//         tmp_buffer_size = tmp_gamma_diff + tmp_beta_diff + tmp_reduce_buf;
+//       } else {
+//         tmp_buffer_size = 0;
+//       }
+//       return tmp_buffer_size;
+//     });
+// }  // namespace oneflow


### PR DESCRIPTION
### 替换使用 Apex 版本的layernorm(elementwise_affine=False)
![image](https://user-images.githubusercontent.com/42901638/147620297-f740cff3-3ad9-4756-bff0-271bbbdd67d3.png)

### apex安装
官网：https://github.com/NVIDIA/apex

```shell
git clone https://github.com/NVIDIA/apex
cd apex
pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
```

使用 Apex 的 LayerNorm
```python
from apex.normalization import FusedLayerNorm as LayerNorm
```