### PR TITLE
[BUG] fixed flow rand init as global tensor bug

### DIFF
--- a/oneflow/user/ops/distributions/uniform_op.cpp
+++ b/oneflow/user/ops/distributions/uniform_op.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/core/framework/op_generated.h"
+#include "oneflow/core/common/balanced_splitter.h"
 
 namespace oneflow {
 
@@ -30,7 +31,22 @@ namespace oneflow {
 }
 
 /*static*/ Maybe<void> UniformOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
-  return InferLogicalTensorDesc(ctx);
+   const Shape& shape = ctx->Attr<Shape>("shape");
+   DimVector dim_vec{shape.dim_vec()};
+
+   const cfg::SbpParallel& out_sbp_para = ctx->SbpParallel4ArgNameAndIndex("out", 0);
+   if (out_sbp_para.has_split_parallel()) {
+    const int64_t& parallel_num = ctx->parallel_ctx().parallel_num();
+    if (parallel_num > 1) {
+      const int64_t& split_axis = out_sbp_para.split_parallel().axis();
+      CHECK_LT_OR_RETURN(split_axis, dim_vec.size());
+      BalancedSplitter bs(shape.At(split_axis), parallel_num);
+      dim_vec[split_axis] = bs.At(ctx->parallel_ctx().parallel_id()).size();
+    }
+  }
+
+  *ctx->OutputShape("out", 0) = Shape(dim_vec);
+  return Maybe<void>::Ok();
 }
 
 /* static */ Maybe<void> UniformOp::GetSbp(user_op::SbpContext* ctx) {

--- a/python/oneflow/test/modules/test_rand.py
+++ b/python/oneflow/test/modules/test_rand.py
@@ -105,6 +105,44 @@ class TestConstantModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
+def _test_consistent_rand(test_case,shape, placement, sbp):
+    x = flow.rand(*shape, placement=placement, sbp=sbp)
+    test_case.assertEqual(x.shape, shape)
+    test_case.assertEqual(x.sbp, sbp)
+    test_case.assertEqual(x.placement, placement)
+
+
+def _test_consistent_rand_graph(test_case,shape, placement, sbp):
+    class ConsistentRandGraph(flow.nn.Graph):
+        def __init__(self,):
+            super().__init__()
+
+        def build(self):
+            x = flow.rand(*shape, placement=placement, sbp=sbp)
+            return x
+
+    c_rand_g = ConsistentRandGraph()
+    x = c_rand_g()
+    test_case.assertEqual(x.shape, shape)
+    test_case.assertEqual(x.sbp, sbp)
+    test_case.assertEqual(x.placement, placement)
+
+
+@unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+@flow.unittest.skip_unless_1n2d()
+class TestRandConsistent(flow.unittest.TestCase):
+    def test_rand_consistent(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["test_fun"] = [_test_consistent_rand, _test_consistent_rand_graph]
+        arg_dict["shape"] = [(2, 3, 4), (2, 5, 2)]
+        arg_dict["placement"] = [
+            flow.placement("cpu", {0: [0, 1]}),
+            flow.placement("cuda", {0: [0, 1]}),
+        ]
+        arg_dict["sbp"] = [(flow.sbp.broadcast,), (flow.sbp.split(0),)]
+        for arg in GenArgList(arg_dict):
+            arg[0](test_case, *arg[1:])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
这个PR修复 module forward 中构造 rand tensor 会报错的bug，相关背景记录在issue : #7340