### PR TITLE
Support view in broadcast elementwise

### DIFF
--- a/oneflow/core/ep/cpu/primitive/binary_functor.h
+++ b/oneflow/core/ep/cpu/primitive/binary_functor.h
@@ -33,6 +33,35 @@ struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kPow, float16, float16> {
   }
 };
 
+
+template<typename Src, typename Dst>
+struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kFMod, Src, Dst> {
+  OF_DEVICE_FUNC Dst operator()(Src src0, Src src1) const { return std::fmod(src0, src1); }
+};
+
+template<>
+struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kFMod, float16, float16> {
+  OF_DEVICE_FUNC float16 operator()(float16 src0, float16 src1) const {
+    return static_cast<float16>(std::fmod(static_cast<float>(src0), static_cast<float>(src1)));
+  }
+};
+
+template<typename Src, typename Dst>
+struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kFloorMod, Src, Dst> {
+  OF_DEVICE_FUNC Dst operator()(Src src0, Src src1) const { 
+    const Src trunc_mod = std::fmod(src0, src1);
+    return (trunc_mod != 0) && ((src1 < 0) != (trunc_mod < 0)) ? trunc_mod + src1 : trunc_mod;
+  }
+};
+
+template<>
+struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kFloorMod, float16, float16> {
+  OF_DEVICE_FUNC float16 operator()(float16 src0, float16 src1) const {
+    const float trunc_mod = std::fmod(static_cast<float>(src0), static_cast<float>(src1));
+    return (trunc_mod != float(0)) && ((src1 < float(0)) != (trunc_mod < float(0))) ? static_cast<float16>(trunc_mod + src1) : static_cast<float16>(trunc_mod);
+  }
+};
+
 }  // namespace broadcast_elementwise_binary
 }  // namespace primitive
 }  // namespace ep

--- a/oneflow/core/ep/cuda/primitive/binary_functor.cuh
+++ b/oneflow/core/ep/cuda/primitive/binary_functor.cuh
@@ -33,12 +33,55 @@ struct BinaryFunctor<DeviceType::kCUDA, BinaryOp::kPow, half, half> {
   }
 };
 
+template<typename Src, typename Dst>
+struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kFMod, Src, Dst> {
+  OF_DEVICE_FUNC Dst operator()(Src src0, Src src1) const { return std::fmod(src0, src1); }
+};
+
+template<>
+struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kFMod, half, half> {
+  OF_DEVICE_FUNC half operator()(half src0, half src1) const {
+    return static_cast<half>(std::fmod(static_cast<float>(src0), static_cast<float>(src1)));
+  }
+};
+
+template<typename Src, typename Dst>
+struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kFloorMod, Src, Dst> {
+  OF_DEVICE_FUNC Dst operator()(Src src0, Src src1) const { 
+    const float trunc_mod = std::fmod(src0, src1);
+    return (trunc_mod != 0) && ((src1 < 0) != (trunc_mod < 0)) ? trunc_mod + src1 : trunc_mod;
+  }
+};
+
+template<>
+struct BinaryFunctor<DeviceType::kCPU, BinaryOp::kFloorMod, half, half> {
+  OF_DEVICE_FUNC half operator()(half src0, half src1) const {
+    const float trunc_mod = std::fmod(static_cast<float>(src0), static_cast<float>(src1));
+    return (trunc_mod != float(0)) && ((static_cast<float>(src1) < float(0)) != (trunc_mod < float(0))) ? static_cast<half>(trunc_mod + static_cast<float>(src1)) : static_cast<half>(trunc_mod);
+  }
+};
+
 #if CUDA_VERSION >= 11000
 
 template<>
 struct BinaryFunctor<DeviceType::kCUDA, BinaryOp::kPow, nv_bfloat16, nv_bfloat16> {
   OF_DEVICE_FUNC nv_bfloat16 operator()(nv_bfloat16 src0, nv_bfloat16 src1) const {
     return static_cast<nv_bfloat16>(pow(static_cast<float>(src0), static_cast<float>(src1)));
+  }
+};
+
+template<>
+struct BinaryFunctor<DeviceType::kCUDA, BinaryOp::kFMod, nv_bfloat16, nv_bfloat16> {
+  OF_DEVICE_FUNC nv_bfloat16 operator()(nv_bfloat16 src0, nv_bfloat16 src1) const {
+    return static_cast<nv_bfloat16>(std::fmod(static_cast<float>(src0), static_cast<float>(src1)));
+  }
+};
+
+template<>
+struct BinaryFunctor<DeviceType::kCUDA, BinaryOp::kFloorMod, nv_bfloat16, nv_bfloat16> {
+  OF_DEVICE_FUNC nv_bfloat16 operator()(nv_bfloat16 src0, nv_bfloat16 src1) const {
+    const nv_bfloat16 trunc_mod = std::fmod(static_cast<float>(src0), static_cast<float>(src1));
+    return (trunc_mod != float(0)) && ((src1 < float(0)) != (trunc_mod < float(0)) ? static_cast<nv_bfloat16>(trunc_mod + src1) : static_cast<nv_bfloat16>(trunc_mod);
   }
 };
 

--- a/oneflow/core/ep/cuda/primitive/broadcast_elementwise_binary.cuh
+++ b/oneflow/core/ep/cuda/primitive/broadcast_elementwise_binary.cuh
@@ -360,6 +360,14 @@ class BroadcastElementwiseBinaryImpl : public BroadcastElementwiseBinary {
         stream, num_src0_dims, src0_dims, reinterpret_cast<const Src*>(src0), num_src1_dims,
         src1_dims, reinterpret_cast<const Src*>(src1), reinterpret_cast<Dst*>(dst));
   }
+
+
+  void Launch(Stream* stream, 
+              size_t num_src0_dims, const int64_t* src0_dims, const int64_t* src0_strides, const void* src0,
+              size_t num_src1_dims, const int64_t* src1_dims, const int64_t* src1_strides, const void* src1,
+              size_t num_dst_dims, const int64_t* dst_dims, const int64_t* dst_strides, void* dst) override {
+                return;
+              }
 };
 
 }  // namespace

--- a/oneflow/core/ep/include/primitive/binary_op.h
+++ b/oneflow/core/ep/include/primitive/binary_op.h
@@ -23,6 +23,7 @@ namespace oneflow {
 namespace ep {
 namespace primitive {
 
+
 enum class BinaryOp {
   // Math
   kAdd,
@@ -32,6 +33,8 @@ enum class BinaryOp {
   kMax,
   kMin,
   kPow,
+  kFloorMod,
+  kFMod,
   // Comparision
   kEqual,
   kNotEqual,
@@ -52,6 +55,22 @@ enum class BinaryOp {
 
 }
 }  // namespace ep
+
+using namespace ep::primitive;
+
+// #define MATH_BINARY_BROADCAST_PRIMITIVE_OP_SEQ                  \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_add", BinaryOp::kAdd)            \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_sub", BinaryOp::kSub)            \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_mul", BinaryOp::kMul)            \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_div", BinaryOp::kDiv)            \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_minimum", BinaryOp::kMin)        \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_maximum", BinaryOp::kMax)        \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_floor_mod", BinaryOp::kFloorMod) \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_fmod", BinaryOp::kFMod)          \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_pow", BinaryOp::kPow)
+
+#define MATH_BINARY_BROADCAST_PRIMITIVE_OP_SEQ                  \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_pow", BinaryOp::kPow)
 
 }  // namespace oneflow
 

--- a/oneflow/core/ep/include/primitive/binary_op.h
+++ b/oneflow/core/ep/include/primitive/binary_op.h
@@ -58,19 +58,19 @@ enum class BinaryOp {
 
 using namespace ep::primitive;
 
-// #define MATH_BINARY_BROADCAST_PRIMITIVE_OP_SEQ                  \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_add", BinaryOp::kAdd)            \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_sub", BinaryOp::kSub)            \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_mul", BinaryOp::kMul)            \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_div", BinaryOp::kDiv)            \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_minimum", BinaryOp::kMin)        \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_maximum", BinaryOp::kMax)        \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_floor_mod", BinaryOp::kFloorMod) \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_fmod", BinaryOp::kFMod)          \
-//   OF_PP_MAKE_TUPLE_SEQ("broadcast_pow", BinaryOp::kPow)
-
 #define MATH_BINARY_BROADCAST_PRIMITIVE_OP_SEQ                  \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_add", BinaryOp::kAdd)            \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_sub", BinaryOp::kSub)            \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_mul", BinaryOp::kMul)            \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_div", BinaryOp::kDiv)            \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_minimum", BinaryOp::kMin)        \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_maximum", BinaryOp::kMax)        \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_floor_mod", BinaryOp::kFloorMod) \
+  OF_PP_MAKE_TUPLE_SEQ("broadcast_fmod", BinaryOp::kFMod)          \
   OF_PP_MAKE_TUPLE_SEQ("broadcast_pow", BinaryOp::kPow)
+
+// #define MATH_BINARY_BROADCAST_PRIMITIVE_OP_SEQ                  \
+//   OF_PP_MAKE_TUPLE_SEQ("broadcast_pow", BinaryOp::kPow)
 
 }  // namespace oneflow
 

--- a/oneflow/core/ep/include/primitive/broadcast_elementwise_binary.h
+++ b/oneflow/core/ep/include/primitive/broadcast_elementwise_binary.h
@@ -31,6 +31,9 @@ class BroadcastElementwiseBinary : public Primitive {
   BroadcastElementwiseBinary() = default;
   ~BroadcastElementwiseBinary() override = default;
 
+  virtual void Launch(Stream* stream, size_t num_src0_dims, const int64_t* src0_dims, const int64_t* src0_strides,
+                      const void* src0, size_t num_src1_dims, const int64_t* src1_dims, const int64_t* src1_strides,
+                      const void* src1, size_t num_dst_dims, const int64_t* dst_dims, const int64_t* dst_strides, void* dst) = 0;
   virtual void Launch(Stream* stream, size_t num_src0_dims, const int64_t* src0_dims,
                       const void* src0, size_t num_src1_dims, const int64_t* src1_dims,
                       const void* src1, void* dst) = 0;

--- a/oneflow/core/framework/stride.h
+++ b/oneflow/core/framework/stride.h
@@ -39,6 +39,11 @@ class Stride final {
 
   // Getters and Setters
   const StrideVector& StrideVec() const { return stride_vec_; }
+  void ToStrideVector(StrideVector* stride_vec) const { 
+    stride_vec->resize(stride_vec_.size());
+    stride_vec->assign(stride_vec_.begin(), stride_vec_.end());
+  }
+
   int64_t NumAxes() const { return stride_vec_.size(); }
   int64_t At(int64_t index) const { return stride_vec_.at(index); }
   void Set(int64_t index, int64_t val) { stride_vec_.at(index) = val; }

--- a/oneflow/user/kernels/math_binary_broadcast_kernels.cpp
+++ b/oneflow/user/kernels/math_binary_broadcast_kernels.cpp
@@ -62,32 +62,32 @@ class MathBinaryBroadcastKernel final : public user_op::OpKernel, public user_op
   REGISTER_USER_KERNEL(OF_PP_PAIR_FIRST(math_type_pair))                              \
       .SetCreateFn<MathBinaryBroadcastKernel<                                         \
           device, OF_PP_PAIR_FIRST(data_type_pair), OF_PP_PAIR_FIRST(data_type_pair), \
-          ep::primitive::BinaryOp::k##OF_PP_PAIR_SECOND(data_type_pair)>                \
+          OF_PP_PAIR_SECOND(math_type_pair)>>()                \
       .SetIsMatchedHob((user_op::HobDeviceType() == device)                           \
                        && (user_op::HobDataType("z", 0) == OF_PP_PAIR_SECOND(data_type_pair)));
 
 OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_MATH_BINARY_BROADCAST_KERNEL,
-                                 MATH_BINARY_BROADCAST_FUNC_SEQ, DEVICE_TYPE_SEQ,
+                                 MATH_BINARY_BROADCAST_PRIMITIVE_OP_SEQ, DEVICE_TYPE_SEQ,
                                  ARITHMETIC_DATA_TYPE_SEQ UNSIGNED_INT_DATA_TYPE_SEQ)
-// gpu half
-#ifdef WITH_CUDA
-OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_MATH_BINARY_BROADCAST_KERNEL,
-                                 MATH_BINARY_BROADCAST_FUNC_SEQ, (DeviceType::kCUDA),
-                                 FLOAT16_DATA_TYPE_SEQ)
-#endif
+// // gpu half
+// #ifdef WITH_CUDA
+// OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_MATH_BINARY_BROADCAST_KERNEL,
+//                                  MATH_BINARY_BROADCAST_FUNC_SEQ, (DeviceType::kCUDA),
+//                                  FLOAT16_DATA_TYPE_SEQ)
+// #endif
 
-#define REGISTER_MATH_BINARY_BROADCAST_LOGICAL_KERNEL(math_type_pair, device, data_type_pair) \
-  REGISTER_USER_KERNEL(OF_PP_PAIR_FIRST(math_type_pair))                                      \
-      .SetCreateFn<MathBinaryBroadcastKernel<                                                 \
-          device, OF_PP_PAIR_FIRST(data_type_pair), int8_t,                                   \
-          &NdarrayUtil<device, OF_PP_PAIR_FIRST(data_type_pair)>::OF_PP_CAT(                  \
-              Broadcast, OF_PP_PAIR_SECOND(math_type_pair))>>()                               \
-      .SetIsMatchedHob((user_op::HobDeviceType() == device)                                   \
-                       && (user_op::HobDataType("x", 0) == OF_PP_PAIR_SECOND(data_type_pair)) \
-                       && (user_op::HobDataType("z", 0) == DataType::kInt8));
+// #define REGISTER_MATH_BINARY_BROADCAST_LOGICAL_KERNEL(math_type_pair, device, data_type_pair) \
+//   REGISTER_USER_KERNEL(OF_PP_PAIR_FIRST(math_type_pair))                                      \
+//       .SetCreateFn<MathBinaryBroadcastKernel<                                                 \
+//           device, OF_PP_PAIR_FIRST(data_type_pair), int8_t,                                   \
+//           &NdarrayUtil<device, OF_PP_PAIR_FIRST(data_type_pair)>::OF_PP_CAT(                  \
+//               Broadcast, OF_PP_PAIR_SECOND(math_type_pair))>>()                               \
+//       .SetIsMatchedHob((user_op::HobDeviceType() == device)                                   \
+//                        && (user_op::HobDataType("x", 0) == OF_PP_PAIR_SECOND(data_type_pair)) \
+//                        && (user_op::HobDataType("z", 0) == DataType::kInt8));
 
-OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_MATH_BINARY_BROADCAST_LOGICAL_KERNEL,
-                                 MATH_BINARY_BROADCAST_LOGICAL_FUNC_SEQ, DEVICE_TYPE_SEQ,
-                                 ARITHMETIC_DATA_TYPE_SEQ UNSIGNED_INT_DATA_TYPE_SEQ)
+// OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_MATH_BINARY_BROADCAST_LOGICAL_KERNEL,
+//                                  MATH_BINARY_BROADCAST_LOGICAL_FUNC_SEQ, DEVICE_TYPE_SEQ,
+//                                  ARITHMETIC_DATA_TYPE_SEQ UNSIGNED_INT_DATA_TYPE_SEQ)
 
 }  // namespace oneflow


### PR DESCRIPTION
# Elementwise view的实现设计

functor -> kernel -> primitive

## functor
部分elementwise操作在functor内会对input tensor做类型转换，其实就是在调用cast，这里的cast应该没法直接支持view。
```python
JUST(tensor_processor.PromoteInputsToCommonDtype(true)
             .AddInputs({x->contiguous(), y->contiguous()})
             .Apply());
```

在functor内，可以将input tensor的stride (如果是inplace，也需要out tensor的stride）目前是通过attr传入，之后应该将stride和shape一样作为kernel里user::tensor的属性。


## kernel
目前elementwise相关的kernel有 
- math_binary_broadcast_kernel (math_broadacst, logical_broadcast)
- scalar_by_tensor_kernel
- elementwise_maximum_minimum_kernel
- elementwise_xpu_kernel (不带broadcast的kernel)
这些kernel可以做一次合并。

在attr中拿到functor传入的stride后
- 如果没有input stride，默认为contiguous
- 如果没有output stride，需要通过output shape推断stride
- 如果有output stride，那么为inplace的view

然后根据情况调用primitive中提供的contiguous/非contiguous接口

## primitive
primitive中对contiguous binary elementwise已经有相关的实现以及优化，如
- Dst维度推导: 如果是view上的inplace的操作，那么dst是需要考虑strides的。可能直接传入dims和strides更加合适。
- 维度简化：
+ 如果src0_dim, src1_dim为1，可以去掉改维度。同样对view适用。
+ 如果src0_dim, src1_dim相等，且前一个维度也想等，合并这两个维度。这在view下只有这两个维度是连续的才行。即src0_strides[k] = src0_dims[k-1] * src0_strides[k-1]
- 对数据进行pack读取：在view上比较sticky, 比如最后一维的数据不一定是相邻的，需要考虑实际的strides。

目前提供了另外一个接口，专门用于处理非contiguous的操作
```C++
virtual void Launch(Stream* stream, size_t num_src0_dims, const int64_t* src0_dims, const int64_t* src0_strides,
                      const void* src0, size_t num_src1_dims, const int64_t* src1_dims, const int64_t* src1_strides,
                      const void* src1, size_t num_dst_dims, const int64_t* dst_dims, const int64_t* dst_strides, void* dst) = 0;
```
即要求传入in/out tensor的shape，data_ptr, strides等信息。考虑kernel里面已经能拿到推断好的output信息，以及inplace的情况，这里要求output的shape和stride是已经推断好的。

目前的实现没有带任何优化，思路为
- 对input tensor做broadcast操作，如x: Tensor(shape(4,1), strides(1,3)) , y: Tensor(shape(1,3), strides(3,1)). x, y 会被broadcast为 x: Tensor(shape(4,3), strides(1,0)) , y: Tensor(shape(4,3), strides(3,0)). 
- broadcast后，input/out tensor的shape都是一样的，即可遍历所有ndIndex做elementwise操作。



