### PR TITLE
OpKernelStateAndCacheProvider

### DIFF
--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -499,9 +499,16 @@ struct LocalCallOpKernelUtil final {
       // skipped.
       state = nullptr;
     }
-    operand->mut_opkernel()->TryInitOpKernelStateAndCache(
-        operand->user_opkernel(), device_ctx, operand->inputs().get(), operand->outputs().get(),
-        operand->consistent_tensor_infer_result().get(), state, cache);
+    auto* provider =
+        dynamic_cast<const user_op::OpKernelStateAndCacheProvider*>(operand->user_opkernel());
+    if (provider != nullptr) {
+      operand->mut_opkernel()->TryInitOpKernelStateAndCache(
+          provider, device_ctx, operand->inputs().get(), operand->outputs().get(),
+          operand->consistent_tensor_infer_result().get(), state, cache);
+    } else {
+      state = nullptr;
+      cache = nullptr;
+    }
   }
 
   static inline Maybe<void> AllocateOutputBlobsMemory(LocalCallOpKernelPhyInstrOperand* operand,

--- a/oneflow/core/framework/op_kernel.h
+++ b/oneflow/core/framework/op_kernel.h
@@ -292,10 +292,11 @@ class OpKernel;
 template<typename T>
 OpKernel* NewOpKernel();
 
-class OpKernel {
+class OpKernelStateAndCacheProvider {
  public:
-  OF_DISALLOW_COPY_AND_MOVE(OpKernel);
-  virtual ~OpKernel() = default;
+  OF_DISALLOW_COPY_AND_MOVE(OpKernelStateAndCacheProvider);
+  OpKernelStateAndCacheProvider() = default;
+  virtual ~OpKernelStateAndCacheProvider() = default;
 
   virtual std::shared_ptr<OpKernelState> CreateOpKernelState(KernelInitContext* ctx) const {
     return std::shared_ptr<OpKernelState>();
@@ -309,6 +310,12 @@ class OpKernel {
                                  std::shared_ptr<OpKernelCache>* cache_ptr) const {
     *cache_ptr = InitOpKernelCache(ctx);
   }
+};
+
+class OpKernel {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(OpKernel);
+  virtual ~OpKernel() = default;
 
   virtual void Compute(KernelComputeContext* ctx, OpKernelState*, const OpKernelCache*) const {
     Compute(ctx);

--- a/oneflow/core/kernel/eager_kernel.h
+++ b/oneflow/core/kernel/eager_kernel.h
@@ -37,6 +37,7 @@ class EagerKernel final : public Kernel {
   void InitOpKernel(const KernelConf& kernel_conf);
   void ForwardDataContent(KernelContext* kernel_ctx) const override { UNIMPLEMENTED(); }
   std::unique_ptr<const user_op::OpKernel> kernel_;
+  const user_op::OpKernelStateAndCacheProvider* state_and_cache_provider_;
   mutable std::shared_ptr<user_op::OpKernelCache> cache_;
 };
 

--- a/oneflow/core/kernel/user_kernel.h
+++ b/oneflow/core/kernel/user_kernel.h
@@ -63,6 +63,7 @@ class UserKernel final : public Kernel {
   mutable std::shared_ptr<user_op::OpKernelCache> opkernel_cache_;
   std::shared_ptr<user_op::OpKernelState> opkernel_state_;
   std::unique_ptr<const user_op::OpKernel> kernel_;
+  const user_op::OpKernelStateAndCacheProvider* state_and_cache_provider_;
   std::unique_ptr<UserKernelComputeContext> ctx_;
   std::unique_ptr<UserKernelInitAndCacheContext> cache_ctx_;
   std::unique_ptr<UserKernelInferContext> infer_ctx_;

--- a/oneflow/user/kernels/avg_pooling_kernel.cpp
+++ b/oneflow/user/kernels/avg_pooling_kernel.cpp
@@ -119,7 +119,8 @@ struct AvgPoolingKernelUtil<DeviceType::kCPU, T> {
 };
 
 template<DeviceType device_type, typename T>
-class AvgPool1dKernel final : public user_op::OpKernel {
+class AvgPool1dKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool1dKernel() = default;
   ~AvgPool1dKernel() = default;
@@ -152,7 +153,8 @@ class AvgPool1dKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class AvgPool1dGradKernel final : public user_op::OpKernel {
+class AvgPool1dGradKernel final : public user_op::OpKernel,
+                                  public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool1dGradKernel() = default;
   ~AvgPool1dGradKernel() = default;
@@ -187,7 +189,8 @@ class AvgPool1dGradKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class AvgPool2dKernel final : public user_op::OpKernel {
+class AvgPool2dKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool2dKernel() = default;
   ~AvgPool2dKernel() = default;
@@ -220,7 +223,8 @@ class AvgPool2dKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class AvgPool2dGradKernel final : public user_op::OpKernel {
+class AvgPool2dGradKernel final : public user_op::OpKernel,
+                                  public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool2dGradKernel() = default;
   ~AvgPool2dGradKernel() = default;
@@ -255,7 +259,8 @@ class AvgPool2dGradKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class AvgPool3dKernel final : public user_op::OpKernel {
+class AvgPool3dKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool3dKernel() = default;
   ~AvgPool3dKernel() = default;
@@ -288,7 +293,8 @@ class AvgPool3dKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class AvgPool3dGradKernel final : public user_op::OpKernel {
+class AvgPool3dGradKernel final : public user_op::OpKernel,
+                                  public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool3dGradKernel() = default;
   ~AvgPool3dGradKernel() = default;

--- a/oneflow/user/kernels/bernoulli_kernel.cpp
+++ b/oneflow/user/kernels/bernoulli_kernel.cpp
@@ -22,7 +22,8 @@ limitations under the License.
 namespace oneflow {
 
 template<typename T, typename K>
-class BernoulliKerenl final : public user_op::OpKernel {
+class BernoulliKerenl final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   BernoulliKerenl() = default;
   ~BernoulliKerenl() override = default;

--- a/oneflow/user/kernels/coco_reader_kernel.cpp
+++ b/oneflow/user/kernels/coco_reader_kernel.cpp
@@ -31,7 +31,8 @@ class COCOReaderWrapper final : public user_op::OpKernelState {
   data::COCODataReader reader_;
 };
 
-class COCOReaderKernel final : public user_op::OpKernel {
+class COCOReaderKernel final : public user_op::OpKernel,
+                               public user_op::OpKernelStateAndCacheProvider {
  public:
   COCOReaderKernel() = default;
   ~COCOReaderKernel() = default;

--- a/oneflow/user/kernels/combined_margin_loss_kernel.cpp
+++ b/oneflow/user/kernels/combined_margin_loss_kernel.cpp
@@ -59,7 +59,8 @@ std::shared_ptr<user_op::OpKernelCache> CreateCombinedMarginLossOpKernelCache(
 }  // namespace
 
 template<typename T, typename K>
-class CombinedMarginLossCpuKernel final : public user_op::OpKernel {
+class CombinedMarginLossCpuKernel final : public user_op::OpKernel,
+                                          public user_op::OpKernelStateAndCacheProvider {
  public:
   CombinedMarginLossCpuKernel() = default;
   ~CombinedMarginLossCpuKernel() override = default;
@@ -120,7 +121,8 @@ OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_COMBINED_MARGIN_LOSS_CPU_KERNEL, FLOAT
                                  INDEX_DATA_TYPE_SEQ)
 
 template<typename T, typename K>
-class CombinedMarginLossGradCpuKernel final : public user_op::OpKernel {
+class CombinedMarginLossGradCpuKernel final : public user_op::OpKernel,
+                                              public user_op::OpKernelStateAndCacheProvider {
  public:
   CombinedMarginLossGradCpuKernel() = default;
   ~CombinedMarginLossGradCpuKernel() override = default;

--- a/oneflow/user/kernels/combined_margin_loss_kernel.cu
+++ b/oneflow/user/kernels/combined_margin_loss_kernel.cu
@@ -104,12 +104,13 @@ std::shared_ptr<user_op::OpKernelCache> CreateCombinedMarginLossOpKernelCache(
 }  // namespace
 
 template<typename T, typename K>
-class CombinedMarginLossGpuKernel final : public user_op::OpKernel {
+class CombinedMarginLossGpuKernel final : public user_op::OpKernel,
+                                          public user_op::OpKernelStateAndCacheProvider {
  public:
   CombinedMarginLossGpuKernel() = default;
   ~CombinedMarginLossGpuKernel() override = default;
 
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   std::shared_ptr<user_op::OpKernelCache> InitOpKernelCache(
       user_op::KernelCacheContext* ctx) const override {
     return CreateCombinedMarginLossOpKernelCache(ctx, "x");
@@ -163,12 +164,13 @@ OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_COMBINED_MARGIN_LOSS_CUDA_KERNEL, FLOA
                                  INDEX_DATA_TYPE_SEQ)
 
 template<typename T, typename K>
-class CombinedMarginLossGradGpuKernel final : public user_op::OpKernel {
+class CombinedMarginLossGradGpuKernel final : public user_op::OpKernel,
+                                              public user_op::OpKernelStateAndCacheProvider {
  public:
   CombinedMarginLossGradGpuKernel() = default;
   ~CombinedMarginLossGradGpuKernel() override = default;
 
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   std::shared_ptr<user_op::OpKernelCache> InitOpKernelCache(
       user_op::KernelCacheContext* ctx) const override {
     return CreateCombinedMarginLossOpKernelCache(ctx, "dy");

--- a/oneflow/user/kernels/conv_cudnn_kernels.cpp
+++ b/oneflow/user/kernels/conv_cudnn_kernels.cpp
@@ -143,7 +143,9 @@ struct ConvCudnnOpKernelCache final : public user_op::OpKernelCache {
 };
 
 template<typename T, size_t NDims>
-class ConvGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class ConvGpuKernel final : public user_op::OpKernel,
+                            public user_op::CudaGraphSupport,
+                            public user_op::OpKernelStateAndCacheProvider {
  public:
   ConvGpuKernel() = default;
   ~ConvGpuKernel() = default;

--- a/oneflow/user/kernels/conv_kernels.cpp
+++ b/oneflow/user/kernels/conv_kernels.cpp
@@ -375,7 +375,8 @@ void InitBiasMulBuf(T* dptr, int64_t num) {
 }
 
 template<typename T, size_t NDims>
-class ConvCpuKernel final : public user_op::OpKernel {
+class ConvCpuKernel final : public user_op::OpKernel,
+                            public user_op::OpKernelStateAndCacheProvider {
  public:
   ConvCpuKernel() = default;
   ~ConvCpuKernel() = default;
@@ -476,7 +477,8 @@ REGISTER_CONV_KERNEL(conv2d, double, 2);
 REGISTER_CONV_KERNEL(conv3d, double, 3);
 
 template<typename T>
-class ConvDataGradCpuKernel final : public user_op::OpKernel {
+class ConvDataGradCpuKernel final : public user_op::OpKernel,
+                                    public user_op::OpKernelStateAndCacheProvider {
  public:
   OF_DISALLOW_COPY_AND_MOVE(ConvDataGradCpuKernel);
   ConvDataGradCpuKernel() = default;
@@ -557,7 +559,8 @@ REGISTER_CONV_DATA_GRAD_KERNEL(conv_data_grad, float);
 REGISTER_CONV_DATA_GRAD_KERNEL(conv_data_grad, double);
 
 template<typename T>
-class ConvFilterGradCpuKernel final : public user_op::OpKernel {
+class ConvFilterGradCpuKernel final : public user_op::OpKernel,
+                                      public user_op::OpKernelStateAndCacheProvider {
  public:
   OF_DISALLOW_COPY_AND_MOVE(ConvFilterGradCpuKernel);
   ConvFilterGradCpuKernel() = default;

--- a/oneflow/user/kernels/deconv_cpu_kernel.cpp
+++ b/oneflow/user/kernels/deconv_cpu_kernel.cpp
@@ -318,7 +318,8 @@ std::shared_ptr<DeconvOpKernelCache<T>> CreateDeconvOpKernelCache(user_op::Kerne
 }
 
 template<typename T>
-class DeconvCpuKernel final : public user_op::OpKernel {
+class DeconvCpuKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   OF_DISALLOW_COPY_AND_MOVE(DeconvCpuKernel);
   DeconvCpuKernel() = default;
@@ -326,7 +327,7 @@ class DeconvCpuKernel final : public user_op::OpKernel {
 
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   void InitOpKernelCache(user_op::KernelCacheContext* ctx, int8_t flag,
                          std::shared_ptr<user_op::OpKernelCache>* cache_ptr) const override {
     if (*cache_ptr != nullptr && (flag & user_op::OpKernelCache::kAttrNotChanged)) {

--- a/oneflow/user/kernels/distributions/normal_kernel.h
+++ b/oneflow/user/kernels/distributions/normal_kernel.h
@@ -26,7 +26,7 @@ namespace oneflow {
 namespace {
 
 template<DeviceType device_type, typename T>
-class NormalKernel final : public user_op::OpKernel {
+class NormalKernel final : public user_op::OpKernel, public user_op::OpKernelStateAndCacheProvider {
  public:
   NormalKernel() = default;
   ~NormalKernel() = default;

--- a/oneflow/user/kernels/distributions/uniform_int_kernel.h
+++ b/oneflow/user/kernels/distributions/uniform_int_kernel.h
@@ -67,7 +67,8 @@ int64_t update_to(int64_t to) {
 }
 
 template<DeviceType device_type, typename T>
-class UniformIntKernel final : public user_op::OpKernel {
+class UniformIntKernel final : public user_op::OpKernel,
+                               public user_op::OpKernelStateAndCacheProvider {
  public:
   UniformIntKernel() = default;
   ~UniformIntKernel() = default;

--- a/oneflow/user/kernels/distributions/uniform_kernel.h
+++ b/oneflow/user/kernels/distributions/uniform_kernel.h
@@ -25,7 +25,8 @@ namespace oneflow {
 namespace {
 
 template<DeviceType device_type, typename T>
-class UniformKernel final : public user_op::OpKernel {
+class UniformKernel final : public user_op::OpKernel,
+                            public user_op::OpKernelStateAndCacheProvider {
  public:
   UniformKernel() = default;
   ~UniformKernel() = default;

--- a/oneflow/user/kernels/dropout_kernel.cpp
+++ b/oneflow/user/kernels/dropout_kernel.cpp
@@ -46,7 +46,8 @@ void FusedDropoutKernel(ep::Stream* stream, const int64_t elem_cnt,
 }
 
 template<typename T>
-class DropoutKernelCPU final : public user_op::OpKernel {
+class DropoutKernelCPU final : public user_op::OpKernel,
+                               public user_op::OpKernelStateAndCacheProvider {
  public:
   DropoutKernelCPU() = default;
   ~DropoutKernelCPU() = default;

--- a/oneflow/user/kernels/dropout_kernel.cu
+++ b/oneflow/user/kernels/dropout_kernel.cu
@@ -399,7 +399,9 @@ struct MaskAndScaleFunctor<nv_bfloat16> {
 #endif
 
 template<typename T>
-class DropoutKernelGPU final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class DropoutKernelGPU final : public user_op::OpKernel,
+                               public user_op::CudaGraphSupport,
+                               public user_op::OpKernelStateAndCacheProvider {
  public:
   DropoutKernelGPU() = default;
   ~DropoutKernelGPU() = default;

--- a/oneflow/user/kernels/eager_b_to_s_kernel.cpp
+++ b/oneflow/user/kernels/eager_b_to_s_kernel.cpp
@@ -156,7 +156,8 @@ size_t InferEagerBToSKernelTmpBufferSize(user_op::InferContext* ctx) {
 }  // namespace
 
 template<DeviceType device_type>
-class EagerBToSKernel final : public user_op::OpKernel {
+class EagerBToSKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerBToSKernel() = default;
   ~EagerBToSKernel() override = default;

--- a/oneflow/user/kernels/eager_nccl_kernels.cpp
+++ b/oneflow/user/kernels/eager_nccl_kernels.cpp
@@ -75,7 +75,8 @@ void InitEagerCclOpKernelCache(user_op::KernelCacheContext* ctx,
 }
 }  // namespace
 
-class EagerCclBroadcastKernel final : public user_op::OpKernel {
+class EagerCclBroadcastKernel final : public user_op::OpKernel,
+                                      public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerCclBroadcastKernel() = default;
   ~EagerCclBroadcastKernel() override = default;
@@ -110,7 +111,8 @@ REGISTER_USER_KERNEL("eager_nccl_broadcast")
     .SetCreateFn<EagerCclBroadcastKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
 
-class EagerCclReduceKernel final : public user_op::OpKernel {
+class EagerCclReduceKernel final : public user_op::OpKernel,
+                                   public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerCclReduceKernel() = default;
   ~EagerCclReduceKernel() override = default;
@@ -146,7 +148,8 @@ REGISTER_USER_KERNEL("eager_nccl_reduce")
     .SetCreateFn<EagerCclReduceKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
 
-class EagerCclAllReduceKernel final : public user_op::OpKernel {
+class EagerCclAllReduceKernel final : public user_op::OpKernel,
+                                      public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerCclAllReduceKernel() = default;
   ~EagerCclAllReduceKernel() override = default;
@@ -177,7 +180,8 @@ REGISTER_USER_KERNEL("eager_nccl_all_reduce")
     .SetCreateFn<EagerCclAllReduceKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
 
-class EagerCclReduceScatterKernel final : public user_op::OpKernel {
+class EagerCclReduceScatterKernel final : public user_op::OpKernel,
+                                          public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerCclReduceScatterKernel() = default;
   ~EagerCclReduceScatterKernel() override = default;
@@ -209,7 +213,8 @@ REGISTER_USER_KERNEL("eager_nccl_reduce_scatter")
     .SetCreateFn<EagerCclReduceScatterKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
 
-class EagerCclAllGatherKernel final : public user_op::OpKernel {
+class EagerCclAllGatherKernel final : public user_op::OpKernel,
+                                      public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerCclAllGatherKernel() = default;
   ~EagerCclAllGatherKernel() override = default;
@@ -240,7 +245,8 @@ REGISTER_USER_KERNEL("eager_nccl_all_gather")
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
 
 template<typename T>
-class EagerCclS2SKernel final : public user_op::OpKernel {
+class EagerCclS2SKernel final : public user_op::OpKernel,
+                                public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerCclS2SKernel() = default;
   ~EagerCclS2SKernel() override = default;

--- a/oneflow/user/kernels/eager_nccl_kernels.cu
+++ b/oneflow/user/kernels/eager_nccl_kernels.cu
@@ -72,13 +72,14 @@ void InitEagerNcclOpKernelCache(user_op::KernelCacheContext* ctx,
 }
 }  // namespace
 
-class EagerNcclAllReduceKernel final : public user_op::OpKernel {
+class EagerNcclAllReduceKernel final : public user_op::OpKernel,
+                                       public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerNcclAllReduceKernel() = default;
   ~EagerNcclAllReduceKernel() override = default;
 
  private:
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   void InitOpKernelCache(user_op::KernelCacheContext* ctx, int8_t flag,
                          std::shared_ptr<user_op::OpKernelCache>* cache_ptr) const override {
     InitEagerNcclOpKernelCache(ctx, cache_ptr);
@@ -104,13 +105,14 @@ REGISTER_USER_KERNEL("eager_nccl_all_reduce")
     .SetCreateFn<EagerNcclAllReduceKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCUDA);
 
-class EagerNcclBroadcastKernel final : public user_op::OpKernel {
+class EagerNcclBroadcastKernel final : public user_op::OpKernel,
+                                       public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerNcclBroadcastKernel() = default;
   ~EagerNcclBroadcastKernel() override = default;
 
  private:
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   void InitOpKernelCache(user_op::KernelCacheContext* ctx, int8_t flag,
                          std::shared_ptr<user_op::OpKernelCache>* cache_ptr) const override {
     InitEagerNcclOpKernelCache(ctx, cache_ptr);
@@ -144,13 +146,14 @@ REGISTER_USER_KERNEL("eager_nccl_broadcast")
     .SetCreateFn<EagerNcclBroadcastKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCUDA);
 
-class EagerNcclReduceKernel final : public user_op::OpKernel {
+class EagerNcclReduceKernel final : public user_op::OpKernel,
+                                    public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerNcclReduceKernel() = default;
   ~EagerNcclReduceKernel() override = default;
 
  private:
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   void InitOpKernelCache(user_op::KernelCacheContext* ctx, int8_t flag,
                          std::shared_ptr<user_op::OpKernelCache>* cache_ptr) const override {
     InitEagerNcclOpKernelCache(ctx, cache_ptr);
@@ -181,13 +184,14 @@ REGISTER_USER_KERNEL("eager_nccl_reduce")
     .SetCreateFn<EagerNcclReduceKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCUDA);
 
-class EagerNcclReduceScatterKernel final : public user_op::OpKernel {
+class EagerNcclReduceScatterKernel final : public user_op::OpKernel,
+                                           public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerNcclReduceScatterKernel() = default;
   ~EagerNcclReduceScatterKernel() override = default;
 
  private:
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   void InitOpKernelCache(user_op::KernelCacheContext* ctx, int8_t flag,
                          std::shared_ptr<user_op::OpKernelCache>* cache_ptr) const override {
     InitEagerNcclOpKernelCache(ctx, cache_ptr);
@@ -219,13 +223,14 @@ REGISTER_USER_KERNEL("eager_nccl_reduce_scatter")
     .SetCreateFn<EagerNcclReduceScatterKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCUDA);
 
-class EagerNcclAllGatherKernel final : public user_op::OpKernel {
+class EagerNcclAllGatherKernel final : public user_op::OpKernel,
+                                       public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerNcclAllGatherKernel() = default;
   ~EagerNcclAllGatherKernel() override = default;
 
  private:
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   void InitOpKernelCache(user_op::KernelCacheContext* ctx, int8_t flag,
                          std::shared_ptr<user_op::OpKernelCache>* cache_ptr) const override {
     InitEagerNcclOpKernelCache(ctx, cache_ptr);
@@ -251,13 +256,14 @@ REGISTER_USER_KERNEL("eager_nccl_all_gather")
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCUDA);
 
 template<typename T>
-class EagerNcclS2SKernel final : public user_op::OpKernel {
+class EagerNcclS2SKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerNcclS2SKernel() = default;
   ~EagerNcclS2SKernel() override = default;
 
  private:
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   void InitOpKernelCache(user_op::KernelCacheContext* ctx, int8_t flag,
                          std::shared_ptr<user_op::OpKernelCache>* cache_ptr) const override {
     InitEagerNcclOpKernelCache(ctx, cache_ptr);

--- a/oneflow/user/kernels/eager_p_to_b_kernel.cpp
+++ b/oneflow/user/kernels/eager_p_to_b_kernel.cpp
@@ -66,7 +66,8 @@ size_t InferEagerPToBKernelTmpBufferSize(user_op::InferContext* ctx) {
 }  // namespace
 
 template<DeviceType device_type>
-class EagerPToBKernel final : public user_op::OpKernel {
+class EagerPToBKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerPToBKernel() = default;
   ~EagerPToBKernel() override = default;

--- a/oneflow/user/kernels/eager_p_to_s_kernel.cpp
+++ b/oneflow/user/kernels/eager_p_to_s_kernel.cpp
@@ -137,7 +137,8 @@ size_t InferEagerPToSKernelTmpBufferSize(user_op::InferContext* ctx) {
 }  // namespace
 
 template<DeviceType device_type>
-class EagerPToSKernel final : public user_op::OpKernel {
+class EagerPToSKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerPToSKernel() = default;
   ~EagerPToSKernel() override = default;

--- a/oneflow/user/kernels/eager_s_to_b_kernel.cpp
+++ b/oneflow/user/kernels/eager_s_to_b_kernel.cpp
@@ -136,7 +136,8 @@ size_t InferEagerSToBKernelTmpBufferSize(user_op::InferContext* ctx) {
 }  // namespace
 
 template<DeviceType device_type>
-class EagerSToBKernel final : public user_op::OpKernel {
+class EagerSToBKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerSToBKernel() = default;
   ~EagerSToBKernel() override = default;

--- a/oneflow/user/kernels/eager_s_to_s_kernel.cpp
+++ b/oneflow/user/kernels/eager_s_to_s_kernel.cpp
@@ -139,7 +139,8 @@ size_t InferNaiveSToSKernelTmpBufferSize(user_op::InferContext* ctx) {
 }  // namespace
 
 template<DeviceType device_type>
-class EagerNaiveSToSKernel final : public user_op::OpKernel {
+class EagerNaiveSToSKernel final : public user_op::OpKernel,
+                                   public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerNaiveSToSKernel() = default;
   ~EagerNaiveSToSKernel() override = default;

--- a/oneflow/user/kernels/eager_symmetric_s_to_p_kernel.cpp
+++ b/oneflow/user/kernels/eager_symmetric_s_to_p_kernel.cpp
@@ -88,7 +88,8 @@ class EagerSymmetricSToPOpKernelCache final : public user_op::OpKernelCache {
 }  // namespace
 
 template<DeviceType device_type>
-class EagerSymmetricSToPKernel final : public user_op::OpKernel {
+class EagerSymmetricSToPKernel final : public user_op::OpKernel,
+                                       public user_op::OpKernelStateAndCacheProvider {
  public:
   EagerSymmetricSToPKernel() = default;
   ~EagerSymmetricSToPKernel() override = default;

--- a/oneflow/user/kernels/gather_kernel.cpp
+++ b/oneflow/user/kernels/gather_kernel.cpp
@@ -59,7 +59,9 @@ void CheckNdSbp(const Shape& hierarchy, int64_t gather_axis, const cfg::NdSbp& i
 }  // namespace
 
 template<DeviceType device_type, typename T, typename K>
-class GatherKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class GatherKernel final : public user_op::OpKernel,
+                           public user_op::CudaGraphSupport,
+                           public user_op::OpKernelStateAndCacheProvider {
  public:
   GatherKernel() = default;
   ~GatherKernel() override = default;

--- a/oneflow/user/kernels/generate_random_batch_permutation_indices_kernel.cpp
+++ b/oneflow/user/kernels/generate_random_batch_permutation_indices_kernel.cpp
@@ -20,7 +20,9 @@ limitations under the License.
 
 namespace oneflow {
 
-class GenerateRandomBatchPermutationIndicesCPUKernel final : public user_op::OpKernel {
+class GenerateRandomBatchPermutationIndicesCPUKernel final
+    : public user_op::OpKernel,
+      public user_op::OpKernelStateAndCacheProvider {
  public:
   GenerateRandomBatchPermutationIndicesCPUKernel() = default;
   ~GenerateRandomBatchPermutationIndicesCPUKernel() = default;

--- a/oneflow/user/kernels/generate_random_batch_permutation_indices_kernel.cu
+++ b/oneflow/user/kernels/generate_random_batch_permutation_indices_kernel.cu
@@ -77,7 +77,9 @@ __global__ void InitializeIndices(int32_t elem_cnt, int32_t* indices_ptr) {
 
 }  // namespace
 
-class GenerateRandomBatchPermutationIndicesGPUKernel final : public user_op::OpKernel {
+class GenerateRandomBatchPermutationIndicesGPUKernel final
+    : public user_op::OpKernel,
+      public user_op::OpKernelStateAndCacheProvider {
  public:
   GenerateRandomBatchPermutationIndicesGPUKernel() = default;
   ~GenerateRandomBatchPermutationIndicesGPUKernel() = default;

--- a/oneflow/user/kernels/gpt_data_loader_kernel.cpp
+++ b/oneflow/user/kernels/gpt_data_loader_kernel.cpp
@@ -123,7 +123,7 @@ class GPTDataLoader final : public OpKernelState {
 };
 
 template<typename T>
-class GPTDataLoaderKernel final : public OpKernel {
+class GPTDataLoaderKernel final : public OpKernel, public OpKernelStateAndCacheProvider {
  public:
   GPTDataLoaderKernel() = default;
   ~GPTDataLoaderKernel() = default;

--- a/oneflow/user/kernels/group_conv_kernel.cpp
+++ b/oneflow/user/kernels/group_conv_kernel.cpp
@@ -387,7 +387,8 @@ void InitBiasMulBuf(T* dptr, int64_t num) {
   for (int64_t i = 0; i < num; ++i) { dptr[i] = 1; }
 }
 template<typename T, size_t NDims>
-class ConvCpuKernel final : public user_op::OpKernel {
+class ConvCpuKernel final : public user_op::OpKernel,
+                            public user_op::OpKernelStateAndCacheProvider {
  public:
   ConvCpuKernel() = default;
   ~ConvCpuKernel() = default;
@@ -504,7 +505,8 @@ REGISTER_CONV_KERNEL(conv2d, double, 2);
 REGISTER_CONV_KERNEL(conv3d, double, 3);
 
 template<typename T>
-class ConvDataGradCpuKernel final : public user_op::OpKernel {
+class ConvDataGradCpuKernel final : public user_op::OpKernel,
+                                    public user_op::OpKernelStateAndCacheProvider {
  public:
   OF_DISALLOW_COPY_AND_MOVE(ConvDataGradCpuKernel);
   ConvDataGradCpuKernel() = default;
@@ -602,7 +604,8 @@ REGISTER_CONV_DATA_GRAD_KERNEL(conv_data_grad, float);
 REGISTER_CONV_DATA_GRAD_KERNEL(conv_data_grad, double);
 
 template<typename T>
-class ConvFilterGradCpuKernel final : public user_op::OpKernel {
+class ConvFilterGradCpuKernel final : public user_op::OpKernel,
+                                      public user_op::OpKernelStateAndCacheProvider {
  public:
   OF_DISALLOW_COPY_AND_MOVE(ConvFilterGradCpuKernel);
   ConvFilterGradCpuKernel() = default;

--- a/oneflow/user/kernels/group_deconv_kernel.cpp
+++ b/oneflow/user/kernels/group_deconv_kernel.cpp
@@ -330,7 +330,8 @@ std::shared_ptr<DeconvOpKernelCache<T>> CreateDeconvOpKernelCache(user_op::Kerne
 }
 
 template<typename T>
-class DeconvCpuKernel final : public user_op::OpKernel {
+class DeconvCpuKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   OF_DISALLOW_COPY_AND_MOVE(DeconvCpuKernel);
   DeconvCpuKernel() = default;
@@ -338,7 +339,7 @@ class DeconvCpuKernel final : public user_op::OpKernel {
 
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 
-  using user_op::OpKernel::InitOpKernelCache;
+  using user_op::OpKernelStateAndCacheProvider::InitOpKernelCache;
   void InitOpKernelCache(user_op::KernelCacheContext* ctx, int8_t flag,
                          std::shared_ptr<user_op::OpKernelCache>* cache_ptr) const override {
     if (*cache_ptr != nullptr && (flag & user_op::OpKernelCache::kAttrNotChanged)) {

--- a/oneflow/user/kernels/image_preprocess_kernels.cpp
+++ b/oneflow/user/kernels/image_preprocess_kernels.cpp
@@ -121,7 +121,9 @@ class CMNAttr final : public user_op::OpKernelState {
 
 }  // namespace
 
-class CropMirrorNormalizeFromStaticShapeToFloatKernel final : public user_op::OpKernel {
+class CropMirrorNormalizeFromStaticShapeToFloatKernel final
+    : public user_op::OpKernel,
+      public user_op::OpKernelStateAndCacheProvider {
  public:
   CropMirrorNormalizeFromStaticShapeToFloatKernel() = default;
   ~CropMirrorNormalizeFromStaticShapeToFloatKernel() override = default;
@@ -203,7 +205,9 @@ REGISTER_USER_KERNEL("crop_mirror_normalize_from_uint8")
                      && (user_op::HobDataType("in", 0) == DataType::kUInt8)
                      && (user_op::HobDataType("out", 0) == DataType::kFloat));
 
-class CropMirrorNormalizeFromTensorBufferToFloatKernel final : public user_op::OpKernel {
+class CropMirrorNormalizeFromTensorBufferToFloatKernel final
+    : public user_op::OpKernel,
+      public user_op::OpKernelStateAndCacheProvider {
  public:
   CropMirrorNormalizeFromTensorBufferToFloatKernel() = default;
   ~CropMirrorNormalizeFromTensorBufferToFloatKernel() override = default;
@@ -310,7 +314,8 @@ class RandBoolGen final : public user_op::OpKernelState {
 
 }  // namespace
 
-class CoinFlipKernel final : public user_op::OpKernel {
+class CoinFlipKernel final : public user_op::OpKernel,
+                             public user_op::OpKernelStateAndCacheProvider {
  public:
   CoinFlipKernel() = default;
   ~CoinFlipKernel() override = default;
@@ -373,7 +378,8 @@ void ImageRandomCropImpl(const TensorBuffer* in_buffer, TensorBuffer* out_buffer
 
 }  // namespace
 
-class ImageRandomCropKernel final : public user_op::OpKernel {
+class ImageRandomCropKernel final : public user_op::OpKernel,
+                                    public user_op::OpKernelStateAndCacheProvider {
  public:
   ImageRandomCropKernel() = default;
   ~ImageRandomCropKernel() override = default;

--- a/oneflow/user/kernels/image_preprocess_kernels.cu
+++ b/oneflow/user/kernels/image_preprocess_kernels.cu
@@ -129,7 +129,8 @@ __global__ void CropMirrorNormalizeGpuImpl(int32_t elem_cnt, const uint8_t* in_d
 
 }  // namespace
 
-class CropMirrorNormalizeGpuKernel final : public user_op::OpKernel {
+class CropMirrorNormalizeGpuKernel final : public user_op::OpKernel,
+                                           public user_op::OpKernelStateAndCacheProvider {
  public:
   CropMirrorNormalizeGpuKernel() = default;
   ~CropMirrorNormalizeGpuKernel() override = default;

--- a/oneflow/user/kernels/model_update_kernels.cpp
+++ b/oneflow/user/kernels/model_update_kernels.cpp
@@ -179,7 +179,8 @@ user_op::InferTmpSizeFn GenInferTmpSizeFn() {
 }
 
 template<DeviceType device_type, typename T, typename K>
-class IndexedSlicesSGDUpdateKernel final : public user_op::OpKernel {
+class IndexedSlicesSGDUpdateKernel final : public user_op::OpKernel,
+                                           public user_op::OpKernelStateAndCacheProvider {
  public:
   IndexedSlicesSGDUpdateKernel() = default;
   ~IndexedSlicesSGDUpdateKernel() override = default;
@@ -307,7 +308,8 @@ REGISTER_MOMENTUM_UPDATE_KERNEL(DeviceType::kCUDA, double, double);
 #endif  // WITH_CUDA
 
 template<DeviceType device_type, typename T, typename K>
-class IndexedSlicesMomentumUpdateKernel final : public user_op::OpKernel {
+class IndexedSlicesMomentumUpdateKernel final : public user_op::OpKernel,
+                                                public user_op::OpKernelStateAndCacheProvider {
  public:
   IndexedSlicesMomentumUpdateKernel() = default;
   ~IndexedSlicesMomentumUpdateKernel() override = default;
@@ -532,7 +534,8 @@ REGISTER_ADAGRAD_UPDATE_KERNEL(DeviceType::kCUDA, double, double);
 #endif  // WITH_CUDA
 
 template<DeviceType device_type, typename T, typename K>
-class IndexedSlicesAdamUpdateKernel final : public user_op::OpKernel {
+class IndexedSlicesAdamUpdateKernel final : public user_op::OpKernel,
+                                            public user_op::OpKernelStateAndCacheProvider {
  public:
   IndexedSlicesAdamUpdateKernel() = default;
   ~IndexedSlicesAdamUpdateKernel() override = default;

--- a/oneflow/user/kernels/nccl_logical_2d_sbp_kernels.cpp
+++ b/oneflow/user/kernels/nccl_logical_2d_sbp_kernels.cpp
@@ -86,7 +86,8 @@ class NcclLogical2DSameDim0KernelCommState final : public user_op::OpKernelState
   ncclComm_t comm_{};
 };
 
-class NcclLogical2DSameDim0AllReduce final : public user_op::OpKernel {
+class NcclLogical2DSameDim0AllReduce final : public user_op::OpKernel,
+                                             public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogical2DSameDim0AllReduce() = default;
   ~NcclLogical2DSameDim0AllReduce() override = default;
@@ -113,7 +114,8 @@ class NcclLogical2DSameDim0AllReduce final : public user_op::OpKernel {
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-class NcclLogical2DSameDim0AllGather final : public user_op::OpKernel {
+class NcclLogical2DSameDim0AllGather final : public user_op::OpKernel,
+                                             public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogical2DSameDim0AllGather() = default;
   ~NcclLogical2DSameDim0AllGather() override = default;
@@ -141,7 +143,9 @@ class NcclLogical2DSameDim0AllGather final : public user_op::OpKernel {
 };
 
 template<typename T>
-class NcclLogical2DSameDim0AllGatherNoncontinuous final : public user_op::OpKernel {
+class NcclLogical2DSameDim0AllGatherNoncontinuous final
+    : public user_op::OpKernel,
+      public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogical2DSameDim0AllGatherNoncontinuous() = default;
   ~NcclLogical2DSameDim0AllGatherNoncontinuous() override = default;
@@ -204,7 +208,8 @@ size_t Infer2DSameDim0AllGatherNoncontinuousKernelTmpBufferSize(user_op::InferCo
 }
 
 template<typename T>
-class NcclLogical2DSameDim0All2All final : public user_op::OpKernel {
+class NcclLogical2DSameDim0All2All final : public user_op::OpKernel,
+                                           public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogical2DSameDim0All2All() = default;
   ~NcclLogical2DSameDim0All2All() override = default;
@@ -363,7 +368,8 @@ class NcclLogical2DSameDim1KernelCommState final : public user_op::OpKernelState
   ncclComm_t comm_{};
 };
 
-class NcclLogical2DSameDim1AllReduce final : public user_op::OpKernel {
+class NcclLogical2DSameDim1AllReduce final : public user_op::OpKernel,
+                                             public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogical2DSameDim1AllReduce() = default;
   ~NcclLogical2DSameDim1AllReduce() override = default;

--- a/oneflow/user/kernels/nccl_logical_kernels.cpp
+++ b/oneflow/user/kernels/nccl_logical_kernels.cpp
@@ -65,7 +65,8 @@ class NcclLogicalKernelCommState final : public user_op::OpKernelState {
   ncclComm_t comm_{};
 };
 
-class NcclLogicalAllReduceKernel final : public user_op::OpKernel {
+class NcclLogicalAllReduceKernel final : public user_op::OpKernel,
+                                         public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogicalAllReduceKernel() = default;
   ~NcclLogicalAllReduceKernel() override = default;
@@ -92,7 +93,8 @@ class NcclLogicalAllReduceKernel final : public user_op::OpKernel {
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-class NcclLogicalReduceScatterKernel final : public user_op::OpKernel {
+class NcclLogicalReduceScatterKernel final : public user_op::OpKernel,
+                                             public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogicalReduceScatterKernel() = default;
   ~NcclLogicalReduceScatterKernel() override = default;
@@ -120,7 +122,8 @@ class NcclLogicalReduceScatterKernel final : public user_op::OpKernel {
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-class NcclLogicalAllGatherKernel final : public user_op::OpKernel {
+class NcclLogicalAllGatherKernel final : public user_op::OpKernel,
+                                         public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogicalAllGatherKernel() = default;
   ~NcclLogicalAllGatherKernel() override = default;
@@ -148,7 +151,8 @@ class NcclLogicalAllGatherKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class NcclLogicalAllGatherNoncontinuous final : public user_op::OpKernel {
+class NcclLogicalAllGatherNoncontinuous final : public user_op::OpKernel,
+                                                public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogicalAllGatherNoncontinuous() = default;
   ~NcclLogicalAllGatherNoncontinuous() override = default;
@@ -210,7 +214,8 @@ size_t InferAllGatherNoncontinuousKernelTmpBufferSize(user_op::InferContext* ctx
 }
 
 template<typename T>
-class NcclLogicalS2SKernel final : public user_op::OpKernel {
+class NcclLogicalS2SKernel final : public user_op::OpKernel,
+                                   public user_op::OpKernelStateAndCacheProvider {
  public:
   NcclLogicalS2SKernel() = default;
   ~NcclLogicalS2SKernel() override = default;

--- a/oneflow/user/kernels/nvtx_range_kernel.cu
+++ b/oneflow/user/kernels/nvtx_range_kernel.cu
@@ -46,7 +46,8 @@ class NvtxOpKernelState final : public user_op::OpKernelState {
   int64_t counter_;
 };
 
-class NvtxStartKernel final : public user_op::OpKernel {
+class NvtxStartKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   NvtxStartKernel() = default;
   ~NvtxStartKernel() override = default;
@@ -89,7 +90,8 @@ REGISTER_USER_KERNEL("nvtx_start")
       return Maybe<void>::Ok();
     });
 
-class NvtxEndKernel final : public user_op::OpKernel {
+class NvtxEndKernel final : public user_op::OpKernel,
+                            public user_op::OpKernelStateAndCacheProvider {
  public:
   NvtxEndKernel() = default;
   ~NvtxEndKernel() override = default;

--- a/oneflow/user/kernels/ofrecord_decoder_kernels.cpp
+++ b/oneflow/user/kernels/ofrecord_decoder_kernels.cpp
@@ -218,7 +218,8 @@ void DecodeRandomCropImageFromOneRecord(const OFRecord& record, TensorBuffer* bu
 
 }  // namespace
 
-class OFRecordImageDecoderRandomCropKernel final : public user_op::OpKernel {
+class OFRecordImageDecoderRandomCropKernel final : public user_op::OpKernel,
+                                                   public user_op::OpKernelStateAndCacheProvider {
  public:
   OFRecordImageDecoderRandomCropKernel() = default;
   ~OFRecordImageDecoderRandomCropKernel() override = default;

--- a/oneflow/user/kernels/ofrecord_image_classification_reader_kernel.cpp
+++ b/oneflow/user/kernels/ofrecord_image_classification_reader_kernel.cpp
@@ -34,7 +34,9 @@ class OFRecordImageClassificationReaderKernelState final : public user_op::OpKer
 
 }  // namespace
 
-class OFRecordImageClassificationReaderKernel final : public user_op::OpKernel {
+class OFRecordImageClassificationReaderKernel final
+    : public user_op::OpKernel,
+      public user_op::OpKernelStateAndCacheProvider {
  public:
   OFRecordImageClassificationReaderKernel() = default;
   ~OFRecordImageClassificationReaderKernel() override = default;

--- a/oneflow/user/kernels/ofrecord_reader_kernel.cpp
+++ b/oneflow/user/kernels/ofrecord_reader_kernel.cpp
@@ -33,7 +33,8 @@ class OFRecordReaderWrapper final : public user_op::OpKernelState {
 
 }  // namespace
 
-class OFRecordReaderKernel final : public user_op::OpKernel {
+class OFRecordReaderKernel final : public user_op::OpKernel,
+                                   public user_op::OpKernelStateAndCacheProvider {
  public:
   OFRecordReaderKernel() = default;
   ~OFRecordReaderKernel() override = default;

--- a/oneflow/user/kernels/onerec_reader_kernel.cpp
+++ b/oneflow/user/kernels/onerec_reader_kernel.cpp
@@ -33,7 +33,8 @@ class OneRecReaderWrapper final : public user_op::OpKernelState {
 
 }  // namespace
 
-class OneRecReaderKernel final : public user_op::OpKernel {
+class OneRecReaderKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   OneRecReaderKernel() = default;
   ~OneRecReaderKernel() override = default;

--- a/oneflow/user/kernels/pack_kernel.cpp
+++ b/oneflow/user/kernels/pack_kernel.cpp
@@ -22,7 +22,7 @@ namespace oneflow {
 namespace {
 
 template<DeviceType device_type>
-class PackKernel final : public user_op::OpKernel {
+class PackKernel final : public user_op::OpKernel, public user_op::OpKernelStateAndCacheProvider {
  public:
   PackKernel() = default;
   ~PackKernel() override = default;

--- a/oneflow/user/kernels/partial_fc_sample_kernel.cu
+++ b/oneflow/user/kernels/partial_fc_sample_kernel.cu
@@ -281,7 +281,8 @@ void MapLabel(ep::Stream* stream, const int64_t num_classes, const int64_t batch
 }  // namespace
 
 template<typename T, typename K>
-class DistributedPartialFcSampleGpuKernel final : public user_op::OpKernel {
+class DistributedPartialFcSampleGpuKernel final : public user_op::OpKernel,
+                                                  public user_op::OpKernelStateAndCacheProvider {
  public:
   DistributedPartialFcSampleGpuKernel() = default;
   ~DistributedPartialFcSampleGpuKernel() override = default;

--- a/oneflow/user/kernels/pool_cpu_kernel.cpp
+++ b/oneflow/user/kernels/pool_cpu_kernel.cpp
@@ -355,7 +355,8 @@ struct PoolCpuKernelUtil {
 }  // namespace
 
 template<typename T>
-class AvgPool1DCpuKernel final : public user_op::OpKernel {
+class AvgPool1DCpuKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool1DCpuKernel() = default;
   ~AvgPool1DCpuKernel() = default;
@@ -374,7 +375,8 @@ class AvgPool1DCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class AvgPool1DGradCpuKernel final : public user_op::OpKernel {
+class AvgPool1DGradCpuKernel final : public user_op::OpKernel,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool1DGradCpuKernel() = default;
   ~AvgPool1DGradCpuKernel() = default;
@@ -393,7 +395,8 @@ class AvgPool1DGradCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class AvgPool2DCpuKernel final : public user_op::OpKernel {
+class AvgPool2DCpuKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool2DCpuKernel() = default;
   ~AvgPool2DCpuKernel() = default;
@@ -412,7 +415,8 @@ class AvgPool2DCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class AvgPool2DGradCpuKernel final : public user_op::OpKernel {
+class AvgPool2DGradCpuKernel final : public user_op::OpKernel,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool2DGradCpuKernel() = default;
   ~AvgPool2DGradCpuKernel() = default;
@@ -431,7 +435,8 @@ class AvgPool2DGradCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class AvgPool3DCpuKernel final : public user_op::OpKernel {
+class AvgPool3DCpuKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool3DCpuKernel() = default;
   ~AvgPool3DCpuKernel() = default;
@@ -450,7 +455,8 @@ class AvgPool3DCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class AvgPool3DGradCpuKernel final : public user_op::OpKernel {
+class AvgPool3DGradCpuKernel final : public user_op::OpKernel,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool3DGradCpuKernel() = default;
   ~AvgPool3DGradCpuKernel() = default;
@@ -469,7 +475,8 @@ class AvgPool3DGradCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class MaxPool1DCpuKernel final : public user_op::OpKernel {
+class MaxPool1DCpuKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool1DCpuKernel() = default;
   ~MaxPool1DCpuKernel() = default;
@@ -488,7 +495,8 @@ class MaxPool1DCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class MaxPool1DGradCpuKernel final : public user_op::OpKernel {
+class MaxPool1DGradCpuKernel final : public user_op::OpKernel,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool1DGradCpuKernel() = default;
   ~MaxPool1DGradCpuKernel() = default;
@@ -507,7 +515,8 @@ class MaxPool1DGradCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class MaxPool2DCpuKernel final : public user_op::OpKernel {
+class MaxPool2DCpuKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool2DCpuKernel() = default;
   ~MaxPool2DCpuKernel() = default;
@@ -526,7 +535,8 @@ class MaxPool2DCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class MaxPool2DGradCpuKernel final : public user_op::OpKernel {
+class MaxPool2DGradCpuKernel final : public user_op::OpKernel,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool2DGradCpuKernel() = default;
   ~MaxPool2DGradCpuKernel() = default;
@@ -545,7 +555,8 @@ class MaxPool2DGradCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class MaxPool3DCpuKernel final : public user_op::OpKernel {
+class MaxPool3DCpuKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool3DCpuKernel() = default;
   ~MaxPool3DCpuKernel() = default;
@@ -564,7 +575,8 @@ class MaxPool3DCpuKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class MaxPool3DGradCpuKernel final : public user_op::OpKernel {
+class MaxPool3DGradCpuKernel final : public user_op::OpKernel,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool3DGradCpuKernel() = default;
   ~MaxPool3DGradCpuKernel() = default;

--- a/oneflow/user/kernels/pool_gpu_kernel.cpp
+++ b/oneflow/user/kernels/pool_gpu_kernel.cpp
@@ -145,7 +145,9 @@ struct PoolGpuKernelUtil {
 }  // namespace
 
 template<typename T>
-class AvgPool1DGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class AvgPool1DGpuKernel final : public user_op::OpKernel,
+                                 public user_op::CudaGraphSupport,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool1DGpuKernel() = default;
   ~AvgPool1DGpuKernel() = default;
@@ -163,7 +165,9 @@ class AvgPool1DGpuKernel final : public user_op::OpKernel, public user_op::CudaG
 };
 
 template<typename T>
-class AvgPool1DGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class AvgPool1DGradGpuKernel final : public user_op::OpKernel,
+                                     public user_op::CudaGraphSupport,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool1DGradGpuKernel() = default;
   ~AvgPool1DGradGpuKernel() = default;
@@ -180,7 +184,9 @@ class AvgPool1DGradGpuKernel final : public user_op::OpKernel, public user_op::C
 };
 
 template<typename T>
-class AvgPool2DGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class AvgPool2DGpuKernel final : public user_op::OpKernel,
+                                 public user_op::CudaGraphSupport,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool2DGpuKernel() = default;
   ~AvgPool2DGpuKernel() = default;
@@ -198,7 +204,9 @@ class AvgPool2DGpuKernel final : public user_op::OpKernel, public user_op::CudaG
 };
 
 template<typename T>
-class AvgPool2DGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class AvgPool2DGradGpuKernel final : public user_op::OpKernel,
+                                     public user_op::CudaGraphSupport,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool2DGradGpuKernel() = default;
   ~AvgPool2DGradGpuKernel() = default;
@@ -216,7 +224,9 @@ class AvgPool2DGradGpuKernel final : public user_op::OpKernel, public user_op::C
 };
 
 template<typename T>
-class AvgPool3DGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class AvgPool3DGpuKernel final : public user_op::OpKernel,
+                                 public user_op::CudaGraphSupport,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool3DGpuKernel() = default;
   ~AvgPool3DGpuKernel() = default;
@@ -234,7 +244,9 @@ class AvgPool3DGpuKernel final : public user_op::OpKernel, public user_op::CudaG
 };
 
 template<typename T>
-class AvgPool3DGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class AvgPool3DGradGpuKernel final : public user_op::OpKernel,
+                                     public user_op::CudaGraphSupport,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   AvgPool3DGradGpuKernel() = default;
   ~AvgPool3DGradGpuKernel() = default;
@@ -252,7 +264,9 @@ class AvgPool3DGradGpuKernel final : public user_op::OpKernel, public user_op::C
 };
 
 template<typename T>
-class MaxPool1DGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class MaxPool1DGpuKernel final : public user_op::OpKernel,
+                                 public user_op::CudaGraphSupport,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool1DGpuKernel() = default;
   ~MaxPool1DGpuKernel() = default;
@@ -270,7 +284,9 @@ class MaxPool1DGpuKernel final : public user_op::OpKernel, public user_op::CudaG
 };
 
 template<typename T>
-class MaxPool1DGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class MaxPool1DGradGpuKernel final : public user_op::OpKernel,
+                                     public user_op::CudaGraphSupport,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool1DGradGpuKernel() = default;
   ~MaxPool1DGradGpuKernel() = default;
@@ -288,7 +304,9 @@ class MaxPool1DGradGpuKernel final : public user_op::OpKernel, public user_op::C
 };
 
 template<typename T>
-class MaxPool2DGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class MaxPool2DGpuKernel final : public user_op::OpKernel,
+                                 public user_op::CudaGraphSupport,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool2DGpuKernel() = default;
   ~MaxPool2DGpuKernel() = default;
@@ -306,7 +324,9 @@ class MaxPool2DGpuKernel final : public user_op::OpKernel, public user_op::CudaG
 };
 
 template<typename T>
-class MaxPool2DGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class MaxPool2DGradGpuKernel final : public user_op::OpKernel,
+                                     public user_op::CudaGraphSupport,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool2DGradGpuKernel() = default;
   ~MaxPool2DGradGpuKernel() = default;
@@ -324,7 +344,9 @@ class MaxPool2DGradGpuKernel final : public user_op::OpKernel, public user_op::C
 };
 
 template<typename T>
-class MaxPool3DGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class MaxPool3DGpuKernel final : public user_op::OpKernel,
+                                 public user_op::CudaGraphSupport,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool3DGpuKernel() = default;
   ~MaxPool3DGpuKernel() = default;
@@ -342,7 +364,9 @@ class MaxPool3DGpuKernel final : public user_op::OpKernel, public user_op::CudaG
 };
 
 template<typename T>
-class MaxPool3DGradGpuKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class MaxPool3DGradGpuKernel final : public user_op::OpKernel,
+                                     public user_op::CudaGraphSupport,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool3DGradGpuKernel() = default;
   ~MaxPool3DGradGpuKernel() = default;

--- a/oneflow/user/kernels/pooling_kernel.cpp
+++ b/oneflow/user/kernels/pooling_kernel.cpp
@@ -113,7 +113,8 @@ struct PoolingKernelUtil<DeviceType::kCPU, T> {
 };
 
 template<DeviceType device_type, typename T>
-class MaxPool1dKernel final : public user_op::OpKernel {
+class MaxPool1dKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool1dKernel() = default;
   ~MaxPool1dKernel() = default;
@@ -149,7 +150,8 @@ class MaxPool1dKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class MaxPool1dGradKernel final : public user_op::OpKernel {
+class MaxPool1dGradKernel final : public user_op::OpKernel,
+                                  public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool1dGradKernel() = default;
   ~MaxPool1dGradKernel() = default;
@@ -187,7 +189,8 @@ class MaxPool1dGradKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class MaxPool2dKernel final : public user_op::OpKernel {
+class MaxPool2dKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool2dKernel() = default;
   ~MaxPool2dKernel() = default;
@@ -223,7 +226,8 @@ class MaxPool2dKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class MaxPool2dGradKernel final : public user_op::OpKernel {
+class MaxPool2dGradKernel final : public user_op::OpKernel,
+                                  public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool2dGradKernel() = default;
   ~MaxPool2dGradKernel() = default;
@@ -261,7 +265,8 @@ class MaxPool2dGradKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class MaxPool3dKernel final : public user_op::OpKernel {
+class MaxPool3dKernel final : public user_op::OpKernel,
+                              public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool3dKernel() = default;
   ~MaxPool3dKernel() = default;
@@ -297,7 +302,8 @@ class MaxPool3dKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class MaxPool3dGradKernel final : public user_op::OpKernel {
+class MaxPool3dGradKernel final : public user_op::OpKernel,
+                                  public user_op::OpKernelStateAndCacheProvider {
  public:
   MaxPool3dGradKernel() = default;
   ~MaxPool3dGradKernel() = default;

--- a/oneflow/user/kernels/random_mask_like_kernel.h
+++ b/oneflow/user/kernels/random_mask_like_kernel.h
@@ -36,7 +36,9 @@ class RandomMaskLikeKernelState : public user_op::OpKernelState {
 namespace {
 
 template<DeviceType device_type>
-class RandomMaskLikeKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class RandomMaskLikeKernel final : public user_op::OpKernel,
+                                   public user_op::CudaGraphSupport,
+                                   public user_op::OpKernelStateAndCacheProvider {
  public:
   RandomMaskLikeKernel() = default;
   ~RandomMaskLikeKernel() = default;

--- a/oneflow/user/kernels/randperm_kernel.cpp
+++ b/oneflow/user/kernels/randperm_kernel.cpp
@@ -22,7 +22,8 @@ limitations under the License.
 #include "oneflow/user/kernels/distributions/common.h"
 namespace oneflow {
 
-class CpuRandPermKernel final : public user_op::OpKernel {
+class CpuRandPermKernel final : public user_op::OpKernel,
+                                public user_op::OpKernelStateAndCacheProvider {
  public:
   CpuRandPermKernel() = default;
   ~CpuRandPermKernel() = default;

--- a/oneflow/user/kernels/randperm_kernel.cu
+++ b/oneflow/user/kernels/randperm_kernel.cu
@@ -35,7 +35,8 @@ __global__ void GeneKeysAndValues(const int32_t n, int32_t* values, int32_t* key
   }
 }
 
-class GpuRandPermKernel final : public user_op::OpKernel {
+class GpuRandPermKernel final : public user_op::OpKernel,
+                                public user_op::OpKernelStateAndCacheProvider {
  public:
   GpuRandPermKernel() = default;
   ~GpuRandPermKernel() = default;

--- a/oneflow/user/kernels/slice_kernel.cpp
+++ b/oneflow/user/kernels/slice_kernel.cpp
@@ -302,7 +302,8 @@ std::shared_ptr<user_op::OpKernelCache> CreateSliceCache(user_op::KernelCacheCon
 }
 
 template<typename T>
-class LogicalSliceKernel final : public user_op::OpKernel {
+class LogicalSliceKernel final : public user_op::OpKernel,
+                                 public user_op::OpKernelStateAndCacheProvider {
  public:
   LogicalSliceKernel() = default;
   ~LogicalSliceKernel() = default;
@@ -351,7 +352,8 @@ class LogicalSliceKernel final : public user_op::OpKernel {
 };
 
 template<typename T>
-class LogicalSliceAssignKernel final : public user_op::OpKernel {
+class LogicalSliceAssignKernel final : public user_op::OpKernel,
+                                       public user_op::OpKernelStateAndCacheProvider {
  public:
   LogicalSliceAssignKernel() = default;
   ~LogicalSliceAssignKernel() = default;

--- a/oneflow/user/kernels/sparse_cross_entropy_kernel.cpp
+++ b/oneflow/user/kernels/sparse_cross_entropy_kernel.cpp
@@ -62,7 +62,8 @@ class SparseCrossEntropyKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T, typename K>
-class SparseCrossEntropyMsKernel final : public user_op::OpKernel {
+class SparseCrossEntropyMsKernel final : public user_op::OpKernel,
+                                         public user_op::OpKernelStateAndCacheProvider {
  public:
   SparseCrossEntropyMsKernel() = default;
   ~SparseCrossEntropyMsKernel() = default;
@@ -167,7 +168,8 @@ class SparseCrossEntropyGradKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T, typename K>
-class SparseCrossEntropyMsGradKernel final : public user_op::OpKernel {
+class SparseCrossEntropyMsGradKernel final : public user_op::OpKernel,
+                                             public user_op::OpKernelStateAndCacheProvider {
  public:
   SparseCrossEntropyMsGradKernel() = default;
   ~SparseCrossEntropyMsGradKernel() = default;

--- a/oneflow/user/kernels/sparse_softmax_cross_entropy_kernel.cpp
+++ b/oneflow/user/kernels/sparse_softmax_cross_entropy_kernel.cpp
@@ -160,7 +160,8 @@ class SparseSoftmaxCrossEntropyGradKernel final : public user_op::OpKernel,
 };
 
 template<DeviceType device_type, typename T, typename K>
-class SparseSoftmaxCrossEntropyMsGradKernel final : public user_op::OpKernel {
+class SparseSoftmaxCrossEntropyMsGradKernel final : public user_op::OpKernel,
+                                                    public user_op::OpKernelStateAndCacheProvider {
  public:
   SparseSoftmaxCrossEntropyMsGradKernel() = default;
   ~SparseSoftmaxCrossEntropyMsGradKernel() = default;

--- a/oneflow/user/kernels/stateful_local_opkernel.h
+++ b/oneflow/user/kernels/stateful_local_opkernel.h
@@ -428,15 +428,16 @@ class StatefulLocalOpKernel final {
   user_op::DataTypeInferFn DataTypeInferFn() const;
 
   void TryInitOpKernelStateAndCache(
-      const user_op::OpKernel* op_kernel, DeviceCtx* device_ctx, EagerBlobObjectListRawPtr inputs,
-      EagerBlobObjectListRawPtr outputs,
+      const user_op::OpKernelStateAndCacheProvider* provider, DeviceCtx* device_ctx,
+      EagerBlobObjectListRawPtr inputs, EagerBlobObjectListRawPtr outputs,
       ConsistentTensorInferResultRawPtr consistent_tensor_infer_result,
       user_op::OpKernelState** state, user_op::OpKernelCache** cache);
 
   vm::EagerBlobObject* mut_temp_blob_object();
 
-  user_op::OpKernelState* mut_opkernel_state(const user_op::OpKernel* opkernel) {
-    return op_kernel_state_map_.at(opkernel).get();
+  user_op::OpKernelState* mut_opkernel_state(
+      const user_op::OpKernelStateAndCacheProvider* provider) {
+    return op_kernel_state_map_.at(provider).get();
   }
 
   bool need_check_mem_case() const { return need_check_mem_case_; }
@@ -462,8 +463,10 @@ class StatefulLocalOpKernel final {
                                    std::shared_ptr<const user_op::OpKernel>>>,
              DataType_MAX>
       dtype2cached_kernels_;
-  HashMap<const user_op::OpKernel*, std::shared_ptr<user_op::OpKernelState>> op_kernel_state_map_;
-  HashMap<const user_op::OpKernel*, std::shared_ptr<user_op::OpKernelCache>> op_kernel_cache_map_;
+  HashMap<const user_op::OpKernelStateAndCacheProvider*, std::shared_ptr<user_op::OpKernelState>>
+      op_kernel_state_map_;
+  HashMap<const user_op::OpKernelStateAndCacheProvider*, std::shared_ptr<user_op::OpKernelCache>>
+      op_kernel_cache_map_;
   HashMap<const user_op::OpKernel*, const user_op::InferTmpSizeFn*> infer_tmp_size_fn_map_;
   std::unique_ptr<vm::EagerBlobObject> tmp_blob_object_;
   std::vector<int64_t> input_tuple_indexes4const_ibns_;

--- a/oneflow/user/kernels/test_kernels.cpp
+++ b/oneflow/user/kernels/test_kernels.cpp
@@ -274,7 +274,8 @@ REGISTER_USER_KERNEL("TestDynamicSource")
     .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCPU)
                      && (user_op::HobDataType("out", 0) == DataType::kFloat));
 
-class TestRandomSourceKernel final : public user_op::OpKernel {
+class TestRandomSourceKernel final : public user_op::OpKernel,
+                                     public user_op::OpKernelStateAndCacheProvider {
  public:
   TestRandomSourceKernel() = default;
   ~TestRandomSourceKernel() = default;

--- a/oneflow/user/kernels/unpack_kernel.cpp
+++ b/oneflow/user/kernels/unpack_kernel.cpp
@@ -22,7 +22,7 @@ namespace oneflow {
 namespace {
 
 template<DeviceType device_type>
-class UnpackKernel final : public user_op::OpKernel {
+class UnpackKernel final : public user_op::OpKernel, public user_op::OpKernelStateAndCacheProvider {
  public:
   UnpackKernel() = default;
   ~UnpackKernel() override = default;

--- a/oneflow/user/kernels/unsorted_segment_sum_kernel.cpp
+++ b/oneflow/user/kernels/unsorted_segment_sum_kernel.cpp
@@ -74,7 +74,9 @@ std::shared_ptr<user_op::OpKernelCache> CreateUnsortedSegmentSumOpKernelCache(
 }  // namespace
 
 template<DeviceType device_type, typename T, typename K>
-class UnsortedSegmentSumKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
+class UnsortedSegmentSumKernel final : public user_op::OpKernel,
+                                       public user_op::CudaGraphSupport,
+                                       public user_op::OpKernelStateAndCacheProvider {
  public:
   UnsortedSegmentSumKernel() = default;
   ~UnsortedSegmentSumKernel() override = default;
@@ -139,7 +141,8 @@ OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_UNSORTED_SEGMENT_SUM_LIKE_KERNEL_CASE,
 
 #ifdef WITH_CUDA
 template<typename K>
-class UnsortedSegmentSumHalfKernel final : public user_op::OpKernel {
+class UnsortedSegmentSumHalfKernel final : public user_op::OpKernel,
+                                           public user_op::OpKernelStateAndCacheProvider {
  public:
   UnsortedSegmentSumHalfKernel() = default;
   ~UnsortedSegmentSumHalfKernel() override = default;


### PR DESCRIPTION
将opkernel state和cache的虚接口移至user_op::OpKernelStateAndCacheProvider类里。

eager下为了提高性能，需要用到`dynamic_cast<const user_op::OpKernelStateAndCacheProvider*>(op_kernel) != nullptr`来判断是否需要准备state和cache。