### PR TITLE
fix bug when batchnorm(affine=False)

### DIFF
--- a/python/oneflow/nn/modules/batchnorm.py
+++ b/python/oneflow/nn/modules/batchnorm.py
@@ -41,8 +41,8 @@ class _NormBase(Module):
             self.weight = flow.nn.Parameter(flow.Tensor(num_features))
             self.bias = flow.nn.Parameter(flow.Tensor(num_features))
         else:
-            self.register_parameter("weight", None)
-            self.register_parameter("bias", None)
+            self.register_buffer("weight", flow.ones(num_features))
+            self.register_buffer("bias", flow.zeros(num_features))
         if self.track_running_stats:
             self.register_buffer("running_mean", flow.Tensor(num_features))
             self.register_buffer("running_var", flow.Tensor(num_features))


### PR DESCRIPTION
此PR完成了：
- 解决了当BatchNorm中affine为False的时候，某些case报错的问题

问题背景：https://github.com/Oneflow-Inc/libai/pull/160#issuecomment-1086582245 ，原因在于 `x->device()` 出错
https://github.com/Oneflow-Inc/oneflow/blob/d3d7f2cfd077aa63e70c5d310e29f1c2c2c5088b/oneflow/core/functional/impl/nn_functor.cpp#L1420-L1421 

解决方法：

在Python层，当 `affine=False` 时，把weight和bias注册成恒为1和0的buffer（而不是为None的parameter），然后视作affine=True进行后续计算

注意事项：
- 之前考虑过其他方法：
  - 仿照LayerNorm，单独增加一个affine=False时对应的functor，但是需要对应kernel实现，受限于cudnn batchnorm的接口（必须传入gamma和beta）实现起来较为困难  
  - 在当前位置修复 `x->device()` 报错的问题，但是每次前向都要创建tensor会造成性能下降
