### PR TITLE
add unittest and int32 support for branch feat-param_support_np_scalar

### DIFF
--- a/oneflow/api/python/functional/indexing.cpp
+++ b/oneflow/api/python/functional/indexing.cpp
@@ -89,6 +89,11 @@ Maybe<void> ParseScalar(PyObject* object, char* data, const DataType& dtype) {
     CHECK_OR_RETURN(PyLong_Check(object)) << "Expected a long value.";
     *(reinterpret_cast<int64_t*>(data)) = PyLong_AsLongLong(object);
     return Maybe<void>::Ok();
+  } else if (dtype == DataType::kInt32) {
+    CHECK_OR_RETURN(PyLong_Check(object) || numpy::PyArrayCheckLongScalar(object))
+        << "Expected a long value.";
+    *(reinterpret_cast<int32_t*>(data)) = PyLong_AsLongLong(object);
+    return Maybe<void>::Ok();
   } else if (dtype == DataType::kUInt8 || dtype == DataType::kBool) {
     CHECK_OR_RETURN(PyBool_Check(object) || PyLong_Check(object))
         << "Expected a boolean or long value.";

--- a/python/oneflow/test/tensor/test_tensor_indexing.py
+++ b/python/oneflow/test/tensor/test_tensor_indexing.py
@@ -23,6 +23,67 @@ import oneflow as flow
 import oneflow.unittest
 
 
+def _test_numpy_scalar_indexing(test_case, numpy_x):
+    x = flow.Tensor(numpy_x)
+
+    np_scalar = np.random.choice(
+        [np.int8, np.int16, np.int32, np.int64], size=(1,)
+    ).item()
+
+    # basic_slice
+    test_case.assertTrue(np.allclose(numpy_x[np_scalar(1)], x[np_scalar(1)].numpy()))
+    test_case.assertTrue(np.allclose(numpy_x[np_scalar(-2)], x[np_scalar(-2)].numpy()))
+    test_case.assertTrue(
+        np.allclose(
+            numpy_x[np_scalar(0), np_scalar(1)], x[np_scalar(0), np_scalar(1)].numpy()
+        )
+    )
+    test_case.assertTrue(
+        np.allclose(
+            numpy_x[(np_scalar(0), np_scalar(1))],
+            x[(np_scalar(0), np_scalar(1))].numpy(),
+        )
+    )
+    test_case.assertTrue(
+        np.allclose(
+            numpy_x[((np_scalar(0), np_scalar(1)))],
+            x[((np_scalar(0), np_scalar(1)))].numpy(),
+        )
+    )
+
+    # advance indexing
+    test_case.assertTrue(
+        np.allclose(
+            numpy_x[[np_scalar(0), np_scalar(1)]],
+            x[[np_scalar(0), np_scalar(1)]].numpy(),
+        )
+    )
+    test_case.assertTrue(
+        np.allclose(
+            numpy_x[[np_scalar(0), np_scalar(1)], [np_scalar(1), np_scalar(0)]],
+            x[[np_scalar(0), np_scalar(1)], [np_scalar(1), np_scalar(0)]].numpy(),
+        )
+    )
+    test_case.assertTrue(
+        np.allclose(
+            numpy_x[
+                [
+                    [np_scalar(0), np_scalar(1)],
+                    [np_scalar(0), np_scalar(1)],
+                    [np_scalar(1), np_scalar(0)],
+                ]
+            ],
+            x[
+                [
+                    [np_scalar(0), np_scalar(1)],
+                    [np_scalar(0), np_scalar(1)],
+                    [np_scalar(1), np_scalar(0)],
+                ]
+            ].numpy(),
+        )
+    )
+
+
 def _test_basic_slice(test_case, numpy_x):
     x = flow.tensor(numpy_x)
 
@@ -277,6 +338,16 @@ class TestTensorIndexing(flow.unittest.TestCase):
 
         numpy_x = np.arange(0, 720, 1).reshape([8, 9, 10]).astype(np.float32)
         _test_combining_indexing(test_case, numpy_x)
+
+    def test_numpy_scalar_indexing(test_case):
+        numpy_x = np.arange(0, 60, 1).reshape([3, 4, 5]).astype(np.float32)
+        _test_numpy_scalar_indexing(test_case, numpy_x)
+
+        numpy_x = np.arange(0, 360, 1).reshape([3, 4, 5, 6]).astype(np.float32)
+        _test_numpy_scalar_indexing(test_case, numpy_x)
+
+        numpy_x = np.arange(0, 720, 1).reshape([8, 9, 10]).astype(np.float32)
+        _test_numpy_scalar_indexing(test_case, numpy_x)
 
     def test_mask_getitem(test_case):
         numpy_x = np.arange(0, 60, 1).reshape([3, 4, 5]).astype(np.float32)

--- a/python/oneflow/test/tensor/test_tensor_indexing.py
+++ b/python/oneflow/test/tensor/test_tensor_indexing.py
@@ -349,6 +349,7 @@ class TestTensorIndexing(flow.unittest.TestCase):
             numpy_x = np.arange(0, 720, 1).reshape([8, 9, 10]).astype(np.float32)
             _test_numpy_scalar_indexing(test_case, numpy_x, np_scalar)
         
+        # TODO: add np.int16 when advance indexing supports np.int16 mapping
         for np_scalar in [np.int32, np.int64]:
             numpy_x = np.arange(0, 60, 1).reshape([3, 4, 5]).astype(np.float32)
             _test_numpy_scalar_advance_indexing(test_case, numpy_x, np_scalar)

--- a/python/oneflow/test/tensor/test_tensor_indexing.py
+++ b/python/oneflow/test/tensor/test_tensor_indexing.py
@@ -23,12 +23,8 @@ import oneflow as flow
 import oneflow.unittest
 
 
-def _test_numpy_scalar_indexing(test_case, numpy_x):
+def _test_numpy_scalar_indexing(test_case, numpy_x, np_scalar):
     x = flow.Tensor(numpy_x)
-
-    np_scalar = np.random.choice(
-        [np.int8, np.int16, np.int32, np.int64], size=(1,)
-    ).item()
 
     # basic_slice
     test_case.assertTrue(np.allclose(numpy_x[np_scalar(1)], x[np_scalar(1)].numpy()))
@@ -51,6 +47,9 @@ def _test_numpy_scalar_indexing(test_case, numpy_x):
         )
     )
 
+def _test_numpy_scalar_advance_indexing(test_case, numpy_x, np_scalar):
+    x = flow.Tensor(numpy_x)
+    
     # advance indexing
     test_case.assertTrue(
         np.allclose(
@@ -340,14 +339,26 @@ class TestTensorIndexing(flow.unittest.TestCase):
         _test_combining_indexing(test_case, numpy_x)
 
     def test_numpy_scalar_indexing(test_case):
-        numpy_x = np.arange(0, 60, 1).reshape([3, 4, 5]).astype(np.float32)
-        _test_numpy_scalar_indexing(test_case, numpy_x)
+        for np_scalar in [np.int8, np.int16, np.int32, np.int64]:
+            numpy_x = np.arange(0, 60, 1).reshape([3, 4, 5]).astype(np.float32)
+            _test_numpy_scalar_indexing(test_case, numpy_x, np_scalar)
 
-        numpy_x = np.arange(0, 360, 1).reshape([3, 4, 5, 6]).astype(np.float32)
-        _test_numpy_scalar_indexing(test_case, numpy_x)
+            numpy_x = np.arange(0, 360, 1).reshape([3, 4, 5, 6]).astype(np.float32)
+            _test_numpy_scalar_indexing(test_case, numpy_x, np_scalar)
 
-        numpy_x = np.arange(0, 720, 1).reshape([8, 9, 10]).astype(np.float32)
-        _test_numpy_scalar_indexing(test_case, numpy_x)
+            numpy_x = np.arange(0, 720, 1).reshape([8, 9, 10]).astype(np.float32)
+            _test_numpy_scalar_indexing(test_case, numpy_x, np_scalar)
+        
+        for np_scalar in [np.int32, np.int64]:
+            numpy_x = np.arange(0, 60, 1).reshape([3, 4, 5]).astype(np.float32)
+            _test_numpy_scalar_advance_indexing(test_case, numpy_x, np_scalar)
+
+            numpy_x = np.arange(0, 360, 1).reshape([3, 4, 5, 6]).astype(np.float32)
+            _test_numpy_scalar_advance_indexing(test_case, numpy_x, np_scalar)
+
+            numpy_x = np.arange(0, 720, 1).reshape([8, 9, 10]).astype(np.float32)
+            _test_numpy_scalar_advance_indexing(test_case, numpy_x, np_scalar)
+        
 
     def test_mask_getitem(test_case):
         numpy_x = np.arange(0, 60, 1).reshape([3, 4, 5]).astype(np.float32)


### PR DESCRIPTION
此PR完成了：
针对 https://github.com/Oneflow-Inc/oneflow/pull/7935 新增的numpy scalar indexing功能，增加了tensor的unittest，增加了advance indexing中对numpy.int32参数的识别