### PR TITLE
Parameter support both inplace op and setter

### DIFF
--- a/oneflow/core/framework/tensor.h
+++ b/oneflow/core/framework/tensor.h
@@ -288,7 +288,7 @@ class Parameter final : public TensorIf<Parameter> {
   Maybe<Symbol<ConsistentTensorMeta>> consistent_tensor_meta() const override {
     return tensor_->consistent_tensor_meta();
   }
-  Maybe<Tensor> data() override { return tensor_; }
+  Maybe<Tensor> data() override { return tensor_->detach(); }
 
   // Must override grad_fn_node function. Otherwise grad_fn will belong to this not tensor_,
   // and it will be wrong when use Parameter.data() in operators.

--- a/oneflow/core/framework/tensor.h
+++ b/oneflow/core/framework/tensor.h
@@ -417,10 +417,7 @@ class MirroredTensor final : public TensorIf<MirroredTensor> {
   bool is_cuda() const override;
 
   const TensorMeta& tensor_meta() const override { return *impl_->tensor_meta(); }
-  Maybe<Tensor> data() override {
-    OF_LOG_ONCE(LOG(WARNING) << "You shouldn't call `.data` for a LocalTensor.");
-    return std::static_pointer_cast<Tensor>(shared_from_this());
-  }
+  Maybe<Tensor> data() override { return this->detach(); }
 
   // Getters valid only for EagerMirroredTensor
   Maybe<vm::EagerBlobObject> eager_blob_object() const override {
@@ -522,10 +519,7 @@ class ConsistentTensor final : public TensorIf<ConsistentTensor> {
     return impl_->cur_rank_phy_tensor();
   }
   bool is_cuda() const override;
-  Maybe<Tensor> data() override {
-    OF_LOG_ONCE(LOG(WARNING) << "You shouldn't call `.data` for a ConsistentTensor.");
-    return std::static_pointer_cast<Tensor>(shared_from_this());
-  }
+  Maybe<Tensor> data() override { return this->detach(); }
 
   // Getters valid only for EagerMirroredTensor
   Maybe<vm::EagerBlobObject> eager_blob_object() const override {

--- a/python/oneflow/test/tensor/test_parameter.py
+++ b/python/oneflow/test/tensor/test_parameter.py
@@ -40,6 +40,12 @@ class TestParameter(flow.unittest.TestCase):
         z.data = y
         return z.grad_fn, z.is_leaf
 
+    @autotest(n=1, check_graph=False)
+    def test_parameter_inplace_modify_data(test_case):
+        x = torch.nn.Parameter(torch.ones(2, 3))
+        x.data.mul_(2)
+        return x
+
     def test_parameter_set_data(test_case):
         a = flow.nn.Parameter(flow.ones(2, 3), False)
         old_id = id(a)


### PR DESCRIPTION
使 Parameter/Tensor 类支持 inplace 修改数据以及 setter 设置数据，在用户初始化权重的时候更容易理解。

其实 Parameter 和 Tensor 类都是可以用 data 的 getter 接口的，拿到的确实是这个对象的数据，如果对其做 inplace 修改的话也是可行的。在 torch 的表现中，Tenor/Parameter .data 接口拿到的确实是这个不需要梯度的 Tensor 对象。这里可以对齐了。