### PR TITLE
Fix error message when couldn't find matched SBP inferring

### DIFF
--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -750,7 +750,7 @@ Maybe<void> Operator::InferNdSbpSignature(
         for (size_t j = 0; j < input_bns().size(); ++j) {
           // NOTE: i is hierarchy dim and j is input_order
           const auto& ibn = input_bns()[j];
-          cfg::NdSbp nd_sbp = JUST(NdSbpInferHint4Ibn(ibn))->nd_sbp();
+          const cfg::NdSbp& nd_sbp = ibn2nd_sbp.at(ibn);
           if (j > 0) {
             got_input_sbp_ss << ", ";
             all_input_sbp_ss << ", ";


### PR DESCRIPTION
address the issue https://github.com/Oneflow-Inc/oneflow/issues/7134

使用的 input hint 可能会获得 1d 的 sbp，使用 ibn2nd_sbp 能保证获取到与 hierarchy 一样维度的 sbp。