### PR TITLE
fix tensor method docstr bug

### DIFF
--- a/python/oneflow/framework/docstr/tensor.py
+++ b/python/oneflow/framework/docstr/tensor.py
@@ -335,6 +335,20 @@ add_docstr(
 )
 
 add_docstr(
+    oneflow.Tensor.sqrt,
+    """
+    See :func:`oneflow.sqrt`
+    """,
+)
+
+add_docstr(
+    oneflow.Tensor.square,
+    """
+    See :func:`oneflow.square`
+    """,
+)
+
+add_docstr(
     oneflow.Tensor.std,
     """
     See :func:`oneflow.std`
@@ -859,6 +873,13 @@ add_docstr(
 )
 
 add_docstr(
+    oneflow.Tensor.addmm,
+    """
+    See :func:`oneflow.addmm`
+    """,
+)
+
+add_docstr(
     oneflow.Tensor.add_,
     """
     In-place version of :func:`oneflow.Tensor.add`.
@@ -899,6 +920,41 @@ add_docstr(
     oneflow.Tensor.cos,
     """
     See :func:`oneflow.cos`
+    """,
+)
+
+add_docstr(
+    oneflow.Tensor.diagonal,
+    """
+    See :func:`oneflow.diagonal`
+    """,
+)
+
+add_docstr(
+    oneflow.Tensor.log,
+    """
+    See :func:`oneflow.log`
+    """,
+)
+
+add_docstr(
+    oneflow.Tensor.ndim,
+    """
+    See :func:`oneflow.Tensor.dim`
+    """,
+)
+
+add_docstr(
+    oneflow.Tensor.rsqrt,
+    """
+    See :func:`oneflow.rsqrt`
+    """,
+)
+
+add_docstr(
+    oneflow.Tensor.cosh,
+    """
+    See :func:`oneflow.cosh`
     """,
 )
 


### PR DESCRIPTION
修复了一部分Tensor方法没有docstr的bug。
- [x] sqrt
- [x] square
- [x] addmm
- [x] cosh
- [x] diagonal
- [x] log
- [x] ndim
- [x] rsqrt

剩下的：
- [ ] stride
- [ ] clone
- [ ] data
- [ ] detach
- [ ] dtype
- [ ] shape

是通过pybind11直接导出的，直接设置docstr会触发错误，后面需要和迟哥讨论一下再解决。

```shell
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/zhangxiaoyu/oneflow/python/oneflow/__init__.py", line 401, in <module>
    import oneflow.framework.docstr as docstr
  File "/home/zhangxiaoyu/oneflow/python/oneflow/framework/docstr/__init__.py", line 30, in <module>
    from .tensor import *
  File "/home/zhangxiaoyu/oneflow/python/oneflow/framework/docstr/tensor.py", line 1563, in <module>
    add_docstr(
  File "/home/zhangxiaoyu/oneflow/python/oneflow/framework/docstr/utils.py", line 32, in add_docstr
    return oneflow._oneflow_internal.add_doc(fun, docstr)
oneflow._oneflow_internal.exception.RuntimeException: 
  File "/home/zhangxiaoyu/oneflow/oneflow/api/python/framework/doc.cpp", line 56, in AddFunctionDoc
    RuntimeError: function is instancemethod, not a valid function.
>>> exit()
```

最后：norm这个算子的docstr比较复杂，设计到pytorch的新老接口替换的问题，也需要再讨论一下。

这个pr可以先合并，以下是本次补充的docstr的截图。


![image](https://user-images.githubusercontent.com/35585791/159107122-96bdfa77-0b35-4846-ae21-909cfd1cf3b1.png)

![image](https://user-images.githubusercontent.com/35585791/159107129-6a5fbfb5-197a-4aa7-a36d-30227d3859f5.png)

![image](https://user-images.githubusercontent.com/35585791/159107135-cc28e360-bb93-4b70-a399-6a3d4823e3cb.png)

![image](https://user-images.githubusercontent.com/35585791/159107142-f3ff8bf6-af9b-46cc-9cb3-f7628d4f6898.png)

![image](https://user-images.githubusercontent.com/35585791/159107147-6efc2fb7-1bf8-433a-a170-9c323e95244a.png)

![image](https://user-images.githubusercontent.com/35585791/159107173-3ba72f25-f1c5-4f75-a2c9-6776f8a1947e.png)

![image](https://user-images.githubusercontent.com/35585791/159107180-13730062-baed-4f46-b17c-008428d77f3f.png)

