### PR TITLE
delete the extra_repr in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,7 +199,7 @@ def should_skip_member(app, what, name, obj, skip, options):
     is_deprecated = oneflow.is_deprecated(obj)
     if is_deprecated:
         print("skipping deprecated", what, name, obj)
-    magical = name in ["__weakref__", "__doc__", "__module__", "__dict__"]
+    magical = name in ["__weakref__", "__doc__", "__module__", "__dict__", "extra_repr"]
     return skip or is_deprecated or magical
 
 


### PR DESCRIPTION
extra_repr 这个函数的作用是 module to_string 的时候子类可以打印出更详细的信息, 但文档中导出这个函数没有任何意义
原文档举例显示
![image](https://user-images.githubusercontent.com/62194666/154062770-1e84c7b7-595d-4a44-a930-6888f350e06e.png)
经过修改显示
![image](https://user-images.githubusercontent.com/62194666/154063007-46660141-59fe-4b9d-8331-1ba37d555076.png)

close https://github.com/Oneflow-Inc/OneTeam/issues/1030
@wyg1997 