### PR TITLE
Align to api with torch

### DIFF
--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -817,6 +817,7 @@ def _format(self, format_spec):
 
 def _to(self, *args, **kwargs):
     new_args = list()
+    # If device is single int, replace it with flow.device("cuda:{device}")
     if len(args) > 0 and isinstance(args[0], int):
         new_args.append(flow.device(f"cuda:{args[0]}"))
         for i in range(1, len(args)):

--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -817,13 +817,12 @@ def _format(self, format_spec):
 
 def _to(self, *args, **kwargs):
     new_args = list()
-    if len(args) > 0:
-        if isinstance(args[0], int):
-            new_args.append(flow.device(f"cuda:{args[0]}"))
-        else:
-            new_args.append(args[0])
-    for i in range(1, len(args)):
-        new_args.append(args[i])
+    if len(args) > 0 and isinstance(args[0], int):
+        new_args.append(flow.device(f"cuda:{args[0]}"))
+        for i in range(1, len(args)):
+            new_args.append(args[i])
+    else:
+        new_args = args
     if ("device" in kwargs) and isinstance(kwargs["device"], int):
         kwargs["device"] = flow.device(f"cuda:{kwargs['device']}")
     return flow._C.to(self, *new_args, **kwargs)

--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -824,8 +824,8 @@ def _to(self, *args, **kwargs):
             new_args.append(args[0])
     for i in range(1, len(args)):
         new_args.append(args[i])
-    if ('device' in kwargs) and isinstance(kwargs['device'], int):
-        kwargs['device'] = flow.device(f"cuda:{kwargs['device']}")
+    if ("device" in kwargs) and isinstance(kwargs["device"], int):
+        kwargs["device"] = flow.device(f"cuda:{kwargs['device']}")
     return flow._C.to(self, *new_args, **kwargs)
 
 

--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -816,7 +816,17 @@ def _format(self, format_spec):
 
 
 def _to(self, *args, **kwargs):
-    return flow._C.to(self, *args, **kwargs)
+    new_args = list()
+    if len(args) > 0:
+        if isinstance(args[0], int):
+            new_args.append(flow.device(f"cuda:{args[0]}"))
+        else:
+            new_args.append(args[0])
+    for i in range(1, len(args)):
+        new_args.append(args[i])
+    if ('device' in kwargs) and isinstance(kwargs['device'], int):
+        kwargs['device'] = flow.device(f"cuda:{kwargs['device']}")
+    return flow._C.to(self, *new_args, **kwargs)
 
 
 def _to_global(self, placement=None, sbp=None, grad_sbp=None):

--- a/python/oneflow/test/modules/test_tensor_to.py
+++ b/python/oneflow/test/modules/test_tensor_to.py
@@ -21,6 +21,8 @@ import numpy as np
 import oneflow as flow
 import oneflow.unittest
 
+from oneflow.test_utils.automated_test_util import *
+
 
 @flow.unittest.skip_unless_1n2d()
 @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
@@ -166,6 +168,17 @@ class TestTo(flow.unittest.TestCase):
         test_case.assertEqual(output.dtype, flow.int)
         test_case.assertEqual(output.device, flow.device("cuda"))
 
+    @autotest(check_graph=True)
+    def test_int_to_args(test_case):
+        device_num = random(0, 2).to(int).value()
+        x = random_tensor(ndim=4).to(device_num)
+        return x
+    
+    @autotest(check_graph=True)
+    def test_int_to_kwargs(test_case):
+        device_num = random(0, 2).to(int).value()
+        x = random_tensor(ndim=4).to(device=device_num)
+        return x
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/oneflow/test/modules/test_tensor_to.py
+++ b/python/oneflow/test/modules/test_tensor_to.py
@@ -173,12 +173,13 @@ class TestTo(flow.unittest.TestCase):
         device_num = random(0, 2).to(int).value()
         x = random_tensor(ndim=4).to(device_num)
         return x
-    
+
     @autotest(check_graph=True)
     def test_int_to_kwargs(test_case):
         device_num = random(0, 2).to(int).value()
         x = random_tensor(ndim=4).to(device=device_num)
         return x
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/oneflow/test/modules/test_tensor_to.py
+++ b/python/oneflow/test/modules/test_tensor_to.py
@@ -168,13 +168,13 @@ class TestTo(flow.unittest.TestCase):
         test_case.assertEqual(output.dtype, flow.int)
         test_case.assertEqual(output.device, flow.device("cuda"))
 
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_int_to_args(test_case):
         device_num = random(0, 2).to(int).value()
         x = random_tensor(ndim=4).to(device_num)
         return x
 
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_int_to_kwargs(test_case):
         device_num = random(0, 2).to(int).value()
         x = random_tensor(ndim=4).to(device=device_num)


### PR DESCRIPTION
支持tensor to方法传single int参数，即tensor.to(1)，tensor.to(device=1)这种用法。单测通过。

关联：https://github.com/Oneflow-Inc/OneTeam/issues/1207#issuecomment-1073432125
