### PR TITLE
fix memory leak in vm

### DIFF
--- a/oneflow/core/vm/virtual_machine.cpp
+++ b/oneflow/core/vm/virtual_machine.cpp
@@ -177,22 +177,21 @@ VirtualMachine::~VirtualMachine() {
 std::function<Maybe<bool>()> VirtualMachine::GetPredicatorNoMoreInstructionsFinished() {
   auto last_total_erased = std::make_shared<size_t>(0);
   auto* vm = Global<VirtualMachine>::Get();
-  if (vm != nullptr) { *last_total_erased = vm->vm().total_erased_lively_instruction_cnt(); }
+  if (vm != nullptr) { *last_total_erased = vm->vm().total_erased_instruction_cnt(); }
   return [last_total_erased]() -> Maybe<bool> {
     auto* vm = Global<VirtualMachine>::Get();
     CHECK_NOTNULL_OR_RETURN(vm) << "virtual machine not initialized.";
-    CHECK_OR_RETURN(!vm->NoMoreErasedLivelyInstructions(last_total_erased.get()))
+    CHECK_OR_RETURN(!vm->NoMoreErasedInstructions(last_total_erased.get()))
         << "blocking instructions\n"
         << vm->GetBlockingDebugString();
     return false;
   };
 }
 
-bool VirtualMachine::NoMoreErasedLivelyInstructions(
-    size_t* last_total_erased_lively_instruction_cnt) const {
-  size_t cnt = vm_->total_erased_lively_instruction_cnt();
-  bool no_more_erased = (*last_total_erased_lively_instruction_cnt == cnt);
-  *last_total_erased_lively_instruction_cnt = cnt;
+bool VirtualMachine::NoMoreErasedInstructions(size_t* last_total_erased_instruction_cnt) const {
+  size_t cnt = vm_->total_erased_instruction_cnt();
+  bool no_more_erased = (*last_total_erased_instruction_cnt == cnt);
+  *last_total_erased_instruction_cnt = cnt;
   return no_more_erased;
 }
 

--- a/oneflow/core/vm/virtual_machine.h
+++ b/oneflow/core/vm/virtual_machine.h
@@ -34,7 +34,7 @@ class VirtualMachine final {
 
   static std::function<Maybe<bool>()> GetPredicatorNoMoreInstructionsFinished();
 
-  bool NoMoreErasedLivelyInstructions(size_t* last_total_erased_lively_instruction_cnt) const;
+  bool NoMoreErasedInstructions(size_t* last_total_erased_instruction_cnt) const;
   std::string GetBlockingDebugString();
 
   Maybe<void> Receive(vm::InstructionMsgList* instr_list);

--- a/oneflow/core/vm/virtual_machine_engine.cpp
+++ b/oneflow/core/vm/virtual_machine_engine.cpp
@@ -148,7 +148,7 @@ std::string VirtualMachineEngine::GetLivelyInstructionListDebugString(int64_t de
 }
 
 void VirtualMachineEngine::LivelyInstructionListPushBack(Instruction* instruction) {
-  ++total_inserted_lively_instruction_cnt_;
+  ++total_inserted_instruction_cnt_;
   mut_lively_instruction_list()->PushBack(instruction);
 }
 
@@ -172,10 +172,9 @@ void VirtualMachineEngine::HandleLocalProbe() {
 
 intrusive::shared_ptr<Instruction> VirtualMachineEngine::LivelyInstructionListErase(
     Instruction* instruction) {
-  ++total_erased_lively_instruction_cnt_;
   auto ret = mut_lively_instruction_list()->Erase(instruction);
   static constexpr int kProbeInterval = 20;
-  if (unlikely(total_erased_lively_instruction_cnt_ % kProbeInterval) == 0) { HandleProbe(); }
+  if (unlikely(total_erased_instruction_cnt_ % kProbeInterval) == 0) { HandleProbe(); }
   return ret;
 }
 
@@ -575,6 +574,7 @@ void VirtualMachineEngine::Callback() {
       // Destruct garbage.
       return Maybe<void>::Ok();
     }));
+    ++total_erased_instruction_cnt_;
   }
 }
 

--- a/oneflow/core/vm/virtual_machine_engine.h
+++ b/oneflow/core/vm/virtual_machine_engine.h
@@ -70,14 +70,11 @@ class VirtualMachineEngine final : public intrusive::Base {
   }
   const Range& machine_id_range() const { return machine_id_range_; }
   std::size_t flying_instruction_cnt() const {
-    return pending_msg_list().thread_unsafe_size() + lively_instruction_list_.size();
+    return pending_msg_list().thread_unsafe_size() + local_pending_msg_list().size()
+           + (total_erased_instruction_cnt() - total_inserted_instruction_cnt());
   }
-  size_t total_inserted_lively_instruction_cnt() const {
-    return total_inserted_lively_instruction_cnt_;
-  }
-  size_t total_erased_lively_instruction_cnt() const {
-    return total_erased_lively_instruction_cnt_;
-  }
+  size_t total_inserted_instruction_cnt() const { return total_inserted_instruction_cnt_; }
+  size_t total_erased_instruction_cnt() const { return total_erased_instruction_cnt_; }
   void InsertProbe(const std::function<bool(VirtualMachineEngine*)>& ProbeFunction);
   const ActiveStreamList& active_stream_list() const { return active_stream_list_; }
   const ThreadCtxList& thread_ctx_list() const { return thread_ctx_list_; }
@@ -188,8 +185,8 @@ class VirtualMachineEngine final : public intrusive::Base {
         local_garbage_msg_list_(),
         ready_instruction_list_(),
         lively_instruction_list_(),
-        total_inserted_lively_instruction_cnt_(0),
-        total_erased_lively_instruction_cnt_(0),
+        total_inserted_instruction_cnt_(0),
+        total_erased_instruction_cnt_(0),
         probe_mutex_(),
         probe_list_(&probe_mutex_),
         local_probe_list_(),
@@ -214,8 +211,8 @@ class VirtualMachineEngine final : public intrusive::Base {
   InstructionMsgList local_garbage_msg_list_;
   ReadyInstructionList ready_instruction_list_;
   LivelyInstructionList lively_instruction_list_;
-  size_t total_inserted_lively_instruction_cnt_;
-  size_t total_erased_lively_instruction_cnt_;
+  size_t total_inserted_instruction_cnt_;
+  std::atomic<size_t> total_erased_instruction_cnt_;
   std::mutex probe_mutex_;
   intrusive::MutexedList<INTRUSIVE_FIELD(Probe, Probe::probe_hook_)> probe_list_;
   intrusive::List<INTRUSIVE_FIELD(Probe, Probe::probe_hook_)> local_probe_list_;


### PR DESCRIPTION
修复vm内存泄漏问题。

发生泄漏是因为指令水位没有控制好，之前一旦指令处理完，会立刻做：1）析构；2）减水位。由于后续析构放到了callback线程里，但仍然把减水位操作遗留在scheduler线程里。这样一来，scheduler告诉main内存水位下降的消息是有误的，这个误差会持续累计，最终造成内存泄漏。