### PR TITLE
Merge optimizer pass ops to fw bw chain for memory reury reuse

### DIFF
--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -100,11 +100,6 @@ bool IsSpecialOpNotConsiderMergeInChain(const Operator* op) {
       return true;
     }
   }
-  // NOTE(chengcheng): ONLY nccl_use_compute_stream = false will exclude optimizer pass ops
-  if (!Global<ResourceDesc, ForSession>::Get()->nccl_use_compute_stream()
-      && IsOptimizerPassOp(op)) {
-    return true;
-  }
   return false;
 }
 


### PR DESCRIPTION
之前处于谨慎起见，让 Optimizer 部分的 op 没有参与内存复用。但是在 amp 情况下， Optimizer 子图还是比较重度的，必须参与复用才能得到良好的内存表现。