### PR TITLE
Fix pooling computation cost function bug

### DIFF
--- a/oneflow/user/ops/avg_pool_op.cpp
+++ b/oneflow/user/ops/avg_pool_op.cpp
@@ -85,13 +85,14 @@ Maybe<void> AvgPoolBackwardGetSbpFn(user_op::SbpContext* ctx) {
 // Logically computation cost of pool op is the product of output data amount and pool kernal data
 // amount. After adding sbp, we just divide it by parallel number if output data is splitted because
 // splitting input and using partial sum for output is not a valid sbp for this op for now.
-Maybe<double> GetComputationCostFn(user_op::ComputeComplexityFnContext* ctx) {
+Maybe<double> GetComputationCostFn(user_op::ComputeComplexityFnContext* ctx,
+                                   const std::string& blob_name) {
   const std::vector<int32_t> pool_size = ctx->Attr<std::vector<int32_t>>("kernel_size");
-  double logical_computation_cost =
-      std::accumulate(pool_size.begin(), pool_size.end(),
-                      ctx->Shape4ArgNameAndIndex("y", 0)->elem_cnt(), std::multiplies<double>());
+  double logical_computation_cost = std::accumulate(
+      pool_size.begin(), pool_size.end(), ctx->Shape4ArgNameAndIndex(blob_name, 0)->elem_cnt(),
+      std::multiplies<double>());
   const auto& parallel_hierarchy = ctx->parallel_desc().hierarchy();
-  const auto& nd_sbp_y = ctx->NdSbp4ArgNameAndIndex("y", 0);
+  const auto& nd_sbp_y = ctx->NdSbp4ArgNameAndIndex(blob_name, 0);
   for (int32_t dim_sbp = 0; dim_sbp < nd_sbp_y.sbp_parallel_size(); dim_sbp++) {
     if (nd_sbp_y.sbp_parallel(dim_sbp).has_split_parallel()) {
       logical_computation_cost /= parallel_hierarchy->At(dim_sbp);
@@ -156,7 +157,7 @@ Maybe<void> BwInferDataType(user_op::InferContext* ctx) {
   }                                                                                      \
   /*static*/ Maybe<double> name##Op::GetComputeComplexity(                               \
       user_op::ComputeComplexityFnContext* ctx) {                                        \
-    return GetComputationCostFn(ctx);                                                    \
+    return GetComputationCostFn(ctx, "y");                                               \
   }
 
 IMPLEMENT_AVGPOOL_FUNCS(AvgPool1D, 1)
@@ -179,7 +180,7 @@ IMPLEMENT_AVGPOOL_FUNCS(AvgPool3D, 3)
   }                                                                                          \
   /*static*/ Maybe<double> name##GradOp::GetComputeComplexity(                               \
       user_op::ComputeComplexityFnContext* ctx) {                                            \
-    return GetComputationCostFn(ctx);                                                        \
+    return GetComputationCostFn(ctx, "dy");                                                  \
   }
 
 IMPLEMENT_AVGPOOL_BACKWARD_FUNCS(AvgPool1D)

--- a/oneflow/user/ops/max_pool_op.cpp
+++ b/oneflow/user/ops/max_pool_op.cpp
@@ -113,13 +113,14 @@ GenBackwardOpConfFn MaxPoolMakeBackwardOpConfFn(const int32_t dim) {
 // Logically computation cost of pool op is the product of output data amount and pool kernal data
 // amount. After adding sbp, we just divide it by parallel number if output data is splitted because
 // splitting input and using partial sum for output is not a valid sbp for this op for now.
-Maybe<double> GetComputationCostFn(user_op::ComputeComplexityFnContext* ctx) {
-  const std::vector<int32_t> pool_size = ctx->Attr<std::vector<int32_t>>("kernel_size");
-  double logical_computation_cost =
-      std::accumulate(pool_size.begin(), pool_size.end(),
-                      ctx->Shape4ArgNameAndIndex("y", 0)->elem_cnt(), std::multiplies<double>());
+Maybe<double> GetComputationCostFn(user_op::ComputeComplexityFnContext* ctx,
+                                   const std::string& blob_name) {
+  const std::vector<int32_t>& pool_size = ctx->Attr<std::vector<int32_t>>("kernel_size");
+  double logical_computation_cost = std::accumulate(
+      pool_size.begin(), pool_size.end(), ctx->Shape4ArgNameAndIndex(blob_name, 0)->elem_cnt(),
+      std::multiplies<double>());
   const auto& parallel_hierarchy = ctx->parallel_desc().hierarchy();
-  const auto& nd_sbp_y = ctx->NdSbp4ArgNameAndIndex("y", 0);
+  const auto& nd_sbp_y = ctx->NdSbp4ArgNameAndIndex(blob_name, 0);
   for (int32_t dim_sbp = 0; dim_sbp < nd_sbp_y.sbp_parallel_size(); dim_sbp++) {
     if (nd_sbp_y.sbp_parallel(dim_sbp).has_split_parallel()) {
       logical_computation_cost /= parallel_hierarchy->At(dim_sbp);
@@ -159,7 +160,7 @@ Maybe<void> BwInferDataType(user_op::InferContext* ctx) {
   }                                                                                      \
   /*static*/ Maybe<double> name##Op::GetComputeComplexity(                               \
       user_op::ComputeComplexityFnContext* ctx) {                                        \
-    return GetComputationCostFn(ctx);                                                    \
+    return GetComputationCostFn(ctx, "y");                                               \
   }
 
 IMPLEMENT_MAXPOOL_FUNCS(MaxPool1D, 1)
@@ -182,7 +183,7 @@ IMPLEMENT_MAXPOOL_FUNCS(MaxPool3D, 3)
   }                                                                                          \
   /*static*/ Maybe<double> name##GradOp::GetComputeComplexity(                               \
       user_op::ComputeComplexityFnContext* ctx) {                                            \
-    return GetComputationCostFn(ctx);                                                        \
+    return GetComputationCostFn(ctx, "dy");                                                  \
   }
 
 IMPLEMENT_MAXPOOL_BACKWARD_FUNCS(MaxPool1D)


### PR DESCRIPTION
根据 oneflow-inc/oneteam#1292 中的优化，pooling 的后向去掉了对 y 的捕获，GetComputationCostFunc 也需要做相应的修改