### PR TITLE
add searchsorted op

### DIFF
--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -180,6 +180,10 @@
   signature: "Tensor (Tensor dz, Tensor x, Tensor y) => PowYGrad"
   bind_python: False
 
+- name: "searchsorted"
+  signature: 'Tensor (Tensor sorted_sequence, Tensor values, Tensor sorter=None, Bool out_int32=False, Bool right=False, String side="left") => SearchSorted'
+  bind_python: True
+
 - name: "scalar_pow_grad"
   signature: "Tensor (Tensor input, Tensor dy, Scalar exponent) => ScalarPowGrad"
   bind_python: False

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -181,7 +181,11 @@
   bind_python: False
 
 - name: "searchsorted"
-  signature: 'Tensor (Tensor sorted_sequence, Tensor values, Tensor sorter=None, Bool out_int32=False, Bool right=False, String side="left") => SearchSorted'
+  signature:
+    [
+      'Tensor (Tensor sorted_sequence, Tensor values, Tensor sorter=None, Bool out_int32=False, Bool right=False) => SearchSorted',
+      'Tensor (Tensor sorted_sequence, Scalar values, Tensor sorter=None, Bool out_int32=False, Bool right=False) => SearchSortedScalar',
+    ]
   bind_python: True
 
 - name: "scalar_pow_grad"

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -183,8 +183,8 @@
 - name: "searchsorted"
   signature:
     [
-      'Tensor (Tensor sorted_sequence, Tensor values, Tensor sorter=None, Bool out_int32=False, Bool right=False) => SearchSorted',
-      'Tensor (Tensor sorted_sequence, Scalar values, Tensor sorter=None, Bool out_int32=False, Bool right=False) => SearchSortedScalar',
+      "Tensor (Tensor sorted_sequence, Tensor values, Bool out_int32=False, Bool right=False, Tensor sorter=None) => SearchSorted",
+      "Tensor (Tensor sorted_sequence, Scalar values, Bool out_int32=False, Bool right=False, Tensor sorter=None) => SearchSortedScalar",
     ]
   bind_python: True
 

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -970,6 +970,8 @@ class SearchSortedFunctor {
     JUST(attrs.SetAttr<bool>("out_int32", out_int32));
     JUST(attrs.SetAttr<bool>("right", right));
     if (sorter) {
+      CHECK_OR_RETURN(IsShapeMatch(sorted_sequence, JUST(sorter))) << "for searchsorted op, boundary and sorter must have the same size";
+      CHECK_OR_RETURN(JUST(sorter)->dtype()->data_type() == DataType::kInt64) << "for searchsorted op, sorter must be a tensor of long";
       return OpInterpUtil::Dispatch<Tensor>(*op_, {sorted_sequence, values, JUST(sorter)}, attrs);
     } else {
       return OpInterpUtil::Dispatch<Tensor>(*no_sorter_op_, {sorted_sequence, values}, attrs);
@@ -1017,6 +1019,8 @@ class SearchSortedScalarFunctor {
       JUST(attrs.SetAttr<double>("values", values_tmp));
     }
     if (sorter) {
+      CHECK_OR_RETURN(IsShapeMatch(sorted_sequence, JUST(sorter))) << "for searchsorted op, boundary and sorter must have the same size";
+      CHECK_OR_RETURN(JUST(sorter)->dtype()->data_type() == DataType::kInt64) << "for searchsorted op, sorter must be a tensor of long";
       return OpInterpUtil::Dispatch<Tensor>(*op_, {sorted_sequence, JUST(sorter)}, attrs);
     } else {
       return OpInterpUtil::Dispatch<Tensor>(*no_sorter_op_, {sorted_sequence}, attrs);

--- a/oneflow/core/functional/impl/common.cpp
+++ b/oneflow/core/functional/impl/common.cpp
@@ -28,6 +28,22 @@ bool IsInplaceValid(const std::shared_ptr<Tensor>& x) {
   return !autograd::GradMode::is_enabled() || !(x->is_leaf() && x->requires_grad());
 }
 
+bool IsShapeMatchBeforeLastDim(const std::shared_ptr<Tensor>& x, const std::shared_ptr<Tensor>& y) {
+  if (x->shape()->NumAxes() != y->shape()->NumAxes()) {
+    LOG(WARNING) << "ERROR1: " << x->shape()->NumAxes() << " " << y->shape()->NumAxes();
+    return false;
+  }
+  const auto& x_shape = x->shape();
+  const auto& y_shape = y->shape();
+  for (int64_t i = 0; i < x_shape->NumAxes()-1; ++i) {
+    if (x_shape->At(i) != y_shape->At(i)) {
+      LOG(WARNING) << "ERROR2: " << i << " " << x_shape->At(i) << " " << y_shape->At(i);
+      return false;
+    }
+  }
+  return true;
+}
+
 Maybe<void> CheckAxis(std::vector<int32_t>& axis, const Shape& shape) {
   int32_t ndim = shape.NumAxes();
   if (axis.size() == 0) {

--- a/oneflow/core/functional/impl/common.cpp
+++ b/oneflow/core/functional/impl/common.cpp
@@ -30,14 +30,26 @@ bool IsInplaceValid(const std::shared_ptr<Tensor>& x) {
 
 bool IsShapeMatchBeforeLastDim(const std::shared_ptr<Tensor>& x, const std::shared_ptr<Tensor>& y) {
   if (x->shape()->NumAxes() != y->shape()->NumAxes()) {
-    LOG(WARNING) << "ERROR1: " << x->shape()->NumAxes() << " " << y->shape()->NumAxes();
     return false;
   }
   const auto& x_shape = x->shape();
   const auto& y_shape = y->shape();
   for (int64_t i = 0; i < x_shape->NumAxes()-1; ++i) {
     if (x_shape->At(i) != y_shape->At(i)) {
-      LOG(WARNING) << "ERROR2: " << i << " " << x_shape->At(i) << " " << y_shape->At(i);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsShapeMatch(const std::shared_ptr<Tensor>& x, const std::shared_ptr<Tensor>& y) {
+  if (x->shape()->NumAxes() != y->shape()->NumAxes()) {
+    return false;
+  }
+  const auto& x_shape = x->shape();
+  const auto& y_shape = y->shape();
+  for (int64_t i = 0; i < x_shape->NumAxes(); ++i) {
+    if (x_shape->At(i) != y_shape->At(i)) {
       return false;
     }
   }

--- a/oneflow/core/functional/impl/common.h
+++ b/oneflow/core/functional/impl/common.h
@@ -29,6 +29,7 @@ static constexpr size_t kMaxOutputCount = 128;
 bool IsStaticZerosTensor(const std::shared_ptr<Tensor>& x);
 bool IsInplaceValid(const std::shared_ptr<Tensor>& x);
 bool IsShapeCanExpandTo(const Shape& shape, const Shape& expand_shape);
+bool IsShapeMatchBeforeLastDim(const std::shared_ptr<Tensor>& x, const std::shared_ptr<Tensor>& y);
 
 Maybe<void> CheckAxis(std::vector<int32_t>& axis, const Shape& shape);
 Maybe<void> CheckInplaceValid(const std::shared_ptr<Tensor>& x);

--- a/oneflow/core/functional/impl/common.h
+++ b/oneflow/core/functional/impl/common.h
@@ -30,6 +30,7 @@ bool IsStaticZerosTensor(const std::shared_ptr<Tensor>& x);
 bool IsInplaceValid(const std::shared_ptr<Tensor>& x);
 bool IsShapeCanExpandTo(const Shape& shape, const Shape& expand_shape);
 bool IsShapeMatchBeforeLastDim(const std::shared_ptr<Tensor>& x, const std::shared_ptr<Tensor>& y);
+bool IsShapeMatch(const std::shared_ptr<Tensor>& x, const std::shared_ptr<Tensor>& y);
 
 Maybe<void> CheckAxis(std::vector<int32_t>& axis, const Shape& shape);
 Maybe<void> CheckInplaceValid(const std::shared_ptr<Tensor>& x);

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -3077,6 +3077,27 @@ def OneFlow_ScatterNdLikeOp : OneFlow_BaseOp<"scatter_nd_like", [NoSideEffect, D
   let has_data_type_infer_fn = 1;
 }
 
+def OneFlow_SearchSortedOp : OneFlow_BaseOp<"searchsorted", [NoSideEffect, NoGrad, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+  let input = (ins
+    OneFlow_Tensor:$sorted_sequence,
+    OneFlow_Tensor:$values,
+    Optional<OneFlow_Tensor>:$sorter
+  );
+  let output = (outs
+    OneFlow_Tensor:$out
+  );
+  let attrs = (ins
+    DefaultValuedAttr<BoolAttr, "false">:$out_int32,
+    DefaultValuedAttr<BoolAttr, "false">:$right,
+    DefaultValuedAttr<StrAttr, "\"left\"">:$side
+  );
+  let has_check_fn = 1;
+  let has_logical_tensor_desc_infer_fn = 1;
+  let has_physical_tensor_desc_infer_fn = 1;
+  let has_get_sbp_fn = 1;
+  let has_data_type_infer_fn = 1;
+}
+
 def OneFlow_SliceOp : OneFlow_BaseOp<"slice", [NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
     OneFlow_Tensor:$x

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -3088,8 +3088,7 @@ def OneFlow_SearchSortedOp : OneFlow_BaseOp<"searchsorted", [NoSideEffect, NoGra
   );
   let attrs = (ins
     DefaultValuedAttr<BoolAttr, "false">:$out_int32,
-    DefaultValuedAttr<BoolAttr, "false">:$right,
-    DefaultValuedAttr<StrAttr, "\"left\"">:$side
+    DefaultValuedAttr<BoolAttr, "false">:$right
   );
   let has_check_fn = 1;
   let has_logical_tensor_desc_infer_fn = 1;
@@ -3097,6 +3096,27 @@ def OneFlow_SearchSortedOp : OneFlow_BaseOp<"searchsorted", [NoSideEffect, NoGra
   let has_get_sbp_fn = 1;
   let has_data_type_infer_fn = 1;
 }
+
+def OneFlow_SearchSortedScalarOp : OneFlow_BaseOp<"searchsorted_scalar", [NoSideEffect, NoGrad, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+  let input = (ins
+    OneFlow_Tensor:$sorted_sequence,
+    Optional<OneFlow_Tensor>:$sorter
+  );
+  let output = (outs
+    OneFlow_Tensor:$out
+  );
+  let attrs = (ins
+    DefaultValuedAttr<BoolAttr, "false">:$out_int32,
+    DefaultValuedAttr<BoolAttr, "false">:$right,
+    DefaultValuedAttr<F32Attr, "0.">:$values
+  );
+  let has_check_fn = 1;
+  let has_logical_tensor_desc_infer_fn = 1;
+  let has_physical_tensor_desc_infer_fn = 1;
+  let has_get_sbp_fn = 1;
+  let has_data_type_infer_fn = 1;
+}
+
 
 def OneFlow_SliceOp : OneFlow_BaseOp<"slice", [NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins

--- a/oneflow/user/kernels/search_sorted_kernel.cpp
+++ b/oneflow/user/kernels/search_sorted_kernel.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 template<typename input_t>
-int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const input_t* sort) {
   // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
   // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
   const int64_t orig_start = start;
@@ -40,7 +40,7 @@ int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const inp
 // std::upper_bound can not be used here since its customized comparator requires both arguments to have the
 // same type, which wouldn't happen when comparing val of input_t to an indexer value from sorter of int64
 template<typename input_t>
-int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const input_t* sort) {
   // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
   // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
   const int64_t orig_start = start;
@@ -78,9 +78,9 @@ class CpuSearchSortedKernel final : public user_op::OpKernel {
     const input_t* values_ptr = values->dptr<input_t>();
     const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
     LOG(WARNING) << "sorter: " << sorter;
-    const int64_t* sorter_ptr = nullptr;
+    const input_t* sorter_ptr = nullptr;
     if (sorter) {
-      sorter_ptr = sorter->dptr<int64_t>();
+      sorter_ptr = sorter->dptr<input_t>();
     }
     output_t* out_ptr = out->mut_dptr<output_t>();
     const int32_t instance_num = values->shape().elem_cnt();
@@ -125,9 +125,9 @@ class CpuSearchSortedScalarKernel final : public user_op::OpKernel {
   void Compute(user_op::KernelComputeContext* ctx) const override {
     const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
     const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
-    const int64_t* sorter_ptr = nullptr;
+    const input_t* sorter_ptr = nullptr;
     if (sorter) {
-      sorter_ptr = sorter->dptr<int64_t>();
+      sorter_ptr = sorter->dptr<input_t>();
     }
     user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
 

--- a/oneflow/user/kernels/search_sorted_kernel.cpp
+++ b/oneflow/user/kernels/search_sorted_kernel.cpp
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/framework/framework.h"
+#include "oneflow/core/kernel/new_kernel_util.h"
+
+namespace oneflow {
+
+template<typename input_t>
+int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+  // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
+  // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
+  const int64_t orig_start = start;
+  while (start < end) {
+    const int64_t mid = start + ((end - start) >> 1);
+    const input_t mid_val = sort ? bd[sort[mid] + orig_start] : bd[mid];
+    if (!(mid_val >= val)) {
+      start = mid + 1;
+    }
+    else {
+      end = mid;
+    }
+  }
+  return start;
+}
+
+// customized upper_bound func to ensure we can properly handle a sorter argument
+// std::upper_bound can not be used here since its customized comparator requires both arguments to have the
+// same type, which wouldn't happen when comparing val of input_t to an indexer value from sorter of int64
+template<typename input_t>
+int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+  // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
+  // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
+  const int64_t orig_start = start;
+  while (start < end) {
+    const int64_t mid = start + ((end - start) >> 1);
+    const input_t mid_val = sort ? bd[sort[mid] + orig_start] : bd[mid];
+    if (!(mid_val > val)) {
+      start = mid + 1;
+    }
+    else {
+      end = mid;
+    }
+  }
+  return start;
+}
+
+
+
+
+
+template<typename input_t, typename output_t>
+class CpuSearchSortedKernel final : public user_op::OpKernel {
+ public:
+  CpuSearchSortedKernel() = default;
+  ~CpuSearchSortedKernel() = default;
+
+ private:
+  void Compute(user_op::KernelComputeContext* ctx) const override {
+    const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
+    const user_op::Tensor* values = ctx->Tensor4ArgNameAndIndex("values", 0);
+    const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
+
+    user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
+    const bool& out_int32 = ctx->Attr<bool>("out_int32");
+    const bool& right = ctx->Attr<bool>("right");
+    const input_t* values_ptr = values->dptr<input_t>();
+
+    const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
+    output_t* out_ptr = out->mut_dptr<output_t>();
+    // const int32_t instance_size = in->shape().At(in->shape().NumAxes() - 1);
+    const int32_t instance_num = values->shape().elem_cnt();
+    // const std::string& direction = ctx->Attr<std::string>("direction");
+    bool is_values_scalar = (values->shape().elem_cnt() == 1 && values->shape().NumAxes() == 0);
+    bool is_sequence_1d = (sorted_sequence->shape().NumAxes() == 1);
+    int64_t values_shape_last = is_values_scalar ? 1 : values->shape().At(values->shape().NumAxes()-1);
+    int64_t sequence_shape_last = sorted_sequence->shape().At(sorted_sequence->shape().NumAxes()-1);
+    FOR_RANGE(int32_t, i, 0, instance_num) {
+      int64_t start_bd = is_sequence_1d ? 0 : i / values_shape_last * sequence_shape_last;
+      int64_t end_bd = start_bd + sequence_shape_last;
+      output_t pos = !right ?
+        cus_lower_bound<>(start_bd, end_bd, values_ptr[i], sequence_ptr, nullptr) - start_bd :
+        cus_upper_bound(start_bd, end_bd, values_ptr[i], sequence_ptr, nullptr) - start_bd;
+
+      // type conversion might happen here
+      out_ptr[i] = pos;
+    }
+  }
+  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+};
+
+// REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<int64_t, int32_t>>().SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
+// REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<int64_t, int64_t>>().SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
+
+
+#define REGISTER_CPU_SEARCH_SORTED_KERNEL(in_dtype, out_dtype)                                              \
+  REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<in_dtype, out_dtype>>().SetIsMatchedHob( \
+      (user_op::HobDeviceType() == DeviceType::kCPU)                                  \
+      && (user_op::HobDataType("out", 0) == GetDataType<out_dtype>::value));
+
+REGISTER_CPU_SEARCH_SORTED_KERNEL(int64_t, int32_t)
+REGISTER_CPU_SEARCH_SORTED_KERNEL(int64_t, int64_t)
+
+
+
+}  // namespace oneflow

--- a/oneflow/user/kernels/search_sorted_kernel.cpp
+++ b/oneflow/user/kernels/search_sorted_kernel.cpp
@@ -74,15 +74,12 @@ class CpuSearchSortedKernel final : public user_op::OpKernel {
     const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
 
     user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
-    const bool& out_int32 = ctx->Attr<bool>("out_int32");
     const bool& right = ctx->Attr<bool>("right");
     const input_t* values_ptr = values->dptr<input_t>();
 
     const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
     output_t* out_ptr = out->mut_dptr<output_t>();
-    // const int32_t instance_size = in->shape().At(in->shape().NumAxes() - 1);
     const int32_t instance_num = values->shape().elem_cnt();
-    // const std::string& direction = ctx->Attr<std::string>("direction");
     bool is_values_scalar = (values->shape().elem_cnt() == 1 && values->shape().NumAxes() == 0);
     bool is_sequence_1d = (sorted_sequence->shape().NumAxes() == 1);
     int64_t values_shape_last = is_values_scalar ? 1 : values->shape().At(values->shape().NumAxes()-1);
@@ -94,7 +91,6 @@ class CpuSearchSortedKernel final : public user_op::OpKernel {
         cus_lower_bound(start_bd, end_bd, values_ptr[i], sequence_ptr, nullptr) - start_bd :
         cus_upper_bound(start_bd, end_bd, values_ptr[i], sequence_ptr, nullptr) - start_bd;
 
-      // type conversion might happen here
       out_ptr[i] = pos;
     }
   }
@@ -127,25 +123,18 @@ class CpuSearchSortedScalarKernel final : public user_op::OpKernel {
     const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
 
     user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
-    const bool& out_int32 = ctx->Attr<bool>("out_int32");
+
     const bool& right = ctx->Attr<bool>("right");
-    // double ord_tmp = JUST(.As<double>());
-    const input_t& values = ctx->Attr<input_t>("values");
-    // const dou* values_ptr = values->dptr<double>();
+    const input_t& values = static_cast<input_t>(ctx->Attr<double>("values"));
 
     const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
     output_t* out_ptr = out->mut_dptr<output_t>();
-    // const int32_t instance_size = in->shape().At(in->shape().NumAxes() - 1);
-    // const std::string& direction = ctx->Attr<std::string>("direction");
-    // bool is_values_scalar = (values->shape().elem_cnt() == 1 && values->shape().NumAxes() == 0);
-    // LOG(WARNING) << "is_values_scalar: " << is_values_scalar;
     int64_t sequence_shape_last = sorted_sequence->shape().At(0);
 
     output_t pos = !right ?
       cus_lower_bound<>(0, sequence_shape_last, values, sequence_ptr, nullptr):
        cus_upper_bound(0, sequence_shape_last, values, sequence_ptr, nullptr);
 
-    // type conversion might happen here
     out_ptr[0] = pos;
 
   }

--- a/oneflow/user/kernels/search_sorted_kernel.cpp
+++ b/oneflow/user/kernels/search_sorted_kernel.cpp
@@ -18,13 +18,11 @@ limitations under the License.
 
 namespace oneflow {
 
-template<typename input_t>
-int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const input_t* sort) {
-  // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
-  // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
-  const int64_t orig_start = start;
+template<typename input_t, typename output_t>
+output_t cus_lower_bound(output_t start, output_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+  const output_t orig_start = start;
   while (start < end) {
-    const int64_t mid = start + ((end - start) >> 1);
+    const output_t mid = start + ((end - start) >> 1);
     const input_t mid_val = sort ? bd[sort[mid] + orig_start] : bd[mid];
     if (!(mid_val >= val)) {
       start = mid + 1;
@@ -36,16 +34,11 @@ int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const inp
   return start;
 }
 
-// customized upper_bound func to ensure we can properly handle a sorter argument
-// std::upper_bound can not be used here since its customized comparator requires both arguments to have the
-// same type, which wouldn't happen when comparing val of input_t to an indexer value from sorter of int64
-template<typename input_t>
-int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const input_t* sort) {
-  // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
-  // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
-  const int64_t orig_start = start;
+template<typename input_t, typename output_t>
+output_t cus_upper_bound(output_t start, output_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+  const output_t orig_start = start;
   while (start < end) {
-    const int64_t mid = start + ((end - start) >> 1);
+    const output_t mid = start + ((end - start) >> 1);
     const input_t mid_val = sort ? bd[sort[mid] + orig_start] : bd[mid];
     if (!(mid_val > val)) {
       start = mid + 1;
@@ -56,7 +49,6 @@ int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const inp
   }
   return start;
 }
-
 
 template<typename input_t, typename output_t>
 class CpuSearchSortedKernel final : public user_op::OpKernel {
@@ -69,27 +61,26 @@ class CpuSearchSortedKernel final : public user_op::OpKernel {
     const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
     const user_op::Tensor* values = ctx->Tensor4ArgNameAndIndex("values", 0);
     const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
-
     user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
     const bool& right = ctx->Attr<bool>("right");
     const input_t* values_ptr = values->dptr<input_t>();
     const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
-    const input_t* sorter_ptr = nullptr;
+    const int64_t* sorter_ptr = nullptr;
     if (sorter) {
-      sorter_ptr = sorter->dptr<input_t>();
+      sorter_ptr = sorter->dptr<int64_t>();
     }
     output_t* out_ptr = out->mut_dptr<output_t>();
     const int32_t instance_num = values->shape().elem_cnt();
     bool is_values_scalar = (values->shape().elem_cnt() == 1 && values->shape().NumAxes() == 0);
     bool is_sequence_1d = (sorted_sequence->shape().NumAxes() == 1);
-    int64_t values_shape_last = is_values_scalar ? 1 : values->shape().At(values->shape().NumAxes()-1);
-    int64_t sequence_shape_last = sorted_sequence->shape().At(sorted_sequence->shape().NumAxes()-1);
+    output_t values_shape_last = is_values_scalar ? 1 : values->shape().At(values->shape().NumAxes()-1);
+    output_t sequence_shape_last = sorted_sequence->shape().At(sorted_sequence->shape().NumAxes()-1);
     FOR_RANGE(int32_t, i, 0, instance_num) {
-      int64_t start_bd = is_sequence_1d ? 0 : i / values_shape_last * sequence_shape_last;
-      int64_t end_bd = start_bd + sequence_shape_last;
+      output_t start_bd = is_sequence_1d ? 0 : i / values_shape_last * sequence_shape_last;
+      output_t end_bd = start_bd + sequence_shape_last;
       output_t pos = !right ?
-        cus_lower_bound<input_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd :
-         cus_upper_bound<input_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd;
+        cus_lower_bound<input_t, output_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd :
+         cus_upper_bound<input_t, output_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd;
 
       out_ptr[i] = pos;
     }
@@ -97,18 +88,15 @@ class CpuSearchSortedKernel final : public user_op::OpKernel {
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-// REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<int64_t, int32_t>>().SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
-// REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<int64_t, int64_t>>().SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
+#define REGISTER_CPU_SEARCH_SORTED_KERNEL(in_dtype, out_dtype)   \
+  REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<OF_PP_PAIR_FIRST(in_dtype), OF_PP_PAIR_FIRST(out_dtype)>>().SetIsMatchedHob( \
+      (user_op::HobDeviceType() == DeviceType::kCPU)     \
+      && (user_op::HobDataType("sorted_sequence", 0) == OF_PP_PAIR_SECOND(in_dtype))   \
+      && (user_op::HobDataType("values", 0) == OF_PP_PAIR_SECOND(in_dtype))   \
+      && (user_op::HobDataType("out", 0) == OF_PP_PAIR_SECOND(out_dtype)));
 
-
-#define REGISTER_CPU_SEARCH_SORTED_KERNEL(in_dtype, out_dtype)                                              \
-  REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<in_dtype, out_dtype>>().SetIsMatchedHob( \
-      (user_op::HobDeviceType() == DeviceType::kCPU)                                  \
-      && (user_op::HobDataType("out", 0) == GetDataType<out_dtype>::value));
-
-REGISTER_CPU_SEARCH_SORTED_KERNEL(int64_t, int32_t)
-REGISTER_CPU_SEARCH_SORTED_KERNEL(int64_t, int64_t)
-
+OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_CPU_SEARCH_SORTED_KERNEL, ARITHMETIC_DATA_TYPE_SEQ,
+                                 INDEX_DATA_TYPE_SEQ)
 
 
 template<typename input_t, typename output_t>
@@ -121,9 +109,9 @@ class CpuSearchSortedScalarKernel final : public user_op::OpKernel {
   void Compute(user_op::KernelComputeContext* ctx) const override {
     const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
     const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
-    const input_t* sorter_ptr = nullptr;
+    const int64_t* sorter_ptr = nullptr;
     if (sorter) {
-      sorter_ptr = sorter->dptr<input_t>();
+      sorter_ptr = sorter->dptr<int64_t>();
     }
     user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
 
@@ -132,23 +120,24 @@ class CpuSearchSortedScalarKernel final : public user_op::OpKernel {
 
     const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
     output_t* out_ptr = out->mut_dptr<output_t>();
-    int64_t sequence_shape_last = sorted_sequence->shape().At(0);
+    output_t sequence_shape_last = sorted_sequence->shape().At(0);
 
     output_t pos = !right ?
-      cus_lower_bound<input_t>(0, sequence_shape_last, values, sequence_ptr, sorter_ptr):
-       cus_upper_bound<input_t>(0, sequence_shape_last, values, sequence_ptr, sorter_ptr);
+      cus_lower_bound<input_t, output_t>(0, sequence_shape_last, values, sequence_ptr, sorter_ptr):
+       cus_upper_bound<input_t, output_t>(0, sequence_shape_last, values, sequence_ptr, sorter_ptr);
 
     out_ptr[0] = pos;
   }
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-#define REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(in_dtype, out_dtype)                                              \
-  REGISTER_USER_KERNEL("searchsorted_scalar").SetCreateFn<CpuSearchSortedScalarKernel<in_dtype, out_dtype>>().SetIsMatchedHob( \
-      (user_op::HobDeviceType() == DeviceType::kCPU)                                  \
-      && (user_op::HobDataType("out", 0) == GetDataType<out_dtype>::value));
+#define REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(in_dtype, out_dtype)    \
+  REGISTER_USER_KERNEL("searchsorted_scalar").SetCreateFn<CpuSearchSortedScalarKernel<OF_PP_PAIR_FIRST(in_dtype), OF_PP_PAIR_FIRST(out_dtype)>>().SetIsMatchedHob( \
+      (user_op::HobDeviceType() == DeviceType::kCPU)    \
+      && (user_op::HobDataType("sorted_sequence", 0) == OF_PP_PAIR_SECOND(in_dtype))    \
+      && (user_op::HobDataType("out", 0) == OF_PP_PAIR_SECOND(out_dtype)));
 
-REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(int64_t, int32_t)
-REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(int64_t, int64_t)
+OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL, ARITHMETIC_DATA_TYPE_SEQ,
+                                 INDEX_DATA_TYPE_SEQ)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/search_sorted_kernel.cpp
+++ b/oneflow/user/kernels/search_sorted_kernel.cpp
@@ -58,9 +58,6 @@ int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const inp
 }
 
 
-
-
-
 template<typename input_t, typename output_t>
 class CpuSearchSortedKernel final : public user_op::OpKernel {
  public:
@@ -77,7 +74,6 @@ class CpuSearchSortedKernel final : public user_op::OpKernel {
     const bool& right = ctx->Attr<bool>("right");
     const input_t* values_ptr = values->dptr<input_t>();
     const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
-    LOG(WARNING) << "sorter: " << sorter;
     const input_t* sorter_ptr = nullptr;
     if (sorter) {
       sorter_ptr = sorter->dptr<input_t>();
@@ -154,13 +150,5 @@ class CpuSearchSortedScalarKernel final : public user_op::OpKernel {
 
 REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(int64_t, int32_t)
 REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(int64_t, int64_t)
-
-
-
-
-
-
-
-
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/search_sorted_kernel.cu
+++ b/oneflow/user/kernels/search_sorted_kernel.cu
@@ -21,7 +21,7 @@ limitations under the License.
 namespace oneflow {
 
 template<typename input_t>
-OF_DEVICE_FUNC int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+OF_DEVICE_FUNC int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const input_t* sort) {
   // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
   // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
   const int64_t orig_start = start;
@@ -42,7 +42,7 @@ OF_DEVICE_FUNC int64_t cus_lower_bound(int64_t start, int64_t end, const input_t
 // std::upper_bound can not be used here since its customized comparator requires both arguments to have the
 // same type, which wouldn't happen when comparing val of input_t to an indexer value from sorter of int64
 template<typename input_t>
-OF_DEVICE_FUNC int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+OF_DEVICE_FUNC int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const input_t* sort) {
   // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
   // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
   const int64_t orig_start = start;
@@ -66,6 +66,7 @@ __global__ void DoSearchSortedLogical(int32_t instance_num, bool is_sequence_1d,
                                       output_t* out_ptr) {
   int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
   int64_t start_bd = is_sequence_1d ? 0 : i / values_shape_last * sequence_shape_last;
+  // LOG(WARNING) << "is sequence 1d: " << is_sequence_1d;
   int64_t end_bd = start_bd + sequence_shape_last;
   output_t pos = !right ?
     cus_lower_bound<input_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd :
@@ -73,6 +74,15 @@ __global__ void DoSearchSortedLogical(int32_t instance_num, bool is_sequence_1d,
   out_ptr[i] = pos;
 }
 
+template<typename input_t, typename output_t>
+__global__ void DoSearchSortedScalarLogical(int64_t sequence_shape_last, bool right, const input_t& values,   \
+                                      const input_t* sequence_ptr, const input_t* sorter_ptr,   \
+                                      output_t* out_ptr) {
+  output_t pos = !right ?
+    cus_lower_bound<input_t>(0, sequence_shape_last, values, sequence_ptr, sorter_ptr) :
+     cus_upper_bound<input_t>(0, sequence_shape_last, values, sequence_ptr, sorter_ptr);
+  out_ptr[0] = pos;
+}
 
 template<typename input_t, typename output_t>
 class GpuSearchSortedKernel final : public user_op::OpKernel {
@@ -83,6 +93,7 @@ class GpuSearchSortedKernel final : public user_op::OpKernel {
  private:
   using user_op::OpKernel::Compute;
   void Compute(user_op::KernelComputeContext* ctx) const override {
+    LOG(WARNING) << "in GpuSearchSortedKernel";
     const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
     const user_op::Tensor* values = ctx->Tensor4ArgNameAndIndex("values", 0);
     const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
@@ -91,9 +102,9 @@ class GpuSearchSortedKernel final : public user_op::OpKernel {
     const bool& right = ctx->Attr<bool>("right");
     const input_t* values_ptr = values->dptr<input_t>();
     const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
-    const int64_t* sorter_ptr = nullptr;
+    const input_t* sorter_ptr = nullptr;
     if (sorter) {
-      sorter_ptr = sorter->dptr<int64_t>();
+      sorter_ptr = sorter->dptr<input_t>();
     }
     output_t* out_ptr = out->mut_dptr<output_t>();
     const int32_t instance_num = values->shape().elem_cnt();
@@ -115,5 +126,45 @@ class GpuSearchSortedKernel final : public user_op::OpKernel {
 
 REGISTER_GPU_SEARCH_SORTED_KERNEL(int64_t, int32_t)
 REGISTER_GPU_SEARCH_SORTED_KERNEL(int64_t, int64_t)
+
+
+template<typename input_t, typename output_t>
+class GpuSearchSortedScalarKernel final : public user_op::OpKernel {
+ public:
+  GpuSearchSortedScalarKernel() = default;
+  ~GpuSearchSortedScalarKernel() = default;
+
+ private:
+  using user_op::OpKernel::Compute;
+  void Compute(user_op::KernelComputeContext* ctx) const override {
+    LOG(WARNING) << "in GpuSearchSortedScalarKernel";
+    const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
+    const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
+    const int64_t* sorter_ptr = nullptr;
+    if (sorter) {
+      sorter_ptr = sorter->dptr<int64_t>();
+    }
+    user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
+
+    const bool& right = ctx->Attr<bool>("right");
+    const input_t& values = static_cast<input_t>(ctx->Attr<double>("values"));
+
+    const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
+    output_t* out_ptr = out->mut_dptr<output_t>();
+    int64_t sequence_shape_last = sorted_sequence->shape().At(0);
+    RUN_CUDA_KERNEL((DoSearchSortedScalarLogical<input_t, output_t>), ctx->stream(), 1,   \
+                     sequence_shape_last, right, values,   \
+                     sequence_ptr, sorter_ptr, out_ptr);
+  }
+  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+};
+
+#define REGISTER_GPU_SEARCH_SORTED_SCALAR_KERNEL(in_dtype, out_dtype)                                              \
+  REGISTER_USER_KERNEL("searchsorted_scalar").SetCreateFn<GpuSearchSortedScalarKernel<in_dtype, out_dtype>>().SetIsMatchedHob( \
+      (user_op::HobDeviceType() == DeviceType::kCUDA)                                  \
+      && (user_op::HobDataType("out", 0) == GetDataType<out_dtype>::value));
+
+REGISTER_GPU_SEARCH_SORTED_SCALAR_KERNEL(int64_t, int32_t)
+REGISTER_GPU_SEARCH_SORTED_SCALAR_KERNEL(int64_t, int64_t)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/search_sorted_kernel.cu
+++ b/oneflow/user/kernels/search_sorted_kernel.cu
@@ -14,12 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "oneflow/core/framework/framework.h"
+#include "oneflow/core/kernel/cuda_graph_support.h"
 #include "oneflow/core/kernel/new_kernel_util.h"
+#include "oneflow/core/device/cuda_util.h"
 
 namespace oneflow {
 
 template<typename input_t>
-int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+OF_DEVICE_FUNC int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
   // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
   // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
   const int64_t orig_start = start;
@@ -40,7 +42,7 @@ int64_t cus_lower_bound(int64_t start, int64_t end, const input_t val, const inp
 // std::upper_bound can not be used here since its customized comparator requires both arguments to have the
 // same type, which wouldn't happen when comparing val of input_t to an indexer value from sorter of int64
 template<typename input_t>
-int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
+OF_DEVICE_FUNC int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const input_t* bd, const int64_t* sort) {
   // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
   // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
   const int64_t orig_start = start;
@@ -57,17 +59,29 @@ int64_t cus_upper_bound(int64_t start, int64_t end, const input_t val, const inp
   return start;
 }
 
-
-
+template<typename input_t, typename output_t>
+__global__ void DoSearchSortedLogical(int32_t instance_num, bool is_sequence_1d, int64_t values_shape_last,  \
+                                      int64_t sequence_shape_last, bool right, const input_t* values_ptr,   \
+                                      const input_t* sequence_ptr, const input_t* sorter_ptr,   \
+                                      output_t* out_ptr) {
+  int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t start_bd = is_sequence_1d ? 0 : i / values_shape_last * sequence_shape_last;
+  int64_t end_bd = start_bd + sequence_shape_last;
+  output_t pos = !right ?
+    cus_lower_bound<input_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd :
+     cus_upper_bound<input_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd;
+  out_ptr[i] = pos;
+}
 
 
 template<typename input_t, typename output_t>
-class CpuSearchSortedKernel final : public user_op::OpKernel {
+class GpuSearchSortedKernel final : public user_op::OpKernel {
  public:
-  CpuSearchSortedKernel() = default;
-  ~CpuSearchSortedKernel() = default;
+  GpuSearchSortedKernel() = default;
+  ~GpuSearchSortedKernel() = default;
 
  private:
+  using user_op::OpKernel::Compute;
   void Compute(user_op::KernelComputeContext* ctx) const override {
     const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
     const user_op::Tensor* values = ctx->Tensor4ArgNameAndIndex("values", 0);
@@ -77,7 +91,6 @@ class CpuSearchSortedKernel final : public user_op::OpKernel {
     const bool& right = ctx->Attr<bool>("right");
     const input_t* values_ptr = values->dptr<input_t>();
     const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
-    LOG(WARNING) << "sorter: " << sorter;
     const int64_t* sorter_ptr = nullptr;
     if (sorter) {
       sorter_ptr = sorter->dptr<int64_t>();
@@ -88,79 +101,19 @@ class CpuSearchSortedKernel final : public user_op::OpKernel {
     bool is_sequence_1d = (sorted_sequence->shape().NumAxes() == 1);
     int64_t values_shape_last = is_values_scalar ? 1 : values->shape().At(values->shape().NumAxes()-1);
     int64_t sequence_shape_last = sorted_sequence->shape().At(sorted_sequence->shape().NumAxes()-1);
-    FOR_RANGE(int32_t, i, 0, instance_num) {
-      int64_t start_bd = is_sequence_1d ? 0 : i / values_shape_last * sequence_shape_last;
-      int64_t end_bd = start_bd + sequence_shape_last;
-      output_t pos = !right ?
-        cus_lower_bound<input_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd :
-         cus_upper_bound<input_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd;
-
-      out_ptr[i] = pos;
-    }
+    RUN_CUDA_KERNEL((DoSearchSortedLogical<input_t, output_t>), ctx->stream(), instance_num, instance_num,   \
+                     is_sequence_1d, values_shape_last, sequence_shape_last, right, values_ptr,   \
+                     sequence_ptr, sorter_ptr, out_ptr);
   }
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-// REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<int64_t, int32_t>>().SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
-// REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<int64_t, int64_t>>().SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCPU);
-
-
-#define REGISTER_CPU_SEARCH_SORTED_KERNEL(in_dtype, out_dtype)                                              \
-  REGISTER_USER_KERNEL("searchsorted").SetCreateFn<CpuSearchSortedKernel<in_dtype, out_dtype>>().SetIsMatchedHob( \
-      (user_op::HobDeviceType() == DeviceType::kCPU)                                  \
+#define REGISTER_GPU_SEARCH_SORTED_KERNEL(in_dtype, out_dtype)   \
+  REGISTER_USER_KERNEL("searchsorted").SetCreateFn<GpuSearchSortedKernel<in_dtype, out_dtype>>().SetIsMatchedHob( \
+      (user_op::HobDeviceType() == DeviceType::kCUDA)   \
       && (user_op::HobDataType("out", 0) == GetDataType<out_dtype>::value));
 
-REGISTER_CPU_SEARCH_SORTED_KERNEL(int64_t, int32_t)
-REGISTER_CPU_SEARCH_SORTED_KERNEL(int64_t, int64_t)
-
-
-
-template<typename input_t, typename output_t>
-class CpuSearchSortedScalarKernel final : public user_op::OpKernel {
- public:
-  CpuSearchSortedScalarKernel() = default;
-  ~CpuSearchSortedScalarKernel() = default;
-
- private:
-  void Compute(user_op::KernelComputeContext* ctx) const override {
-    const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
-    const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
-    const int64_t* sorter_ptr = nullptr;
-    if (sorter) {
-      sorter_ptr = sorter->dptr<int64_t>();
-    }
-    user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
-
-    const bool& right = ctx->Attr<bool>("right");
-    const input_t& values = static_cast<input_t>(ctx->Attr<double>("values"));
-
-    const input_t* sequence_ptr = sorted_sequence->dptr<input_t>();
-    output_t* out_ptr = out->mut_dptr<output_t>();
-    int64_t sequence_shape_last = sorted_sequence->shape().At(0);
-
-    output_t pos = !right ?
-      cus_lower_bound<input_t>(0, sequence_shape_last, values, sequence_ptr, sorter_ptr):
-       cus_upper_bound<input_t>(0, sequence_shape_last, values, sequence_ptr, sorter_ptr);
-
-    out_ptr[0] = pos;
-  }
-  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
-};
-
-#define REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(in_dtype, out_dtype)                                              \
-  REGISTER_USER_KERNEL("searchsorted_scalar").SetCreateFn<CpuSearchSortedScalarKernel<in_dtype, out_dtype>>().SetIsMatchedHob( \
-      (user_op::HobDeviceType() == DeviceType::kCPU)                                  \
-      && (user_op::HobDataType("out", 0) == GetDataType<out_dtype>::value));
-
-REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(int64_t, int32_t)
-REGISTER_CPU_SEARCH_SORTED_SCALAR_KERNEL(int64_t, int64_t)
-
-
-
-
-
-
-
-
+REGISTER_GPU_SEARCH_SORTED_KERNEL(int64_t, int32_t)
+REGISTER_GPU_SEARCH_SORTED_KERNEL(int64_t, int64_t)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/search_sorted_kernel.cu
+++ b/oneflow/user/kernels/search_sorted_kernel.cu
@@ -66,7 +66,6 @@ __global__ void DoSearchSortedLogical(int32_t instance_num, bool is_sequence_1d,
                                       output_t* out_ptr) {
   CUDA_1D_KERNEL_LOOP(i, instance_num) {
     int64_t start_bd = is_sequence_1d ? 0 : i / values_shape_last * sequence_shape_last;
-    // LOG(WARNING) << "is sequence 1d: " << is_sequence_1d;
     int64_t end_bd = start_bd + sequence_shape_last;
     output_t pos = !right ?
       cus_lower_bound<input_t>(start_bd, end_bd, values_ptr[i], sequence_ptr, sorter_ptr) - start_bd :
@@ -76,7 +75,7 @@ __global__ void DoSearchSortedLogical(int32_t instance_num, bool is_sequence_1d,
 }
 
 template<typename input_t, typename output_t>
-__global__ void DoSearchSortedScalarLogical(int64_t sequence_shape_last, bool right, const input_t& values,   \
+__global__ void DoSearchSortedScalarLogical(int64_t sequence_shape_last, bool right, const input_t values,   \
                                       const input_t* sequence_ptr, const input_t* sorter_ptr,   \
                                       output_t* out_ptr) {
   CUDA_1D_KERNEL_LOOP(i, 1) {
@@ -96,7 +95,6 @@ class GpuSearchSortedKernel final : public user_op::OpKernel {
  private:
   using user_op::OpKernel::Compute;
   void Compute(user_op::KernelComputeContext* ctx) const override {
-    LOG(WARNING) << "in GpuSearchSortedKernel";
     const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
     const user_op::Tensor* values = ctx->Tensor4ArgNameAndIndex("values", 0);
     const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
@@ -140,7 +138,6 @@ class GpuSearchSortedScalarKernel final : public user_op::OpKernel {
  private:
   using user_op::OpKernel::Compute;
   void Compute(user_op::KernelComputeContext* ctx) const override {
-    LOG(WARNING) << "in GpuSearchSortedScalarKernel";
     const user_op::Tensor* sorted_sequence = ctx->Tensor4ArgNameAndIndex("sorted_sequence", 0);
     const user_op::Tensor* sorter = ctx->Tensor4ArgNameAndIndex("sorter", 0);
     const int64_t* sorter_ptr = nullptr;

--- a/oneflow/user/ops/search_sorted_op.cpp
+++ b/oneflow/user/ops/search_sorted_op.cpp
@@ -48,7 +48,6 @@ namespace oneflow {
 
 /* static */ Maybe<void> SearchSortedOp::InferDataType(user_op::InferContext* ctx) {
   const bool& out_int32 = ctx->Attr<bool>("out_int32");
-  LOG(WARNING) << "00000000000000000000000000000";
   if (out_int32) {
     *ctx->OutputDType("out", 0) = DataType::kInt32;
   } else {

--- a/oneflow/user/ops/search_sorted_op.cpp
+++ b/oneflow/user/ops/search_sorted_op.cpp
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/framework/framework.h"
+#include "oneflow/core/framework/op_generated.h"
+
+namespace oneflow {
+
+/* static */ Maybe<void> SearchSortedOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
+  *ctx->OutputShape("out", 0) = ctx->InputShape("values", 0);
+  return Maybe<void>::Ok();
+}
+
+/*static*/ Maybe<void> SearchSortedOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
+  return InferLogicalTensorDesc(ctx);
+}
+
+/* static */ Maybe<void> SearchSortedOp::GetSbp(user_op::SbpContext* ctx) {
+  const user_op::TensorDesc& in_tensor = ctx->LogicalTensorDesc4InputArgNameAndIndex("in", 0);
+  FOR_RANGE(int64_t, i, 0, in_tensor.shape().NumAxes() - 1) {
+    ctx->NewBuilder().Split(ctx->inputs(), i).Split(ctx->outputs(), i).Build();
+  }
+  return Maybe<void>::Ok();
+}
+
+/* static */ Maybe<void> SearchSortedOp::CheckAttr(const user_op::UserOpDefWrapper& def,
+                                              const user_op::UserOpConfWrapper& conf) {
+  const std::string& side = conf.attr<std::string>("side");
+  CHECK_OR_RETURN(side == "left" || side == "right") << "for searchsorted op, side can only be 'left' or 'right' but got " << side;
+  const std::string& right = conf.attr<std::string>("right");
+  CHECK_OR_RETURN((right == "True" and side == "right") or (right == "False" and side == "left")) << "for searchsorted op,  \
+                  side and right can't be set to opposites, but got side of " << side << " while right was " << right;
+  
+  return Maybe<void>::Ok();
+}
+
+/* static */ Maybe<void> SearchSortedOp::InferDataType(user_op::InferContext* ctx) {
+  const bool& out_int32 = ctx->Attr<bool>("out_int32");
+  LOG(WARNING) << "00000000000000000000000000000";
+  if (out_int32) {
+    *ctx->OutputDType("out", 0) = DataType::kInt32;
+  } else {
+    *ctx->OutputDType("out", 0) = DataType::kInt64;
+  }
+  return Maybe<void>::Ok();
+}
+
+}  // namespace oneflow

--- a/python/oneflow/__init__.py
+++ b/python/oneflow/__init__.py
@@ -187,6 +187,7 @@ from oneflow._C import not_equal
 from oneflow._C import not_equal as ne
 from oneflow._C import less as lt
 from oneflow._C import less_equal as le
+from oneflow._C import searchsorted
 from oneflow._oneflow_internal import _set_num_threads as set_num_threads
 
 from . import sbp

--- a/python/oneflow/test/modules/test_searchsorted.py
+++ b/python/oneflow/test/modules/test_searchsorted.py
@@ -1,0 +1,152 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from collections import OrderedDict
+
+import numpy as np
+from oneflow.test_utils.test_util import GenArgList
+
+import oneflow as flow
+import oneflow.unittest
+
+
+def _test_search_sorted(test_case, device):
+    sorted_sequence = flow.tensor(
+        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=flow.int64, device=flow.device(device)
+    )
+    values = flow.tensor(
+        np.array([[3, 6, 9], [3, 6, 9]]), dtype=flow.int64, device=flow.device(device)
+    )
+    gt = np.array([[1, 3, 4], [1, 2, 4]])
+    output = flow.searchsorted(sorted_sequence, values)
+    test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
+    test_case.assertTrue(output.dtype == flow.int64)
+    print("_test_search_sorted")
+
+
+def _test_search_sorted_1(test_case, device):
+    sorted_sequence = flow.tensor(
+        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=flow.int64, device=flow.device(device)
+    )
+    values = flow.tensor(
+        np.array([[3, 6, 9], [3, 6, 9]]), dtype=flow.int64, device=flow.device(device)
+    )
+    gt = np.array([[2, 3, 5], [1, 3, 4]])
+    output = flow.searchsorted(sorted_sequence, values, right=True)
+    test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
+    test_case.assertTrue(output.dtype == flow.int64)
+    print("_test_search_sorted_1")
+
+
+def _test_search_sorted_2(test_case, device):
+    sorted_sequence_1d = flow.tensor(
+        np.array([1, 3, 5, 7, 9]), dtype=flow.int64, device=flow.device(device)
+    )
+    values = flow.tensor(
+        np.array([3, 6, 9]), dtype=flow.int64, device=flow.device(device)
+    )
+    gt = np.array([1, 3, 4])
+    output = flow.searchsorted(sorted_sequence_1d, values)
+    test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
+    test_case.assertTrue(output.dtype == flow.int64)
+    print("_test_search_sorted_2")
+
+
+def _test_search_sorted_3(test_case, device):
+    sorted_sequence = flow.tensor(
+        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=flow.int64, device=flow.device(device)
+    )
+    values = flow.tensor(
+        np.array([[3, 6, 9], [3, 6, 9]]), dtype=flow.int64, device=flow.device(device)
+    )
+    gt = np.array([[1, 3, 4], [1, 2, 4]])
+    output = flow.searchsorted(sorted_sequence, values, out_int32=True)
+    test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
+    test_case.assertTrue(output.dtype == flow.int32)
+    print("_test_search_sorted_3")
+
+
+def _test_search_sorted_4(test_case, device):
+    sorted_sequence = flow.tensor(
+        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=flow.int64, device=flow.device(device)
+    )
+    values = flow.tensor(
+        np.array([[3, 6, 9], [3, 6, 9]]), dtype=flow.int64, device=flow.device(device)
+    )
+    sorter = flow.tensor(np.array([[4, 3, 2, 1, 0], [3, 2, 4, 0, 1]]), dtype=flow.int64, device=flow.device(device))
+    gt = np.array([[0, 5, 5], [0, 0, 2]])
+    output = flow.searchsorted(sorted_sequence, values, sorter=sorter)
+    test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
+    test_case.assertTrue(output.dtype == flow.int64)
+    print("_test_search_sorted_4")
+
+
+def _test_search_sorted_5(test_case, device):
+    sorted_sequence_1d = flow.tensor(
+        np.array([1, 3, 5, 7, 9]), dtype=flow.int64, device=flow.device(device)
+    )
+    gt = np.array(2)
+    output = flow.searchsorted(sorted_sequence_1d, 5)
+    test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
+    test_case.assertTrue(output.dtype == flow.int64)
+    print("_test_search_sorted_5")
+
+
+def _test_search_sorted_6(test_case, device):
+    sorted_sequence_1d = flow.tensor(
+        np.array([1, 3, 5, 7, 9]), dtype=flow.int64, device=flow.device(device)
+    )
+    gt = np.array(3)
+    output = flow.searchsorted(sorted_sequence_1d, 5, right=True)
+    test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
+    test_case.assertTrue(output.dtype == flow.int64)
+    print("_test_search_sorted_6")
+
+
+def _test_search_sorted_7(test_case, device):
+    sorted_sequence_1d = flow.tensor(
+        np.array([1, 3, 5, 7, 9]), dtype=flow.int64, device=flow.device(device)
+    )
+    gt = np.array(2)
+    output = flow.searchsorted(sorted_sequence_1d, 5, out_int32=True)
+    test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
+    test_case.assertTrue(output.dtype == flow.int32)
+    print("_test_search_sorted_7")
+
+
+
+@flow.unittest.skip_unless_1n1d()
+class TestSearch_Sorted(flow.unittest.TestCase):
+    def test_search_sorted(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["test_fun"] = [
+            _test_search_sorted,
+            _test_search_sorted_1,
+            _test_search_sorted_2,
+            _test_search_sorted_3,
+            _test_search_sorted_4,
+            _test_search_sorted_5,
+            _test_search_sorted_6,
+            _test_search_sorted_7,
+        ]
+        arg_dict["device"] = ["cpu", "cuda"]
+        for arg in GenArgList(arg_dict):
+            arg[0](test_case, *arg[1:])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/oneflow/test/modules/test_searchsorted.py
+++ b/python/oneflow/test/modules/test_searchsorted.py
@@ -24,12 +24,12 @@ import oneflow as flow
 import oneflow.unittest
 
 
-def _test_search_sorted(test_case, device):
+def _test_search_sorted(test_case, input_dtype, device):
     sorted_sequence = flow.tensor(
-        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=flow.int64, device=flow.device(device)
+        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=input_dtype, device=flow.device(device)
     )
     values = flow.tensor(
-        np.array([[3, 6, 9], [3, 6, 9]]), dtype=flow.int64, device=flow.device(device)
+        np.array([[3, 6, 9], [3, 6, 9]]), dtype=input_dtype, device=flow.device(device)
     )
     gt = np.array([[1, 3, 4], [1, 2, 4]])
     output = flow.searchsorted(sorted_sequence, values)
@@ -37,12 +37,12 @@ def _test_search_sorted(test_case, device):
     test_case.assertTrue(output.dtype == flow.int64)
 
 
-def _test_search_sorted_1(test_case, device):
+def _test_search_sorted_1(test_case, input_dtype, device):
     sorted_sequence = flow.tensor(
-        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=flow.int64, device=flow.device(device)
+        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=input_dtype, device=flow.device(device)
     )
     values = flow.tensor(
-        np.array([[3, 6, 9], [3, 6, 9]]), dtype=flow.int64, device=flow.device(device)
+        np.array([[3, 6, 9], [3, 6, 9]]), dtype=input_dtype, device=flow.device(device)
     )
     gt = np.array([[2, 3, 5], [1, 3, 4]])
     output = flow.searchsorted(sorted_sequence, values, right=True)
@@ -50,12 +50,12 @@ def _test_search_sorted_1(test_case, device):
     test_case.assertTrue(output.dtype == flow.int64)
 
 
-def _test_search_sorted_2(test_case, device):
+def _test_search_sorted_2(test_case, input_dtype, device):
     sorted_sequence_1d = flow.tensor(
-        np.array([1, 3, 5, 7, 9]), dtype=flow.int64, device=flow.device(device)
+        np.array([1, 3, 5, 7, 9]), dtype=input_dtype, device=flow.device(device)
     )
     values = flow.tensor(
-        np.array([3, 6, 9]), dtype=flow.int64, device=flow.device(device)
+        np.array([3, 6, 9]), dtype=input_dtype, device=flow.device(device)
     )
     gt = np.array([1, 3, 4])
     output = flow.searchsorted(sorted_sequence_1d, values)
@@ -63,12 +63,12 @@ def _test_search_sorted_2(test_case, device):
     test_case.assertTrue(output.dtype == flow.int64)
 
 
-def _test_search_sorted_3(test_case, device):
+def _test_search_sorted_3(test_case, input_dtype, device):
     sorted_sequence = flow.tensor(
-        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=flow.int64, device=flow.device(device)
+        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=input_dtype, device=flow.device(device)
     )
     values = flow.tensor(
-        np.array([[3, 6, 9], [3, 6, 9]]), dtype=flow.int64, device=flow.device(device)
+        np.array([[3, 6, 9], [3, 6, 9]]), dtype=input_dtype, device=flow.device(device)
     )
     gt = np.array([[1, 3, 4], [1, 2, 4]])
     output = flow.searchsorted(sorted_sequence, values, out_int32=True)
@@ -76,12 +76,12 @@ def _test_search_sorted_3(test_case, device):
     test_case.assertTrue(output.dtype == flow.int32)
 
 
-def _test_search_sorted_4(test_case, device):
+def _test_search_sorted_4(test_case, input_dtype, device):
     sorted_sequence = flow.tensor(
-        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=flow.int64, device=flow.device(device)
+        np.array([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]), dtype=input_dtype, device=flow.device(device)
     )
     values = flow.tensor(
-        np.array([[3, 6, 9], [3, 6, 9]]), dtype=flow.int64, device=flow.device(device)
+        np.array([[3, 6, 9], [3, 6, 9]]), dtype=input_dtype, device=flow.device(device)
     )
     sorter = flow.tensor(np.array([[4, 3, 2, 1, 0], [3, 2, 4, 0, 1]]), dtype=flow.int64, device=flow.device(device))
     gt = np.array([[0, 5, 5], [0, 0, 2]])
@@ -90,9 +90,9 @@ def _test_search_sorted_4(test_case, device):
     test_case.assertTrue(output.dtype == flow.int64)
 
 
-def _test_search_sorted_5(test_case, device):
+def _test_search_sorted_5(test_case, input_dtype, device):
     sorted_sequence_1d = flow.tensor(
-        np.array([1, 3, 5, 7, 9]), dtype=flow.int64, device=flow.device(device)
+        np.array([1, 3, 5, 7, 9]), dtype=input_dtype, device=flow.device(device)
     )
     gt = np.array(2)
     output = flow.searchsorted(sorted_sequence_1d, 5)
@@ -100,9 +100,9 @@ def _test_search_sorted_5(test_case, device):
     test_case.assertTrue(output.dtype == flow.int64)
 
 
-def _test_search_sorted_6(test_case, device):
+def _test_search_sorted_6(test_case, input_dtype, device):
     sorted_sequence_1d = flow.tensor(
-        np.array([1, 3, 5, 7, 9]), dtype=flow.int64, device=flow.device(device)
+        np.array([1, 3, 5, 7, 9]), dtype=input_dtype, device=flow.device(device)
     )
     gt = np.array(3)
     output = flow.searchsorted(sorted_sequence_1d, 5, right=True)
@@ -110,9 +110,9 @@ def _test_search_sorted_6(test_case, device):
     test_case.assertTrue(output.dtype == flow.int64)
 
 
-def _test_search_sorted_7(test_case, device):
+def _test_search_sorted_7(test_case, input_dtype, device):
     sorted_sequence_1d = flow.tensor(
-        np.array([1, 3, 5, 7, 9]), dtype=flow.int64, device=flow.device(device)
+        np.array([1, 3, 5, 7, 9]), dtype=input_dtype, device=flow.device(device)
     )
     gt = np.array(2)
     output = flow.searchsorted(sorted_sequence_1d, 5, out_int32=True)
@@ -134,6 +134,7 @@ class TestSearch_Sorted(flow.unittest.TestCase):
             _test_search_sorted_6,
             _test_search_sorted_7,
         ]
+        arg_dict["input_dtype"] = [flow.int8, flow.int32, flow.int64, flow.float, flow.double]
         arg_dict["device"] = ["cpu", "cuda"]
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])

--- a/python/oneflow/test/modules/test_searchsorted.py
+++ b/python/oneflow/test/modules/test_searchsorted.py
@@ -35,7 +35,6 @@ def _test_search_sorted(test_case, device):
     output = flow.searchsorted(sorted_sequence, values)
     test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
     test_case.assertTrue(output.dtype == flow.int64)
-    print("_test_search_sorted")
 
 
 def _test_search_sorted_1(test_case, device):
@@ -49,7 +48,6 @@ def _test_search_sorted_1(test_case, device):
     output = flow.searchsorted(sorted_sequence, values, right=True)
     test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
     test_case.assertTrue(output.dtype == flow.int64)
-    print("_test_search_sorted_1")
 
 
 def _test_search_sorted_2(test_case, device):
@@ -63,7 +61,6 @@ def _test_search_sorted_2(test_case, device):
     output = flow.searchsorted(sorted_sequence_1d, values)
     test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
     test_case.assertTrue(output.dtype == flow.int64)
-    print("_test_search_sorted_2")
 
 
 def _test_search_sorted_3(test_case, device):
@@ -77,7 +74,6 @@ def _test_search_sorted_3(test_case, device):
     output = flow.searchsorted(sorted_sequence, values, out_int32=True)
     test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
     test_case.assertTrue(output.dtype == flow.int32)
-    print("_test_search_sorted_3")
 
 
 def _test_search_sorted_4(test_case, device):
@@ -92,7 +88,6 @@ def _test_search_sorted_4(test_case, device):
     output = flow.searchsorted(sorted_sequence, values, sorter=sorter)
     test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
     test_case.assertTrue(output.dtype == flow.int64)
-    print("_test_search_sorted_4")
 
 
 def _test_search_sorted_5(test_case, device):
@@ -103,7 +98,6 @@ def _test_search_sorted_5(test_case, device):
     output = flow.searchsorted(sorted_sequence_1d, 5)
     test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
     test_case.assertTrue(output.dtype == flow.int64)
-    print("_test_search_sorted_5")
 
 
 def _test_search_sorted_6(test_case, device):
@@ -114,7 +108,6 @@ def _test_search_sorted_6(test_case, device):
     output = flow.searchsorted(sorted_sequence_1d, 5, right=True)
     test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
     test_case.assertTrue(output.dtype == flow.int64)
-    print("_test_search_sorted_6")
 
 
 def _test_search_sorted_7(test_case, device):
@@ -125,8 +118,6 @@ def _test_search_sorted_7(test_case, device):
     output = flow.searchsorted(sorted_sequence_1d, 5, out_int32=True)
     test_case.assertTrue(np.allclose(output.numpy(), gt, 0.0001, 0.0001))
     test_case.assertTrue(output.dtype == flow.int32)
-    print("_test_search_sorted_7")
-
 
 
 @flow.unittest.skip_unless_1n1d()


### PR DESCRIPTION
背景：NERF网络需要用到这个算子
算子描述：
参考pytorch的实现https://pytorch.org/docs/stable/generated/torch.searchsorted.html?highlight=searchsorted#torch.searchsorted
接口和功能基本都与pytorch对齐。由于pytorch的参数列表中的right和side所表示的意思相同，在oneflow中仅保留right。