### PR TITLE
fix empty bug

### DIFF
--- a/oneflow/core/common/data_type.cpp
+++ b/oneflow/core/common/data_type.cpp
@@ -49,7 +49,7 @@ bool IsPODAndHalfDataType(DataType data_type) {
   switch (data_type) {
 #define POD_AND_HALF_CASE(type_cpp, type_proto) \
   case type_proto: return true;
-    OF_PP_FOR_EACH_TUPLE(POD_AND_HALF_CASE, POD_AND_HALF_DATA_TYPE_SEQ)
+    OF_PP_FOR_EACH_TUPLE(POD_AND_HALF_CASE, POD_AND_HALF_DATA_TYPE_SEQ BOOL_DATA_TYPE_SEQ)
     default: return false;
   }
 #undef POD_AND_HALF_CASE

--- a/oneflow/user/kernels/empty_kernel.cpp
+++ b/oneflow/user/kernels/empty_kernel.cpp
@@ -47,15 +47,9 @@ class EmptyKernel final : public OpKernel {
 #define REGISTER_EMPTY_KERNEL(device, dtype_pair) \
   REGISTER_EMPTY_XPU_KERNEL(device, OF_PP_PAIR_FIRST(dtype_pair))
 
-#define TB_DATA_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(TensorBuffer, DataType::kTensorBuffer)
-#define TOTAL_DATA_TYPE_SEQ ALL_DATA_TYPE_SEQ TB_DATA_TYPE_SEQ
+#define TOTAL_DATA_TYPE_SEQ ALL_DATA_TYPE_SEQ BUFFER_DATA_TYPE_SEQ BOOL_DATA_TYPE_SEQ
 OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_EMPTY_KERNEL, DEVICE_TYPE_SEQ, TOTAL_DATA_TYPE_SEQ)
 #undef TOTAL_DATA_TYPE_SEQ
-
-REGISTER_EMPTY_XPU_KERNEL(DeviceType::kCPU, float16);
-#ifdef WITH_CUDA
-REGISTER_EMPTY_XPU_KERNEL(DeviceType::kCUDA, float16);
-#endif  // WITH_CUDA
 
 }  // namespace user_op
 }  // namespace oneflow


### PR DESCRIPTION
1. TensorBuffer类型重复定义，TensorBuffer的类型在其它文件也有同样定义，暂时把这部分去掉：
```
#define TB_DATA_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(TensorBuffer, DataType::kTensorBuffer)
#define TOTAL_DATA_TYPE_SEQ ALL_DATA_TYPE_SEQ TB_DATA_TYPE_SEQ
OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_EMPTY_KERNEL, DEVICE_TYPE_SEQ, TOTAL_DATA_TYPE_SEQ)
#undef TOTAL_DATA_TYPE_SEQ
```

2. bool、uint8类型未定义，这是由于上面代码中用到的公共宏ALL_DATA_TYPE_SEQ中的类型不全导致的，暂时在empty里修改

3. float16重复定义，这个类型的定义已经包含在上面的OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE这个展开中，并且涵盖了不同的设备类型，下面这段可以去掉：
```
REGISTER_EMPTY_XPU_KERNEL(DeviceType::kCPU, float16);
#ifdef WITH_CUDA
REGISTER_EMPTY_XPU_KERNEL(DeviceType::kCUDA, float16);
#endif  // WITH_CUDA
```