### PR TITLE
add doc for pybind type

### DIFF
--- a/oneflow/api/python/framework/doc.cpp
+++ b/oneflow/api/python/framework/doc.cpp
@@ -42,6 +42,14 @@ py::object AddFunctionDoc(py::object f, const std::string& doc_string) {
                           << " already has a docstring.";
     }
     f->func_doc = PyUnicode_FromString(doc_str);
+  } else if (py::isinstance<py::detail::generic_type>(f)) {
+    if (py::hasattr(f, "__doc__")) {
+      auto doc = py::getattr(f, "__doc__");
+      if (!doc.is(py::none())) {
+        THROW(RuntimeError) << Py_TYPE(obj)->tp_name << " already has a docstring.";
+      }
+    }
+    py::setattr(f, "__doc__", py::reinterpret_steal<py::object>(PyUnicode_FromString(doc_str)));
   } else {
     THROW(RuntimeError) << "function is " << Py_TYPE(obj)->tp_name << ", not a valid function.";
   }


### PR DESCRIPTION
给 `add_docstr` 添加更多的判断分支，使得能够为更多的类型对象添加 docstring