### PR TITLE
nccl use compute stream default true

### DIFF
--- a/oneflow/core/job/resource.proto
+++ b/oneflow/core/job/resource.proto
@@ -53,7 +53,7 @@ message Resource {
   optional CollectiveBoxingConf collective_boxing_conf = 19;
 
   // NOTE(chengcheng) to reuse nccl memory and speed up
-  optional bool nccl_use_compute_stream = 30 [default = false];
+  optional bool nccl_use_compute_stream = 30 [default = true];
   optional bool disable_group_boxing_by_dst_parallel = 31 [default = false];
 
   optional CudnnConfig cudnn_conf = 32;


### PR DESCRIPTION
将 nccl.use_compute_stream 默认置为 true。 内存资源认为是比计算资源更紧俏的资源。
