### PR TITLE
[dtr] eager eviction in remat

### DIFF
--- a/oneflow/core/eager/eager_blob_object.cpp
+++ b/oneflow/core/eager/eager_blob_object.cpp
@@ -120,6 +120,17 @@ DTREagerBlobObject::~DTREagerBlobObject() {
   blob_.reset();
 }
 
+void DTREagerBlobObject::pin() {
+    pinned_++;
+    if (oneflow::DTRDebugEnabled()) {std::cout << "pinned " << this << ", " << (pinned_ - 1) << " to " << pinned_ << std::endl;}
+}
+
+void DTREagerBlobObject::unpin() {
+    CHECK_GT(pinned_, 0) << this;
+    pinned_--;
+    if (oneflow::DTRDebugEnabled()) {std::cout << "unpinned " << this << ", " << (pinned_ + 1) << " to " << pinned_ << std::endl;}
+}
+
 Maybe<void> DTREagerBlobObject::evict() {
   evict_flag_ = true;
   JUST(DeallocateBlobDataPtr());
@@ -138,7 +149,7 @@ Maybe<void> DTREagerBlobObject::InitBlobAttrs(
     std::shared_ptr<LocalCallOpKernelPhyInstrOperand>& operand) {
   // reset DTREageBlobObject properties
   compute_time_ = 0;
-  pinned_ = 0;
+  // pinned_ = 0;
 
   // current time
   update_access_time();
@@ -381,8 +392,10 @@ void DTREagerBlobObject::set_compute_time(double val) {
   } else {
     compute_time_ = blob_body_bytes_;
   }
-  if (compute_op_type_name() == "add_n") { compute_time_ *= (blob_body_bytes_ * blob_body_bytes_); }
-  // else if (compute_op_type_name() == "conv2d") { compute_time_ *= (blob_body_bytes_); }
+  // if (compute_op_type_name() == "add_n") { compute_time_ *= (blob_body_bytes_ * blob_body_bytes_); }
+  if (compute_op_type_name() == "conv2d") { compute_time_ *= (blob_body_bytes_); }
+  if (compute_op_type_name() == "conv_filter_grad") { compute_time_ *= (blob_body_bytes_); }
+  if (compute_op_type_name() == "conv_data_grad") { compute_time_ *= (blob_body_bytes_); }
   if (oneflow::DTRDebugEnabled()) {
     LOG(INFO) << "Compute time of " << this << ": " << compute_time_ << ", compute op "
               << compute_op_type_name() << std::endl;

--- a/oneflow/core/eager/eager_blob_object.cpp
+++ b/oneflow/core/eager/eager_blob_object.cpp
@@ -121,17 +121,22 @@ DTREagerBlobObject::~DTREagerBlobObject() {
 }
 
 void DTREagerBlobObject::pin() {
-    pinned_++;
-    if (oneflow::DTRDebugEnabled()) {std::cout << "pinned " << this << ", " << (pinned_ - 1) << " to " << pinned_ << std::endl;}
+  pinned_++;
+  if (oneflow::DTRDebugEnabled()) {
+    LOG(INFO) << "pinned " << this << ", " << (pinned_ - 1) << " to " << pinned_ << std::endl;
+  }
 }
 
 void DTREagerBlobObject::unpin() {
-    CHECK_GT(pinned_, 0) << this;
-    pinned_--;
-    if (oneflow::DTRDebugEnabled()) {std::cout << "unpinned " << this << ", " << (pinned_ + 1) << " to " << pinned_ << std::endl;}
+  CHECK_GT(pinned_, 0) << this;
+  pinned_--;
+  if (oneflow::DTRDebugEnabled()) {
+    LOG(INFO) << "unpinned " << this << ", " << (pinned_ + 1) << " to " << pinned_ << std::endl;
+  }
 }
 
 Maybe<void> DTREagerBlobObject::evict() {
+  if (oneflow::DTRDebugEnabled()) { LOG(INFO) << "evict " << this; }
   evict_flag_ = true;
   JUST(DeallocateBlobDataPtr());
   if (blob_) { blob_->reset_dptr(nullptr); }
@@ -392,7 +397,8 @@ void DTREagerBlobObject::set_compute_time(double val) {
   } else {
     compute_time_ = blob_body_bytes_;
   }
-  // if (compute_op_type_name() == "add_n") { compute_time_ *= (blob_body_bytes_ * blob_body_bytes_); }
+  // if (compute_op_type_name() == "add_n") { compute_time_ *= (blob_body_bytes_ *
+  // blob_body_bytes_); }
   if (compute_op_type_name() == "conv2d") { compute_time_ *= (blob_body_bytes_); }
   if (compute_op_type_name() == "conv_filter_grad") { compute_time_ *= (blob_body_bytes_); }
   if (compute_op_type_name() == "conv_data_grad") { compute_time_ *= (blob_body_bytes_); }

--- a/oneflow/core/eager/eager_blob_object.cpp
+++ b/oneflow/core/eager/eager_blob_object.cpp
@@ -407,9 +407,9 @@ void DTREagerBlobObject::set_compute_time(double val) {
   }
   // if (compute_op_type_name() == "add_n") { compute_time_ *= (blob_body_bytes_ *
   // blob_body_bytes_); }
-  if (compute_op_type_name() == "conv2d") { compute_time_ *= (blob_body_bytes_); }
-  if (compute_op_type_name() == "conv_filter_grad") { compute_time_ *= (blob_body_bytes_); }
-  if (compute_op_type_name() == "conv_data_grad") { compute_time_ *= (blob_body_bytes_); }
+  // if (compute_op_type_name() == "conv2d") { compute_time_ *= (blob_body_bytes_); }
+  // if (compute_op_type_name() == "conv_filter_grad") { compute_time_ *= (blob_body_bytes_); }
+  // if (compute_op_type_name() == "conv_data_grad") { compute_time_ *= (blob_body_bytes_); }
   if (oneflow::DTRDebugEnabled()) {
     LOG(INFO) << "Compute time of " << this << ": " << compute_time_ << ", compute op "
               << compute_op_type_name() << std::endl;

--- a/oneflow/core/eager/eager_blob_object.h
+++ b/oneflow/core/eager/eager_blob_object.h
@@ -203,14 +203,8 @@ class DTREagerBlobObject final : public EagerBlobObject {
   bool is_evictable() const;
   bool is_bp_required() const { return is_bp_required_; }
 
-  void pin() {
-    pinned_++;
-    if (oneflow::DTRDebugEnabled()) {std::cout << "pinned " << this << ", " << (pinned_ - 1) << " to " << pinned_ << std::endl;}
-  }
-  void unpin() {
-    pinned_--;
-    if (oneflow::DTRDebugEnabled()) {std::cout << "unpinned " << this << ", " << (pinned_ + 1) << " to " << pinned_ << std::endl;}
-  }
+  void pin();
+  void unpin();
   void update_access_time();
   void update_user_ops(std::shared_ptr<LocalCallOpKernelPhyInstrOperand>& operand);
   Maybe<void> evict();

--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -742,18 +742,6 @@ Maybe<void> IncReferenceNumOfRecomputedTensor(
         dtr_blob_object->pin();
         LOG(INFO) << dtr_blob_object << " in memory? " << dtr_blob_object->is_in_memory();
         if (!dtr_blob_object->is_in_memory()) {
-          // if (oneflow::DTRDebugEnabled()) {
-          //   LOG(INFO) << operand->shared_opkernel()->op_type_name() << ": increase reference num
-          //   of
-          //   "
-          //             << dtr_blob_object << " from "
-          //             << Global<one::DTRTensorPool>::Get()->reference_nums_[dtr_blob_object] << "
-          //             to "
-          //             << Global<one::DTRTensorPool>::Get()->reference_nums_[dtr_blob_object] + 1;
-          // }
-          //
-          // Global<one::DTRTensorPool>::Get()->reference_nums_[dtr_blob_object]++;
-
           const auto local_call_op = DTROp2LocalCallOp(dtr_blob_object->compute_op());
           CHECK_NOTNULL_OR_RETURN(local_call_op);
 
@@ -798,7 +786,6 @@ inline Maybe<void> LocalCallOpKernelUtil::ComputeInstruction(vm::Instruction* in
     auto operand =
         JUST(LocalCallOpKernelUtil::GetSharedLocalCallOpKernelPhyInstrOperand(instruction));
 
-    CHECK_OR_RETURN(Global<one::DTRTensorPool>::Get()->reference_nums_.empty());
     CHECK_OR_RETURN(Global<one::DTRTensorPool>::Get()->need_eager_eviction_ebos_.empty());
     if (oneflow::DTRDebugLevel() >= 1) {
       LOG(INFO) << "all compute ok for " << operand->opkernel().op_type_name() << std::endl;

--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -564,37 +564,6 @@ struct DTRLocalCallOpKernelUtil final : public LocalCallOpKernelUtil {
             Global<one::DTRTensorPool>::Get()->need_eager_eviction_ebos_.erase(dtr_blob_object);
             JUST(dtr_blob_object->evict());
           }
-          // if (Global<one::DTRTensorPool>::Get()->reference_nums_.count(dtr_blob_object) > 0) {
-          //   // if (oneflow::DTRDebugEnabled()) {
-          //   //   LOG(INFO) << operand->shared_opkernel()->op_type_name()
-          //   //             << ": decrease reference num of " << dtr_blob_object << " from "
-          //   //             << Global<one::DTRTensorPool>::Get()->reference_nums_[dtr_blob_object]
-          //   //             << " to "
-          //   //             << Global<one::DTRTensorPool>::Get()->reference_nums_[dtr_blob_object]
-          //   - 1;
-          //   // }
-          //   // Global<one::DTRTensorPool>::Get()->reference_nums_[dtr_blob_object]--;
-          //   if (Global<one::DTRTensorPool>::Get()->reference_nums_[dtr_blob_object] == 0) {
-          //     Global<one::DTRTensorPool>::Get()->reference_nums_.erase(dtr_blob_object);
-          //     if (Global<one::DTRTensorPool>::Get()->need_eager_eviction_ebos_.count(
-          //             dtr_blob_object)
-          //         > 0) {
-          //       if (oneflow::DTRDebugEnabled()) {
-          //         LOG(INFO) << "going to evict " << dtr_blob_object
-          //                   << " in recomputation, whose dptr is " <<
-          //                   dtr_blob_object->blob().dptr()
-          //                   << ", compute op: " << dtr_blob_object->compute_op_type_name()
-          //                   << ", size: " << dtr_blob_object->blob().ByteSizeOfBlobBody()
-          //                   << ", is in memory: " << dtr_blob_object->is_in_memory() <<
-          //                   std::endl;
-          //       }
-          //       Global<one::DTRTensorPool>::Get()->need_eager_eviction_ebos_.erase(dtr_blob_object);
-          //       JUST(dtr_blob_object->evict());
-          //     }
-          //   }
-          // } else {
-          //   LOG(INFO) << "def";
-          // }
           return Maybe<void>::Ok();
         }));
     LOG(INFO) << "unpin input end";

--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -273,13 +273,11 @@ struct LocalCallOpKernelUtil {
 
   static inline Maybe<void> AllocateOutputBlobsMemory(LocalCallOpKernelPhyInstrOperand* operand,
                                                       DeviceCtx* device_ctx) {
-    Global<one::DTRTensorPool>::Get()->set_current_op_type_name(operand->opkernel().op_type_name());
     JUST(operand->ForEachOutputTensor([&](vm::EagerBlobObject* blob_object) -> Maybe<void> {
       JUST(blob_object->TryAllocateBlobBodyMemory(device_ctx));
       CHECK_NOTNULL_OR_RETURN(blob_object->tensor_buffer()->blob_dptr());
       return Maybe<void>::Ok();
     }));
-    Global<one::DTRTensorPool>::Get()->set_current_op_type_name("");
     JUST(ForEachDTROutputTensor(
         operand, [&](const std::shared_ptr<vm::DTREagerBlobObject>& object) -> Maybe<void> {
           CHECK_OR_RETURN(object->is_in_memory());

--- a/oneflow/core/eager/release_tensor_instruction_type.cpp
+++ b/oneflow/core/eager/release_tensor_instruction_type.cpp
@@ -37,16 +37,18 @@ void EvictDTRTensorInstructionType::Compute(vm::Instruction* instruction) const 
       dynamic_cast<const vm::ReleaseTensorArgPhyInstrOperand*>(phy_instr_operand.get());
   CHECK_NOTNULL(ptr);
   if (std::getenv("OF_DTR_NO_EE") == nullptr) {
-    if (oneflow::DTRDebugEnabled()) {
-      std::cout << "eager eviction tensor " << ptr->eager_blob_object().get() << " with ref count "
-                << ptr->eager_blob_object().use_count() << std::endl;
-    }
     const auto& ebo =
         CHECK_NOTNULL(std::dynamic_pointer_cast<vm::DTREagerBlobObject>(ptr->eager_blob_object()));
+    if (oneflow::DTRDebugEnabled()) {
+      LOG(INFO) << "eager eviction tensor " << ebo.get() << " of op "
+                << ebo->compute_op_type_name() << " with size " << ebo->BlobBodyBytes();
+    }
     if (!ebo->is_evictable()) {
-      // std::cout << "skip because non evictable" << std::endl;
+      if (oneflow::DTRDebugEnabled()) {
+        LOG(INFO) << "but skip because non evictable" << std::endl;
+      }
     } else if (ebo->is_pinned()) {
-      // std::cout << "skip because pinned" << std::endl;
+      if (oneflow::DTRDebugEnabled()) { LOG(INFO) << "but skip because pinned" << std::endl; }
     } else {
       CHECK_JUST(ebo->evict());
     }

--- a/oneflow/core/framework/op_expr_grad_function.h
+++ b/oneflow/core/framework/op_expr_grad_function.h
@@ -37,7 +37,7 @@ class AutoGradCaptureState {
     saved_tensors_.push_back(tensor);
 
     if (auto dtr_mirrored_tensor = dynamic_cast<one::DTRMirroredTensor*>(tensor.get())) {
-      dtr_mirrored_tensor->set_blob_object_bp_required();
+      CHECK_JUST(dtr_mirrored_tensor->set_blob_object_bp_required());
     }
     return offset;
   }

--- a/oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp
@@ -183,7 +183,6 @@ Maybe<void> NaiveInterpret(const UserOpExpr& user_op_expr, const TensorTuple& in
     output_eager_blob_objects->at(index)->set_is_shape_synced(false);
   }
 
-  if (oneflow::DTRDebugEnabled()) { LOG(INFO) << kernel->op_type_name(); }
   for (const auto& output : *outputs) {
     if (auto dtr_output = std::dynamic_pointer_cast<DTRMirroredTensor>(output)) {
       JUST(dtr_output->set_tensor_inputs(inputs));

--- a/oneflow/core/framework/tensor.cpp
+++ b/oneflow/core/framework/tensor.cpp
@@ -151,7 +151,7 @@ Maybe<Tensor> MirroredTensor::clone() const {
 }
 
 Maybe<void> DTRMirroredTensor::set_blob_object_bp_required() {
-  auto blob_object = CHECK_JUST(eager_blob_object());
+  auto blob_object = JUST(eager_blob_object());
   if (auto dtr_eager_blob_object = std::dynamic_pointer_cast<vm::DTREagerBlobObject>(blob_object)) {
     // if (auto* dtr_eager_blob_object = dynamic_cast<vm::DTREagerBlobObject*>(blob_object.get())) {
     dtr_eager_blob_object->set_bp_required(true);

--- a/oneflow/core/framework/tensor_pool.cpp
+++ b/oneflow/core/framework/tensor_pool.cpp
@@ -50,14 +50,6 @@ void printInfo(const std::shared_ptr<vm::DTREagerBlobObject>& debo) {
 }
 }  // namespace
 
-void DTRTensorPool::set_current_op_type_name(std::string op_type_name) {
-  current_op_type_name_ = std::move(op_type_name);
-}
-
-const std::string& DTRTensorPool::current_op_type_name() {
-  return current_op_type_name_;
-}
-
 void DTRTensorPool::inc_num_eviction() { num_eviction_++; }
 
 Maybe<vm::DTREagerBlobObject*> DTRTensorPool::find_best_tensor() {

--- a/oneflow/core/framework/tensor_pool.cpp
+++ b/oneflow/core/framework/tensor_pool.cpp
@@ -27,8 +27,6 @@ class LocalCallOpKernelPhyInstrOperand;
 namespace one {
 
 DTRTensorPool::DTRTensorPool() : duration_(0), total_memory_bytes_(0), num_eviction_(0), num_recomputation_(0), num_destruction_(0) {
-  // candidates_ = std::set<std::weak_ptr<vm::DTREagerBlobObject>>();
-  candidates_ = std::vector<std::weak_ptr<vm::DTREagerBlobObject>>();
   start_time_ = std::chrono::steady_clock::now();
 }
 
@@ -51,6 +49,14 @@ void printInfo(const std::shared_ptr<vm::DTREagerBlobObject>& debo) {
             << std::endl;
 }
 }  // namespace
+
+void DTRTensorPool::set_current_op_type_name(std::string op_type_name) {
+  current_op_type_name_ = std::move(op_type_name);
+}
+
+const std::string& DTRTensorPool::current_op_type_name() {
+  return current_op_type_name_;
+}
 
 void DTRTensorPool::inc_num_eviction() { num_eviction_++; }
 

--- a/oneflow/core/framework/tensor_pool.h
+++ b/oneflow/core/framework/tensor_pool.h
@@ -36,6 +36,7 @@ struct DTRTensorPool {
     std::cout << "Times of eviction: " << num_eviction_ << std::endl;
     std::cout << "Times of recomputation: " << num_recomputation_ << std::endl;
     std::cout << "Times of destruction: " << num_destruction_ << std::endl;
+    std::cout << "duration_: " << duration_ << std::endl;
     if (oneflow::DTRDebugEnabled()) { CHECK_JUST(display()); }
   }
 

--- a/oneflow/core/framework/tensor_pool.h
+++ b/oneflow/core/framework/tensor_pool.h
@@ -39,6 +39,9 @@ struct DTRTensorPool {
     if (oneflow::DTRDebugEnabled()) { CHECK_JUST(display()); }
   }
 
+  void set_current_op_type_name(std::string op_type_name);
+  const std::string& current_op_type_name();
+
   void set_total_memory(size_t mem);
   size_t get_total_memory();
 
@@ -60,6 +63,10 @@ struct DTRTensorPool {
   void update_after_compute(vm::DTREagerBlobObject* dtr_blob_object);
   Maybe<void> update_after_evict(vm::DTREagerBlobObject* dtr_blob_object);
 
+  std::set<vm::LocalCallOpKernelPhyInstrOperand*> operand_visited_;
+  HashMap<vm::DTREagerBlobObject*, int> reference_nums_;
+  std::set<vm::DTREagerBlobObject*> need_eager_eviction_ebos_;
+
   // TODO: Implementation of disjoint-set data structure
 
  private:
@@ -72,6 +79,7 @@ struct DTRTensorPool {
   int num_eviction_;
   int num_recomputation_;
   int num_destruction_;
+  std::string current_op_type_name_;
 };
 
 }  // namespace one

--- a/oneflow/core/framework/tensor_pool.h
+++ b/oneflow/core/framework/tensor_pool.h
@@ -39,9 +39,6 @@ struct DTRTensorPool {
     if (oneflow::DTRDebugEnabled()) { CHECK_JUST(display()); }
   }
 
-  void set_current_op_type_name(std::string op_type_name);
-  const std::string& current_op_type_name();
-
   void set_total_memory(size_t mem);
   size_t get_total_memory();
 

--- a/oneflow/core/framework/tensor_pool.h
+++ b/oneflow/core/framework/tensor_pool.h
@@ -64,7 +64,6 @@ struct DTRTensorPool {
   Maybe<void> update_after_pesudo_evict(vm::DTREagerBlobObject* dtr_blob_object);
 
   std::set<vm::DTRInstrOperand*> operand_visited_;
-  HashMap<vm::DTREagerBlobObject*, int> reference_nums_;
   std::set<vm::DTREagerBlobObject*> need_eager_eviction_ebos_;
 
   // TODO: Implementation of disjoint-set data structure
@@ -79,7 +78,6 @@ struct DTRTensorPool {
   int num_eviction_;
   int num_recomputation_;
   int num_destruction_;
-  std::string current_op_type_name_;
 };
 
 }  // namespace one

--- a/oneflow/core/framework/tensor_pool.h
+++ b/oneflow/core/framework/tensor_pool.h
@@ -63,7 +63,7 @@ struct DTRTensorPool {
   void update_after_compute(vm::DTREagerBlobObject* dtr_blob_object);
   Maybe<void> update_after_evict(vm::DTREagerBlobObject* dtr_blob_object);
 
-  std::set<vm::LocalCallOpKernelPhyInstrOperand*> operand_visited_;
+  std::set<vm::DTRInstrOperand*> operand_visited_;
   HashMap<vm::DTREagerBlobObject*, int> reference_nums_;
   std::set<vm::DTREagerBlobObject*> need_eager_eviction_ebos_;
 

--- a/oneflow/core/vm/dtr_cuda_allocator.cpp
+++ b/oneflow/core/vm/dtr_cuda_allocator.cpp
@@ -284,8 +284,7 @@ DtrCudaAllocator::Piece* DtrCudaAllocator::EvictAndFindPiece(size_t size) {
         if (oneflow::DTRDebugEnabled()) {
           LOG(INFO) << "skip tensor: " << end_tensor
                     << ", size: " << end_tensor->blob_body_bytes_double() << ", compute op "
-                    << end_tensor->compute_op_type_name();
-          LOG(INFO) << "num_pinned: " << end_tensor->num_pinned()
+                    << end_tensor->compute_op_type_name() << ", num_pinned: " << end_tensor->num_pinned()
                     << ", is_evictable: " << end_tensor->is_evictable();
         }
         end++;
@@ -300,14 +299,14 @@ DtrCudaAllocator::Piece* DtrCudaAllocator::EvictAndFindPiece(size_t size) {
         CHECK_JUST(Global<one::DTRTensorPool>::Get()->update_after_pesudo_evict(end_tensor));
       }
       cost += get_cost(end_tensor, -1);
-      end++;
-
       if (oneflow::DTRDebugEnabled()) {
-        LOG(INFO) << "move end, compute op: "
+        LOG(INFO) << "move end, include op: "
                   << (end_tensor != nullptr ? end_tensor->compute_op_type_name() : "no tensor")
                   << ", size: " << end->second->size
                   << ", total_size: " << total_size << ", cost: " << cost;
       }
+      end++;
+
     } else {
       if (min_cost > cost) {
         min_cost = cost;
@@ -325,7 +324,7 @@ DtrCudaAllocator::Piece* DtrCudaAllocator::EvictAndFindPiece(size_t size) {
       }
       cost -= get_cost(start_tensor, coeff);
       if (oneflow::DTRDebugEnabled()) {
-        LOG(INFO) << "move start, compute op: "
+        LOG(INFO) << "move start, exclude op: "
                   << (start_tensor != nullptr ? start_tensor->compute_op_type_name() : "no tensor")
                   << ", size: " << start->second->size
                   << ", total_size: " << total_size << ", cost: " << cost;

--- a/oneflow/core/vm/dtr_cuda_allocator.cpp
+++ b/oneflow/core/vm/dtr_cuda_allocator.cpp
@@ -169,23 +169,7 @@ DtrCudaAllocator::Piece* DtrCudaAllocator::FindPiece(size_t aligned_size) {
           piece->bin_num = kInvalidBinNum;
           piece->is_free = false;
         } else if (piece->size > aligned_size) {
-          const std::string& name = Global<one::DTRTensorPool>::Get()->current_op_type_name();
-          const bool choose_left = [&]() {
-            if (std::getenv("OF_DTR_NLR") != nullptr) {
-              std::vector<std::string> high_compute_cost_names{"conv2d", "conv_data_grad",
-                                                               "conv_filter_grad"};
-              if (std::find(high_compute_cost_names.cbegin(), high_compute_cost_names.cend(), name)
-                  != high_compute_cost_names.cend()) {
-                return true;
-              }
-              return false;
-
-            } else {
-              return left_;
-            }
-          }();
-          if (choose_left) {
-            if (oneflow::DTRDebugEnabled()) { LOG(INFO) << "left: " << name; }
+          if (left_) {
             piece->bin_num = kInvalidBinNum;
             piece->is_free = false;
 


### PR DESCRIPTION
在开始重计算之前递归查询到所有需要重计算的 op（这后续也可以用来打印更友好的调试信息），相当于临时建立了一个小的计算图并对这个计算图进行前向。前向过程中，不再被需要的中间 activation 会被及时 evict，相当于在重计算过程中也实现了 eager eviction。