### PR TITLE
fix_placement_check_device_id_bug

### DIFF
--- a/oneflow/core/job/parallel_desc.cpp
+++ b/oneflow/core/job/parallel_desc.cpp
@@ -322,6 +322,9 @@ Maybe<void> ParallelDesc::CheckDeviceIdsIsValid() const {
   if (likely(JUST(IsMultiClient()))) {
     const auto& sorted_dev_phy_ids_iter =
         machine_id2sorted_dev_phy_ids_->find(GlobalProcessCtx::Rank());
+    for (int64_t machine_id : sorted_machine_ids_) {
+      CHECK_LT_OR_RETURN(machine_id, GlobalProcessCtx::WorldSize());
+    }
     if (sorted_dev_phy_ids_iter != machine_id2sorted_dev_phy_ids_->end()) {
       for (int64_t dev_phy_id : *sorted_dev_phy_ids_iter->second) {
         if (device_type_ == DeviceType::kCUDA) {


### PR DESCRIPTION
修复```ParallelDesc::CheckDeviceIdsIsValid()```中的bug，需要检查placement中的machine_id（即 rank） 全部合法