### PR TITLE
Refactor eager tmp buffer

### DIFF
--- a/oneflow/core/eager/call_context.h
+++ b/oneflow/core/eager/call_context.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "oneflow/core/framework/attr_map.h"
 #include "oneflow/core/eager/eager_blob_object.h"
 #include "oneflow/core/framework/op_interpreter.h"
+#include "oneflow/core/common/shape_view.h"
 
 namespace oneflow {
 
@@ -33,15 +34,40 @@ using EagerBlobObjectListPtr =
 
 }  // namespace one
 
+class DeviceCtx;
+
 namespace eager {
 
 struct CallContext {
+  CallContext(
+      ComposedAttrMap&& composed_attrs, const one::EagerBlobObjectListPtr& inputs,
+      const one::EagerBlobObjectListPtr& outputs,
+      const std::shared_ptr<const one::ConsistentTensorInferResult>& consistent_tensor_infer_result,
+      const one::OpExprInterpContext& op_interp_ctx,
+      const std::shared_ptr<one::StatefulLocalOpKernel> opkernel)
+      : composed_attrs(composed_attrs),
+        inputs(inputs),
+        outputs(outputs),
+        consistent_tensor_infer_result(consistent_tensor_infer_result),
+        op_interp_ctx(op_interp_ctx),
+        opkernel(opkernel),
+        tmp_buffer_ptr(nullptr),
+        tmp_buffer_size(0),
+        shape_view(&tmp_buffer_size, 1),
+        mut_shape_view(&tmp_buffer_size, 1),
+        device_ctx(nullptr) {}
+
   ComposedAttrMap composed_attrs;
   one::EagerBlobObjectListPtr inputs;
   one::EagerBlobObjectListPtr outputs;
   std::shared_ptr<const one::ConsistentTensorInferResult> consistent_tensor_infer_result;
   const one::OpExprInterpContext op_interp_ctx;
   const std::shared_ptr<one::StatefulLocalOpKernel> opkernel;
+  char* tmp_buffer_ptr;
+  int64_t tmp_buffer_size;
+  ShapeView shape_view;
+  MutShapeView mut_shape_view;
+  DeviceCtx* device_ctx;
 };
 
 class ThreadLocalCallContextScope final {

--- a/oneflow/core/eager/call_context.h
+++ b/oneflow/core/eager/call_context.h
@@ -24,6 +24,7 @@ namespace oneflow {
 
 namespace one {
 
+class StatefulLocalOpKernel;
 class ConsistentTensorInferResult;
 
 using EagerBlobObjectList = std::vector<std::shared_ptr<vm::EagerBlobObject>>;
@@ -40,6 +41,7 @@ struct CallContext {
   one::EagerBlobObjectListPtr outputs;
   std::shared_ptr<const one::ConsistentTensorInferResult> consistent_tensor_infer_result;
   const one::OpExprInterpContext op_interp_ctx;
+  const std::shared_ptr<one::StatefulLocalOpKernel> opkernel;
 };
 
 class ThreadLocalCallContextScope final {

--- a/oneflow/core/eager/local_call_opkernel_phy_instr_operand.cpp
+++ b/oneflow/core/eager/local_call_opkernel_phy_instr_operand.cpp
@@ -27,14 +27,8 @@ LocalCallOpKernelPhyInstrOperand::LocalCallOpKernelPhyInstrOperand(
     const std::shared_ptr<const one::ConsistentTensorInferResult>& consistent_tensor_infer_result,
     const one::OpExprInterpContext& op_interp_ctx,
     const one::DevVmDepObjectConsumeMode dev_vm_dep_object_consume_mode)
-    : call_ctx_{
-        .composed_attrs = ComposedAttrMap(op_interp_ctx.attrs, opkernel->base_attrs()),
-        .inputs = inputs,
-        .outputs = outputs,
-        .consistent_tensor_infer_result = consistent_tensor_infer_result,
-        .op_interp_ctx = op_interp_ctx,
-        .opkernel = opkernel,
-      },
+    : call_ctx_(ComposedAttrMap(op_interp_ctx.attrs, opkernel->base_attrs()), inputs, outputs,
+                consistent_tensor_infer_result, op_interp_ctx, opkernel),
       dev_vm_dep_object_consume_mode_(dev_vm_dep_object_consume_mode),
       input_dependences_(),
       output_dependences_() {

--- a/oneflow/core/eager/local_call_opkernel_phy_instr_operand.cpp
+++ b/oneflow/core/eager/local_call_opkernel_phy_instr_operand.cpp
@@ -33,8 +33,8 @@ LocalCallOpKernelPhyInstrOperand::LocalCallOpKernelPhyInstrOperand(
         .outputs = outputs,
         .consistent_tensor_infer_result = consistent_tensor_infer_result,
         .op_interp_ctx = op_interp_ctx,
+        .opkernel = opkernel,
       },
-      opkernel_(opkernel),
       dev_vm_dep_object_consume_mode_(dev_vm_dep_object_consume_mode),
       input_dependences_(),
       output_dependences_() {

--- a/oneflow/core/eager/local_call_opkernel_phy_instr_operand.cpp
+++ b/oneflow/core/eager/local_call_opkernel_phy_instr_operand.cpp
@@ -46,7 +46,8 @@ LocalCallOpKernelPhyInstrOperand::LocalCallOpKernelPhyInstrOperand(
 
 Maybe<void> LocalCallOpKernelPhyInstrOperand::Init() {
   return WithThisCallContext([this]() -> Maybe<void> {
-    return mut_opkernel()->ChooseOpKernel(&user_opkernel_, &need_temp_storage_);
+    return mut_opkernel()->ChooseOpKernel(&user_opkernel_, &infer_tmp_size_fn_,
+                                          &need_temp_storage_);
   });
 }
 

--- a/oneflow/core/eager/local_call_opkernel_phy_instr_operand.h
+++ b/oneflow/core/eager/local_call_opkernel_phy_instr_operand.h
@@ -55,7 +55,7 @@ class LocalCallOpKernelPhyInstrOperand final : public vm::PhyInstrOperand {
     return std::shared_ptr<LocalCallOpKernelPhyInstrOperand>(ptr);
   }
 
-  const one::StatefulLocalOpKernel& opkernel() const { return *opkernel_; }
+  const one::StatefulLocalOpKernel& opkernel() const { return *call_ctx_.opkernel; }
   const one::EagerBlobObjectListPtr& inputs() const { return call_ctx_.inputs; }
   const one::EagerBlobObjectListPtr& outputs() const { return call_ctx_.outputs; }
   const AttrMap& attrs() const { return call_ctx_.op_interp_ctx.attrs; }
@@ -64,7 +64,7 @@ class LocalCallOpKernelPhyInstrOperand final : public vm::PhyInstrOperand {
     return dev_vm_dep_object_consume_mode_;
   }
 
-  one::StatefulLocalOpKernel* mut_opkernel() { return opkernel_.get(); }
+  one::StatefulLocalOpKernel* mut_opkernel() { return call_ctx_.opkernel.get(); }
 
   template<typename DoEachT>
   Maybe<void> ForEachOutputTensor(const DoEachT& DoEach) {
@@ -102,7 +102,6 @@ class LocalCallOpKernelPhyInstrOperand final : public vm::PhyInstrOperand {
   void InitStreamSequentialDependence();
 
   eager::CallContext call_ctx_;
-  std::shared_ptr<one::StatefulLocalOpKernel> opkernel_;
   const user_op::OpKernel* user_opkernel_;
   const user_op::InferTmpSizeFn* infer_tmp_size_fn_;
   bool need_temp_storage_;

--- a/oneflow/core/eager/local_call_opkernel_phy_instr_operand.h
+++ b/oneflow/core/eager/local_call_opkernel_phy_instr_operand.h
@@ -90,6 +90,8 @@ class LocalCallOpKernelPhyInstrOperand final : public vm::PhyInstrOperand {
     return call_ctx_.consistent_tensor_infer_result;
   }
 
+  eager::CallContext* mut_call_ctx() { return &call_ctx_; }
+
  private:
   LocalCallOpKernelPhyInstrOperand(
       const std::shared_ptr<one::StatefulLocalOpKernel>& opkernel,

--- a/oneflow/core/eager/local_call_opkernel_phy_instr_operand.h
+++ b/oneflow/core/eager/local_call_opkernel_phy_instr_operand.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "oneflow/core/vm/phy_instr_operand.h"
 #include "oneflow/core/eager/call_context.h"
 #include "oneflow/core/eager/dev_vm_dep_object_consume_mode.h"
+#include "oneflow/core/framework/user_op_kernel_registry.h"
 
 namespace oneflow {
 
@@ -82,6 +83,7 @@ class LocalCallOpKernelPhyInstrOperand final : public vm::PhyInstrOperand {
 
   bool need_temp_storage() const { return need_temp_storage_; }
   const user_op::OpKernel* user_opkernel() const { return user_opkernel_; }
+  const user_op::InferTmpSizeFn& infer_tmp_size_fn() const { return *infer_tmp_size_fn_; }
 
   const std::shared_ptr<const one::ConsistentTensorInferResult>& consistent_tensor_infer_result()
       const {
@@ -102,6 +104,7 @@ class LocalCallOpKernelPhyInstrOperand final : public vm::PhyInstrOperand {
   eager::CallContext call_ctx_;
   std::shared_ptr<one::StatefulLocalOpKernel> opkernel_;
   const user_op::OpKernel* user_opkernel_;
+  const user_op::InferTmpSizeFn* infer_tmp_size_fn_;
   bool need_temp_storage_;
   const one::DevVmDepObjectConsumeMode dev_vm_dep_object_consume_mode_;
   DependenceVector input_dependences_;

--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -80,7 +80,7 @@ struct LocalCallOpKernelUtil final {
 
  private:
   static inline void InferTempStorageBlobDesc(LocalCallOpKernelPhyInstrOperand* operand) {
-    const auto& InferTmpSizeFn = operand->opkernel().GetInferTmpSizeFn(operand->user_opkernel());
+    const auto& InferTmpSizeFn = operand->infer_tmp_size_fn();
     auto* temp_blob_desc = operand->mut_opkernel()->mut_temp_blob_object()->mut_blob_desc();
     CHECK(temp_blob_desc->data_type() == DataType::kChar);
     one::LocalUserOpInferContext* op_infer_ctx =

--- a/oneflow/core/eager/opkernel_instruction_type.cpp
+++ b/oneflow/core/eager/opkernel_instruction_type.cpp
@@ -83,8 +83,7 @@ struct LocalCallOpKernelUtil final {
     const auto& InferTmpSizeFn = operand->infer_tmp_size_fn();
     auto* temp_blob_desc = operand->mut_opkernel()->mut_temp_blob_object()->mut_blob_desc();
     CHECK(temp_blob_desc->data_type() == DataType::kChar);
-    one::LocalUserOpInferContext* op_infer_ctx =
-        operand->opkernel().op_infer_ctx_for_scheduler_thread();
+    one::LocalUserOpInferContext* op_infer_ctx = operand->opkernel().op_infer_ctx();
     size_t temp_size = InferTmpSizeFn(op_infer_ctx);
     temp_blob_desc->mut_shape() = Shape({static_cast<int64_t>(temp_size)});
     temp_blob_desc->set_is_dynamic(true);

--- a/oneflow/user/kernels/stateful_local_opkernel.cpp
+++ b/oneflow/user/kernels/stateful_local_opkernel.cpp
@@ -378,7 +378,7 @@ Maybe<void> InitTensorTupleIndexes4Bns(const std::shared_ptr<const OperatorConf>
 
   const std::string& device_tag = op_conf->device_tag();
   const user_op::UserOpConfWrapper* user_op_conf = opkernel->user_op_conf_.get();
-  opkernel->op_infer_ctx_for_scheduler_thread_.reset(
+  opkernel->op_infer_ctx_.reset(
       new LocalUserOpInferContext(user_op_conf, input_arg_tuple, output_arg_tuple));
   opkernel->compute_ctx_.reset(new LocalUserKernelComputeContext(nullptr, device_tag, user_op_conf,
                                                                  input_arg_tuple, output_arg_tuple,

--- a/oneflow/user/kernels/stateful_local_opkernel.h
+++ b/oneflow/user/kernels/stateful_local_opkernel.h
@@ -387,7 +387,9 @@ class StatefulLocalOpKernel final {
 
   void set_need_check_mem_case(bool value) { need_check_mem_case_ = value; }
 
-  Maybe<void> ChooseOpKernel(const user_op::OpKernel** user_opkernel, bool* need_temp_storage);
+  Maybe<void> ChooseOpKernel(const user_op::OpKernel** user_opkernel,
+                             const user_op::InferTmpSizeFn** infer_tmp_size_fn,
+                             bool* need_temp_storage);
 
   const OperatorConf& op_conf() const { return *op_conf_; }
 
@@ -410,8 +412,6 @@ class StatefulLocalOpKernel final {
 
   bool need_check_mem_case() const { return need_check_mem_case_; }
 
-  const user_op::InferTmpSizeFn& GetInferTmpSizeFn(const user_op::OpKernel* op_kernel) const;
-
   std::shared_ptr<OperatorConf> op_conf_;
   AttrMap base_attrs_;
   std::unique_ptr<user_op::UserOpConfWrapper> user_op_conf_;
@@ -432,7 +432,6 @@ class StatefulLocalOpKernel final {
       dtype2cached_kernels_;
   HashMap<const user_op::OpKernel*, std::shared_ptr<user_op::OpKernelState>> op_kernel_state_map_;
   HashMap<const user_op::OpKernel*, std::shared_ptr<user_op::OpKernelCache>> op_kernel_cache_map_;
-  HashMap<const user_op::OpKernel*, const user_op::InferTmpSizeFn*> infer_tmp_size_fn_map_;
   std::unique_ptr<vm::EagerBlobObject> tmp_blob_object_;
   std::vector<int64_t> input_tuple_indexes4const_ibns_;
   std::vector<int64_t> input_tuple_indexes4mut_ibns_;

--- a/oneflow/user/kernels/stateful_local_opkernel.h
+++ b/oneflow/user/kernels/stateful_local_opkernel.h
@@ -381,9 +381,7 @@ class StatefulLocalOpKernel final {
 
   const AttrMap& base_attrs() const { return base_attrs_; }
 
-  LocalUserOpInferContext* op_infer_ctx_for_scheduler_thread() const {
-    return op_infer_ctx_for_scheduler_thread_.get();
-  }
+  LocalUserOpInferContext* op_infer_ctx() const { return op_infer_ctx_.get(); }
 
   void set_need_check_mem_case(bool value) { need_check_mem_case_ = value; }
 
@@ -417,7 +415,7 @@ class StatefulLocalOpKernel final {
   std::unique_ptr<user_op::UserOpConfWrapper> user_op_conf_;
   Symbol<Stream> stream_;
   std::unique_ptr<LocalUserKernelRegContext> reg_ctx_;
-  std::unique_ptr<LocalUserOpInferContext> op_infer_ctx_for_scheduler_thread_;
+  std::unique_ptr<LocalUserOpInferContext> op_infer_ctx_;
   std::unique_ptr<LocalUserKernelComputeContext> compute_ctx_;
   std::shared_ptr<const ArgTuple> input_arg_tuple_;
   std::shared_ptr<const ArgTuple> output_arg_tuple_;


### PR DESCRIPTION
使StatefullOpKernel完全线程安全，具体来说。
1. 重构StatefullOpKernel里的temp_storage，使之完全线程安全，同时不再依赖EagerBlobObject。
2. 让StatefullOpKernel里的device_ctx，也线程安全。