### PR TITLE
tensormeta add member is_contiguous

### DIFF
--- a/oneflow/api/python/framework/tensor.cpp
+++ b/oneflow/api/python/framework/tensor.cpp
@@ -97,10 +97,6 @@ void ApiRegisterTensorHook(const std::shared_ptr<Tensor>& self, const AutogradMe
   return RegisterTensorHook(self, hook).GetOrThrow();
 }
 
-bool ApiIsContiguous(const std::shared_ptr<Tensor>& tensor) {
-  return tensor->is_contiguous();
-}
-
 py::tuple ApiTensorGetPyTupleOfSbp(const Tensor& tensor) {
   return *TensorGetPyTupleOfSbp(tensor).GetPtrOrThrow();
 }
@@ -163,7 +159,7 @@ ONEFLOW_API_PYBIND11_MODULE("", m) {
              const auto& stride = t.stride().GetPtrOrThrow()->StrideVec();
              return py::tuple(py::make_iterator(stride.begin(), stride.end()));
            })
-      .def("is_contiguous", &ApiIsContiguous)
+      .def("is_contiguous", &Tensor::is_contiguous)
       .def_property_readonly("grad_fn", &Tensor::grad_fn_node)
       .def_property_readonly("is_leaf", &Tensor::is_leaf)
       .def_property("requires_grad", &Tensor::requires_grad, &ApiSetRequiresGrad)

--- a/oneflow/api/python/framework/tensor.cpp
+++ b/oneflow/api/python/framework/tensor.cpp
@@ -98,7 +98,7 @@ void ApiRegisterTensorHook(const std::shared_ptr<Tensor>& self, const AutogradMe
 }
 
 bool ApiIsContiguous(const std::shared_ptr<Tensor>& tensor) {
-  return IsContiguous(tensor).GetOrThrow();
+  return tensor->is_contiguous();
 }
 
 py::tuple ApiTensorGetPyTupleOfSbp(const Tensor& tensor) {

--- a/oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp
@@ -141,6 +141,7 @@ Maybe<void> NaiveInterpret(const UserOpExpr& user_op_expr, const TensorTuple& in
     auto* tensor_impl = JUST(TensorImpl4Tensor(outputs->at(i)));
     if (!output_eager_blob_objects->at(i)) {
       tensor_impl->mut_tensor_meta()->set_stride(std::make_shared<Stride>(*tensor_impl->shape()));
+      tensor_impl->mut_tensor_meta()->set_is_contiguous(true);
       const auto& dep_object = JUST(GetLocalDepObjectFromDevicePool(op_device));
       JUST(tensor_impl->InitEagerBlobObject(dep_object));
       output_eager_blob_objects->at(i) = JUST(tensor_impl->eager_blob_object());

--- a/oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp
@@ -141,7 +141,6 @@ Maybe<void> NaiveInterpret(const UserOpExpr& user_op_expr, const TensorTuple& in
     auto* tensor_impl = JUST(TensorImpl4Tensor(outputs->at(i)));
     if (!output_eager_blob_objects->at(i)) {
       tensor_impl->mut_tensor_meta()->set_stride(std::make_shared<Stride>(*tensor_impl->shape()));
-      tensor_impl->mut_tensor_meta()->set_is_contiguous(true);
       const auto& dep_object = JUST(GetLocalDepObjectFromDevicePool(op_device));
       JUST(tensor_impl->InitEagerBlobObject(dep_object));
       output_eager_blob_objects->at(i) = JUST(tensor_impl->eager_blob_object());

--- a/oneflow/core/framework/tensor.cpp
+++ b/oneflow/core/framework/tensor.cpp
@@ -39,7 +39,7 @@ Maybe<MirroredTensor> StaticZerosTensor::AsMirroredTensor() {
 }
 
 std::shared_ptr<Tensor> Parameter::contiguous() const {
-  if (tensor_->is_contiguous()) { std::const_pointer_cast<Tensor>(shared_from_this()); }
+  if (tensor_->is_contiguous()) { return std::const_pointer_cast<Tensor>(shared_from_this()); }
   return std::make_shared<Parameter>(tensor_->contiguous(), this->requires_grad());
 }
 

--- a/oneflow/core/framework/tensor.cpp
+++ b/oneflow/core/framework/tensor.cpp
@@ -39,8 +39,8 @@ Maybe<MirroredTensor> StaticZerosTensor::AsMirroredTensor() {
 }
 
 std::shared_ptr<Tensor> Parameter::contiguous() const {
-  if (CHECK_JUST(IsContiguous(tensor_))) {
-    return std::const_pointer_cast<Tensor>(shared_from_this());
+  if(tensor_->is_contiguous()){
+    std::const_pointer_cast<Tensor>(shared_from_this());
   }
   return std::make_shared<Parameter>(tensor_->contiguous(), this->requires_grad());
 }
@@ -68,9 +68,12 @@ Maybe<Tensor> MirroredTensor::detach() const {
   return tensor;
 }
 
+
 std::shared_ptr<Tensor> MirroredTensor::contiguous() const {
   std::shared_ptr<Tensor> tensor = std::const_pointer_cast<Tensor>(shared_from_this());
-  if (CHECK_JUST(IsContiguous(tensor))) { return tensor; }
+  if(tensor->is_contiguous()){
+    return tensor;
+  }
   return CHECK_JUST(functional::ToContiguous(tensor));
 }
 
@@ -83,7 +86,9 @@ Maybe<Tensor> MirroredTensor::clone() const {
 
 std::shared_ptr<Tensor> ConsistentTensor::contiguous() const {
   std::shared_ptr<Tensor> tensor = std::const_pointer_cast<Tensor>(shared_from_this());
-  if (CHECK_JUST(IsContiguous(tensor))) { return tensor; }
+  if(tensor->is_contiguous()){
+    return tensor;
+  }
   return CHECK_JUST(functional::ToContiguous(tensor));
 }
 

--- a/oneflow/core/framework/tensor.cpp
+++ b/oneflow/core/framework/tensor.cpp
@@ -39,9 +39,7 @@ Maybe<MirroredTensor> StaticZerosTensor::AsMirroredTensor() {
 }
 
 std::shared_ptr<Tensor> Parameter::contiguous() const {
-  if(tensor_->is_contiguous()){
-    std::const_pointer_cast<Tensor>(shared_from_this());
-  }
+  if (tensor_->is_contiguous()) { std::const_pointer_cast<Tensor>(shared_from_this()); }
   return std::make_shared<Parameter>(tensor_->contiguous(), this->requires_grad());
 }
 
@@ -68,12 +66,9 @@ Maybe<Tensor> MirroredTensor::detach() const {
   return tensor;
 }
 
-
 std::shared_ptr<Tensor> MirroredTensor::contiguous() const {
   std::shared_ptr<Tensor> tensor = std::const_pointer_cast<Tensor>(shared_from_this());
-  if(tensor->is_contiguous()){
-    return tensor;
-  }
+  if (tensor->is_contiguous()) { return tensor; }
   return CHECK_JUST(functional::ToContiguous(tensor));
 }
 
@@ -86,9 +81,7 @@ Maybe<Tensor> MirroredTensor::clone() const {
 
 std::shared_ptr<Tensor> ConsistentTensor::contiguous() const {
   std::shared_ptr<Tensor> tensor = std::const_pointer_cast<Tensor>(shared_from_this());
-  if(tensor->is_contiguous()){
-    return tensor;
-  }
+  if (tensor->is_contiguous()) { return tensor; }
   return CHECK_JUST(functional::ToContiguous(tensor));
 }
 

--- a/oneflow/core/framework/tensor.h
+++ b/oneflow/core/framework/tensor.h
@@ -86,6 +86,7 @@ class Tensor : public std::enable_shared_from_this<Tensor> {
   virtual bool requires_grad() const = 0;
   virtual bool is_leaf() const = 0;
   virtual bool retain_grad() const = 0;
+  virtual bool is_contiguous() const = 0;
   virtual std::shared_ptr<const FunctionNode> grad_fn_node() const = 0;
   virtual Maybe<Tensor> acc_grad() const = 0;
   virtual Maybe<TensorArg> current_grad() const = 0;
@@ -183,6 +184,10 @@ class StaticZerosTensor final : public Tensor {
   bool retain_grad() const override {
     PRINT_BUG_PROMPT_AND_ABORT();
     return false;
+  }
+  bool is_contiguous() const override {
+    PRINT_BUG_PROMPT_AND_ABORT();
+    return true;
   }
   std::shared_ptr<const FunctionNode> grad_fn_node() const override {
     PRINT_BUG_PROMPT_AND_ABORT();
@@ -334,6 +339,7 @@ class Parameter final : public TensorIf<Parameter> {
   bool requires_grad() const override { return tensor_->requires_grad(); }
   bool is_leaf() const override { return true; }
   bool retain_grad() const override { return tensor_->retain_grad(); }
+  bool is_contiguous() const override { return tensor_->is_contiguous(); }
   Maybe<Tensor> acc_grad() const override { return tensor_->acc_grad(); }
   Maybe<TensorArg> current_grad() const override { return tensor_->current_grad(); }
   Maybe<Tensor> detach() const override { return tensor_->detach(); }
@@ -446,6 +452,7 @@ class MirroredTensor final : public TensorIf<MirroredTensor> {
   bool requires_grad() const override { return impl_->requires_grad(); }
   bool is_leaf() const override { return impl_->is_leaf(); }
   bool retain_grad() const override { return impl_->retain_grad(); }
+  bool is_contiguous() const override { return impl_->tensor_meta()->is_contiguous(); }
   bool has_autograd_meta() const override { return impl_->has_autograd_meta(); }
 
   // Setters for autograd
@@ -557,6 +564,7 @@ class ConsistentTensor final : public TensorIf<ConsistentTensor> {
   bool requires_grad() const override { return impl_->requires_grad(); }
   bool is_leaf() const override { return impl_->is_leaf(); }
   bool retain_grad() const override { return impl_->retain_grad(); }
+  bool is_contiguous() const override { return true; }
   bool has_autograd_meta() const override { return impl_->has_autograd_meta(); }
 
   // Setters for autograd

--- a/oneflow/core/framework/tensor.h
+++ b/oneflow/core/framework/tensor.h
@@ -62,6 +62,7 @@ class Tensor : public std::enable_shared_from_this<Tensor> {
   virtual bool is_local() const { return !is_consistent(); }
   virtual bool is_lazy() const = 0;
   virtual bool is_eager() const { return !is_lazy(); }
+  virtual bool is_contiguous() const = 0;
   virtual const TensorMeta& tensor_meta() const = 0;
   virtual Maybe<Tensor> data() = 0;
   virtual Maybe<Symbol<ConsistentTensorMeta>> consistent_tensor_meta() const { OF_UNIMPLEMENTED(); }
@@ -86,7 +87,6 @@ class Tensor : public std::enable_shared_from_this<Tensor> {
   virtual bool requires_grad() const = 0;
   virtual bool is_leaf() const = 0;
   virtual bool retain_grad() const = 0;
-  virtual bool is_contiguous() const = 0;
   virtual std::shared_ptr<const FunctionNode> grad_fn_node() const = 0;
   virtual Maybe<Tensor> acc_grad() const = 0;
   virtual Maybe<TensorArg> current_grad() const = 0;
@@ -452,7 +452,7 @@ class MirroredTensor final : public TensorIf<MirroredTensor> {
   bool requires_grad() const override { return impl_->requires_grad(); }
   bool is_leaf() const override { return impl_->is_leaf(); }
   bool retain_grad() const override { return impl_->retain_grad(); }
-  bool is_contiguous() const override { return impl_->tensor_meta()->is_contiguous(); }
+  bool is_contiguous() const override { return impl_->is_contiguous(); }
   bool has_autograd_meta() const override { return impl_->has_autograd_meta(); }
 
   // Setters for autograd
@@ -564,7 +564,7 @@ class ConsistentTensor final : public TensorIf<ConsistentTensor> {
   bool requires_grad() const override { return impl_->requires_grad(); }
   bool is_leaf() const override { return impl_->is_leaf(); }
   bool retain_grad() const override { return impl_->retain_grad(); }
-  bool is_contiguous() const override { return true; }
+  bool is_contiguous() const override { return impl_->is_contiguous(); }
   bool has_autograd_meta() const override { return impl_->has_autograd_meta(); }
 
   // Setters for autograd

--- a/oneflow/core/framework/tensor_impl.cpp
+++ b/oneflow/core/framework/tensor_impl.cpp
@@ -186,7 +186,7 @@ MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape
                                        Symbol<Device> device,
                                        const std::shared_ptr<const Stride>& stride,
                                        int64_t storage_offset)
-    : TensorMeta(shape, dtype), device_(device), stride_(stride), storage_offset_(storage_offset) {}
+    : TensorMeta(shape, dtype), device_(device), storage_offset_(storage_offset) { set_stride(stride); }
 
 bool MirroredTensorMeta::operator==(const MirroredTensorMeta& other) const {
   // It's correct to ignore is_dynamic_ field.

--- a/oneflow/core/framework/tensor_impl.cpp
+++ b/oneflow/core/framework/tensor_impl.cpp
@@ -171,22 +171,23 @@ MirroredTensorMeta::MirroredTensorMeta()
     : TensorMeta(std::make_shared<const Shape>(), DataType::kInvalidDataType),
       device_(Symbol<Device>()),
       stride_(std::make_shared<const Stride>()),
-      is_contiguous_(true),
-      storage_offset_(0) {}
+      storage_offset_(0) {
+  set_stride(std::make_shared<const Stride>());
+}
 
 MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
                                        Symbol<Device> device)
-    : TensorMeta(shape, dtype),
-      device_(device),
-      stride_(std::make_shared<const Stride>(*shape)),
-      is_contiguous_(true),
-      storage_offset_(0) {}
+    : TensorMeta(shape, dtype), device_(device), storage_offset_(0) {
+  set_stride(std::make_shared<const Stride>(*shape));
+}
 
 MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
                                        Symbol<Device> device,
                                        const std::shared_ptr<const Stride>& stride,
                                        int64_t storage_offset)
-    : TensorMeta(shape, dtype), device_(device), storage_offset_(storage_offset) { set_stride(stride); }
+    : TensorMeta(shape, dtype), device_(device), storage_offset_(storage_offset) {
+  set_stride(stride);
+}
 
 bool MirroredTensorMeta::operator==(const MirroredTensorMeta& other) const {
   // It's correct to ignore is_dynamic_ field.

--- a/oneflow/core/framework/tensor_impl.cpp
+++ b/oneflow/core/framework/tensor_impl.cpp
@@ -171,6 +171,7 @@ MirroredTensorMeta::MirroredTensorMeta()
     : TensorMeta(std::make_shared<const Shape>(), DataType::kInvalidDataType),
       device_(Symbol<Device>()),
       stride_(std::make_shared<const Stride>()),
+      is_contiguous_(true),
       storage_offset_(0) {}
 
 MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
@@ -178,6 +179,7 @@ MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape
     : TensorMeta(shape, dtype),
       device_(device),
       stride_(std::make_shared<const Stride>(*shape)),
+      is_contiguous_(true),
       storage_offset_(0) {}
 
 MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
@@ -185,6 +187,13 @@ MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape
                                        const std::shared_ptr<const Stride>& stride,
                                        int64_t storage_offset)
     : TensorMeta(shape, dtype), device_(device), stride_(stride), storage_offset_(storage_offset) {}
+
+MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
+                                       Symbol<Device> device,
+                                       const std::shared_ptr<const Stride>& stride,
+                                       bool is_contiguous,
+                                       int64_t storage_offset)
+    : TensorMeta(shape, dtype), device_(device), stride_(stride), is_contiguous_(is_contiguous), storage_offset_(storage_offset) {}
 
 bool MirroredTensorMeta::operator==(const MirroredTensorMeta& other) const {
   // It's correct to ignore is_dynamic_ field.

--- a/oneflow/core/framework/tensor_impl.cpp
+++ b/oneflow/core/framework/tensor_impl.cpp
@@ -188,13 +188,6 @@ MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape
                                        int64_t storage_offset)
     : TensorMeta(shape, dtype), device_(device), stride_(stride), storage_offset_(storage_offset) {}
 
-MirroredTensorMeta::MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
-                                       Symbol<Device> device,
-                                       const std::shared_ptr<const Stride>& stride,
-                                       bool is_contiguous,
-                                       int64_t storage_offset)
-    : TensorMeta(shape, dtype), device_(device), stride_(stride), is_contiguous_(is_contiguous), storage_offset_(storage_offset) {}
-
 bool MirroredTensorMeta::operator==(const MirroredTensorMeta& other) const {
   // It's correct to ignore is_dynamic_ field.
   return *this->shape_ptr() == *other.shape_ptr() && this->dtype() == other.dtype()

--- a/oneflow/core/framework/tensor_impl.h
+++ b/oneflow/core/framework/tensor_impl.h
@@ -107,7 +107,7 @@ class MirroredTensorImpl : public TensorImpl {
   DataType dtype() const override { return tensor_meta_->dtype(); }
   const Symbol<Device>& device() const { return tensor_meta_->device(); }
   const std::shared_ptr<const MirroredTensorMeta>& tensor_meta() const { return tensor_meta_; }
-  bool is_contiguous() const override{ return tensor_meta_->is_contiguous(); }
+  bool is_contiguous() const override { return tensor_meta_->is_contiguous(); }
 
   // Setters
   MirroredTensorMeta* mut_tensor_meta() {
@@ -191,10 +191,10 @@ class LazyMirroredTensorImpl final : public MirroredTensorImpl {
   // Getters
   const std::shared_ptr<const Shape>& shape() const override { return tensor_meta()->shape_ptr(); }
   bool is_lazy() const override { return true; }
-  bool is_contiguous() const override { 
-    // TODO:(zhaoluyang) default return true for now, 
+  bool is_contiguous() const override {
+    // TODO:(zhaoluyang) default return true for now,
     // but should return real status while stride/view mechanism is ready in lazy-mirrored mode
-    return true; 
+    return true;
   }
 
   // Getters valid only for EagerMirroredTensorImpl
@@ -262,10 +262,10 @@ class LazyConsistentTensorImpl final : public ConsistentTensorImpl {
 
   // Getters
   bool is_lazy() const override { return true; }
-  bool is_contiguous() const override { 
-    // TODO:(zhaoluyang) default return true for now, 
+  bool is_contiguous() const override {
+    // TODO:(zhaoluyang) default return true for now,
     // but should return real status while stride/view mechanism is ready in lazy-consistent mode
-    return true; 
+    return true;
   }
 };
 
@@ -276,10 +276,10 @@ class EagerConsistentTensorImpl final : public ConsistentTensorImpl {
 
   // Getters
   bool is_lazy() const override { return false; }
-  bool is_contiguous() const override { 
-    // TODO:(zhaoluyang) default return true for now, 
+  bool is_contiguous() const override {
+    // TODO:(zhaoluyang) default return true for now,
     // but should return real status while stride/view mechanism is ready in eager-consistent mode
-    return true; 
+    return true;
   }
 
   Maybe<MirroredTensor> cur_rank_phy_tensor() const override { return cur_rank_phy_tensor_; }

--- a/oneflow/core/framework/tensor_impl.h
+++ b/oneflow/core/framework/tensor_impl.h
@@ -68,6 +68,7 @@ class TensorImpl {
   virtual Maybe<bool> has_eager_blob_object() const = 0;
   virtual Maybe<const Stride> stride() const { OF_UNIMPLEMENTED(); }
   virtual Maybe<int64_t> storage_offset() const { OF_UNIMPLEMENTED(); }
+  virtual bool is_contiguous() const = 0;
 
   // Getters for autograd
   Maybe<Tensor> acc_grad() const;
@@ -106,6 +107,7 @@ class MirroredTensorImpl : public TensorImpl {
   DataType dtype() const override { return tensor_meta_->dtype(); }
   const Symbol<Device>& device() const { return tensor_meta_->device(); }
   const std::shared_ptr<const MirroredTensorMeta>& tensor_meta() const { return tensor_meta_; }
+  bool is_contiguous() const override{ return tensor_meta_->is_contiguous(); }
 
   // Setters
   MirroredTensorMeta* mut_tensor_meta() {
@@ -189,6 +191,11 @@ class LazyMirroredTensorImpl final : public MirroredTensorImpl {
   // Getters
   const std::shared_ptr<const Shape>& shape() const override { return tensor_meta()->shape_ptr(); }
   bool is_lazy() const override { return true; }
+  bool is_contiguous() const override { 
+    // TODO:(zhaoluyang) default return true for now, 
+    // but should return real status while stride/view mechanism is ready in lazy-mirrored mode
+    return true; 
+  }
 
   // Getters valid only for EagerMirroredTensorImpl
   Maybe<vm::EagerBlobObject> eager_blob_object() const override { RETURN_ERROR_WITH_BUG_PROMPT(); }
@@ -215,6 +222,7 @@ class EagerMirroredTensorImpl final : public MirroredTensorImpl {
   const std::shared_ptr<const Shape>& shape() const override;
   Maybe<MirroredTensorImpl> detach() const override;
   bool is_lazy() const override { return false; }
+  bool is_contiguous() const override { return tensor_meta_->is_contiguous(); }
 
   // Getters valid only for EagerMirroredTensorImpl
   Maybe<vm::EagerBlobObject> eager_blob_object() const override {
@@ -254,6 +262,11 @@ class LazyConsistentTensorImpl final : public ConsistentTensorImpl {
 
   // Getters
   bool is_lazy() const override { return true; }
+  bool is_contiguous() const override { 
+    // TODO:(zhaoluyang) default return true for now, 
+    // but should return real status while stride/view mechanism is ready in lazy-consistent mode
+    return true; 
+  }
 };
 
 class EagerConsistentTensorImpl final : public ConsistentTensorImpl {
@@ -263,6 +276,11 @@ class EagerConsistentTensorImpl final : public ConsistentTensorImpl {
 
   // Getters
   bool is_lazy() const override { return false; }
+  bool is_contiguous() const override { 
+    // TODO:(zhaoluyang) default return true for now, 
+    // but should return real status while stride/view mechanism is ready in eager-consistent mode
+    return true; 
+  }
 
   Maybe<MirroredTensor> cur_rank_phy_tensor() const override { return cur_rank_phy_tensor_; }
   void reset_cur_rank_phy_tensor(const std::shared_ptr<MirroredTensor>& val) {

--- a/oneflow/core/framework/tensor_meta.cpp
+++ b/oneflow/core/framework/tensor_meta.cpp
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/framework/tensor_meta.h"
+#include "oneflow/core/framework/stride.h"
+
+namespace oneflow {
+namespace one {
+
+bool IsContiguous(const Shape& shape, const Stride& stride) {
+  if (!shape.is_initialized() || shape.NumAxes() < 1 || shape.elem_cnt() <= 1) { return true; }
+  int64_t dim = shape.NumAxes();
+  int64_t expected_stride = 1;
+  bool contig_if_nonempty = true;
+  for (int64_t i = dim - 1; i >= 0; --i) {
+    // Contiguous by default when any dim is equal to zero
+    // https://stackoverflow.com/questions/31681324/identify-contiguous-segments-of-a-non-contiguous-numpy-array
+    if (shape.At(i) == 0) { return true; }
+    if (contig_if_nonempty && shape.At(i) != 1) {
+      if (stride.At(i) != expected_stride) { contig_if_nonempty = false; }
+      expected_stride *= shape.At(i);
+    }
+  }
+  return contig_if_nonempty;
+}
+
+}  // namespace one
+}  // namespace oneflow

--- a/oneflow/core/framework/tensor_meta.h
+++ b/oneflow/core/framework/tensor_meta.h
@@ -70,15 +70,20 @@ class MirroredTensorMeta : public TensorMeta {
   MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
                      Symbol<Device> device, const std::shared_ptr<const Stride>& stride,
                      int64_t storage_offset);
+  MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
+                     Symbol<Device> device, const std::shared_ptr<const Stride>& stride,
+                     bool is_contiguous, int64_t storage_offset);
   virtual ~MirroredTensorMeta() = default;
 
   const Symbol<Device>& device() const { return device_; }
   const Stride& stride() const { return *stride_; }
+  bool is_contiguous() const { return is_contiguous_; }
   const std::shared_ptr<const Stride>& stride_ptr() const { return stride_; }
   int64_t storage_offset() const { return storage_offset_; }
 
   Symbol<Device>* mut_device() { return &device_; }
   void set_stride(const std::shared_ptr<const Stride>& stride) { stride_ = stride; }
+  void set_is_contiguous(bool is_contiguous) { is_contiguous_ = is_contiguous; }
   void set_storage_offset(int64_t offset) { storage_offset_ = offset; }
 
   bool operator==(const MirroredTensorMeta& other) const;
@@ -87,6 +92,7 @@ class MirroredTensorMeta : public TensorMeta {
  private:
   Symbol<Device> device_;
   std::shared_ptr<const Stride> stride_;
+  bool is_contiguous_;
   int64_t storage_offset_;
 };
 

--- a/oneflow/core/framework/tensor_meta.h
+++ b/oneflow/core/framework/tensor_meta.h
@@ -32,6 +32,8 @@ class ParallelDesc;
 
 namespace one {
 
+bool IsContiguous(const Shape& shape, const Stride& stride);
+
 class TensorMeta : public user_op::TensorDesc {
  public:
   TensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype)
@@ -70,9 +72,6 @@ class MirroredTensorMeta : public TensorMeta {
   MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
                      Symbol<Device> device, const std::shared_ptr<const Stride>& stride,
                      int64_t storage_offset);
-  MirroredTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
-                     Symbol<Device> device, const std::shared_ptr<const Stride>& stride,
-                     bool is_contiguous, int64_t storage_offset);
   virtual ~MirroredTensorMeta() = default;
 
   const Symbol<Device>& device() const { return device_; }
@@ -82,8 +81,10 @@ class MirroredTensorMeta : public TensorMeta {
   int64_t storage_offset() const { return storage_offset_; }
 
   Symbol<Device>* mut_device() { return &device_; }
-  void set_stride(const std::shared_ptr<const Stride>& stride) { stride_ = stride; }
-  void set_is_contiguous(bool is_contiguous) { is_contiguous_ = is_contiguous; }
+  void set_stride(const std::shared_ptr<const Stride>& stride) { 
+    stride_ = stride; 
+    is_contiguous_ = IsContiguous(shape(), *stride_);
+  }
   void set_storage_offset(int64_t offset) { storage_offset_ = offset; }
 
   bool operator==(const MirroredTensorMeta& other) const;

--- a/oneflow/core/framework/tensor_meta.h
+++ b/oneflow/core/framework/tensor_meta.h
@@ -81,8 +81,8 @@ class MirroredTensorMeta : public TensorMeta {
   int64_t storage_offset() const { return storage_offset_; }
 
   Symbol<Device>* mut_device() { return &device_; }
-  void set_stride(const std::shared_ptr<const Stride>& stride) { 
-    stride_ = stride; 
+  void set_stride(const std::shared_ptr<const Stride>& stride) {
+    stride_ = stride;
     is_contiguous_ = IsContiguous(shape(), *stride_);
   }
   void set_storage_offset(int64_t offset) { storage_offset_ = offset; }

--- a/oneflow/core/framework/tensor_methods.cpp
+++ b/oneflow/core/framework/tensor_methods.cpp
@@ -29,7 +29,6 @@ namespace oneflow {
 namespace one {
 namespace view {
 
-
 Maybe<Tensor> BasicView(const std::shared_ptr<Tensor>& input, const Shape& target_shape,
                         int64_t storage_offset) {
   /**

--- a/oneflow/core/framework/tensor_methods.h
+++ b/oneflow/core/framework/tensor_methods.h
@@ -25,9 +25,11 @@ namespace one {
 
 class Tensor;
 
-Maybe<bool> IsContiguous(const std::shared_ptr<Tensor>& tensor);
-
 namespace view {
+
+bool IsContiguous(const Shape& shape, const Stride& stride);
+
+Maybe<bool> IsContiguous(const std::shared_ptr<Tensor>& tensor);
 
 Maybe<Tensor> BasicView(const std::shared_ptr<Tensor>& input, const Shape& target_shape,
                         int64_t storage_offset);

--- a/oneflow/core/framework/tensor_methods.h
+++ b/oneflow/core/framework/tensor_methods.h
@@ -27,9 +27,6 @@ class Tensor;
 
 namespace view {
 
-bool IsContiguous(const Shape& shape, const Stride& stride);
-
-Maybe<bool> IsContiguous(const std::shared_ptr<Tensor>& tensor);
 
 Maybe<Tensor> BasicView(const std::shared_ptr<Tensor>& input, const Shape& target_shape,
                         int64_t storage_offset);

--- a/oneflow/core/framework/tensor_methods.h
+++ b/oneflow/core/framework/tensor_methods.h
@@ -27,7 +27,6 @@ class Tensor;
 
 namespace view {
 
-
 Maybe<Tensor> BasicView(const std::shared_ptr<Tensor>& input, const Shape& target_shape,
                         int64_t storage_offset);
 

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -2404,7 +2404,8 @@ class MeshgridFunctor {
     Shape view_shape(view_shape_vec);
     for (int i = 0; i < size; ++i) {
       view_shape.Set(i, -1);
-      std::shared_ptr<one::Tensor> reshaped = JUST(Reshape(tensor_consts.at(i), view_shape))->contiguous();
+      std::shared_ptr<one::Tensor> reshaped =
+          JUST(Reshape(tensor_consts.at(i), view_shape))->contiguous();
       grids[i] = JUST(Expand(reshaped, grids_shape));
       view_shape.Set(i, 1);
     }
@@ -2574,7 +2575,8 @@ class InTopKFunctor {
     CHECK_EQ_OR_RETURN(predictions->ndim(), 2) << "The dimension of predictions must be 2";
     MutableAttrMap attrs;
     JUST(attrs.SetAttr<int32_t>("k", k));
-    return OpInterpUtil::Dispatch<Tensor>(*op_, {targets->contiguous(), predictions->contiguous()}, attrs);
+    return OpInterpUtil::Dispatch<Tensor>(*op_, {targets->contiguous(), predictions->contiguous()},
+                                          attrs);
   }
 
  private:

--- a/oneflow/user/kernels/to_contiguous_kernel.cu
+++ b/oneflow/user/kernels/to_contiguous_kernel.cu
@@ -50,7 +50,7 @@ struct StrideParam {
 
 template<size_t ndim>
 __device__ __forceinline__ int64_t compute_index(int64_t out_offset, StrideParam<ndim> out_params,
-                                 const StrideParam<ndim>& in_params) {
+                                                 const StrideParam<ndim>& in_params) {
   int64_t in_offset = 0;
   int64_t remaining = out_offset;
 
@@ -68,12 +68,11 @@ __device__ __forceinline__ int64_t compute_index(int64_t out_offset, StrideParam
   return in_offset;
 }
 
-
 template<typename T, size_t ndim>
 __global__ void to_contiguous(int64_t count, StrideParam<ndim> in_stride,
                               StrideParam<ndim> out_stride, const T* in_dptr, T* out_dptr) {
-  for (int64_t out_idx = blockIdx.x * blockDim.x + threadIdx.x, step = blockDim.x * gridDim.x; out_idx < count; out_idx += step)
-  {
+  for (int64_t out_idx = blockIdx.x * blockDim.x + threadIdx.x, step = blockDim.x * gridDim.x;
+       out_idx < count; out_idx += step) {
     int64_t in_idx = compute_index<ndim>(out_idx, out_stride, in_stride);
     out_dptr[out_idx] = in_dptr[in_idx];
   }
@@ -136,12 +135,13 @@ struct ToContiguousUtil<DeviceType::kCUDA, T> : ToContiguousUtilBase {
       }
       if (is_same) {
         // if input tensor's strides equals to output's, than just copy one memory-contiguous tensor
-        OF_CUDA_CHECK(cudaMemcpyAsync(out_dptr + out_offset * dsize, in_dptr + in_offset * dsize, element_count * dsize, cudaMemcpyDeviceToDevice,
-                                    stream->As<ep::CudaStream>()->cuda_stream()));
-      } else{
+        OF_CUDA_CHECK(cudaMemcpyAsync(out_dptr + out_offset * dsize, in_dptr + in_offset * dsize,
+                                      element_count * dsize, cudaMemcpyDeviceToDevice,
+                                      stream->As<ep::CudaStream>()->cuda_stream()));
+      } else {
         const int ndim = contiguous_dim + 1;
         to_contiguous_fn_map.call(ndim)(stream, element_count, in_stride, out_stride, in_dptr,
-                                      out_dptr);
+                                        out_dptr);
       }
     }
   }


### PR DESCRIPTION
- [x] view工作推进计划中的第5.项任务：https://github.com/Oneflow-Inc/OneTeam/issues/776#issuecomment-999281851 

- 将tensor的is_contiguous属性增加至tensormeta，初始化tensor时根据stride和shape推导并设置，避免tensor->contiguous()时频繁调用IsContiguous()来判断