### PR TITLE
Auto parallel/fast collector

### DIFF
--- a/oneflow/core/auto_parallel/binary_set.cpp
+++ b/oneflow/core/auto_parallel/binary_set.cpp
@@ -44,7 +44,7 @@ void BinarySet::Initialize(int32_t size_of_set) {
 }
 
 // Check if i-th element in this subset
-int32_t BinarySet::CheckExistency(int32_t i) {
+int32_t BinarySet::CheckExistency(int32_t i) const {
   int32_t k = i / bit_of_BinarySetEntryType;
   int32_t j = i % bit_of_BinarySetEntryType;
   return BinarySetValues[k] >> j & 1;
@@ -91,7 +91,7 @@ int32_t BinarySet::Total() {
 }
 
 // Output all the elements in the subset
-void BinarySet::OutPut(std::vector<int32_t>& out) {
+void BinarySet::OutPut(std::vector<int32_t>& out) const {
   out.clear();
   for (int32_t i = 0; i < SizeOfSet; i++) {
     if (CheckExistency(i)) { out.emplace_back(i); }
@@ -99,7 +99,7 @@ void BinarySet::OutPut(std::vector<int32_t>& out) {
 }
 
 // Output all the elements in the subset
-void BinarySet::QuickOutPut(std::vector<int32_t>& out) {
+void BinarySet::QuickOutPut(std::vector<int32_t>& out) const {
   out.clear();
   for (int32_t i = 0; i < BinarySetValues.size(); i++) {
     BinarySetEntryType x = BinarySetValues[i];

--- a/oneflow/core/auto_parallel/binary_set.h
+++ b/oneflow/core/auto_parallel/binary_set.h
@@ -47,7 +47,7 @@ class BinarySet {
   // Initialization
   void Initialize(int32_t size_of_set);
   // Check if i-th element in this subset
-  int32_t CheckExistency(int32_t i);
+  int32_t CheckExistency(int32_t i) const;
   // Add i-th element into this subset
   void AddEntry(int32_t i);
   // Take i-th element out from this subset
@@ -59,9 +59,9 @@ class BinarySet {
   // Count number of elements in this subset
   int32_t Total();
   // Output all the elements in the subset
-  void OutPut(std::vector<int32_t>& out);
+  void OutPut(std::vector<int32_t>& out) const;
   // Output all the elements in the subset
-  void QuickOutPut(std::vector<int32_t>& out);
+  void QuickOutPut(std::vector<int32_t>& out) const;
   // Add elements of input into this subset
   void AddEntrys(std::vector<int32_t>& in);
   // If two binary sets are equal to each other

--- a/oneflow/core/auto_parallel/sbp_collector.cpp
+++ b/oneflow/core/auto_parallel/sbp_collector.cpp
@@ -271,7 +271,8 @@ void SbpCollector::ProxySbpCandidate(
     // store all the binary sets of SBP Parallel into an unordered_set.
     std::unordered_set<BinarySet, BinarySetHasher> ParallelCandidates;
 
-    DfsSbpSet(0, max_num_sbp_proxy, index2sbp_set[index], ParallelCandidates);
+    DfsSbpSet(0, max_num_sbp_proxy, index2sbp_set[index], index2sbp_set[index].begin(),
+              ParallelCandidates);
 
     // Initialize sbp proxy
     SbpNode<NdSbpSignature>* sbp_proxy = InitializePorxy(sbp_graph, ParallelCandidates);
@@ -309,6 +310,7 @@ void SbpCollector::ProxySbpCandidate(
 // Depth first search to collect Sbp Parallel information for different lbis
 void SbpCollector::DfsSbpSet(int32_t depth, int32_t max_depth,
                              const std::unordered_set<int32_t>& sbp_sets,
+                             const std::unordered_set<int32_t>::iterator start_it,
                              std::unordered_set<BinarySet, BinarySetHasher>& ParallelCandidates) {
   if (depth > 0) {
     // store the binary set into an unordered_set
@@ -316,12 +318,17 @@ void SbpCollector::DfsSbpSet(int32_t depth, int32_t max_depth,
   }
   if (depth >= max_depth) { return; }
 
-  // go through all the sbp parallel of different candidates
-  for (int32_t SbpParallelNum : sbp_sets) {
+  // go through the rest of the sbp parallel
+  std::unordered_set<int32_t>::iterator curr_it = start_it;
+  while (curr_it != sbp_sets.end()) {
+    // Take the value out
+    int32_t SbpParallelNum = *curr_it;
+    // Then move to the next pointer
+    ++curr_it;
     if (accumulator[SbpParallelNum] == 0) {
       bs_buffer.AddEntry(SbpParallelNum);
       ++accumulator[SbpParallelNum];
-      DfsSbpSet(depth + 1, max_depth, sbp_sets, ParallelCandidates);
+      DfsSbpSet(depth + 1, max_depth, sbp_sets, curr_it, ParallelCandidates);
       bs_buffer.DeleteEntry(SbpParallelNum);
       --accumulator[SbpParallelNum];
     }

--- a/oneflow/core/auto_parallel/sbp_collector.cpp
+++ b/oneflow/core/auto_parallel/sbp_collector.cpp
@@ -186,11 +186,6 @@ void SbpCollector::ProxySbpCandidate(
   // HashMap<std::string, HashMap<LogicalBlobId, SbpNode<NdSbpSignature>*>>&
   //     op_name2lbi2sbp_proxy;
 
-  // mapping from a logical blob id to a group of consumers and corresponding input blob names.
-  // mapping from consumers and input blob names to an unordered_set of SBP Parallel.
-  HashMap<std::pair<std::string, LogicalBlobId>,
-          HashMap<std::pair<std::string, std::string>, std::unordered_set<int32_t>>>
-      producer_lbi2consumer_bn2sbp_set;
   // mapping from a logical blob id to index
   HashMap<LogicalBlobId, int32_t> lbi2index;
   // mapping from the index to producer, consuemr and corresponding input blob name, possible sbp

--- a/oneflow/core/auto_parallel/sbp_collector.h
+++ b/oneflow/core/auto_parallel/sbp_collector.h
@@ -67,8 +67,7 @@ class SbpCollector {
   // Initialize copy cost from proxy of producer to consumers
   void InitializeCopyCostFromProxy2Consumer(
       SbpNode<NdSbpSignature>* sbp_proxy,
-      HashMap<std::pair<std::string, std::string>, std::unordered_set<int32_t>>&
-          consumer_bn2sbp_set,
+      const std::vector<std::pair<const OpNode*, std::string>>& consumer_bns,
       HashMap<std::string, SbpNode<NdSbpSignature>*>& op_name2sbp_node);
 
   // Export list of possible combination of Sbp Parallels
@@ -77,13 +76,12 @@ class SbpCollector {
                          SbpGraph<NdSbpSignature>& sbp_graph);
 
  private:
+  // Maximum number of possible sbp in the proxy
+  unsigned long max_num_sbp_proxy_ = 3;
+
   // Depth first search to collect Sbp Parallel information for different lbis
-  void DfsSbpSet(
-      HashMap<std::pair<std::string, std::string>, std::unordered_set<int32_t>>::iterator it,
-      HashMap<std::pair<std::string, std::string>, std::unordered_set<int32_t>>&
-          consumer_bn2sbp_set,
-      HashMap<std::string, SbpNode<NdSbpSignature>*>& op_name2sbp_node,
-      std::unordered_set<BinarySet, BinarySetHasher>& ParallelCandidates);
+  void DfsSbpSet(int32_t depth, int32_t max_depth, const std::unordered_set<int32_t>& sbp_sets,
+                 std::unordered_set<BinarySet, BinarySetHasher>& ParallelCandidates);
 };  // class SbpCollector
 
 }  // namespace auto_parallel

--- a/oneflow/core/auto_parallel/sbp_collector.h
+++ b/oneflow/core/auto_parallel/sbp_collector.h
@@ -81,6 +81,7 @@ class SbpCollector {
 
   // Depth first search to collect Sbp Parallel information for different lbis
   void DfsSbpSet(int32_t depth, int32_t max_depth, const std::unordered_set<int32_t>& sbp_sets,
+                 const std::unordered_set<int32_t>::iterator sbp_set_it,
                  std::unordered_set<BinarySet, BinarySetHasher>& ParallelCandidates);
 };  // class SbpCollector
 


### PR DESCRIPTION
加速sbp collector

给sbp collector下游的上限设到了3.

也就是一个节点即使有100个下游，这些下游最多只会有3个不同的sbp。(一般 B, S0 都够用了, 保险起见，多加一个)

这样那种2D sbp也不怕了，之前一个代理节点可能会有 25^5 种策略， 所以巨慢，也不是跑不通，但是跑一次要等20-40分钟。