### PR TITLE
Fix the bug of judging whether a data type supports boxing

### DIFF
--- a/oneflow/core/common/data_type.cpp
+++ b/oneflow/core/common/data_type.cpp
@@ -84,12 +84,12 @@ bool IsSupportRequireGradDataType(DataType data_type) {
 }
 bool NotSupportBoxingDataType(DataType data_type) {
   switch (data_type) {
-#define POD_CASE(type_cpp, type_proto) \
+#define NO_BOXING_CASE(type_cpp, type_proto) \
   case type_proto: return true;
-    OF_PP_FOR_EACH_TUPLE(POD_CASE, NO_BOXING_DATA_TYPE_SEQ)
+    OF_PP_FOR_EACH_TUPLE(NO_BOXING_CASE, NO_BOXING_DATA_TYPE_SEQ)
     default: return false;
   }
-#undef POD_CASE
+#undef NO_BOXING_CASE
 }
 
 size_t GetSizeOfDataType(DataType data_type) {

--- a/oneflow/core/common/data_type.cpp
+++ b/oneflow/core/common/data_type.cpp
@@ -82,6 +82,15 @@ bool IsSupportRequireGradDataType(DataType data_type) {
   }
 #undef REQUIRE_GRAD_CASE
 }
+bool NotSupportBoxingDataType(DataType data_type) {
+  switch (data_type) {
+#define POD_CASE(type_cpp, type_proto) \
+  case type_proto: return true;
+    OF_PP_FOR_EACH_TUPLE(POD_CASE, NO_BOXING_DATA_TYPE_SEQ)
+    default: return false;
+  }
+#undef POD_CASE
+}
 
 size_t GetSizeOfDataType(DataType data_type) {
   switch (data_type) {

--- a/oneflow/core/common/data_type.h
+++ b/oneflow/core/common/data_type.h
@@ -238,6 +238,7 @@ bool IsSupportRequireGradDataType(DataType data_type);
 bool IsPODDataType(DataType data_type);
 bool IsPODAndHalfDataType(DataType data_type);
 bool IsIndexDataType(DataType data_type);
+bool NotSupportBoxingDataType(DataType data_type);
 size_t GetSizeOfDataType(DataType data_type);
 
 inline bool operator==(const OptInt64& lhs, const OptInt64& rhs) {

--- a/oneflow/core/common/data_type_seq.h
+++ b/oneflow/core/common/data_type_seq.h
@@ -61,4 +61,8 @@ limitations under the License.
   OF_PP_MAKE_TUPLE_SEQ(uint8_t, DataType::kUInt8) \
   OF_PP_MAKE_TUPLE_SEQ(float, DataType::kFloat)
 
+#define NO_BOXING_DATA_TYPE_SEQ                       \
+  OF_PP_MAKE_TUPLE_SEQ(OFRecord, DataType::kOFRecord) \
+  OF_PP_MAKE_TUPLE_SEQ(TensorBuffer, DataType::kTensorBuffer)
+
 #endif  // ONEFLOW_CORE_COMMON_DATA_TYPE_SEQ_H_

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -703,9 +703,9 @@ Maybe<void> Operator::GreedilyFindMinCopyCostNdSbp(
       double total_copy_cost = 0.0;
       for (const auto& ibn : input_bns()) {
         const auto& blob_modifier_ = InputBlobModifier4Ibn(ibn);
-        bool is_same_sbp =
-            (blob_modifier_.has_is_mutable() && blob_modifier_.is_mutable())
-            || (!IsPODDataType(JUST(NdSbpInferHint4Ibn(ibn))->logical_blob_desc().data_type()));
+        bool is_same_sbp = (blob_modifier_.has_is_mutable() && blob_modifier_.is_mutable())
+                           || NotSupportBoxingDataType(
+                               JUST(NdSbpInferHint4Ibn(ibn))->logical_blob_desc().data_type());
         total_copy_cost += JUST(ComputeCopyCostBetweenNdSbp(
             JUST(NdSbpInferHint4Ibn(ibn))->nd_sbp(),
             JUST(VectorAt(nd_sbp_sig_list, i)).bn_in_op2nd_sbp().at(ibn),

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -699,19 +699,24 @@ Maybe<void> Operator::GreedilyFindMinCopyCostNdSbp(
   if (nd_sbp_sig_list.size() == 1) {
     select_sbp_idx = 0;
   } else {
+    std::vector<bool> is_same_sbp(input_bns().size());
+    for (int32_t ibn_id = 0; ibn_id < input_bns().size(); ibn_id++) {
+      const auto& ibn = input_bns().at(ibn_id);
+      const auto& blob_modifier_ = InputBlobModifier4Ibn(ibn);
+      is_same_sbp[ibn_id] = (blob_modifier_.has_is_mutable() && blob_modifier_.is_mutable())
+                            || NotSupportBoxingDataType(
+                                JUST(NdSbpInferHint4Ibn(ibn))->logical_blob_desc().data_type());
+    }
     for (int32_t i = 0; i < nd_sbp_sig_list.size(); ++i) {
       double total_copy_cost = 0.0;
-      for (const auto& ibn : input_bns()) {
-        const auto& blob_modifier_ = InputBlobModifier4Ibn(ibn);
-        bool is_same_sbp = (blob_modifier_.has_is_mutable() && blob_modifier_.is_mutable())
-                           || NotSupportBoxingDataType(
-                               JUST(NdSbpInferHint4Ibn(ibn))->logical_blob_desc().data_type());
+      for (int32_t ibn_id = 0; ibn_id < input_bns().size(); ibn_id++) {
+        const auto& ibn = input_bns().at(ibn_id);
+        const auto& producer_infer_hint4ibn = JUST(NdSbpInferHint4Ibn(ibn));
         total_copy_cost += JUST(ComputeCopyCostBetweenNdSbp(
-            JUST(NdSbpInferHint4Ibn(ibn))->nd_sbp(),
+            producer_infer_hint4ibn->nd_sbp(),
             JUST(VectorAt(nd_sbp_sig_list, i)).bn_in_op2nd_sbp().at(ibn),
-            JUST(NdSbpInferHint4Ibn(ibn))->logical_blob_desc(),
-            JUST(NdSbpInferHint4Ibn(ibn))->parallel_desc(), *JUST(GetParallelDesc4BnInOp(ibn)),
-            is_same_sbp));
+            producer_infer_hint4ibn->logical_blob_desc(), producer_infer_hint4ibn->parallel_desc(),
+            *JUST(GetParallelDesc4BnInOp(ibn)), is_same_sbp[ibn_id]));
         // Reduce inquiries
         if (total_copy_cost > min_copy_cost) { break; }
       }
@@ -729,9 +734,12 @@ Maybe<void> Operator::GreedilyFindMinCopyCostNdSbp(
       err << "candidate nd sbp signature are: "
           << *JUST(NdSbpSignatureListAsString(nd_sbp_sig_list, input_bns(), output_bns()));
       err << ", but inputs sbp are:";
-      for (const auto& ibn : input_bns()) {
+      for (int32_t ibn_id = 0; ibn_id < input_bns().size(); ibn_id++) {
+        const auto& ibn = input_bns().at(ibn_id);
         const NdSbp& nd_sbp = JUST(NdSbpInferHint4Ibn(ibn))->nd_sbp();
-        err << " " << ibn << ": " << NdSbpToString(nd_sbp) << ";";
+        err << " " << ibn << ": " << NdSbpToString(nd_sbp);
+        if (!is_same_sbp[ibn_id]) { err << " [ transfer disabled ]"; }
+        err << ";";
       }
 
       return Error::RuntimeError() << err.str();


### PR DESCRIPTION
这里对应的issue是 

- https://github.com/Oneflow-Inc/oneflow/issues/7513

上面issue的bug是scaler的sbp引起的（0 size tensor），但是在修复以后其实还是跑不通，会有matmul推理不出合适sbp的bug。
发现是operator.cpp的GreedilyFindMinCopyCostNdSbp()里面判断一个data type是否支持boxing出了问题。
IsPODDataType(DataType::kFloat16)返回的是false。
[之前用 IsPODDataType() 来做是否支持boxing的依据是因为 GetSizeOfDataType() 里面的描述。]

处理方法就是加一个是否支持boxing 的 sequence。
