### PR TITLE
fix_tensor_numpy_bug

### DIFF
--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -958,8 +958,9 @@ def _numpy(self):
         tensors = flow.tensor_buffer_to_list_of_tensors(self, shapes, dtypes)
         return [t.numpy() for t in tensors]
     if self.is_global:
-        sbp_list = [flow.sbp.broadcast for _ in range(len(self.sbp))]
-        self = self.to_global(placement=self.placement, sbp=sbp_list).to_local()
+        self = self.to_global(
+            placement=flow.env.all_device_placement("cpu"), sbp=flow.sbp.broadcast
+        ).to_local()
     assert self.is_local
     if self.device != flow.device("cpu"):
         self = self.cpu()


### PR DESCRIPTION
修复tensor.numpy的bug，调用tensor.numpy时应该将数据广播到所有rank上，而不是仅广播到tensor的placement覆盖的rank上