### PR TITLE
AutoParallel mainstem algorithm add mutable_op_ctrl_edge

### DIFF
--- a/oneflow/core/auto_parallel/sbp_constructor.h
+++ b/oneflow/core/auto_parallel/sbp_constructor.h
@@ -38,7 +38,8 @@ class SbpConstructor final {
         use_sbp_collector_(!Global<ResourceDesc, ForSession>::Get()
                                 ->resource()
                                 .disable_group_boxing_by_dst_parallel()
-                           && job->job_conf().enable_auto_parallel_sbp_collector()) {
+                           && job->job_conf().enable_auto_parallel_sbp_collector()),
+        op_graph_(&op_graph) {
     sbp_graph_.SetWaitTime(job->job_conf().auto_parallel_wait_time());
     sbp_graph_.SetTransferCost(job->job_conf().auto_parallel_transfer_cost());
     CHECK_JUST(Init(op_graph, job));
@@ -61,6 +62,7 @@ class SbpConstructor final {
   Maybe<void> InitComputationCost(const OpGraph& op_graph);
   Maybe<void> InitCopyCost(const OpGraph& op_graph);
   Maybe<void> ApplyMainstemAlgo();
+  Maybe<HashMap<const OpNode*, HashSet<std::string>>> GetMutableOpCtrlDeps(const OpGraph& op_graph);
   // Load logical blob ids onto sbp edges
   void LoadLbi2SbpEdge(const OpGraph& op_graph);
 
@@ -68,6 +70,7 @@ class SbpConstructor final {
   bool enable_mainstem_algo_;
   bool use_sbp_collector_;
   SbpGraph<NdSbpSignature> sbp_graph_;
+  const OpGraph* op_graph_;
   HashMap<std::string, SbpNode<NdSbpSignature>*> op_name2sbp_node_;
 };
 

--- a/oneflow/core/auto_parallel/sbp_graph.h
+++ b/oneflow/core/auto_parallel/sbp_graph.h
@@ -123,7 +123,9 @@ class SbpGraph {
   void DetectAdjustOverlap(double CostRatio);
 
   // Compute the minimum and maximum layer of each node in the graph
-  int32_t ComputeLayer(oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node);
+  int32_t ComputeLayer(oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node,
+                       const oneflow::HashMap<const OpNode*, oneflow::HashSet<std::string>>&
+                           op_node2mutable_op_ctrl_deps);
 
   // Find the mianstem of the sbp graph, then reduce the wait time for tributaries
   void FindMainstem(int32_t max_MinLayer,
@@ -912,16 +914,22 @@ void SbpGraph<SbpSignature>::DetectAdjustOverlap(double CostRatio) {
 // Compute the minimum and maximum layer of each node in the graph
 template<class SbpSignature>
 int32_t SbpGraph<SbpSignature>::ComputeLayer(
-    oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node) {
+    oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node,
+    const oneflow::HashMap<const OpNode*, oneflow::HashSet<std::string>>&
+        op_node2mutable_op_ctrl_deps) {
   // Compute minimum layer
-  for (SbpNode<SbpSignature>* this_node : NodeList) { this_node->GetMinLayer(op_name2sbp_node); }
+  for (SbpNode<SbpSignature>* this_node : NodeList) {
+    this_node->GetMinLayer(op_name2sbp_node, op_node2mutable_op_ctrl_deps);
+  }
   // Find the largest minimum layer
   int32_t max_MinLayer = -1;
   for (SbpNode<SbpSignature>* this_node : NodeList) {
-    if (max_MinLayer < this_node->MinLayer) { max_MinLayer = this_node->MinLayer; }
+    max_MinLayer = std::max(max_MinLayer, this_node->MinLayer);
   }
   // Compute maximum layer
-  for (SbpNode<SbpSignature>* this_node : NodeList) { this_node->SpreadMaxLayer(op_name2sbp_node); }
+  for (SbpNode<SbpSignature>* this_node : NodeList) {
+    this_node->SpreadMaxLayer(op_name2sbp_node, op_node2mutable_op_ctrl_deps);
+  }
   for (SbpNode<SbpSignature>* this_node : NodeList) { this_node->LiftMaxLayer(max_MinLayer); }
   return max_MinLayer;
 }

--- a/oneflow/core/auto_parallel/sbp_graph.h
+++ b/oneflow/core/auto_parallel/sbp_graph.h
@@ -924,7 +924,7 @@ int32_t SbpGraph<SbpSignature>::ComputeLayer(
   // Find the largest minimum layer
   int32_t max_MinLayer = -1;
   for (SbpNode<SbpSignature>* this_node : NodeList) {
-    max_MinLayer = std::max(max_MinLayer, this_node->MinLayer);
+    if (max_MinLayer < this_node->MinLayer) { max_MinLayer = this_node->MinLayer; }
   }
   // Compute maximum layer
   for (SbpNode<SbpSignature>* this_node : NodeList) {

--- a/oneflow/core/auto_parallel/sbp_node.h
+++ b/oneflow/core/auto_parallel/sbp_node.h
@@ -184,9 +184,13 @@ class SbpNode {
   void DetectSpreadOverlap(double overlap_ratio);
 
   // Get or compute the minimum layer of this node
-  int32_t GetMinLayer(oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node);
+  int32_t GetMinLayer(oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node,
+                      const oneflow::HashMap<const OpNode*, oneflow::HashSet<std::string>>&
+                          op_node2mutable_op_ctrl_deps);
   // Spread the minimum layer to compute the maximum layer of producers
-  void SpreadMaxLayer(oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node);
+  void SpreadMaxLayer(oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node,
+                      const oneflow::HashMap<const OpNode*, oneflow::HashSet<std::string>>&
+                          op_node2mutable_op_ctrl_deps);
   // Drop down the maximum layer with the minimum layer form consumer
   void DropMaxLayer(int32_t upper_bound);
   // Set MaxLayer = MinLayer if this node does not have any consumer
@@ -681,18 +685,32 @@ void SbpNode<SbpSignature>::DetectSpreadOverlap(double overlap_ratio) {
 // Get or compute the minimum layer of this node
 template<class SbpSignature>
 int32_t SbpNode<SbpSignature>::GetMinLayer(
-    oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node) {
+    oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node,
+    const oneflow::HashMap<const OpNode*, oneflow::HashSet<std::string>>&
+        op_node2mutable_op_ctrl_deps) {
   if (MinLayer >= 0) { return MinLayer; }
   if (!op_node) { return MinLayer; }
   for (SbpEdge<SbpSignature>* this_edge : EdgesIn) {
-    int32_t producer_min_layer = this_edge->StartNode->GetMinLayer(op_name2sbp_node);
-    if (producer_min_layer > MinLayer) { MinLayer = producer_min_layer; }
+    int32_t producer_min_layer =
+        this_edge->StartNode->GetMinLayer(op_name2sbp_node, op_node2mutable_op_ctrl_deps);
+    MinLayer = std::max(MinLayer, producer_min_layer);
   }
   for (const auto& ctrl_in_op_name : op_node->op().op_conf().ctrl_in_op_name()) {
     auto it = op_name2sbp_node.find(ctrl_in_op_name);
     if (it != op_name2sbp_node.end()) {
-      int32_t producer_min_layer = it->second->GetMinLayer(op_name2sbp_node);
-      if (producer_min_layer > MinLayer) { MinLayer = producer_min_layer; }
+      int32_t producer_min_layer =
+          it->second->GetMinLayer(op_name2sbp_node, op_node2mutable_op_ctrl_deps);
+      MinLayer = std::max(MinLayer, producer_min_layer);
+    }
+  }
+  if (op_node2mutable_op_ctrl_deps.find(op_node) != op_node2mutable_op_ctrl_deps.end()) {
+    for (const auto& ctrl_in_op_name : op_node2mutable_op_ctrl_deps.at(op_node)) {
+      auto it = op_name2sbp_node.find(ctrl_in_op_name);
+      if (it != op_name2sbp_node.end()) {
+        int32_t producer_min_layer =
+            it->second->GetMinLayer(op_name2sbp_node, op_node2mutable_op_ctrl_deps);
+        MinLayer = std::max(MinLayer, producer_min_layer);
+      }
     }
   }
   return ++MinLayer;
@@ -701,7 +719,9 @@ int32_t SbpNode<SbpSignature>::GetMinLayer(
 // Spread the minimum layer to compute the maximum layer of producers
 template<class SbpSignature>
 void SbpNode<SbpSignature>::SpreadMaxLayer(
-    oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node) {
+    oneflow::HashMap<std::string, SbpNode<SbpSignature>*>& op_name2sbp_node,
+    const oneflow::HashMap<const OpNode*, oneflow::HashSet<std::string>>&
+        op_node2mutable_op_ctrl_deps) {
   if (MinLayer <= 0) { return; }
   int32_t producer_max_lay = MinLayer - 1;
   for (SbpEdge<SbpSignature>* this_edge : EdgesIn) {
@@ -710,6 +730,12 @@ void SbpNode<SbpSignature>::SpreadMaxLayer(
   for (const auto& ctrl_in_op_name : op_node->op().op_conf().ctrl_in_op_name()) {
     auto it = op_name2sbp_node.find(ctrl_in_op_name);
     if (it != op_name2sbp_node.end()) { it->second->DropMaxLayer(producer_max_lay); }
+  }
+  if (op_node2mutable_op_ctrl_deps.find(op_node) != op_node2mutable_op_ctrl_deps.end()) {
+    for (const auto& ctrl_in_op_name : op_node2mutable_op_ctrl_deps.at(op_node)) {
+      auto it = op_name2sbp_node.find(ctrl_in_op_name);
+      if (it != op_name2sbp_node.end()) { it->second->DropMaxLayer(producer_max_lay); }
+    }
   }
 }
 

--- a/oneflow/core/auto_parallel/sbp_node.h
+++ b/oneflow/core/auto_parallel/sbp_node.h
@@ -693,14 +693,14 @@ int32_t SbpNode<SbpSignature>::GetMinLayer(
   for (SbpEdge<SbpSignature>* this_edge : EdgesIn) {
     int32_t producer_min_layer =
         this_edge->StartNode->GetMinLayer(op_name2sbp_node, op_node2mutable_op_ctrl_deps);
-    MinLayer = std::max(MinLayer, producer_min_layer);
+    if (producer_min_layer > MinLayer) { MinLayer = producer_min_layer; }
   }
   for (const auto& ctrl_in_op_name : op_node->op().op_conf().ctrl_in_op_name()) {
     auto it = op_name2sbp_node.find(ctrl_in_op_name);
     if (it != op_name2sbp_node.end()) {
       int32_t producer_min_layer =
           it->second->GetMinLayer(op_name2sbp_node, op_node2mutable_op_ctrl_deps);
-      MinLayer = std::max(MinLayer, producer_min_layer);
+      if (producer_min_layer > MinLayer) { MinLayer = producer_min_layer; }
     }
   }
   if (op_node2mutable_op_ctrl_deps.find(op_node) != op_node2mutable_op_ctrl_deps.end()) {
@@ -709,7 +709,7 @@ int32_t SbpNode<SbpSignature>::GetMinLayer(
       if (it != op_name2sbp_node.end()) {
         int32_t producer_min_layer =
             it->second->GetMinLayer(op_name2sbp_node, op_node2mutable_op_ctrl_deps);
-        MinLayer = std::max(MinLayer, producer_min_layer);
+        if (producer_min_layer > MinLayer) { MinLayer = producer_min_layer; }
       }
     }
   }


### PR DESCRIPTION
自动并行 Mainstem 算法考虑到 mutable 消费时添加控制边的逻辑，可以更准确估计传输和计算的重叠关系。