### PR TITLE
Exclude ubuntu debug shared lib off in simple CI

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -91,6 +91,9 @@ jobs:
             cmake_generator: "Ninja"
             build_shared_libs: "OFF"
           - test_suite: ubuntu
+            cmake_build_type: "Debug"
+            build_shared_libs: "OFF"
+          - test_suite: ubuntu
             cmake_generator: "Unix Makefiles"
             cmake_build_type: "Release"
     steps:


### PR DESCRIPTION
关闭 Simple CI 的静态链接、开启 debug的build，因为符号太多链接的时候一定会被系统 kill