### PR TITLE
move scheduler back to self host

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
 
   wait_for_gpu_slot:
     name: Wait for GPU slots
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, scheduler]
     concurrency:
       group: build-and-test-wait-for-gpu-slot
       cancel-in-progress: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,9 +121,6 @@ jobs:
   wait_for_gpu_slot:
     name: Wait for GPU slots
     runs-on: [self-hosted, Linux, scheduler]
-    concurrency:
-      group: build-and-test-wait-for-gpu-slot
-      cancel-in-progress: false
     needs: [build-oneflow]
     if: github.event.pull_request.draft == false && github.base_ref == 'master' && contains(github.event.pull_request.requested_reviewers.*.login, 'oneflow-ci-bot')
     continue-on-error: true


### PR DESCRIPTION
讲 gpu schedule 放到self hosted运行，减少疑惑，但是因为网络，可能造成更长的等待时间，之后考虑租一个AWS小机器运行它