### PR TITLE
Fix optional MAX_V

### DIFF
--- a/oneflow/core/job_rewriter/adam_optm.cpp
+++ b/oneflow/core/job_rewriter/adam_optm.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 */
 #include "oneflow/core/job_rewriter/optimizer.h"
 #include "oneflow/core/framework/framework.h"
-#include "oneflow/core/operator/operator.h"
 
 namespace oneflow {
 

--- a/oneflow/core/job_rewriter/adam_optm.cpp
+++ b/oneflow/core/job_rewriter/adam_optm.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #include "oneflow/core/job_rewriter/optimizer.h"
 #include "oneflow/core/framework/framework.h"
+#include "oneflow/core/operator/operator.h"
 
 namespace oneflow {
 
@@ -94,12 +95,6 @@ void GenerateOptimizerOpConf(JobPassCtx* ctx, const OpNode& var_op_node,
   const VariableOp* var_op = dynamic_cast<const VariableOp*>(&var_op_node.op());
   CHECK_NOTNULL(var_op);
 
-  OperatorConf m_var(GenerateAdamHelperVariableOpConf(*var_op, "m", 0.f));
-  OperatorConf v_var(GenerateAdamHelperVariableOpConf(*var_op, "v", 0.f));
-  OperatorConf max_v_var(GenerateAdamHelperVariableOpConf(*var_op, "max_v", 0.f));
-
-  job_builder->AddOps(var_op_node.parallel_desc().parallel_conf(), {m_var, v_var, max_v_var});
-
   user_op::UserOpConfWrapperBuilder adam_update_op_builder(var_op->op_name() + "_optimizer");
   float beta1 = 0.9;
   float beta2 = 0.999;
@@ -123,6 +118,17 @@ void GenerateOptimizerOpConf(JobPassCtx* ctx, const OpNode& var_op_node,
   } else {
     UNIMPLEMENTED();
   }
+
+  OperatorConf m_var(GenerateAdamHelperVariableOpConf(*var_op, "m", 0.f));
+  OperatorConf v_var(GenerateAdamHelperVariableOpConf(*var_op, "v", 0.f));
+  OperatorConf max_v_var{};
+  if (amsgrad) {
+    max_v_var = GenerateAdamHelperVariableOpConf(*var_op, "max_v", 0.f);
+    job_builder->AddOps(var_op_node.parallel_desc().parallel_conf(), {m_var, v_var, max_v_var});
+  } else {
+    job_builder->AddOps(var_op_node.parallel_desc().parallel_conf(), {m_var, v_var});
+  }
+
   const std::string& train_step_lbn = job_builder->job().job_conf().train_conf().train_step_lbn();
   const std::string& learning_rate_lbn = optimizer_conf.learning_rate_lbn();
 
@@ -173,7 +179,6 @@ void GenerateOptimizerOpConf(JobPassCtx* ctx, const OpNode& var_op_node,
         .Input("bias_correction2", bias_correction2_lbn)
         .Input("m", GenVariableOutputLbn(m_var))
         .Input("v", GenVariableOutputLbn(v_var))
-        .Input("max_v", GenVariableOutputLbn(max_v_var))
         .Attr<float>("beta1", beta1)
         .Attr<float>("beta2", beta2)
         .Attr<float>("epsilon", epsilon)
@@ -188,7 +193,6 @@ void GenerateOptimizerOpConf(JobPassCtx* ctx, const OpNode& var_op_node,
         .Input("learning_rate", learning_rate_lbn)
         .Input("m", GenVariableOutputLbn(m_var))
         .Input("v", GenVariableOutputLbn(v_var))
-        .Input("max_v", GenVariableOutputLbn(max_v_var))
         .Attr<float>("beta1", beta1)
         .Attr<float>("beta2", beta2)
         .Attr<float>("epsilon", epsilon)
@@ -197,6 +201,9 @@ void GenerateOptimizerOpConf(JobPassCtx* ctx, const OpNode& var_op_node,
         .Attr<bool>("do_bias_correction", false)
         .ScopeSymbolId(var_op->op_conf().scope_symbol_id());
   }
+
+  if (amsgrad) { adam_update_op_builder.Input("max_v", GenVariableOutputLbn(max_v_var)); }
+
   SetDynamicLossScaleSkipIf(ctx, &adam_update_op_builder);
   const auto adam_update_op = adam_update_op_builder.Build();
   job_builder->AddOps(var_op_node.parallel_desc().parallel_conf(), {adam_update_op.op_conf()});

--- a/oneflow/core/job_rewriter/fuse_update_ops_pass.cpp
+++ b/oneflow/core/job_rewriter/fuse_update_ops_pass.cpp
@@ -169,10 +169,12 @@ Maybe<void> FuseUpdateOpsPass::Apply(const OpGraph& op_graph, JobBuilder* job_bu
     } else if (user_op_conf.op_type_name() == "adam_update") {
       fused_op_builder.Input("m", user_op_conf.input("m", 0))
           .Input("v", user_op_conf.input("v", 0))
-          .Input("max_v", user_op_conf.input("max_v", 0))
           .Attr<float>("beta1", user_op_conf.attr<float>("beta1"))
           .Attr<float>("beta2", user_op_conf.attr<float>("beta2"))
           .Attr<float>("epsilon", user_op_conf.attr<float>("epsilon"));
+      if (user_op_conf.has_input("max_v", 0)) {
+        fused_op_builder.Input("max_v", user_op_conf.input("max_v", 0));
+      }
       if (user_op_conf.has_input("bias_correction1", 0)) {
         fused_op_builder.Input("bias_correction1", user_op_conf.input("bias_correction1", 0));
       }

--- a/oneflow/core/job_rewriter/indexed_slices_optimizer_rewrite_pass.cpp
+++ b/oneflow/core/job_rewriter/indexed_slices_optimizer_rewrite_pass.cpp
@@ -117,10 +117,12 @@ Maybe<void> IndexedSlicesOptimizerRewritePass::Apply(const OpGraph& op_graph,
     } else if (user_op_conf.op_type_name() == "adam_update") {
       indexed_slices_op_builder.Input("m", user_op_conf.input("m", 0))
           .Input("v", user_op_conf.input("v", 0))
-          .Input("max_v", user_op_conf.input("max_v", 0))
           .Attr<float>("beta1", user_op_conf.attr<float>("beta1"))
           .Attr<float>("beta2", user_op_conf.attr<float>("beta2"))
           .Attr<float>("epsilon", user_op_conf.attr<float>("epsilon"));
+      if (user_op_conf.has_input("max_v", 0)) {
+        indexed_slices_op_builder.Input("max_v", user_op_conf.input("max_v", 0));
+      }
     } else {
       return;
     }

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -5407,7 +5407,7 @@ def OneFlow_AdamUpdateOp : OneFlow_BaseOp<"adam_update", [NoGrad, AttrSizedOpera
     Optional<OneFlow_Tensor>:$bias_correction2,
     OneFlow_Tensor:$m,
     OneFlow_Tensor:$v,
-    OneFlow_Tensor:$max_v
+    Optional<OneFlow_Tensor>:$max_v
   );
   let attrs = (ins
     DefaultValuedAttr<F32Attr, "0.">:$learning_rate_val,
@@ -5443,7 +5443,7 @@ def OneFlow_IndexedSlicesAdamUpdateOp : OneFlow_BaseOp<"indexed_slices_adam_upda
     Optional<OneFlow_Tensor>:$bias_correction2,
     OneFlow_Tensor:$m,
     OneFlow_Tensor:$v,
-    OneFlow_Tensor:$max_v
+    Optional<OneFlow_Tensor>:$max_v
   );
   let attrs = (ins
     DefaultValuedAttr<F32Attr, "0.">:$learning_rate_val,

--- a/oneflow/user/kernels/model_update_kernels.cpp
+++ b/oneflow/user/kernels/model_update_kernels.cpp
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#include "glog/logging.h"
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/user/kernels/model_update_kernel_util.h"
 #include "oneflow/user/kernels/indexed_slices_reduce_sum_kernel_util.h"

--- a/python/oneflow/nn/optimizer/adam.py
+++ b/python/oneflow/nn/optimizer/adam.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import collections
 import math
 from typing import Callable, Dict, Iterator, List, Tuple, Union
 
@@ -143,13 +142,22 @@ class Adam(Optimizer):
                 assert param.is_leaf, "parameters must be leaf tensor"
                 self._state[param] = dict()
 
-        self._op = (
+        self._op_with_amsgrad = (
             flow.stateful_op("adam_update")
             .Input("model")
             .Input("model_diff")
             .Input("m")
             .Input("v")
             .Input("max_v")
+            .Build()
+        )
+
+        self._op_without_amsgrad = (
+            flow.stateful_op("adam_update")
+            .Input("model")
+            .Input("model_diff")
+            .Input("m")
+            .Input("v")
             .Build()
         )
 
@@ -192,16 +200,28 @@ class Adam(Optimizer):
                         self._state[param]["exp_avg"] = flow.zeros_like(param)
                     if "exp_avg_sq" not in self._state[param]:
                         self._state[param]["exp_avg_sq"] = flow.zeros_like(param)
-                    if "max_exp_avg_sq" not in self._state[param]:
-                        self._state[param]["max_exp_avg_sq"] = flow.zeros_like(param)
+                    if param_group["amsgrad"]:
+                        if "max_exp_avg_sq" not in self._state[param]:
+                            self._state[param]["max_exp_avg_sq"] = flow.zeros_like(
+                                param
+                            )
+
                     m_tensor = self._state[param]["exp_avg"]
                     v_tensor = self._state[param]["exp_avg_sq"]
-                    max_v_tensor = self._state[param]["max_exp_avg_sq"]
-                    flow._C.dispatch_adam_update(
-                        self._op,
-                        (param, param.grad, m_tensor, v_tensor, max_v_tensor),
-                        **kwargs,
-                    )
+
+                    if param_group["amsgrad"]:
+                        max_v_tensor = self._state[param]["max_exp_avg_sq"]
+                        flow._C.dispatch_adam_update(
+                            self._op_with_amsgrad,
+                            (param, param.grad, m_tensor, v_tensor, max_v_tensor),
+                            **kwargs,
+                        )
+                    else:
+                        flow._C.dispatch_adam_update(
+                            self._op_without_amsgrad,
+                            (param, param.grad, m_tensor, v_tensor),
+                            **kwargs,
+                        )
 
             self._state["step"] += 1
 

--- a/python/oneflow/nn/optimizer/adamw.py
+++ b/python/oneflow/nn/optimizer/adamw.py
@@ -145,13 +145,21 @@ class AdamW(Optimizer):
                 assert param.is_leaf, "parameters must be leaf tensor"
                 self._state[param] = dict()
 
-        self._op = (
+        self._op_with_amsgrad = (
             flow.stateful_op("adam_update")
             .Input("model")
             .Input("model_diff")
             .Input("m")
             .Input("v")
             .Input("max_v")
+            .Build()
+        )
+        self._op_without_amsgrad = (
+            flow.stateful_op("adam_update")
+            .Input("model")
+            .Input("model_diff")
+            .Input("m")
+            .Input("v")
             .Build()
         )
 
@@ -195,16 +203,27 @@ class AdamW(Optimizer):
                         self._state[param]["exp_avg"] = flow.zeros_like(param)
                     if "exp_avg_sq" not in self._state[param]:
                         self._state[param]["exp_avg_sq"] = flow.zeros_like(param)
-                    if "max_exp_avg_sq" not in self._state[param]:
-                        self._state[param]["max_exp_avg_sq"] = flow.zeros_like(param)
+                    if param_group["amsgrad"]:
+                        if "max_exp_avg_sq" not in self._state[param]:
+                            self._state[param]["max_exp_avg_sq"] = flow.zeros_like(
+                                param
+                            )
                     m_tensor = self._state[param]["exp_avg"]
                     v_tensor = self._state[param]["exp_avg_sq"]
-                    max_v_tensor = self._state[param]["max_exp_avg_sq"]
-                    flow._C.dispatch_adam_update(
-                        self._op,
-                        (param, param.grad, m_tensor, v_tensor, max_v_tensor),
-                        **kwargs,
-                    )
+
+                    if param_group["amsgrad"]:
+                        max_v_tensor = self._state[param]["max_exp_avg_sq"]
+                        flow._C.dispatch_adam_update(
+                            self._op_with_amsgrad,
+                            (param, param.grad, m_tensor, v_tensor, max_v_tensor),
+                            **kwargs,
+                        )
+                    else:
+                        flow._C.dispatch_adam_update(
+                            self._op_without_amsgrad,
+                            (param, param.grad, m_tensor, v_tensor),
+                            **kwargs,
+                        )
 
             self._state["step"] += 1
             return loss

--- a/python/oneflow/test/modules/test_optim_adam.py
+++ b/python/oneflow/test/modules/test_optim_adam.py
@@ -77,9 +77,7 @@ def compare_with_numpy_adam(
             train_one_iter(random_grad_seq[i])
             if i == reload_state_step:
                 state_dict = adam.state_dict()
-                adam = flow.optim.Adam(
-                    [{"params": [x],}], do_bias_correction=do_bias_correction,
-                )
+                adam = flow.optim.Adam([{"params": [x],}],)
                 if save_load_by_pickle:
                     with tempfile.TemporaryDirectory() as save_dir:
                         flow.save(state_dict, save_dir)
@@ -185,9 +183,7 @@ def compare_with_numpy_adam_clip_grad(
             train_one_iter(random_grad_seq[i])
             if i == reload_state_step:
                 state_dict = adam.state_dict()
-                adam = flow.optim.Adam(
-                    [{"params": [x],}], do_bias_correction=do_bias_correction,
-                )
+                adam = flow.optim.Adam([{"params": [x],}])
                 if save_load_by_pickle:
                     with tempfile.TemporaryDirectory() as save_dir:
                         flow.save(state_dict, save_dir)


### PR DESCRIPTION
以往Adam/AdamW无论开不开启 amsgrad 都会额外设置一块 max_v 显存

该PR将amsgrad所需要的max_v tensor设置为optional，只会在amsgrad才会存储相关变量

经过欧阳测试，关闭amsgrad后显存显著降低1000Mb