### PR TITLE
check numerics dump data, count not finite support half

### DIFF
--- a/oneflow/core/ep/cuda/cuda_stream.cpp
+++ b/oneflow/core/ep/cuda/cuda_stream.cpp
@@ -160,6 +160,10 @@ cudnnHandle_t CudaStream::cudnn_handle() const { return cudnn_handle_; }
 
 const cudaDeviceProp& CudaStream::device_properties() const { return device_->properties(); }
 
+int CudaStream::cuda_arch() const {
+  return device_->properties().major * 100 + device_->properties().minor * 10;
+}
+
 #ifdef WITH_CUDA_GRAPHS
 
 void CudaStream::BeginGraphCapture() {

--- a/oneflow/core/ep/cuda/cuda_stream.h
+++ b/oneflow/core/ep/cuda/cuda_stream.h
@@ -86,6 +86,7 @@ class CudaStream : public Stream {
   cublasHandle_t cublas_handle() const;
   cudnnHandle_t cudnn_handle() const;
   const cudaDeviceProp& device_properties() const;
+  int cuda_arch() const;
 
   void InitLaunchConfigWithWaves(CudaLaunchConfig* config, size_t elem_cnt, size_t block_size,
                                  size_t max_waves) const {

--- a/oneflow/core/kernel/cuda_check_numerics_kernel_observer.cu
+++ b/oneflow/core/kernel/cuda_check_numerics_kernel_observer.cu
@@ -26,12 +26,15 @@ __device__ bool IsNotFinite(T x) {
   return !isfinite(x);
 }
 
-#if __CUDA_ARCH__ >= 530
 template<>
 __device__ bool IsNotFinite<half>(half x) {
+#if __CUDA_ARCH__ >= 530
   return (__hisinf(x) || __hisnan(x));
-}
+#else
+  __trap();
+  return true;
 #endif
+}
 
 template<typename T>
 __global__ void HasNotFiniteGpuKernel(const int64_t n, const T* x, volatile bool* has_not_finite) {
@@ -60,6 +63,7 @@ bool HasNotFinite(ep::Stream* stream, const int64_t elem_cnt, const T* data_ptr,
 
 bool HasNotFiniteGpu(ep::Stream* stream, const Blob* blob, bool* has_not_finite_host,
                      bool* has_not_finite_device) {
+  auto* cuda_stream = stream->As<ep::CudaStream>();
   const DataType dtype = blob->data_type();
   const int64_t elem_cnt = blob->shape().elem_cnt();
   if (dtype == kFloat) {
@@ -69,16 +73,33 @@ bool HasNotFiniteGpu(ep::Stream* stream, const Blob* blob, bool* has_not_finite_
     return HasNotFinite<double>(stream, elem_cnt, blob->dptr<double>(), has_not_finite_host,
                                 has_not_finite_device);
   } else if (dtype == kFloat16) {
-#if __CUDA_ARCH__ >= 530
-    return HasNotFinite<half>(stream, elem_cnt, blob->dptr<half>(), has_not_finite_host,
-                              has_not_finite_device);
-#else
-    LOG(FATAL) << "use half need nvcc arch >= 530";
-    return true;
-#endif
+    if (cuda_stream->cuda_arch() >= 530) {
+      return HasNotFinite<half>(stream, elem_cnt, blob->dptr<half>(), has_not_finite_host,
+                                has_not_finite_device);
+    } else {
+      LOG(FATAL) << "use half need nvcc arch >= 530";
+      return true;
+    }
   } else {
     return false;
   }
+}
+
+void DumpBlob(KernelContext* ctx, const std::string& bn) {
+  Blob* blob = ctx->BnInOp2Blob(bn);
+  if (blob != nullptr) {
+    std::vector<char> buffer(blob->ByteSizeOfBlobBody());
+    OF_CUDA_CHECK(
+        cudaMemcpy(buffer.data(), blob->dptr(), blob->ByteSizeOfBlobBody(), cudaMemcpyDefault));
+    OF_CUDA_CHECK(cudaDeviceSynchronize());
+    std::ofstream ofs(bn);
+    ofs.write(buffer.data(), blob->ByteSizeOfBlobBody());
+  }
+}
+
+void DumpBlobs(KernelContext* ctx, const Kernel* kernel) {
+  for (const auto& obn : kernel->op_attribute().output_bns()) { DumpBlob(ctx, obn); }
+  for (const auto& ibn : kernel->op_attribute().input_bns()) { DumpBlob(ctx, ibn); }
 }
 
 }  // namespace
@@ -103,6 +124,10 @@ void CudaCheckNumericsKernelObserver::DidForwardDataContent(KernelContext* ctx,
     if (blob != nullptr) {
       bool has_not_finite =
           HasNotFiniteGpu(ctx->stream(), blob, has_not_finite_host_, has_not_finite_device_);
+      if (has_not_finite
+          && ParseBooleanFromEnv("ONEFLOW_DEBUG_KERNEL_SYNC_CHECK_NUMERICS_DUMP", false)) {
+        DumpBlobs(ctx, kernel);
+      }
       CHECK(!has_not_finite) << kernel->op_conf().name() << " : " << obn << " has nan or inf";
     }
   }


### PR DESCRIPTION
1. count not finite support half
2. fix check numerics half check
3. support dump data when nan or inf, env ONEFLOW_DEBUG_KERNEL_SYNC_CHECK_NUMERICS_DUMP