### PR TITLE
Add feature stage

### DIFF
--- a/python/oneflow/nn/graph/block_config.py
+++ b/python/oneflow/nn/graph/block_config.py
@@ -19,6 +19,8 @@ class BlockConfig(object):
     r"""Configurations on Module Block in nn.Graph.
 
     When an nn.Module is added into an nn.Graph, it is wrapped into a ModuleBlock. You can set or get optimization configs on an nn.Module with it's `ModuleBlock.config`. 
+
+    This feature is in Beta Stage.
     """
 
     def __init__(self):
@@ -43,6 +45,7 @@ class BlockConfig(object):
             self.module_pipeline.m_stage0.config.stage_id = 0
             self.module_pipeline.m_stage1.config.stage_id = 1
 
+        This feature is in Beta Stage.
         """
         return self._stage_id
 
@@ -80,6 +83,7 @@ class BlockConfig(object):
 
             graph = Graph()
 
+        This feature is in Beta Stage.
         """
         return self._activation_checkpointing
 

--- a/python/oneflow/nn/graph/graph.py
+++ b/python/oneflow/nn/graph/graph.py
@@ -87,6 +87,8 @@ class Graph(object):
 
     Note:
         nn.Graph cannot be nested at the moment.
+
+    This feature is in Beta Stage.
     """
     _child_init_cnt = dict()
 
@@ -105,7 +107,8 @@ class Graph(object):
             ...         # Then define the graph attributes
             ...     def build(self):
             ...         pass
-
+        
+        This feature is in RC Stage.
         """
         self._generate_name()
         self.config = GraphConfig()
@@ -177,6 +180,7 @@ class Graph(object):
             * ``Tensor``
             * ``None``
 
+        This feature is in RC Stage.
         """
         raise NotImplementedError()
 
@@ -201,6 +205,8 @@ class Graph(object):
             will do the computaion graph generation and optimization at the first call.
 
             Donot override this function.
+
+        This feature is in RC Stage.
         """
         if not self._is_compiled:
             with graph_build_util.GLogScopeContext(
@@ -274,6 +280,8 @@ class Graph(object):
             optim (oneflow.optim.Optimizer): The optimizer.
             lr_sch : The learning rate scheduler, see oneflow.optim.lr_scheduler.
             is_sparse: When set to be True, treat optim as a sparse optimizer. Default is False.
+
+        This feature is in Beta Stage.
         """
         opt_dict = dict()
         assert optim is not None, "optimizer cannot be None"
@@ -301,6 +309,8 @@ class Graph(object):
 
     def set_grad_scaler(self, grad_scaler: GradScaler = None):
         r"""Set the GradScaler for gradient and loss scaling.
+
+        This feature is in Alpha Stage.
         """
         assert isinstance(grad_scaler, (GradScaler, StaticGradScaler))
         self._grad_scaler = grad_scaler
@@ -321,6 +331,7 @@ class Graph(object):
         Returns:
             dict: a dictionary containing the whole state of the graph.
 
+        This feature is in Beta Stage.
         """
         # Sync to make sure states has been updated.
         oneflow._oneflow_internal.eager.Sync()
@@ -374,6 +385,8 @@ class Graph(object):
 
         Note:
             nn.Graph's state dict can only be loaded before the first call of a graph.
+
+        This feature is in Beta Stage.
         """
         assert (
             not self._is_compiled
@@ -402,14 +415,10 @@ class Graph(object):
     @property
     def name(self):
         r"""Name auto-generated for this graph.
+
+        This feature is in Beta Stage.
         """
         return self._name
-
-    @property
-    def training(self):
-        r"""In traninig mode if the graph has an optimizer.
-        """
-        return self.config.training
 
     def debug(
         self,
@@ -445,6 +454,8 @@ class Graph(object):
             ranks (int or list(int)): choose ranks to print the debug information. Default rank ``0``.
                 You can choose any valid rank. Ranks equals ``-1`` means debug on all ranks.
             mode (bool): whether to set debug mode (``True``) or not (``False``). Default: ``True``.
+
+        This feature is in Beta Stage.
         """
         assert isinstance(v_level, int)
         assert v_level >= 0, "The min verbose debug info level is 0."
@@ -488,6 +499,7 @@ class Graph(object):
             out_tensors = g(input_tensors)
             print(g) # Inputs and Outputs infos are added
 
+        This feature is in Beta Stage.
         """
         child_lines = []
         child_lines.append(add_indent(repr(self.config), 2))
@@ -1128,6 +1140,8 @@ class Graph(object):
             (MODULE:linear:Linear(in_features=3, out_features=8, bias=False)): (
               (PARAMETER:linear.weight:tensor(..., size=(8, 3), dtype=oneflow.float32, requires_grad=True)): ()
             )
+
+        This feature is in Beta Stage.
         """
         if "_name" not in self.__dict__:
             raise AttributeError(

--- a/python/oneflow/nn/graph/graph_config.py
+++ b/python/oneflow/nn/graph/graph_config.py
@@ -23,6 +23,8 @@ import oneflow._oneflow_internal.oneflow.core.job.job_conf as job_conf_cfg
 
 class GraphConfig(object):
     r"""For configuration of nn.Graph.
+
+    This feature is in Beta Stage.
     """
 
     def __init__(self):
@@ -58,6 +60,7 @@ class GraphConfig(object):
 
         Args:
             value (int): graph ouputs buffer size.
+        This feature is in Alpha Stage.
         """
         self._outputs_buffer_size = value
 
@@ -82,6 +85,8 @@ class GraphConfig(object):
 
         Args:
             mode (bool, optional): The default vaule is True.
+
+        This feature is in Beta Stage.
         """
         assert type(mode) is bool
         self.proto.set_enable_auto_mixed_precision(mode)
@@ -107,6 +112,8 @@ class GraphConfig(object):
 
         Args:
             mode (bool, optional): The default vaule is True.
+
+        This feature is in Alpha Stage.
         """
         self.proto.set_enable_fuse_model_update_ops(mode)
 
@@ -133,6 +140,8 @@ class GraphConfig(object):
 
         Args:
             mode (bool, optional): The default vaule is True.
+
+        This feature is in Alpha Stage.
         """
         self.proto.set_enable_fuse_add_to_output(mode)
 
@@ -160,6 +169,8 @@ class GraphConfig(object):
 
         Args:
             mode (bool, optional): The default vaule is True.
+
+        This feature is in Alpha Stage.
         """
         self.proto.set_enable_fuse_cast_scale(mode)
 
@@ -185,6 +196,8 @@ class GraphConfig(object):
 
         Args:
             value (int): num of steps.
+
+        This feature is in Alpha Stage.
         """
         self.proto.set_num_gradient_accumulation_steps(value)
 
@@ -213,6 +226,8 @@ class GraphConfig(object):
             mode (str): "distributed_split" or "non_distributed". "distributed_split" mode
                          will shard each optimizer state across devices. "non_distributed" mode
                          will place each optimizer state to only one device.
+
+        This feature is in Beta Stage.
         """
         assert mode in ("distributed_split", "non_distributed")
         self.proto.set_optimizer_placement_optimization_mode(mode)
@@ -239,6 +254,8 @@ class GraphConfig(object):
 
         Args:
             value (int): min size value.
+
+        This feature is in Beta Stage.
         """
         assert isinstance(value, int)
         assert value >= 1
@@ -275,6 +292,8 @@ class GraphConfig(object):
 
         Args:
             value (bool, optional): The default vaule is True.
+
+        This feature is in Beta Stage.
         """
         self.proto.mutable_xrt_config().set_use_xla_jit(value)
 
@@ -309,6 +328,8 @@ class GraphConfig(object):
 
         Args:
             value (bool, optional): The default vaule is True.
+
+        This feature is in Beta Stage.
         """
         self.proto.mutable_xrt_config().set_use_tensorrt(value)
 
@@ -341,6 +362,8 @@ class GraphConfig(object):
 
         Args:
             value (bool, optional): The default vaule is True.
+
+        This feature is in Beta Stage.
         """
         self.proto.mutable_xrt_config().set_use_openvino(value)
 
@@ -366,6 +389,8 @@ class GraphConfig(object):
     
         Args:
             mode (bool, optional): The default vaule is True.
+
+        This feature is in Alpha Stage.
         """
         self.proto.set_cudnn_conv_heuristic_search_algo(mode)
 


### PR DESCRIPTION
给API Doc加上Feature成熟度分级：
- 标记所有用户接口的状态
- 让用户有大致的预期，不会过高、也不过低
- 指导我们的开发，把Feature从早期推向成熟，通过搜索就能知道当前Feature状态
- 为发布提供细粒度的参考依据，我们哪些feature的stage进步了

## Feature Stage
- Alpah Stage
  - 完成了基本功能，通过了白盒单测
  - 早期特性，后面可能会修改
  - 提供了API Doc
- Beta Stage
  - 功能完备
  - 通过了特意构造的更多样的Corner Case覆盖
  - 提供了Tutorial Doc
  - 设计稳定了，但是还有修改的可能
  - 种子用户实际用例中要小心翼翼，还有待解决的Bug
- Release candidate Stage(RC)
  - 功能完备、性能稳定，有比较严谨的验证和说明，达到上生产环境标准了；
  - 被一定范围内的种子用户实际使用过
  - 在新用户的测试使用中比较稳定的工作
  - 出错收敛，出错提示友好
  - 确定代码、文档基本不会改动了
- Stable Stage
  - 通过了上面的所有阶段
  - 在用户实际用例中几乎没有bug
  - 承诺用户后面基本不会再改动了，保证接口的稳定性

参考资料：
- https://en.wikipedia.org/wiki/Software_release_life_cycle
- https://agones.dev/site/docs/guides/feature-stages/
- https://www.leewayhertz.com/software-release-process/
- [PyTorch beta feature](https://github.com/pytorch/pytorch/search?q=%22beta+feature%22)
- [PyTorch is beta](https://github.com/pytorch/pytorch/search?q=%22in+beta%22)