### PR TITLE
Dev rocm

### DIFF
--- a/oneflow/core/common/data_type.cpp
+++ b/oneflow/core/common/data_type.cpp
@@ -153,6 +153,21 @@ void CheckDataType() {
   CHECK_DEVICE_FP16(GetMinVal);
 #undef CHECK_DEVICE_FP16
 
+#if defined(WITH_HIP)
+
+#define CHECK_DEVICE_FP16(get_val)                              \
+  do {                                                          \
+    float16 host_fp16 = get_val<float16>();                     \
+    half device_fp16 = get_val<half>();                         \
+    CHECK_EQ(*(uint16_t*)&host_fp16, *(uint16_t*)&device_fp16); \
+  } while (0)
+
+  CHECK_DEVICE_FP16(GetZeroVal);
+  CHECK_DEVICE_FP16(GetOneVal);
+  CHECK_DEVICE_FP16(GetMaxVal);
+  CHECK_DEVICE_FP16(GetMinVal);
+#undef CHECK_DEVICE_FP16
+
 #endif
 
 #define CHECK_MAX_VAL(T, limit_value) CHECK_EQ(GetMaxVal<T>(), std::numeric_limits<T>::max());

--- a/oneflow/core/common/device_type.h
+++ b/oneflow/core/common/device_type.h
@@ -31,10 +31,21 @@ struct hash<oneflow::DeviceType> final {
 
 namespace oneflow {
 
+inline std::string DeviceTypeName(DeviceType device_type) {
+  switch (device_type) {
+    case kCPU: return "cpu";
+    case kCUDA: return "cuda";
+    default: return "invalid";
+  }
+}
+
 inline std::string PrintAvailableDevices() {
   std::string str("[");
   str += "\"cpu\"";
 #ifdef WITH_CUDA
+  str += ", \"cuda\"";
+#endif
+#ifdef WITH_HIP
   str += ", \"cuda\"";
 #endif
   str += ", \"auto\"";  // "auto" is a fake device type for random generator.
@@ -43,6 +54,10 @@ inline std::string PrintAvailableDevices() {
 }
 
 #if defined(WITH_CUDA)
+#define DEVICE_TYPE_SEQ                  \
+  OF_PP_MAKE_TUPLE_SEQ(DeviceType::kCPU) \
+  OF_PP_MAKE_TUPLE_SEQ(DeviceType::kCUDA)
+#elif defined(WITH_HIP)
 #define DEVICE_TYPE_SEQ                  \
   OF_PP_MAKE_TUPLE_SEQ(DeviceType::kCPU) \
   OF_PP_MAKE_TUPLE_SEQ(DeviceType::kCUDA)

--- a/oneflow/core/cuda/atomic.cuh
+++ b/oneflow/core/cuda/atomic.cuh
@@ -220,4 +220,207 @@ __device__ __forceinline__ double Max(double* address, const double val) {
 
 #endif  // defined(__CUDACC__)
 
+#if defined(__HIPCC__)
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <cstdint>
+// #if CUDA_VERSION >= 11000
+// #include <cuda_bf16.h>
+// #endif  // CUDA_VERSION >= 11000
+namespace oneflow {
+
+namespace cuda {
+
+namespace atomic {
+
+namespace internal {
+
+template<typename T, typename U>
+__device__ __forceinline__ T CastCASImpl(T* address, T compare, T val) {
+  static_assert(sizeof(T) == sizeof(U), "");
+  U ret = atomicCAS(reinterpret_cast<U*>(address), *(reinterpret_cast<U*>(&compare)),
+                    *(reinterpret_cast<U*>(&val)));
+  return *(reinterpret_cast<T*>(&ret));
+}
+
+template<typename T>
+__device__ __forceinline__ typename std::enable_if<sizeof(T) == sizeof(unsigned int), T>::type
+CASImpl(T* address, T compare, T val) {
+  return CastCASImpl<T, unsigned int>(address, compare, val);
+}
+
+template<typename T>
+__device__ __forceinline__
+    typename std::enable_if<sizeof(T) == sizeof(unsigned long long int), T>::type
+    CASImpl(T* address, T compare, T val) {
+  return CastCASImpl<T, unsigned long long int>(address, compare, val);
+}
+
+template<typename T>
+__device__ __forceinline__ typename std::enable_if<sizeof(T) == sizeof(unsigned short int), T>::type
+CASImpl(T* address, T compare, T val) {
+// #if __CUDA_ARCH__ >= 700
+//   return CastCASImpl<T, unsigned short int>(address, compare, val);
+// #else
+  __trap();
+  return 0;
+// #endif  // __CUDA_ARCH__ >= 700
+}
+
+__device__ __forceinline__ int CASImpl(int* address, int compare, int val) {
+  return atomicCAS(address, compare, val);
+}
+
+__device__ __forceinline__ unsigned int CASImpl(unsigned int* address, unsigned int compare,
+                                                unsigned int val) {
+  return atomicCAS(address, compare, val);
+}
+
+__device__ __forceinline__ unsigned long long int CASImpl(unsigned long long int* address,
+                                                          unsigned long long int compare,
+                                                          unsigned long long int val) {
+  return atomicCAS(address, compare, val);
+}
+
+// #if __CUDA_ARCH__ >= 700
+
+__device__ __forceinline__ unsigned short int CASImpl(unsigned short int* address,
+                                                      unsigned short int compare,
+                                                      unsigned short int val) {
+  return atomicCAS(address, compare, val);
+}
+
+// #endif  // __CUDA_ARCH__ >= 700
+
+template<typename T>
+struct AddOp {
+  __device__ __forceinline__ T operator()(T a, T b) { return a + b; }
+};
+
+template<typename T, template<typename> class BinaryOp>
+__device__ __forceinline__ T AtomicCASBinaryImpl(T* address, T val) {
+  T old = *address;
+  T assumed;
+  do {
+    assumed = old;
+    old = CASImpl(address, assumed, BinaryOp<T>()(old, val));
+  } while (old != assumed);
+  return old;
+}
+
+template<typename T>
+__device__ __forceinline__ T AddImpl(T* address, T val) {
+  return AtomicCASBinaryImpl<T, AddOp>(address, val);
+}
+
+__device__ __forceinline__ int AddImpl(int* address, int val) { return atomicAdd(address, val); }
+
+__device__ __forceinline__ unsigned int AddImpl(unsigned int* address, unsigned int val) {
+  return atomicAdd(address, val);
+}
+
+__device__ __forceinline__ unsigned long long int AddImpl(unsigned long long int* address,
+                                                          unsigned long long int val) {
+  return atomicAdd(address, val);
+}
+
+__device__ __forceinline__ uint64_t AddImpl(uint64_t* address, uint64_t val) {
+  static_assert(sizeof(uint64_t) == sizeof(unsigned long long int), "");
+  return static_cast<uint64_t>(atomicAdd(reinterpret_cast<unsigned long long int*>(address),
+                                         static_cast<unsigned long long int>(val)));
+}
+
+__device__ __forceinline__ float AddImpl(float* address, float val) {
+  return atomicAdd(address, val);
+}
+
+// #if __CUDA_ARCH__ >= 600
+
+__device__ __forceinline__ double AddImpl(double* address, double val) {
+  return atomicAdd(address, val);
+}
+
+__device__ __forceinline__ half2 AddImpl(half2* address, half2 val) {
+  return atomicAdd(address, val);
+}
+
+// #endif  // __CUDA_ARCH__ >= 600
+
+// #if __CUDA_ARCH__ >= 700
+
+__device__ __forceinline__ half AddImpl(half* address, half val) { return atomicAdd(address, val); }
+
+// #endif  // __CUDA_ARCH__ >= 700
+
+// #if __CUDA_ARCH__ >= 800
+
+// __device__ __forceinline__ nv_bfloat16 AddImpl(nv_bfloat16* address, nv_bfloat16 val) {
+//   return atomicAdd(address, val);
+// }
+
+// #endif  // __CUDA_ARCH__ >= 800
+
+// #if __CUDA_ARCH__ < 530
+
+// __device__ __forceinline__ half2 AddImpl(half2* address, half2 val) {
+//   __trap();
+//   return val;
+// }
+
+// #endif  // __CUDA_ARCH__ < 530
+
+}  // namespace internal
+
+template<typename T, typename U>
+__device__ __forceinline__ typename std::enable_if<!std::is_same<T, U>::value, T>::type Cast(U v) {
+  return static_cast<T>(v);
+}
+
+template<typename T, typename U>
+__device__ __forceinline__ typename std::enable_if<std::is_same<T, U>::value, T>::type Cast(U v) {
+  return v;
+}
+
+template<typename T, typename U, typename V>
+__device__ __forceinline__ T CAS(T* address, U compare, V val) {
+  return internal::CASImpl(address, Cast<T>(compare), Cast<T>(val));
+}
+
+template<typename T, typename U>
+__device__ __forceinline__ T Add(T* address, U val) {
+  return internal::AddImpl(address, Cast<T>(val));
+}
+
+__device__ __forceinline__ float Max(float* address, const float val) {
+  int* address_as_i = (int*)address;
+  int old = *address_as_i;
+  int assumed = 0;
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_i, assumed, __float_as_int(fmaxf(val, __int_as_float(assumed))));
+  } while (assumed != old);
+  return __int_as_float(old);
+}
+
+__device__ __forceinline__ double Max(double* address, const double val) {
+  unsigned long long int* address_as_i = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_i;
+  unsigned long long int assumed = 0;
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_i, assumed,
+                    __double_as_longlong(fmax(val, __longlong_as_double(assumed))));
+  } while (assumed != old);
+  return __longlong_as_double(old);
+}
+
+}  // namespace atomic
+
+}  // namespace cuda
+
+}  // namespace oneflow
+
+#endif  // defined(__HIPCC__)
+
 #endif  // ONEFLOW_CORE_CUDA_ATOMIC_H_

--- a/oneflow/core/cuda/elementwise.cuh
+++ b/oneflow/core/cuda/elementwise.cuh
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef ONEFLOW_CORE_CUDA_ELEMENTWISE_H_
 #define ONEFLOW_CORE_CUDA_ELEMENTWISE_H_
 
+#ifdef WITH_CUDA
+
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <algorithm>
@@ -213,5 +215,209 @@ inline cudaError_t Ternary(FunctorT functor, int64_t n, R* r, const A* a, const 
 }  // namespace cuda
 
 }  // namespace oneflow
+
+#endif  // WITH_CUDA
+
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <algorithm>
+#include <type_traits>
+
+namespace oneflow {
+
+namespace cuda {
+
+namespace elementwise {
+
+constexpr int kBlockSize = 256;
+constexpr int kNumWaves = 32;
+
+inline hipError_t GetNumBlocks(int64_t n, int* num_blocks) {
+  int dev;
+  {
+    hipError_t err = hipGetDevice(&dev);
+    if (err != hipSuccess) { return err; }
+  }
+  int sm_count;
+  {
+    hipError_t err = hipDeviceGetAttribute(&sm_count, hipDeviceAttributeMultiprocessorCount, dev);
+    if (err != hipSuccess) { return err; }
+  }
+  int tpm;
+  {
+    hipError_t err = hipDeviceGetAttribute(&tpm, hipDeviceAttributeMaxThreadsPerMultiProcessor, dev);
+    if (err != hipSuccess) { return err; }
+  }
+  *num_blocks = std::max<int>(1, std::min<int64_t>((n + kBlockSize - 1) / kBlockSize,
+                                                   sm_count * tpm / kBlockSize * kNumWaves));
+  return hipSuccess;
+}
+
+template<typename T, int pack_size>
+struct GetPackType {
+  using type = typename std::aligned_storage<pack_size * sizeof(T), pack_size * sizeof(T)>::type;
+};
+
+template<typename T, int pack_size>
+using PackType = typename GetPackType<T, pack_size>::type;
+
+template<typename T, int pack_size>
+union Pack {
+  static_assert(sizeof(PackType<T, pack_size>) == sizeof(T) * pack_size, "");
+  __device__ Pack() {
+    // do nothing
+  }
+  PackType<T, pack_size> storage;
+  T elem[pack_size];
+};
+
+template<typename T, int pack_size>
+__device__ inline Pack<T, pack_size> FetchPack(const PackType<T, pack_size>* ptr) {
+  Pack<T, pack_size> pack;
+  pack.storage = *ptr;
+  return pack;
+}
+
+constexpr int kMaxPackBytes = 128 / 8;
+constexpr int kMaxPackSize = 8;
+
+constexpr int Min(int a, int b) { return a < b ? a : b; }
+
+template<typename T>
+constexpr int PackSize() {
+  return Min(kMaxPackBytes / sizeof(T), kMaxPackSize);
+}
+
+template<typename T, typename U, typename... Args>
+constexpr int PackSize() {
+  return Min(PackSize<T>(), PackSize<U, Args...>());
+}
+
+template<typename T>
+class HasApply2 {
+  typedef char one;
+  struct two {
+    char x[2];
+  };
+
+  template<typename C>
+  static one test(decltype(&C::Apply2));
+  template<typename C>
+  static two test(...);
+
+ public:
+  enum { value = sizeof(test<T>(0)) == sizeof(char) };
+};
+
+template<int pack_size, typename FunctorT, typename R, typename... IN>
+__device__ typename std::enable_if<HasApply2<FunctorT>::value == true && pack_size % 2 == 0,
+                                   PackType<R, pack_size>>::type
+ApplyPack(const FunctorT& functor, const IN... in[pack_size]) {
+  Pack<R, pack_size> ret;
+#pragma unroll
+  for (int j = 0; j < pack_size; j += 2) { functor.Apply2(ret.elem + j, (in + j)...); }
+  return ret.storage;
+}
+
+template<int pack_size, typename FunctorT, typename R, typename... IN>
+__device__
+    typename std::enable_if<HasApply2<FunctorT>::value == false, PackType<R, pack_size>>::type
+    ApplyPack(const FunctorT& functor, const IN... in[pack_size]) {
+  Pack<R, pack_size> ret;
+#pragma unroll
+  for (int j = 0; j < pack_size; ++j) { ret.elem[j] = functor((in[j])...); }
+  return ret.storage;
+}
+
+template<int pack_size, bool tail, typename FactoryT, typename R, typename... IN>
+__global__ void __launch_bounds__(kBlockSize)
+    ApplyGeneric(FactoryT factory, int64_t n_pack, PackType<R, pack_size>* pack_r,
+                 const PackType<IN, pack_size>*... pack_in, int64_t n_tail, R* tail_r,
+                 const IN*... tail_in) {
+  auto functor = factory();
+  const int global_tid = blockIdx.x * kBlockSize + threadIdx.x;
+  for (int64_t i = global_tid; i < n_pack; i += blockDim.x * gridDim.x) {
+    pack_r[i] = ApplyPack<pack_size, decltype(functor), R, IN...>(
+        functor, (FetchPack<IN, pack_size>(pack_in + i).elem)...);
+  }
+  if (tail && global_tid < n_tail) { tail_r[global_tid] = functor((tail_in[global_tid])...); }
+}
+
+template<typename FunctorT>
+struct SimpleFactory {
+  explicit SimpleFactory(FunctorT functor) : tpl(functor) {}
+  __device__ FunctorT operator()() const { return tpl; }
+
+ private:
+  FunctorT tpl;
+};
+
+template<typename FactoryT, typename R, typename... IN>
+struct GenericLauncher {
+  static hipError_t Launch(FactoryT factory, int64_t n, R* r, const IN*... in,
+                            hipStream_t stream) {
+    constexpr int pack_size = PackSize<R, IN...>();
+    const int64_t n_pack = n / pack_size;
+    const int64_t tail_offset = n_pack * pack_size;
+    const int64_t n_tail = n - tail_offset;
+    int num_blocks;
+    {
+      hipError_t err = GetNumBlocks(n_pack, &num_blocks);
+      if (err != hipSuccess) { return err; }
+    }
+    auto func = n_tail > 0 ? ApplyGeneric<pack_size, true, FactoryT, R, IN...>
+                           : ApplyGeneric<pack_size, false, FactoryT, R, IN...>;
+    func<<<num_blocks, kBlockSize, 0, stream>>>(
+        factory, n_pack, reinterpret_cast<PackType<R, pack_size>*>(r),
+        (reinterpret_cast<const PackType<IN, pack_size>*>(in))..., n_tail, r + tail_offset,
+        (in + tail_offset)...);
+    return hipPeekAtLastError();
+  }
+};
+
+template<typename FactoryT, typename R, typename A>
+inline hipError_t UnaryWithFactory(FactoryT factory, int64_t n, R* r, const A* a,
+                                    hipStream_t stream) {
+  return GenericLauncher<FactoryT, R, A>::Launch(factory, n, r, a, stream);
+}
+
+template<typename FunctorT, typename R, typename A>
+inline hipError_t Unary(FunctorT functor, int64_t n, R* r, const A* a, hipStream_t stream) {
+  return UnaryWithFactory(SimpleFactory<FunctorT>(functor), n, r, a, stream);
+}
+
+template<typename FactoryT, typename R, typename A, typename B>
+inline hipError_t BinaryWithFactory(FactoryT factory, int64_t n, R* r, const A* a, const B* b,
+                                     hipStream_t stream) {
+  return GenericLauncher<FactoryT, R, A, B>::Launch(factory, n, r, a, b, stream);
+}
+
+template<typename FunctorT, typename R, typename A, typename B>
+inline hipError_t Binary(FunctorT functor, int64_t n, R* r, const A* a, const B* b,
+                          hipStream_t stream) {
+  return BinaryWithFactory(SimpleFactory<FunctorT>(functor), n, r, a, b, stream);
+}
+
+template<typename FactoryT, typename R, typename A, typename B, typename C>
+inline hipError_t TernaryWithFactory(FactoryT factory, int64_t n, R* r, const A* a, const B* b,
+                                      const C* c, hipStream_t stream) {
+  return GenericLauncher<FactoryT, R, A, B, C>::Launch(factory, n, r, a, b, c, stream);
+}
+
+template<typename FunctorT, typename R, typename A, typename B, typename C>
+inline hipError_t Ternary(FunctorT functor, int64_t n, R* r, const A* a, const B* b, const C* c,
+                           hipStream_t stream) {
+  return TernaryWithFactory(SimpleFactory<FunctorT>(functor), n, r, a, b, c, stream);
+}
+
+}  // namespace elementwise
+
+}  // namespace cuda
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP
 
 #endif  // ONEFLOW_CORE_CUDA_ELEMENTWISE_H_

--- a/oneflow/core/cuda/layer_norm.cuh
+++ b/oneflow/core/cuda/layer_norm.cuh
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef ONEFLOW_CORE_CUDA_LAYER_NORM_H_
 #define ONEFLOW_CORE_CUDA_LAYER_NORM_H_
 
+#ifdef WITH_CUDA
+
 #include <cub/cub.cuh>
 #include <math_constants.h>
 #include <assert.h>
@@ -1454,5 +1456,1451 @@ DispatchLayerNormGrad(cudaStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_sc
 }  // namespace cuda
 
 }  // namespace oneflow
+
+#endif  // WITH_CUDA
+
+#ifdef WITH_HIP
+
+#include "hip/hip_runtime.h"
+#include <hipcub/hipcub.hpp>
+// #include <math_constants.h>
+#include <assert.h>
+
+namespace oneflow {
+
+namespace cuda {
+
+namespace layer_norm {
+
+constexpr int kWarpSize = 32;
+
+template<typename T>
+struct SumOp {
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const { return a + b; }
+};
+
+template<typename T>
+struct MaxOp {
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const { return max(a, b); }
+};
+
+template<template<typename> class ReductionOp, typename T, int thread_group_width = kWarpSize>
+__inline__ __device__ T WarpAllReduce(T val) {
+  for (int mask = thread_group_width / 2; mask > 0; mask /= 2) {
+    val = ReductionOp<T>()(val, __shfl_xor(0xffffffff, val, mask, thread_group_width));
+  }
+  return val;
+}
+
+template<template<typename> class ReductionOp, typename T, int block_size>
+__inline__ __device__ T BlockAllReduce(T val) {
+  typedef hipcub::BlockReduce<T, block_size> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  __shared__ T result_broadcast;
+  T result = BlockReduce(temp_storage).Reduce(val, ReductionOp<T>());
+  if (threadIdx.x == 0) { result_broadcast = result; }
+  __syncthreads();
+  return result_broadcast;
+}
+
+template<typename T>
+__inline__ __device__ T Div(T a, T b);
+
+template<>
+__inline__ __device__ float Div<float>(float a, float b) {
+#ifdef OF_LAYER_NORM_USE_FAST_MATH
+  return __fdividef(a, b);
+#else
+  return a / b;
+#endif
+}
+
+template<>
+__inline__ __device__ double Div<double>(double a, double b) {
+  return a / b;
+}
+
+template<typename T>
+__inline__ __device__ T Rsqrt(T x);
+
+template<>
+__inline__ __device__ float Rsqrt<float>(float x) {
+#ifdef OF_LAYER_NORM_USE_FAST_MATH
+  return __frsqrt_rn(x);
+#else
+  return rsqrt(x);
+#endif
+}
+
+template<>
+__inline__ __device__ double Rsqrt<double>(double x) {
+  return rsqrt(x);
+}
+
+template<class Func>
+inline hipError_t GetNumBlocks(Func func, int64_t block_size, size_t dynamic_smem_size,
+                                int64_t max_blocks, int64_t waves, int* num_blocks) {
+  int dev;
+  {
+    hipError_t err = hipGetDevice(&dev);
+    if (err != hipSuccess) { return err; }
+  }
+  int sm_count;
+  {
+    hipError_t err = hipDeviceGetAttribute(&sm_count, hipDeviceAttributeMultiprocessorCount, dev);
+    if (err != hipSuccess) { return err; }
+  }
+  int max_active_blocks;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(&max_active_blocks, func,
+                                                                    block_size, dynamic_smem_size);
+  }
+  *num_blocks =
+      std::max<int>(1, std::min<int64_t>(max_blocks, sm_count * max_active_blocks * waves));
+  return hipSuccess;
+}
+
+template<typename T>
+struct DefaultComputeType {
+  using type = T;
+};
+
+template<>
+struct DefaultComputeType<half> {
+  using type = float;
+};
+
+// #if CUDA_VERSION >= 11000
+// template<>
+// struct DefaultComputeType<nv_bfloat16> {
+//   using type = float;
+// };
+// #endif  // CUDA_VERSION >= 11000
+
+template<typename T, int N>
+struct GetPackType {
+  using type = typename std::aligned_storage<N * sizeof(T), N * sizeof(T)>::type;
+};
+
+template<typename T, int N>
+using PackType = typename GetPackType<T, N>::type;
+
+template<typename T, int N>
+union Pack {
+  static_assert(sizeof(PackType<T, N>) == sizeof(T) * N, "");
+  __device__ Pack() {
+    // do nothing
+  }
+  PackType<T, N> storage;
+  T elem[N];
+};
+
+template<typename SRC, typename DST>
+struct DirectLoad {
+  DirectLoad(const SRC* src, int64_t row_size) : src(src), row_size(row_size) {}
+  template<int N>
+  __device__ void load(DST* dst, int64_t row, int64_t col) const {
+    Pack<SRC, N> pack;
+    const int64_t offset = (row * row_size + col) / N;
+    pack.storage = *(reinterpret_cast<const PackType<SRC, N>*>(src) + offset);
+#pragma unroll
+    for (int i = 0; i < N; ++i) { dst[i] = static_cast<DST>(pack.elem[i]); }
+  }
+  const SRC* src;
+  int64_t row_size;
+};
+
+template<typename SRC, typename DST>
+struct DirectStore {
+  DirectStore(DST* dst, int64_t row_size) : dst(dst), row_size(row_size) {}
+  template<int N>
+  __device__ void store(const SRC* src, int64_t row, int64_t col) {
+    Pack<DST, N> pack;
+    const int64_t offset = (row * row_size + col) / N;
+#pragma unroll
+    for (int i = 0; i < N; ++i) { pack.elem[i] = static_cast<DST>(src[i]); }
+    *(reinterpret_cast<PackType<DST, N>*>(dst) + offset) = pack.storage;
+  }
+  DST* dst;
+  int64_t row_size;
+};
+
+template<typename T>
+inline __device__ void WelfordCombine(T val, T* mean, T* m2, T* count) {
+  // Use Welford Online algorithem to compute mean and variance
+  // For more details you can refer to:
+  // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+  *count += 1;
+  T delta1 = val - *mean;
+  *mean += Div(delta1, *count);
+  T delta2 = val - *mean;
+  *m2 += delta1 * delta2;
+}
+
+template<typename T>
+inline __device__ void WelfordCombine(T b_mean, T b_m2, T b_count, T* mean, T* m2, T* count) {
+  if (b_count == 0) { return; }
+  T new_count = *count + b_count;
+  T nb_over_n = Div(b_count, new_count);
+  T delta = b_mean - *mean;
+  *mean += delta * nb_over_n;
+  *m2 += b_m2 + delta * delta * (*count) * nb_over_n;
+  *count = new_count;
+}
+
+template<typename T, int thread_group_width = kWarpSize>
+__inline__ __device__ void WelfordWarpReduce(T thread_mean, T thread_m2, T thread_count, T* mean,
+                                             T* m2, T* count) {
+  *mean = thread_mean;
+  *m2 = thread_m2;
+  *count = thread_count;
+  for (int mask = thread_group_width / 2; mask > 0; mask /= 2) {
+    T b_mean = __shfl_down(0xffffffff, *mean, mask, thread_group_width);
+    T b_m2 = __shfl_down(0xffffffff, *m2, mask, thread_group_width);
+    T b_count = __shfl_down(0xffffffff, *count, mask, thread_group_width);
+    WelfordCombine(b_mean, b_m2, b_count, mean, m2, count);
+  }
+}
+
+template<typename T, int thread_group_width = kWarpSize>
+__inline__ __device__ void WelfordWarpAllReduce(T thread_mean, T thread_m2, T thread_count, T* mean,
+                                                T* m2, T* count) {
+  WelfordWarpReduce<T, thread_group_width>(thread_mean, thread_m2, thread_count, mean, m2, count);
+  *mean = __shfl(0xffffffff, *mean, 0, thread_group_width);
+  *m2 = __shfl(0xffffffff, *m2, 0, thread_group_width);
+  *count = __shfl(0xffffffff, *count, 0, thread_group_width);
+}
+
+template<typename T>
+__inline__ __device__ void WelfordBlockAllReduce(T thread_mean, T thread_m2, T thread_count,
+                                                 T* result_mean, T* result_m2, T* result_count) {
+  __shared__ T mean_shared[kWarpSize];
+  __shared__ T m2_shared[kWarpSize];
+  __shared__ T count_shared[kWarpSize];
+  __shared__ T mean_result_broadcast;
+  __shared__ T m2_result_broadcast;
+  __shared__ T count_result_broadcast;
+  const int lid = threadIdx.x % kWarpSize;
+  const int wid = threadIdx.x / kWarpSize;
+  T warp_mean = 0;
+  T warp_m2 = 0;
+  T warp_count = 0;
+  WelfordWarpReduce(thread_mean, thread_m2, thread_count, &warp_mean, &warp_m2, &warp_count);
+  __syncthreads();
+  if (lid == 0) {
+    mean_shared[wid] = warp_mean;
+    m2_shared[wid] = warp_m2;
+    count_shared[wid] = warp_count;
+  }
+  __syncthreads();
+  if (wid == 0) {
+    if (threadIdx.x < blockDim.x / kWarpSize) {
+      warp_mean = mean_shared[lid];
+      warp_m2 = m2_shared[lid];
+      warp_count = count_shared[lid];
+    } else {
+      warp_mean = static_cast<T>(0);
+      warp_m2 = static_cast<T>(0);
+      warp_count = static_cast<T>(0);
+    }
+    __syncwarp();
+    T block_mean = 0;
+    T block_m2 = 0;
+    T block_count = 0;
+    WelfordWarpReduce(warp_mean, warp_m2, warp_count, &block_mean, &block_m2, &block_count);
+    if (lid == 0) {
+      mean_result_broadcast = block_mean;
+      m2_result_broadcast = block_m2;
+      count_result_broadcast = block_count;
+    }
+  }
+  __syncthreads();
+  *result_mean = mean_result_broadcast;
+  *result_m2 = m2_result_broadcast;
+  *result_count = count_result_broadcast;
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int cols_per_thread,
+         int thread_group_width, int rows_per_access, bool padding>
+__global__ void LayerNormWarpImpl(LOAD load, STORE store, const int64_t rows, const int64_t cols,
+                                  const double epsilon, ComputeType* mean,
+                                  ComputeType* inv_variance) {
+  static_assert(cols_per_thread % pack_size == 0, "");
+  static_assert(thread_group_width <= kWarpSize, "");
+  static_assert(kWarpSize % thread_group_width == 0, "");
+  constexpr int num_packs = cols_per_thread / pack_size;
+  assert(cols <= cols_per_thread * thread_group_width);
+  ComputeType buf[rows_per_access][cols_per_thread];
+  const int64_t global_thread_group_id = blockIdx.x * blockDim.y + threadIdx.y;
+  const int64_t num_global_thread_group = gridDim.x * blockDim.y;
+  const int64_t lane_id = threadIdx.x;
+  const int64_t step = num_global_thread_group * rows_per_access;
+  for (int64_t row = global_thread_group_id * rows_per_access; row < rows; row += step) {
+    ComputeType thread_mean[rows_per_access];
+    ComputeType thread_m2[rows_per_access];
+    ComputeType thread_count[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      thread_mean[row_id] = 0;
+      thread_m2[row_id] = 0;
+      thread_count[row_id] = 0;
+      ComputeType* row_buf = buf[row_id];
+#pragma unroll
+      for (int pack_id = 0; pack_id < num_packs; ++pack_id) {
+        const int col = (pack_id * thread_group_width + lane_id) * pack_size;
+        const int pack_offset = pack_id * pack_size;
+        if (!padding || col < cols) {
+          load.template load<pack_size>(row_buf + pack_offset, row + row_id, col);
+#pragma unroll
+          for (int i = 0; i < pack_size; ++i) {
+            WelfordCombine(row_buf[pack_offset + i], thread_mean + row_id, thread_m2 + row_id,
+                           thread_count + row_id);
+          }
+        } else {
+#pragma unroll
+          for (int i = 0; i < pack_size; ++i) { row_buf[pack_offset + i] = 0; }
+        }
+      }
+    }
+    ComputeType warp_mean[rows_per_access];
+    ComputeType warp_m2[rows_per_access];
+    ComputeType warp_count[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      int global_row_id = row + row_id;
+      ComputeType* row_buf = buf[row_id];
+      WelfordWarpAllReduce<ComputeType, thread_group_width>(
+          thread_mean[row_id], thread_m2[row_id], thread_count[row_id], warp_mean + row_id,
+          warp_m2 + row_id, warp_count + row_id);
+      ComputeType row_mean = warp_mean[row_id];
+      ComputeType row_variance =
+          max(Div(warp_m2[row_id], warp_count[row_id]), static_cast<ComputeType>(0.0));
+      ComputeType row_inv_var = Rsqrt(row_variance + static_cast<ComputeType>(epsilon));
+      if (lane_id == 0) {
+        mean[global_row_id] = row_mean;
+        inv_variance[global_row_id] = row_inv_var;
+      }
+#pragma unroll
+      for (int i = 0; i < cols_per_thread; ++i) {
+        row_buf[i] = (row_buf[i] - row_mean) * row_inv_var;
+      }
+#pragma unroll
+      for (int i = 0; i < num_packs; ++i) {
+        const int col = (i * thread_group_width + lane_id) * pack_size;
+        if (!padding || col < cols) {
+          store.template store<pack_size>(row_buf + i * pack_size, global_row_id, col);
+        }
+      }
+    }
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int cols_per_thread,
+         int thread_group_width, int rows_per_access, bool padding>
+inline hipError_t LaunchLayerNormWarpImpl(hipStream_t stream, LOAD load, STORE store,
+                                           const int64_t rows, const int64_t cols,
+                                           const double epsilon, ComputeType* mean,
+                                           ComputeType* inv_variance) {
+  constexpr int block_size = 128;
+  constexpr int waves = 32;
+  static_assert(block_size % thread_group_width == 0, "");
+  constexpr int thread_groups_per_block = block_size / thread_group_width;
+  dim3 block_dim(thread_group_width, thread_groups_per_block);
+  const int64_t num_blocks =
+      (rows / rows_per_access + thread_groups_per_block - 1) / thread_groups_per_block;
+  int grid_dim_x;
+  {
+    hipError_t err =
+        GetNumBlocks(LayerNormWarpImpl<LOAD, STORE, ComputeType, pack_size, cols_per_thread,
+                                       thread_group_width, rows_per_access, padding>,
+                     block_size, 0, num_blocks, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  LayerNormWarpImpl<LOAD, STORE, ComputeType, pack_size, cols_per_thread, thread_group_width,
+                    rows_per_access, padding>
+      <<<grid_dim_x, block_dim, 0, stream>>>(load, store, rows, cols, epsilon, mean, inv_variance);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int cols_per_thread,
+         int thread_group_width, int rows_per_access>
+inline hipError_t DispatchLayerNormWarpImplPadding(hipStream_t stream, LOAD load, STORE store,
+                                                    const int64_t rows, const int64_t cols,
+                                                    const double epsilon, ComputeType* mean,
+                                                    ComputeType* inv_variance) {
+  if (cols == cols_per_thread * thread_group_width) {
+    return LaunchLayerNormWarpImpl<LOAD, STORE, ComputeType, pack_size, cols_per_thread,
+                                   thread_group_width, rows_per_access, false>(
+        stream, load, store, rows, cols, epsilon, mean, inv_variance);
+  } else {
+    return LaunchLayerNormWarpImpl<LOAD, STORE, ComputeType, pack_size, cols_per_thread,
+                                   thread_group_width, rows_per_access, true>(
+        stream, load, store, rows, cols, epsilon, mean, inv_variance);
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size>
+typename std::enable_if<pack_size == 1, hipError_t>::type DispatchLayerNormWarpImplCols(
+    hipStream_t stream, LOAD load, STORE store, const int64_t rows, const int64_t cols,
+    const double epsilon, ComputeType* mean, ComputeType* inv_variance) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                   \
+  else if (cols <= (thread_group_width)*pack_size) {                                          \
+    if (rows % 2 == 0) {                                                                      \
+      return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size, \
+                                              thread_group_width, 2>(                         \
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);                      \
+    } else {                                                                                  \
+      return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size, \
+                                              thread_group_width, 1>(                         \
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);                      \
+    }                                                                                         \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                     \
+  else if (cols <= (col)*kWarpSize) {                                                            \
+    return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, col, kWarpSize, \
+                                            1>(stream, load, store, rows, cols, epsilon, mean,   \
+                                               inv_variance);                                    \
+  }
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(3)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(5)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(7)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(9)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(11)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(13)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(15)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(17)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(19)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(21)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(23)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(25)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(27)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(29)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(31)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size>
+typename std::enable_if<pack_size == 2, hipError_t>::type DispatchLayerNormWarpImplCols(
+    hipStream_t stream, LOAD load, STORE store, const int64_t rows, const int64_t cols,
+    const double epsilon, ComputeType* mean, ComputeType* inv_variance) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                   \
+  else if (cols <= (thread_group_width)*pack_size) {                                          \
+    if (rows % 2 == 0) {                                                                      \
+      return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size, \
+                                              thread_group_width, 2>(                         \
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);                      \
+    } else {                                                                                  \
+      return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size, \
+                                              thread_group_width, 1>(                         \
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);                      \
+    }                                                                                         \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                     \
+  else if (cols <= (col)*kWarpSize) {                                                            \
+    return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, col, kWarpSize, \
+                                            1>(stream, load, store, rows, cols, epsilon, mean,   \
+                                               inv_variance);                                    \
+  }
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size>
+typename std::enable_if<pack_size == 4, hipError_t>::type DispatchLayerNormWarpImplCols(
+    hipStream_t stream, LOAD load, STORE store, const int64_t rows, const int64_t cols,
+    const double epsilon, ComputeType* mean, ComputeType* inv_variance) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                   \
+  else if (cols <= (thread_group_width)*pack_size) {                                          \
+    if (rows % 2 == 0) {                                                                      \
+      return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size, \
+                                              thread_group_width, 2>(                         \
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);                      \
+    } else {                                                                                  \
+      return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size, \
+                                              thread_group_width, 1>(                         \
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);                      \
+    }                                                                                         \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                     \
+  else if (cols <= (col)*kWarpSize) {                                                            \
+    return DispatchLayerNormWarpImplPadding<LOAD, STORE, ComputeType, pack_size, col, kWarpSize, \
+                                            1>(stream, load, store, rows, cols, epsilon, mean,   \
+                                               inv_variance);                                    \
+  }
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+struct DispatchLayerNormWarpImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                         const int64_t cols, const double epsilon, ComputeType* mean,
+                         ComputeType* inv_variance) {
+    if (cols % 4 == 0) {
+      return DispatchLayerNormWarpImplCols<LOAD, STORE, ComputeType, 4>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    } else if (cols % 2 == 0) {
+      return DispatchLayerNormWarpImplCols<LOAD, STORE, ComputeType, 2>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    } else {
+      return DispatchLayerNormWarpImplCols<LOAD, STORE, ComputeType, 1>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    }
+  }
+};
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline hipError_t DispatchLayerNormWarpImpl(hipStream_t stream, LOAD load, STORE store,
+                                             const int64_t rows, const int64_t cols,
+                                             const double epsilon, ComputeType* mean,
+                                             ComputeType* inv_variance) {
+  return DispatchLayerNormWarpImplPackSize<LOAD, STORE, ComputeType>()(
+      stream, load, store, rows, cols, epsilon, mean, inv_variance);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int block_size>
+__global__ void LayerNormBlockSMemImpl(LOAD load, STORE store, const int64_t rows,
+                                       const int64_t cols, const double epsilon, ComputeType* mean,
+                                       ComputeType* inv_variance) {
+  extern __shared__ __align__(sizeof(double)) unsigned char shared_buf[];
+  auto* buf = reinterpret_cast<ComputeType*>(shared_buf);
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = static_cast<int>(cols) / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType thread_mean = 0;
+    ComputeType thread_m2 = 0;
+    ComputeType thread_count = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      load.template load<pack_size>(pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        buf[i * num_packs + pack_id] = pack[i];
+        WelfordCombine(pack[i], &thread_mean, &thread_m2, &thread_count);
+      }
+    }
+    ComputeType row_mean = 0;
+    ComputeType row_m2 = 0;
+    ComputeType row_count = 0;
+    WelfordBlockAllReduce<ComputeType>(thread_mean, thread_m2, thread_count, &row_mean, &row_m2,
+                                       &row_count);
+    ComputeType row_variance = max(Div(row_m2, row_count), static_cast<ComputeType>(0.0));
+    ComputeType row_inv_var = Rsqrt(row_variance + static_cast<ComputeType>(epsilon));
+    if (threadIdx.x == 0) {
+      mean[row] = row_mean;
+      inv_variance[row] = row_inv_var;
+    }
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        pack[i] = (buf[i * num_packs + pack_id] - row_mean) * row_inv_var;
+      }
+      store.template store<pack_size>(pack, row, pack_id * pack_size);
+    }
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int block_size>
+inline hipError_t LaunchLayerNormBlockSMemImpl(hipStream_t stream, LOAD load, STORE store,
+                                                int smem, const int64_t rows, const int64_t cols,
+                                                const double epsilon, ComputeType* mean,
+                                                ComputeType* inv_variance) {
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    hipError_t err =
+        GetNumBlocks(LayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size>,
+                     block_size, smem, rows, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  LayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size>
+      <<<grid_dim_x, block_size, smem, stream>>>(load, store, rows, cols, epsilon, mean,
+                                                 inv_variance);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size>
+inline hipError_t TryDispatchLayerNormBlockSMemImplBlockSize(
+    hipStream_t stream, LOAD load, STORE store, const int64_t rows, const int64_t cols,
+    const double epsilon, ComputeType* mean, ComputeType* inv_variance, bool* success) {
+  constexpr int block_size_conf_1 = 128;
+  constexpr int block_size_conf_2 = 256;
+  constexpr int block_size_conf_3 = 512;
+  constexpr int block_size_conf_4 = 1024;
+  const size_t smem = cols * sizeof(ComputeType);
+  int max_active_blocks_conf_1;
+
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_1,
+        LayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_1>,
+        block_size_conf_1, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_1 <= 0) {
+    *success = false;
+    return hipSuccess;
+  }
+  int max_active_blocks_conf_4;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_4,
+        LayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_4>,
+        block_size_conf_4, smem);
+    if (err != hipSuccess) { return err; }
+  }
+
+  if (max_active_blocks_conf_4 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_4>(
+        stream, load, store, smem, rows, cols, epsilon, mean, inv_variance);
+  }
+  int max_active_blocks_conf_3;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_3,
+        LayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_3>,
+        block_size_conf_3, smem);
+    if (err != hipSuccess) { return err; }
+  }
+
+  if (max_active_blocks_conf_3 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_3>(
+        stream, load, store, smem, rows, cols, epsilon, mean, inv_variance);
+  }
+  int max_active_blocks_conf_2;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_2,
+        LayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_2>,
+        block_size_conf_2, smem);
+    if (err != hipSuccess) { return err; }
+  }
+
+  if (max_active_blocks_conf_2 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_2>(
+        stream, load, store, smem, rows, cols, epsilon, mean, inv_variance);
+  }
+  *success = true;
+  return LaunchLayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_1>(
+      stream, load, store, smem, rows, cols, epsilon, mean, inv_variance);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+struct TryDispatchLayerNormBlockSMemImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                         const int64_t cols, const double epsilon, ComputeType* mean,
+                         ComputeType* inv_variance, bool* success) {
+    if (cols % 4 == 0) {
+      return TryDispatchLayerNormBlockSMemImplBlockSize<LOAD, STORE, ComputeType, 4>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance, success);
+    } else if (cols % 2 == 0) {
+      return TryDispatchLayerNormBlockSMemImplBlockSize<LOAD, STORE, ComputeType, 2>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance, success);
+    } else {
+      return TryDispatchLayerNormBlockSMemImplBlockSize<LOAD, STORE, ComputeType, 1>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance, success);
+    }
+  }
+};
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline hipError_t TryDispatchLayerNormBlockSMemImpl(hipStream_t stream, LOAD load, STORE store,
+                                                     const int64_t rows, const int64_t cols,
+                                                     const double epsilon, ComputeType* mean,
+                                                     ComputeType* inv_variance, bool* success) {
+  return TryDispatchLayerNormBlockSMemImplPackSize<LOAD, STORE, ComputeType>()(
+      stream, load, store, rows, cols, epsilon, mean, inv_variance, success);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int block_size>
+__global__ void LayerNormBlockUncachedImpl(LOAD load, STORE store, const int64_t rows,
+                                           const int64_t cols, const double epsilon,
+                                           ComputeType* mean, ComputeType* inv_variance) {
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = static_cast<int>(cols) / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType thread_mean = 0;
+    ComputeType thread_m2 = 0;
+    ComputeType thread_count = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      load.template load<pack_size>(pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        WelfordCombine(pack[i], &thread_mean, &thread_m2, &thread_count);
+      }
+    }
+    ComputeType row_mean = 0;
+    ComputeType row_m2 = 0;
+    ComputeType row_count = 0;
+    WelfordBlockAllReduce<ComputeType>(thread_mean, thread_m2, thread_count, &row_mean, &row_m2,
+                                       &row_count);
+    ComputeType row_variance = max(Div(row_m2, row_count), static_cast<ComputeType>(0.0));
+    ComputeType row_inv_var = Rsqrt(row_variance + static_cast<ComputeType>(epsilon));
+    if (threadIdx.x == 0) {
+      mean[row] = row_mean;
+      inv_variance[row] = row_inv_var;
+    }
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      const int pack_offset = pack_id * pack_size;
+      load.template load<pack_size>(pack, row, pack_offset);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) { pack[i] = (pack[i] - row_mean) * row_inv_var; }
+      store.template store<pack_size>(pack, row, pack_offset);
+    }
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size>
+inline hipError_t LaunchLayerNormBlockUncachedImpl(hipStream_t stream, LOAD load, STORE store,
+                                                    const int64_t rows, const int64_t cols,
+                                                    const double epsilon, ComputeType* mean,
+                                                    ComputeType* inv_variance) {
+  constexpr int block_size = 1024;
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    hipError_t err =
+        GetNumBlocks(LayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, pack_size, block_size>,
+                     block_size, 0, rows, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  LayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, pack_size, block_size>
+      <<<grid_dim_x, block_size, 0, stream>>>(load, store, rows, cols, epsilon, mean, inv_variance);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+struct DispatchLayerNormBlockUncachedImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                         const int64_t cols, const double epsilon, ComputeType* mean,
+                         ComputeType* inv_variance) {
+    if (cols % 4 == 0) {
+      return LaunchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, 4>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    } else if (cols % 2 == 0) {
+      return LaunchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, 2>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    } else {
+      return LaunchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, 1>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    }
+  }
+};
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline hipError_t DispatchLayerNormBlockUncachedImpl(hipStream_t stream, LOAD load, STORE store,
+                                                      const int64_t rows, const int64_t cols,
+                                                      const double epsilon, ComputeType* mean,
+                                                      ComputeType* inv_variance) {
+  return DispatchLayerNormBlockUncachedImplPackSize<LOAD, STORE, ComputeType>()(
+      stream, load, store, rows, cols, epsilon, mean, inv_variance);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline typename std::enable_if<!std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchLayerNorm(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                  const int64_t cols, const double epsilon, ComputeType* mean,
+                  ComputeType* inv_variance) {
+  if (cols <= 1024) {
+    return DispatchLayerNormWarpImpl<LOAD, STORE, ComputeType>(stream, load, store, rows, cols,
+                                                               epsilon, mean, inv_variance);
+  } else {
+    bool dispatch_smem_impl_success;
+    {
+      hipError_t err = TryDispatchLayerNormBlockSMemImpl<LOAD, STORE, ComputeType>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance,
+          &dispatch_smem_impl_success);
+      if (err != hipSuccess) { return err; }
+    }
+    if (!dispatch_smem_impl_success) {
+      return DispatchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    }
+    return hipSuccess;
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline typename std::enable_if<std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchLayerNorm(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                  const int64_t cols, const double epsilon, ComputeType* mean,
+                  ComputeType* inv_variance) {
+  return DispatchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType>(
+      stream, load, store, rows, cols, epsilon, mean, inv_variance);
+}
+
+/*
+LayerNormGrad dx:
+normalized = (x - mean) * inv_var
+sum_stats1 = sum(scaled_dy)
+sum_stats2 = sum(scaled_dy * normalized)
+dx = cols * dy - sum_stats1 - normalized * sum_stats2
+dx *= inv_var / cols
+*/
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size, int cols_per_thread, int thread_group_width, int rows_per_access,
+         bool padding>
+__global__ void LayerNormGradWarpImpl(LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy, STORE store,
+                                      const ComputeType* mean, const ComputeType* inv_variance,
+                                      const int64_t rows, const int64_t cols) {
+  static_assert(cols_per_thread % pack_size == 0, "");
+  constexpr int pack_per_thread = cols_per_thread / pack_size;
+  assert(cols <= cols_per_thread * thread_group_width);
+  static_assert(thread_group_width <= kWarpSize, "");
+  static_assert(kWarpSize % thread_group_width == 0, "");
+  ComputeType normalized_buf[rows_per_access][cols_per_thread];
+  ComputeType dy_buf[rows_per_access][cols_per_thread];
+  const ComputeType one_over_cols = static_cast<ComputeType>(1.0) / static_cast<ComputeType>(cols);
+  const int64_t global_thread_group_id = blockIdx.x * blockDim.y + threadIdx.y;
+  const int64_t num_global_thread_group = gridDim.x * blockDim.y;
+  const int lane_id = threadIdx.x;
+  const int64_t step = num_global_thread_group * rows_per_access;
+  for (int64_t row = global_thread_group_id * rows_per_access; row < rows; row += step) {
+    ComputeType sum_stats1[rows_per_access];
+    ComputeType sum_stats2[rows_per_access];
+    ComputeType inv_variance_buf[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      const int global_row_id = row + row_id;
+      ComputeType mean_val = mean[global_row_id];
+      inv_variance_buf[row_id] = inv_variance[global_row_id];
+      sum_stats1[row_id] = 0;
+      sum_stats2[row_id] = 0;
+      ComputeType* row_normalized_buf = normalized_buf[row_id];
+      ComputeType* row_dy_buf = dy_buf[row_id];
+#pragma unroll
+      for (int pack_id = 0; pack_id < pack_per_thread; ++pack_id) {
+        const int col = (pack_id * thread_group_width + lane_id) * pack_size;
+        const int pack_offset = pack_id * pack_size;
+        if (!padding || col < cols) {
+          load_x.template load<pack_size>(row_normalized_buf + pack_offset, global_row_id, col);
+          load_scaled_dy.template load<pack_size>(row_dy_buf + pack_offset, global_row_id, col);
+#pragma unroll
+          for (int i = 0; i < pack_size; ++i) {
+            const int col_id = pack_offset + i;
+            // row_normalized_buf store x
+            row_normalized_buf[col_id] =
+                (row_normalized_buf[col_id] - mean_val) * inv_variance_buf[row_id];
+            sum_stats1[row_id] += row_dy_buf[col_id];
+            sum_stats2[row_id] += row_dy_buf[col_id] * row_normalized_buf[col_id];
+          }
+        }
+      }
+    }
+    ComputeType warp_sum_stats1[rows_per_access];
+    ComputeType warp_sum_stats2[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      warp_sum_stats1[row_id] =
+          WarpAllReduce<SumOp, ComputeType, thread_group_width>(sum_stats1[row_id]);
+      warp_sum_stats2[row_id] =
+          WarpAllReduce<SumOp, ComputeType, thread_group_width>(sum_stats2[row_id]);
+    }
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      const int global_row_id = row + row_id;
+      ComputeType* row_normalized_buf = normalized_buf[row_id];
+      ComputeType* row_dy_buf = dy_buf[row_id];
+      const ComputeType inv_variance_over_cols = inv_variance_buf[row_id] * one_over_cols;
+#pragma unroll
+      for (int pack_id = 0; pack_id < pack_per_thread; ++pack_id) {
+        const int col = (pack_id * thread_group_width + lane_id) * pack_size;
+        if (!padding || col < cols) {
+          for (int i = 0; i < pack_size; ++i) {
+            const int col_id = pack_id * pack_size + i;
+            row_dy_buf[col_id] = (cols * row_dy_buf[col_id] - warp_sum_stats1[row_id]
+                                  - row_normalized_buf[col_id] * warp_sum_stats2[row_id])
+                                 * inv_variance_over_cols;
+          }
+          store.template store<pack_size>(row_dy_buf + pack_id * pack_size, global_row_id, col);
+        }
+      }
+    }
+  }
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size, int cols_per_thread, int thread_group_width, int rows_per_access,
+         bool padding>
+inline hipError_t LaunchLayerNormGradWarpImpl(hipStream_t stream, LOAD_X load_x,
+                                               LOAD_SCALED_DY load_scaled_dy, STORE store,
+                                               const ComputeType* mean,
+                                               const ComputeType* inv_variance, const int64_t rows,
+                                               const int64_t cols) {
+  constexpr int block_size = 128;
+  constexpr int waves = 32;
+  static_assert(block_size % thread_group_width == 0, "");
+  constexpr int thread_groups_per_block = block_size / thread_group_width;
+  dim3 block_dim(thread_group_width, thread_groups_per_block);
+  const int64_t num_blocks =
+      (rows / rows_per_access + thread_groups_per_block - 1) / thread_groups_per_block;
+  int grid_dim_x;
+  {
+    hipError_t err = GetNumBlocks(
+        LayerNormGradWarpImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                              cols_per_thread, thread_group_width, rows_per_access, padding>,
+        block_size, 0, num_blocks, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  LayerNormGradWarpImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size, cols_per_thread,
+                        thread_group_width, rows_per_access, padding>
+      <<<grid_dim_x, block_dim, 0, stream>>>(load_x, load_scaled_dy, store, mean, inv_variance,
+                                             rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size, int cols_per_thread, int thread_group_width, int rows_per_access>
+inline hipError_t DispatchLayerNormGradWarpImplPadding(hipStream_t stream, LOAD_X load_x,
+                                                        LOAD_SCALED_DY load_scaled_dy, STORE store,
+                                                        const ComputeType* mean,
+                                                        const ComputeType* inv_variance,
+                                                        const int64_t rows, const int64_t cols) {
+  if (cols == cols_per_thread * thread_group_width) {
+    return LaunchLayerNormGradWarpImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                       cols_per_thread, thread_group_width, rows_per_access, false>(
+        stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+  } else {
+    return LaunchLayerNormGradWarpImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                       cols_per_thread, thread_group_width, rows_per_access, true>(
+        stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+  }
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size>
+typename std::enable_if<pack_size == 1, hipError_t>::type DispatchLayerNormGradWarpImplCols(
+    hipStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy, STORE store,
+    const ComputeType* mean, const ComputeType* inv_variance, const int64_t rows,
+    const int64_t cols) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                     \
+  else if (cols <= (thread_group_width)*pack_size) {                                            \
+    if (rows % 2 == 0) {                                                                        \
+      return DispatchLayerNormGradWarpImplPadding<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType,   \
+                                                  pack_size, pack_size, thread_group_width, 2>( \
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);               \
+    } else {                                                                                    \
+      return DispatchLayerNormGradWarpImplPadding<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType,   \
+                                                  pack_size, pack_size, thread_group_width, 1>( \
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);               \
+    }                                                                                           \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                \
+  else if (cols <= (col)*kWarpSize) {                                                       \
+    return DispatchLayerNormGradWarpImplPadding<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, \
+                                                pack_size, col, kWarpSize, 1>(              \
+        stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);             \
+  }
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(3)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(5)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(7)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(9)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(11)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(13)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(15)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(17)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(19)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(21)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(23)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(25)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(27)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(29)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(31)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size>
+typename std::enable_if<pack_size == 2, hipError_t>::type DispatchLayerNormGradWarpImplCols(
+    hipStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy, STORE store,
+    const ComputeType* mean, const ComputeType* inv_variance, const int64_t rows,
+    const int64_t cols) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                     \
+  else if (cols <= (thread_group_width)*pack_size) {                                            \
+    if (rows % 2 == 0) {                                                                        \
+      return DispatchLayerNormGradWarpImplPadding<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType,   \
+                                                  pack_size, pack_size, thread_group_width, 2>( \
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);               \
+    } else {                                                                                    \
+      return DispatchLayerNormGradWarpImplPadding<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType,   \
+                                                  pack_size, pack_size, thread_group_width, 1>( \
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);               \
+    }                                                                                           \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                \
+  else if (cols <= (col)*kWarpSize) {                                                       \
+    return DispatchLayerNormGradWarpImplPadding<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, \
+                                                pack_size, col, kWarpSize, 1>(              \
+        stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);             \
+  }
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType>
+struct DispatchLayerNormGradWarpImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy,
+                         STORE store, const ComputeType* mean, const ComputeType* inv_variance,
+                         const int64_t rows, const int64_t cols) {
+    if (cols % 2 == 0) {
+      return DispatchLayerNormGradWarpImplCols<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, 2>(
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+    } else {
+      return DispatchLayerNormGradWarpImplCols<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, 1>(
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+    }
+  }
+};
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType>
+inline hipError_t DispatchLayerNormGradWarpImpl(hipStream_t stream, LOAD_X load_x,
+                                                 LOAD_SCALED_DY load_scaled_dy, STORE store,
+                                                 const ComputeType* mean,
+                                                 const ComputeType* inv_variance,
+                                                 const int64_t rows, const int64_t cols) {
+  return DispatchLayerNormGradWarpImplPackSize<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType>()(
+      stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size, int block_size>
+__global__ void LayerNormGradBlockSMemImpl(LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy,
+                                           STORE store, const ComputeType* mean,
+                                           const ComputeType* inv_variance, const int64_t rows,
+                                           const int64_t cols) {
+  extern __shared__ __align__(sizeof(double)) unsigned char grad_shared_buf[];
+  auto* normalized_buf = reinterpret_cast<ComputeType*>(grad_shared_buf);
+  auto* dy_buf = normalized_buf + cols;
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = static_cast<int>(cols) / pack_size;
+  const ComputeType one_over_cols = static_cast<ComputeType>(1.0) / static_cast<ComputeType>(cols);
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType sum_stats1 = 0;
+    ComputeType sum_stats2 = 0;
+    const ComputeType mean_val = mean[row];
+    const ComputeType inv_variance_val = inv_variance[row];
+    const ComputeType inv_variance_over_cols = inv_variance_val * one_over_cols;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType x_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      load_x.template load<pack_size>(x_pack, row, pack_id * pack_size);
+      load_scaled_dy.template load<pack_size>(dy_pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        const int buf_offset = i * num_packs + pack_id;
+        ComputeType normalized = (x_pack[i] - mean_val) * inv_variance_val;
+        normalized_buf[buf_offset] = normalized;
+        dy_buf[buf_offset] = dy_pack[i];
+        sum_stats1 += dy_pack[i];
+        sum_stats2 += dy_pack[i] * normalized;
+      }
+    }
+    const ComputeType row_sum_stats1 = BlockAllReduce<SumOp, ComputeType, block_size>(sum_stats1);
+    const ComputeType row_sum_stats2 = BlockAllReduce<SumOp, ComputeType, block_size>(sum_stats2);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        const int buf_offset = i * num_packs + pack_id;
+        pack[i] = (cols * dy_buf[buf_offset] - row_sum_stats1
+                   - normalized_buf[buf_offset] * row_sum_stats2)
+                  * inv_variance_over_cols;
+      }
+      store.template store<pack_size>(pack, row, pack_id * pack_size);
+    }
+  }
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size, int block_size>
+inline hipError_t LaunchLayerNormGradBlockSMemImpl(hipStream_t stream, LOAD_X load_x,
+                                                    LOAD_SCALED_DY load_scaled_dy, STORE store,
+                                                    const ComputeType* mean,
+                                                    const ComputeType* inv_variance, int smem,
+                                                    const int64_t rows, const int64_t cols) {
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    hipError_t err = GetNumBlocks(LayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE,
+                                                              ComputeType, pack_size, block_size>,
+                                   block_size, smem, rows, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  LayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size, block_size>
+      <<<grid_dim_x, block_size, smem, stream>>>(load_x, load_scaled_dy, store, mean, inv_variance,
+                                                 rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size>
+inline hipError_t TryDispatchLayerNormGradBlockSMemImplBlockSize(
+    hipStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy, STORE store,
+    const ComputeType* mean, const ComputeType* inv_variance, const int64_t rows,
+    const int64_t cols, bool* success) {
+  constexpr int block_size_conf_1 = 128;
+  constexpr int block_size_conf_2 = 256;
+  constexpr int block_size_conf_3 = 512;
+  constexpr int block_size_conf_4 = 1024;
+  const size_t smem = cols * sizeof(ComputeType) * 2;
+  int max_active_blocks_conf_1;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_1,
+        LayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                   block_size_conf_1>,
+        block_size_conf_1, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_1 <= 0) {
+    *success = false;
+    return hipSuccess;
+  }
+  int max_active_blocks_conf_4;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_4,
+        LayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                   block_size_conf_4>,
+        block_size_conf_4, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_4 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                            block_size_conf_4>(
+        stream, load_x, load_scaled_dy, store, mean, inv_variance, smem, rows, cols);
+  }
+  int max_active_blocks_conf_3;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_3,
+        LayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                   block_size_conf_3>,
+        block_size_conf_3, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_3 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                            block_size_conf_3>(
+        stream, load_x, load_scaled_dy, store, mean, inv_variance, smem, rows, cols);
+  }
+  int max_active_blocks_conf_2;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_2,
+        LayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                   block_size_conf_2>,
+        block_size_conf_2, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_2 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                            block_size_conf_2>(
+        stream, load_x, load_scaled_dy, store, mean, inv_variance, smem, rows, cols);
+  }
+  *success = true;
+  return LaunchLayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size,
+                                          block_size_conf_1>(stream, load_x, load_scaled_dy, store,
+                                                             mean, inv_variance, smem, rows, cols);
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType>
+struct TryDispatchLayerNormGradBlockSMemImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy,
+                         STORE store, const ComputeType* mean, const ComputeType* inv_variance,
+                         const int64_t rows, const int64_t cols, bool* success) {
+    if (cols % 2 == 0) {
+      return TryDispatchLayerNormGradBlockSMemImplBlockSize<LOAD_X, LOAD_SCALED_DY, STORE,
+                                                            ComputeType, 2>(
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols, success);
+    } else {
+      return TryDispatchLayerNormGradBlockSMemImplBlockSize<LOAD_X, LOAD_SCALED_DY, STORE,
+                                                            ComputeType, 1>(
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols, success);
+    }
+  }
+};
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType>
+inline hipError_t TryDispatchLayerNormGradBlockSMemImpl(hipStream_t stream, LOAD_X load_x,
+                                                         LOAD_SCALED_DY load_scaled_dy, STORE store,
+                                                         const ComputeType* mean,
+                                                         const ComputeType* inv_variance,
+                                                         const int64_t rows, const int64_t cols,
+                                                         bool* success) {
+  return TryDispatchLayerNormGradBlockSMemImplPackSize<LOAD_X, LOAD_SCALED_DY, STORE,
+                                                       ComputeType>()(
+      stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols, success);
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size, int block_size>
+__global__ void LayerNormGradBlockUncachedImpl(LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy,
+                                               STORE store, const ComputeType* mean,
+                                               const ComputeType* inv_variance, const int64_t rows,
+                                               const int64_t cols) {
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = static_cast<int>(cols) / pack_size;
+  const ComputeType one_over_cols = static_cast<ComputeType>(1.0) / static_cast<ComputeType>(cols);
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    const ComputeType mean_val = mean[row];
+    const ComputeType inv_variance_val = inv_variance[row];
+    const ComputeType inv_variance_over_cols = inv_variance_val * one_over_cols;
+    ComputeType sum_stats1 = 0;
+    ComputeType sum_stats2 = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType x_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      load_x.template load<pack_size>(x_pack, row, pack_id * pack_size);
+      load_scaled_dy.template load<pack_size>(dy_pack, row, pack_id * pack_size);
+
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        sum_stats1 += dy_pack[i];
+        sum_stats2 += dy_pack[i] * (x_pack[i] - mean_val) * inv_variance_val;
+      }
+    }
+    const ComputeType row_sum_stats1 = BlockAllReduce<SumOp, ComputeType, block_size>(sum_stats1);
+    const ComputeType row_sum_stats2 = BlockAllReduce<SumOp, ComputeType, block_size>(sum_stats2);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType x_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      load_x.template load<pack_size>(x_pack, row, pack_id * pack_size);
+      load_scaled_dy.template load<pack_size>(dy_pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        dy_pack[i] = (cols * dy_pack[i] - row_sum_stats1
+                      - (x_pack[i] - mean_val) * inv_variance_val * row_sum_stats2)
+                     * inv_variance_over_cols;
+      }
+      store.template store<pack_size>(dy_pack, row, pack_id * pack_size);
+    }
+  }
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType,
+         int pack_size>
+inline hipError_t LaunchLayerNormGradBlockUncachedImpl(hipStream_t stream, LOAD_X load_x,
+                                                        LOAD_SCALED_DY load_scaled_dy, STORE store,
+                                                        const ComputeType* mean,
+                                                        const ComputeType* inv_variance,
+                                                        const int64_t rows, const int64_t cols) {
+  constexpr int block_size = 1024;
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    hipError_t err =
+        GetNumBlocks(LayerNormGradBlockUncachedImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType,
+                                                    pack_size, block_size>,
+                     block_size, 0, rows, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  LayerNormGradBlockUncachedImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, pack_size, block_size>
+      <<<grid_dim_x, block_size, 0, stream>>>(load_x, load_scaled_dy, store, mean, inv_variance,
+                                              rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType>
+struct DispatchLayerNormGradBlockUncachedImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy,
+                         STORE store, const ComputeType* mean, const ComputeType* inv_variance,
+                         const int64_t rows, const int64_t cols) {
+    if (cols % 2 == 0 && cols > kWarpSize) {
+      return LaunchLayerNormGradBlockUncachedImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, 2>(
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+    } else {
+      return LaunchLayerNormGradBlockUncachedImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType, 1>(
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+    }
+  }
+};
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType>
+inline hipError_t DispatchLayerNormGradBlockUncachedImpl(hipStream_t stream, LOAD_X load_x,
+                                                          LOAD_SCALED_DY load_scaled_dy,
+                                                          STORE store, const ComputeType* mean,
+                                                          const ComputeType* inv_variance,
+                                                          const int64_t rows, const int64_t cols) {
+  return DispatchLayerNormGradBlockUncachedImplPackSize<LOAD_X, LOAD_SCALED_DY, STORE,
+                                                        ComputeType>()(
+      stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType>
+inline typename std::enable_if<!std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchLayerNormGrad(hipStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy,
+                      STORE store, const ComputeType* mean, const ComputeType* inv_variance,
+                      const int64_t rows, const int64_t cols) {
+  if (cols <= 1024) {
+    return DispatchLayerNormGradWarpImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType>(
+        stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+  } else {
+    bool dispatch_smem_impl_success;
+    {
+      hipError_t err =
+          TryDispatchLayerNormGradBlockSMemImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType>(
+              stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols,
+              &dispatch_smem_impl_success);
+      if (err != hipSuccess) { return err; }
+    }
+    if (!dispatch_smem_impl_success) {
+      return DispatchLayerNormGradBlockUncachedImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType>(
+          stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+    }
+    return hipSuccess;
+  }
+}
+
+template<typename LOAD_X, typename LOAD_SCALED_DY, typename STORE, typename ComputeType>
+inline typename std::enable_if<std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchLayerNormGrad(hipStream_t stream, LOAD_X load_x, LOAD_SCALED_DY load_scaled_dy,
+                      STORE store, const ComputeType* mean, const ComputeType* inv_variance,
+                      const int64_t rows, const int64_t cols) {
+  return DispatchLayerNormGradBlockUncachedImpl<LOAD_X, LOAD_SCALED_DY, STORE, ComputeType>(
+      stream, load_x, load_scaled_dy, store, mean, inv_variance, rows, cols);
+}
+
+}  // namespace layer_norm
+
+}  // namespace cuda
+
+}  // namespace oneflow
+
+
+#endif  // WITH_HIP
 
 #endif  // ONEFLOW_CORE_CUDA_LAYER_NORM_H_

--- a/oneflow/core/cuda/softmax.cuh
+++ b/oneflow/core/cuda/softmax.cuh
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef ONEFLOW_CORE_CUDA_SOFTMAX_H_
 #define ONEFLOW_CORE_CUDA_SOFTMAX_H_
 
+#ifdef WITH_CUDA
+
 #include <cub/cub.cuh>
 #include <math_constants.h>
 #include <assert.h>
@@ -1355,5 +1357,1350 @@ DispatchLogSoftmaxGrad(cudaStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STOR
 }  // namespace cuda
 
 }  // namespace oneflow
+
+#endif // WITH_CUDA
+
+#ifdef WITH_HIP
+
+#include <hipcub/hipcub.hpp>
+// #include <math_constants.h>
+#include <assert.h>
+#include <hip/hip_runtime.h>
+
+// #if CUDA_VERSION >= 11000
+// #include <cuda_bf16.h>
+// #endif  // CUDA_VERSION >= 11000
+
+namespace oneflow {
+
+namespace cuda {
+
+namespace softmax {
+
+constexpr int kWarpSize = 32;
+
+template<typename T>
+struct SumOp {
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const { return a + b; }
+};
+
+template<typename T>
+struct MaxOp {
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const { return max(a, b); }
+};
+
+template<template<typename> class ReductionOp, typename T, int thread_group_width = kWarpSize>
+__inline__ __device__ T WarpAllReduce(T val) {
+  for (int mask = thread_group_width / 2; mask > 0; mask /= 2) {
+    val = ReductionOp<T>()(val, __shfl_xor(0xffffffff, val, mask));
+  }
+  return val;
+}
+
+template<template<typename> class ReductionOp, typename T, int block_size>
+__inline__ __device__ T BlockAllReduce(T val) {
+  typedef hipcub::BlockReduce<T, block_size> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  __shared__ T result_broadcast;
+  T result = BlockReduce(temp_storage).Reduce(val, ReductionOp<T>());
+  if (threadIdx.x == 0) { result_broadcast = result; }
+  __syncthreads();
+  return result_broadcast;
+}
+
+template<typename T>
+__inline__ __device__ T Inf();
+
+template<>
+__inline__ __device__ float Inf<float>() {
+  return __int_as_float(0x7f800000U);
+}
+
+template<>
+__inline__ __device__ double Inf<double>() {
+  return __longlong_as_double(0x7ff0000000000000ULL);
+}
+
+template<typename T>
+__inline__ __device__ T Exp(T x);
+
+template<>
+__inline__ __device__ float Exp<float>(float x) {
+#ifdef OF_SOFTMAX_USE_FAST_MATH
+  return __expf(x);
+#else
+  return exp(x);
+#endif
+}
+
+template<>
+__inline__ __device__ double Exp<double>(double x) {
+  return exp(x);
+}
+
+template<typename T>
+__inline__ __device__ T Div(T a, T b);
+
+template<>
+__inline__ __device__ float Div<float>(float a, float b) {
+#ifdef OF_SOFTMAX_USE_FAST_MATH
+  return __fdividef(a, b);
+#else
+  return a / b;
+#endif
+}
+
+template<>
+__inline__ __device__ double Div<double>(double a, double b) {
+  return a / b;
+}
+
+template<typename T>
+__inline__ __device__ T Log(T x);
+
+template<>
+__inline__ __device__ float Log<float>(float x) {
+#ifdef OF_SOFTMAX_USE_FAST_MATH
+  return __logf(x);
+#else
+  return log(x);
+#endif
+}
+template<>
+__inline__ __device__ double Log<double>(double x) {
+  return log(x);
+}
+
+inline hipError_t GetNumBlocks(int64_t block_size, int64_t max_blocks, int64_t waves,
+                                int* num_blocks) {
+  int dev;
+  {
+    hipError_t err = hipGetDevice(&dev);
+    if (err != hipSuccess) { return err; }
+  }
+  int sm_count;
+  {
+    hipError_t err = hipDeviceGetAttribute(&sm_count, hipDeviceAttributeMultiprocessorCount, dev);
+    if (err != hipSuccess) { return err; }
+  }
+  int tpm;
+  {
+    hipError_t err = hipDeviceGetAttribute(&tpm, hipDeviceAttributeMaxThreadsPerMultiProcessor, dev);
+    if (err != hipSuccess) { return err; }
+  }
+  *num_blocks =
+      std::max<int>(1, std::min<int64_t>(max_blocks, sm_count * tpm / block_size * waves));
+  return hipSuccess;
+}
+
+template<typename T>
+struct DefaultComputeType {
+  using type = T;
+};
+
+template<>
+struct DefaultComputeType<half> {
+  using type = float;
+};
+
+// #if CUDA_VERSION >= 11000
+// template<>
+// struct DefaultComputeType<nv_bfloat16> {
+//   using type = float;
+// };
+// #endif  // CUDA_VERSION >= 11000
+
+template<typename T, int N>
+struct GetPackType {
+  using type = typename std::aligned_storage<N * sizeof(T), N * sizeof(T)>::type;
+};
+
+template<typename T, int N>
+using PackType = typename GetPackType<T, N>::type;
+
+template<typename T, int N>
+union Pack {
+  static_assert(sizeof(PackType<T, N>) == sizeof(T) * N, "");
+  __device__ Pack() {
+    // do nothing
+  }
+  PackType<T, N> storage;
+  T elem[N];
+};
+
+template<typename SRC, typename DST>
+struct DirectLoad {
+  DirectLoad(const SRC* src, int64_t row_size) : src(src), row_size(row_size) {}
+  template<int N>
+  __device__ void load(DST* dst, int64_t row, int64_t col) const {
+    Pack<SRC, N> pack;
+    const int64_t offset = (row * row_size + col) / N;
+    pack.storage = *(reinterpret_cast<const PackType<SRC, N>*>(src) + offset);
+#pragma unroll
+    for (int i = 0; i < N; ++i) { dst[i] = static_cast<DST>(pack.elem[i]); }
+  }
+  const SRC* src;
+  int64_t row_size;
+};
+
+template<typename SRC, typename DST>
+struct DirectStore {
+  DirectStore(DST* dst, int64_t row_size) : dst(dst), row_size(row_size) {}
+  template<int N>
+  __device__ void store(const SRC* src, int64_t row, int64_t col) {
+    Pack<DST, N> pack;
+    const int64_t offset = (row * row_size + col) / N;
+#pragma unroll
+    for (int i = 0; i < N; ++i) { pack.elem[i] = static_cast<DST>(src[i]); }
+    *(reinterpret_cast<PackType<DST, N>*>(dst) + offset) = pack.storage;
+  }
+  DST* dst;
+  int64_t row_size;
+};
+
+enum class Algorithm {
+  kSoftmax = 0,
+  kLogSoftmax = 1,
+};
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int cols_per_thread,
+         int thread_group_width, int rows_per_access, bool padding, Algorithm algorithm>
+__global__ void SoftmaxWarpImpl(LOAD load, STORE store, const int64_t rows, const int64_t cols) {
+  static_assert(cols_per_thread % pack_size == 0, "");
+  static_assert(thread_group_width <= kWarpSize, "");
+  static_assert(kWarpSize % thread_group_width == 0, "");
+  constexpr int num_packs = cols_per_thread / pack_size;
+  assert(cols <= cols_per_thread * thread_group_width);
+  ComputeType buf[rows_per_access][cols_per_thread];
+  const int global_thread_group_id = blockIdx.x * blockDim.y + threadIdx.y;
+  const int num_global_thread_group = gridDim.x * blockDim.y;
+  const int lane_id = threadIdx.x;
+  const int64_t step = num_global_thread_group * rows_per_access;
+  for (int64_t row = global_thread_group_id * rows_per_access; row < rows; row += step) {
+    ComputeType thread_max[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      thread_max[row_id] = -Inf<ComputeType>();
+      ComputeType* row_buf = buf[row_id];
+#pragma unroll
+      for (int pack_id = 0; pack_id < num_packs; ++pack_id) {
+        const int pack_offset = pack_id * pack_size;
+        const int col = (pack_id * thread_group_width + lane_id) * pack_size;
+        if (!padding || col < cols) {
+          load.template load<pack_size>(row_buf + pack_offset, row + row_id, col);
+#pragma unroll
+          for (int i = 0; i < pack_size; ++i) {
+            thread_max[row_id] = max(thread_max[row_id], row_buf[pack_offset + i]);
+          }
+        } else {
+#pragma unroll
+          for (int i = 0; i < pack_size; ++i) { row_buf[pack_offset + i] = -Inf<ComputeType>(); }
+        }
+      }
+    }
+    ComputeType warp_max[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      warp_max[row_id] = WarpAllReduce<MaxOp, ComputeType, thread_group_width>(thread_max[row_id]);
+    }
+    ComputeType thread_sum[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      thread_sum[row_id] = 0;
+      ComputeType* row_buf = buf[row_id];
+#pragma unroll
+      for (int i = 0; i < cols_per_thread; ++i) {
+        if (algorithm == Algorithm::kSoftmax) {
+          row_buf[i] = Exp(row_buf[i] - warp_max[row_id]);
+          thread_sum[row_id] += row_buf[i];
+        } else if (algorithm == Algorithm::kLogSoftmax) {
+          row_buf[i] -= warp_max[row_id];
+          thread_sum[row_id] += Exp(row_buf[i]);
+        } else {
+          __trap();
+        }
+      }
+    }
+    ComputeType warp_sum[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      warp_sum[row_id] = WarpAllReduce<SumOp, ComputeType, thread_group_width>(thread_sum[row_id]);
+    }
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      ComputeType* row_buf = buf[row_id];
+#pragma unroll
+      for (int i = 0; i < cols_per_thread; ++i) {
+        if (algorithm == Algorithm::kSoftmax) {
+          row_buf[i] = Div(row_buf[i], warp_sum[row_id]);
+        } else if (algorithm == Algorithm::kLogSoftmax) {
+          row_buf[i] -= Log(warp_sum[row_id]);
+        } else {
+          __trap();
+        }
+      }
+#pragma unroll
+      for (int i = 0; i < num_packs; ++i) {
+        const int col = (i * thread_group_width + lane_id) * pack_size;
+        if (!padding || col < cols) {
+          store.template store<pack_size>(row_buf + i * pack_size, row + row_id, col);
+        }
+      }
+    }
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int cols_per_thread,
+         int thread_group_width, int rows_per_access, bool padding, Algorithm algorithm>
+inline hipError_t LaunchSoftmaxWarpImpl(hipStream_t stream, LOAD load, STORE store,
+                                         const int64_t rows, const int64_t cols) {
+  constexpr int block_size = 128;
+  constexpr int waves = 32;
+  static_assert(block_size % thread_group_width == 0, "");
+  constexpr int thread_groups_per_block = block_size / thread_group_width;
+  dim3 block_dim(thread_group_width, thread_groups_per_block);
+  const int64_t num_blocks =
+      (rows / rows_per_access + thread_groups_per_block - 1) / thread_groups_per_block;
+  int grid_dim_x;
+  {
+    hipError_t err = GetNumBlocks(block_size, num_blocks, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  SoftmaxWarpImpl<LOAD, STORE, ComputeType, pack_size, cols_per_thread, thread_group_width,
+                  rows_per_access, padding, algorithm>
+      <<<grid_dim_x, block_dim, 0, stream>>>(load, store, rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int cols_per_thread,
+         int thread_group_width, int rows_per_access, Algorithm algorithm>
+inline hipError_t DispatchSoftmaxWarpImplPadding(hipStream_t stream, LOAD load, STORE store,
+                                                  const int64_t rows, const int64_t cols) {
+  if (cols == cols_per_thread * thread_group_width) {
+    return LaunchSoftmaxWarpImpl<LOAD, STORE, ComputeType, pack_size, cols_per_thread,
+                                 thread_group_width, rows_per_access, false, algorithm>(
+        stream, load, store, rows, cols);
+  } else {
+    return LaunchSoftmaxWarpImpl<LOAD, STORE, ComputeType, pack_size, cols_per_thread,
+                                 thread_group_width, rows_per_access, true, algorithm>(
+        stream, load, store, rows, cols);
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, Algorithm algorithm>
+typename std::enable_if<pack_size == 1, hipError_t>::type DispatchSoftmaxWarpImplCols(
+    hipStream_t stream, LOAD load, STORE store, const int64_t rows, const int64_t cols) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                        \
+  else if (cols <= (thread_group_width)*pack_size) {                                               \
+    if (rows % 2 == 0) {                                                                           \
+      return DispatchSoftmaxWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size,        \
+                                            thread_group_width, 2, algorithm>(stream, load, store, \
+                                                                              rows, cols);         \
+    } else {                                                                                       \
+      return DispatchSoftmaxWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size,        \
+                                            thread_group_width, 1, algorithm>(stream, load, store, \
+                                                                              rows, cols);         \
+    }                                                                                              \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                      \
+  else if (cols <= (col)*kWarpSize) {                                                             \
+    return DispatchSoftmaxWarpImplPadding<LOAD, STORE, ComputeType, pack_size, col, kWarpSize, 1, \
+                                          algorithm>(stream, load, store, rows, cols);            \
+  }
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(3)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(5)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(7)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(9)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(11)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(13)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(15)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(17)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(19)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(21)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(23)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(25)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(27)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(29)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(31)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, Algorithm algorithm>
+typename std::enable_if<pack_size == 2, hipError_t>::type DispatchSoftmaxWarpImplCols(
+    hipStream_t stream, LOAD load, STORE store, const int64_t rows, const int64_t cols) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                        \
+  else if (cols <= (thread_group_width)*pack_size) {                                               \
+    if (rows % 2 == 0) {                                                                           \
+      return DispatchSoftmaxWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size,        \
+                                            thread_group_width, 2, algorithm>(stream, load, store, \
+                                                                              rows, cols);         \
+    } else {                                                                                       \
+      return DispatchSoftmaxWarpImplPadding<LOAD, STORE, ComputeType, pack_size, pack_size,        \
+                                            thread_group_width, 1, algorithm>(stream, load, store, \
+                                                                              rows, cols);         \
+    }                                                                                              \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                      \
+  else if (cols <= (col)*kWarpSize) {                                                             \
+    return DispatchSoftmaxWarpImplPadding<LOAD, STORE, ComputeType, pack_size, col, kWarpSize, 1, \
+                                          algorithm>(stream, load, store, rows, cols);            \
+  }
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, Algorithm algorithm>
+struct DispatchSoftmaxWarpImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                         const int64_t cols) {
+    if (cols % 2 == 0) {
+      return DispatchSoftmaxWarpImplCols<LOAD, STORE, ComputeType, 2, algorithm>(stream, load,
+                                                                                 store, rows, cols);
+    } else {
+      return DispatchSoftmaxWarpImplCols<LOAD, STORE, ComputeType, 1, algorithm>(stream, load,
+                                                                                 store, rows, cols);
+    }
+  }
+};
+
+template<typename LOAD, typename STORE, typename ComputeType, Algorithm algorithm>
+inline hipError_t DispatchSoftmaxWarpImpl(hipStream_t stream, LOAD load, STORE store,
+                                           const int64_t rows, const int64_t cols) {
+  return DispatchSoftmaxWarpImplPackSize<LOAD, STORE, ComputeType, algorithm>()(stream, load, store,
+                                                                                rows, cols);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int block_size,
+         Algorithm algorithm>
+__global__ void SoftmaxBlockSMemImpl(LOAD load, STORE store, const int64_t rows,
+                                     const int64_t cols) {
+  extern __shared__ __align__(sizeof(double)) unsigned char shared_buf[];
+  auto* buf = reinterpret_cast<ComputeType*>(shared_buf);
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = cols / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType thread_max = -Inf<ComputeType>();
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      load.template load<pack_size>(pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        buf[i * num_packs + pack_id] = pack[i];
+        thread_max = max(thread_max, pack[i]);
+      }
+    }
+    const ComputeType row_max = BlockAllReduce<MaxOp, ComputeType, block_size>(thread_max);
+    ComputeType thread_sum = 0;
+    for (int col = tid; col < cols; col += block_size) {
+      if (algorithm == Algorithm::kSoftmax) {
+        const ComputeType exp_x = Exp(buf[col] - row_max);
+        buf[col] = exp_x;
+        thread_sum += exp_x;
+      } else {
+        const ComputeType x = buf[col] - row_max;
+        buf[col] = x;
+        thread_sum += Exp(x);
+      }
+    }
+    const ComputeType row_sum = BlockAllReduce<SumOp, ComputeType, block_size>(thread_sum);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        if (algorithm == Algorithm::kSoftmax) {
+          pack[i] = Div(buf[i * num_packs + pack_id], row_sum);
+        } else if (algorithm == Algorithm::kLogSoftmax) {
+          pack[i] = buf[i * num_packs + pack_id] - Log(row_sum);
+        } else {
+          __trap();
+        }
+      }
+      store.template store<pack_size>(pack, row, pack_id * pack_size);
+    }
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int block_size,
+         Algorithm algorithm>
+inline hipError_t LaunchSoftmaxBlockSMemImpl(hipStream_t stream, LOAD load, STORE store, int smem,
+                                              const int64_t rows, const int64_t cols) {
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    hipError_t err = GetNumBlocks(block_size, rows, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  SoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size, algorithm>
+      <<<grid_dim_x, block_size, smem, stream>>>(load, store, rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, Algorithm algorithm>
+inline hipError_t TryDispatchSoftmaxBlockSMemImplBlockSize(hipStream_t stream, LOAD load,
+                                                            STORE store, const int64_t rows,
+                                                            const int64_t cols, bool* success) {
+  constexpr int block_size_conf_1 = 128;
+  constexpr int block_size_conf_2 = 256;
+  constexpr int block_size_conf_3 = 512;
+  constexpr int block_size_conf_4 = 1024;
+  const size_t smem = cols * sizeof(ComputeType);
+  int max_active_blocks_conf_1;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_1,
+        SoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_1, algorithm>,
+        block_size_conf_1, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_1 <= 0) {
+    *success = false;
+    return hipSuccess;
+  }
+  int max_active_blocks_conf_4;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_4,
+        SoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_4, algorithm>,
+        block_size_conf_4, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_4 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchSoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_4,
+                                      algorithm>(stream, load, store, smem, rows, cols);
+  }
+  int max_active_blocks_conf_3;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_3,
+        SoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_3, algorithm>,
+        block_size_conf_3, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_3 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchSoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_3,
+                                      algorithm>(stream, load, store, smem, rows, cols);
+  }
+  int max_active_blocks_conf_2;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_2,
+        SoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_2, algorithm>,
+        block_size_conf_2, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_2 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchSoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_2,
+                                      algorithm>(stream, load, store, smem, rows, cols);
+  }
+  *success = true;
+  return LaunchSoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size_conf_1,
+                                    algorithm>(stream, load, store, smem, rows, cols);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, Algorithm algorithm>
+struct TryDispatchSoftmaxBlockSMemImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                         const int64_t cols, bool* success) {
+    if (cols % 2 == 0) {
+      return TryDispatchSoftmaxBlockSMemImplBlockSize<LOAD, STORE, ComputeType, 2, algorithm>(
+          stream, load, store, rows, cols, success);
+    } else {
+      return TryDispatchSoftmaxBlockSMemImplBlockSize<LOAD, STORE, ComputeType, 1, algorithm>(
+          stream, load, store, rows, cols, success);
+    }
+  }
+};
+
+template<typename LOAD, typename STORE, typename ComputeType, Algorithm algorithm>
+inline hipError_t TryDispatchSoftmaxBlockSMemImpl(hipStream_t stream, LOAD load, STORE store,
+                                                   const int64_t rows, const int64_t cols,
+                                                   bool* success) {
+  return TryDispatchSoftmaxBlockSMemImplPackSize<LOAD, STORE, ComputeType, algorithm>()(
+      stream, load, store, rows, cols, success);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, int block_size,
+         Algorithm algorithm>
+__global__ void SoftmaxBlockUncachedImpl(LOAD load, STORE store, const int64_t rows,
+                                         const int64_t cols) {
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = cols / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType thread_max = -Inf<ComputeType>();
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      load.template load<pack_size>(pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) { thread_max = max(thread_max, pack[i]); }
+    }
+    const ComputeType row_max = BlockAllReduce<MaxOp, ComputeType, block_size>(thread_max);
+    ComputeType thread_sum = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      load.template load<pack_size>(pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) { thread_sum += Exp(pack[i] - row_max); }
+    }
+    const ComputeType row_sum = BlockAllReduce<SumOp, ComputeType, block_size>(thread_sum);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      load.template load<pack_size>(pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        if (algorithm == Algorithm::kSoftmax) {
+          pack[i] = Div(Exp(pack[i] - row_max), row_sum);
+        } else if (algorithm == Algorithm::kLogSoftmax) {
+          pack[i] = (pack[i] - row_max) - Log(row_sum);
+        } else {
+          __trap();
+        }
+      }
+      store.template store<pack_size>(pack, row, pack_id * pack_size);
+    }
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, int pack_size, Algorithm algorithm>
+inline hipError_t LaunchSoftmaxBlockUncachedImpl(hipStream_t stream, LOAD load, STORE store,
+                                                  const int64_t rows, const int64_t cols) {
+  constexpr int block_size = 1024;
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    hipError_t err = GetNumBlocks(block_size, rows, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  SoftmaxBlockUncachedImpl<LOAD, STORE, ComputeType, pack_size, block_size, algorithm>
+      <<<grid_dim_x, block_size, 0, stream>>>(load, store, rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD, typename STORE, typename ComputeType, Algorithm algorithm>
+struct DispatchSoftmaxBlockUncachedImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                         const int64_t cols) {
+    if (cols % 2 == 0) {
+      return LaunchSoftmaxBlockUncachedImpl<LOAD, STORE, ComputeType, 2, algorithm>(
+          stream, load, store, rows, cols);
+    } else {
+      return LaunchSoftmaxBlockUncachedImpl<LOAD, STORE, ComputeType, 1, algorithm>(
+          stream, load, store, rows, cols);
+    }
+  }
+};
+
+template<typename LOAD, typename STORE, typename ComputeType, Algorithm algorithm>
+inline hipError_t DispatchSoftmaxBlockUncachedImpl(hipStream_t stream, LOAD load, STORE store,
+                                                    const int64_t rows, const int64_t cols) {
+  return DispatchSoftmaxBlockUncachedImplPackSize<LOAD, STORE, ComputeType, algorithm>()(
+      stream, load, store, rows, cols);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline typename std::enable_if<!std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchSoftmax(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                const int64_t cols) {
+  if (cols <= 1024) {
+    return DispatchSoftmaxWarpImpl<LOAD, STORE, ComputeType, Algorithm::kSoftmax>(
+        stream, load, store, rows, cols);
+  } else {
+    bool dispatch_smem_impl_success;
+    {
+      hipError_t err =
+          TryDispatchSoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, Algorithm::kSoftmax>(
+              stream, load, store, rows, cols, &dispatch_smem_impl_success);
+      if (err != hipSuccess) { return err; }
+    }
+    if (!dispatch_smem_impl_success) {
+      return DispatchSoftmaxBlockUncachedImpl<LOAD, STORE, ComputeType, Algorithm::kSoftmax>(
+          stream, load, store, rows, cols);
+    }
+    return hipSuccess;
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline typename std::enable_if<std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchSoftmax(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                const int64_t cols) {
+  return DispatchSoftmaxBlockUncachedImpl<LOAD, STORE, ComputeType, Algorithm::kSoftmax>(
+      stream, load, store, rows, cols);
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline typename std::enable_if<!std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchLogSoftmax(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                   const int64_t cols) {
+  if (cols <= 1024) {
+    return DispatchSoftmaxWarpImpl<LOAD, STORE, ComputeType, Algorithm::kLogSoftmax>(
+        stream, load, store, rows, cols);
+  } else {
+    bool dispatch_smem_impl_success;
+    {
+      hipError_t err =
+          TryDispatchSoftmaxBlockSMemImpl<LOAD, STORE, ComputeType, Algorithm::kLogSoftmax>(
+              stream, load, store, rows, cols, &dispatch_smem_impl_success);
+      if (err != hipSuccess) { return err; }
+    }
+    if (!dispatch_smem_impl_success) {
+      return DispatchSoftmaxBlockUncachedImpl<LOAD, STORE, ComputeType, Algorithm::kLogSoftmax>(
+          stream, load, store, rows, cols);
+    }
+    return hipSuccess;
+  }
+}
+
+template<typename LOAD, typename STORE, typename ComputeType>
+inline typename std::enable_if<std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchLogSoftmax(hipStream_t stream, LOAD load, STORE store, const int64_t rows,
+                   const int64_t cols) {
+  return DispatchSoftmaxBlockUncachedImpl<LOAD, STORE, ComputeType, Algorithm::kLogSoftmax>(
+      stream, load, store, rows, cols);
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         int cols_per_thread, int thread_group_width, int rows_per_access, bool padding,
+         Algorithm algorithm>
+__global__ void SoftmaxGradWarpImpl(LOAD_Y load_y, LOAD_DY load_dy, STORE store, const int64_t rows,
+                                    const int64_t cols) {
+  static_assert(cols_per_thread % pack_size == 0, "");
+  constexpr int pack_per_thread = cols_per_thread / pack_size;
+  assert(cols <= cols_per_thread * thread_group_width);
+  static_assert(thread_group_width <= kWarpSize, "");
+  static_assert(kWarpSize % thread_group_width == 0, "");
+  ComputeType y_buf[rows_per_access][cols_per_thread];
+  ComputeType dy_buf[rows_per_access][cols_per_thread];
+  const int global_thread_group_id = blockIdx.x * blockDim.y + threadIdx.y;
+  const int num_global_thread_group = gridDim.x * blockDim.y;
+  const int lane_id = threadIdx.x;
+  const int64_t step = num_global_thread_group * rows_per_access;
+  for (int64_t row = global_thread_group_id * rows_per_access; row < rows; row += step) {
+    ComputeType thread_sum[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      thread_sum[row_id] = 0;
+      ComputeType* row_y_buf = y_buf[row_id];
+      ComputeType* row_dy_buf = dy_buf[row_id];
+#pragma unroll
+      for (int pack_id = 0; pack_id < pack_per_thread; ++pack_id) {
+        const int pack_offset = pack_id * pack_size;
+        const int col = (pack_id * thread_group_width + lane_id) * pack_size;
+        if (!padding || col < cols) {
+          load_y.template load<pack_size>(row_y_buf + pack_offset, row + row_id, col);
+          load_dy.template load<pack_size>(row_dy_buf + pack_offset, row + row_id, col);
+#pragma unroll
+          for (int i = 0; i < pack_size; ++i) {
+            if (algorithm == Algorithm::kSoftmax) {
+              thread_sum[row_id] += row_y_buf[pack_offset + i] * row_dy_buf[pack_offset + i];
+            } else if (algorithm == Algorithm::kLogSoftmax) {
+              thread_sum[row_id] += row_dy_buf[pack_offset + i];
+            } else {
+              __trap();
+            }
+          }
+        }
+      }
+    }
+    ComputeType warp_sum[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      warp_sum[row_id] = WarpAllReduce<SumOp, ComputeType, thread_group_width>(thread_sum[row_id]);
+    }
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      ComputeType* row_y_buf = y_buf[row_id];
+      ComputeType* row_dy_buf = dy_buf[row_id];
+#pragma unroll
+      for (int pack_id = 0; pack_id < pack_per_thread; ++pack_id) {
+        const int pack_offset = pack_id * pack_size;
+        const int col = (pack_id * thread_group_width + lane_id) * pack_size;
+        if (!padding || col < cols) {
+          for (int i = 0; i < pack_size; ++i) {
+            if (algorithm == Algorithm::kSoftmax) {
+              row_dy_buf[pack_offset + i] =
+                  (row_dy_buf[pack_offset + i] - warp_sum[row_id]) * row_y_buf[pack_offset + i];
+            } else if (algorithm == Algorithm::kLogSoftmax) {
+              row_dy_buf[pack_offset + i] -= Exp(row_y_buf[pack_offset + i]) * warp_sum[row_id];
+            } else {
+              __trap();
+            }
+          }
+          store.template store<pack_size>(row_dy_buf + pack_offset, row + row_id, col);
+        }
+      }
+    }
+  }
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         int cols_per_thread, int thread_group_width, int rows_per_access, bool padding,
+         Algorithm algorithm>
+inline hipError_t LaunchSoftmaxGradWarpImpl(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy,
+                                             STORE store, const int64_t rows, const int64_t cols) {
+  constexpr int block_size = 128;
+  constexpr int waves = 32;
+  static_assert(block_size % thread_group_width == 0, "");
+  constexpr int thread_groups_per_block = block_size / thread_group_width;
+  dim3 block_dim(thread_group_width, thread_groups_per_block);
+  const int64_t num_blocks =
+      (rows / rows_per_access + thread_groups_per_block - 1) / thread_groups_per_block;
+  int grid_dim_x;
+  {
+    hipError_t err = GetNumBlocks(block_size, num_blocks, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  SoftmaxGradWarpImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, cols_per_thread,
+                      thread_group_width, rows_per_access, padding, algorithm>
+      <<<grid_dim_x, block_dim, 0, stream>>>(load_y, load_dy, store, rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         int cols_per_thread, int thread_group_width, int rows_per_access, Algorithm algorithm>
+inline hipError_t DispatchSoftmaxGradWarpImplPadding(hipStream_t stream, LOAD_Y load_y,
+                                                      LOAD_DY load_dy, STORE store,
+                                                      const int64_t rows, const int64_t cols) {
+  if (cols == cols_per_thread * thread_group_width) {
+    return LaunchSoftmaxGradWarpImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size,
+                                     cols_per_thread, thread_group_width, rows_per_access, false,
+                                     algorithm>(stream, load_y, load_dy, store, rows, cols);
+  } else {
+    return LaunchSoftmaxGradWarpImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size,
+                                     cols_per_thread, thread_group_width, rows_per_access, true,
+                                     algorithm>(stream, load_y, load_dy, store, rows, cols);
+  }
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         Algorithm algorithm>
+typename std::enable_if<pack_size == 1, hipError_t>::type DispatchSoftmaxGradWarpImplCols(
+    hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store, const int64_t rows,
+    const int64_t cols) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                     \
+  else if (cols <= (thread_group_width)*pack_size) {                                            \
+    if (rows % 2 == 0) {                                                                        \
+      return DispatchSoftmaxGradWarpImplPadding<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, \
+                                                pack_size, thread_group_width, 2, algorithm>(   \
+          stream, load_y, load_dy, store, rows, cols);                                          \
+    } else {                                                                                    \
+      return DispatchSoftmaxGradWarpImplPadding<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, \
+                                                pack_size, thread_group_width, 1, algorithm>(   \
+          stream, load_y, load_dy, store, rows, cols);                                          \
+    }                                                                                           \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                       \
+  else if (cols <= (col)*kWarpSize) {                                                              \
+    return DispatchSoftmaxGradWarpImplPadding<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, col, \
+                                              kWarpSize, 1, algorithm>(stream, load_y, load_dy,    \
+                                                                       store, rows, cols);         \
+  }
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(3)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(5)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(7)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(9)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(11)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(13)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(15)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(17)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(19)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(21)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(23)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(25)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(27)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(29)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(31)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         Algorithm algorithm>
+typename std::enable_if<pack_size == 2, hipError_t>::type DispatchSoftmaxGradWarpImplCols(
+    hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store, const int64_t rows,
+    const int64_t cols) {
+  if (cols <= 0) { return hipErrorInvalidValue; }
+#define DEFINE_ONE_ELIF(thread_group_width)                                                     \
+  else if (cols <= (thread_group_width)*pack_size) {                                            \
+    if (rows % 2 == 0) {                                                                        \
+      return DispatchSoftmaxGradWarpImplPadding<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, \
+                                                pack_size, thread_group_width, 2, algorithm>(   \
+          stream, load_y, load_dy, store, rows, cols);                                          \
+    } else {                                                                                    \
+      return DispatchSoftmaxGradWarpImplPadding<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, \
+                                                pack_size, thread_group_width, 1, algorithm>(   \
+          stream, load_y, load_dy, store, rows, cols);                                          \
+    }                                                                                           \
+  }
+  DEFINE_ONE_ELIF(1)
+  DEFINE_ONE_ELIF(2)
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(col)                                                                       \
+  else if (cols <= (col)*kWarpSize) {                                                              \
+    return DispatchSoftmaxGradWarpImplPadding<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, col, \
+                                              kWarpSize, 1, algorithm>(stream, load_y, load_dy,    \
+                                                                       store, rows, cols);         \
+  }
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(6)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(10)
+  DEFINE_ONE_ELIF(12)
+  DEFINE_ONE_ELIF(14)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(18)
+  DEFINE_ONE_ELIF(20)
+  DEFINE_ONE_ELIF(22)
+  DEFINE_ONE_ELIF(24)
+  DEFINE_ONE_ELIF(26)
+  DEFINE_ONE_ELIF(28)
+  DEFINE_ONE_ELIF(30)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+  else {
+    return hipErrorInvalidValue;
+  }
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType,
+         Algorithm algorithm>
+struct DispatchSoftmaxGradWarpImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                         const int64_t rows, const int64_t cols) {
+    if (cols % 2 == 0) {
+      return DispatchSoftmaxGradWarpImplCols<LOAD_Y, LOAD_DY, STORE, ComputeType, 2, algorithm>(
+          stream, load_y, load_dy, store, rows, cols);
+    } else {
+      return DispatchSoftmaxGradWarpImplCols<LOAD_Y, LOAD_DY, STORE, ComputeType, 1, algorithm>(
+          stream, load_y, load_dy, store, rows, cols);
+    }
+  }
+};
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType,
+         Algorithm algorithm>
+inline hipError_t DispatchSoftmaxGradWarpImpl(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy,
+                                               STORE store, const int64_t rows,
+                                               const int64_t cols) {
+  return DispatchSoftmaxGradWarpImplPackSize<LOAD_Y, LOAD_DY, STORE, ComputeType, algorithm>()(
+      stream, load_y, load_dy, store, rows, cols);
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         int block_size, Algorithm algorithm>
+__global__ void SoftmaxGradBlockSMemImpl(LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                                         const int64_t rows, const int64_t cols) {
+  extern __shared__ __align__(sizeof(double)) unsigned char grad_shared_buf[];
+  auto* y_buf = reinterpret_cast<ComputeType*>(grad_shared_buf);
+  auto* dy_buf = y_buf + cols;
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = cols / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType thread_sum = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType y_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      load_y.template load<pack_size>(y_pack, row, pack_id * pack_size);
+      load_dy.template load<pack_size>(dy_pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        y_buf[i * num_packs + pack_id] = y_pack[i];
+        dy_buf[i * num_packs + pack_id] = dy_pack[i];
+        if (algorithm == Algorithm::kSoftmax) {
+          thread_sum += y_pack[i] * dy_pack[i];
+        } else if (algorithm == Algorithm::kLogSoftmax) {
+          thread_sum += dy_pack[i];
+        } else {
+          __trap();
+        }
+      }
+    }
+    const ComputeType row_sum = BlockAllReduce<SumOp, ComputeType, block_size>(thread_sum);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        if (algorithm == Algorithm::kSoftmax) {
+          pack[i] = (dy_buf[i * num_packs + pack_id] - row_sum) * y_buf[i * num_packs + pack_id];
+        } else if (algorithm == Algorithm::kLogSoftmax) {
+          pack[i] = dy_buf[i * num_packs + pack_id] - Exp(y_buf[i * num_packs + pack_id]) * row_sum;
+        } else {
+          __trap();
+        }
+      }
+      store.template store<pack_size>(pack, row, pack_id * pack_size);
+    }
+  }
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         int block_size, Algorithm algorithm>
+inline hipError_t LaunchSoftmaxGradBlockSMemImpl(hipStream_t stream, LOAD_Y load_y,
+                                                  LOAD_DY load_dy, STORE store, int smem,
+                                                  const int64_t rows, const int64_t cols) {
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    hipError_t err = GetNumBlocks(block_size, rows, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  SoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, block_size, algorithm>
+      <<<grid_dim_x, block_size, smem, stream>>>(load_y, load_dy, store, rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         Algorithm algorithm>
+inline hipError_t TryDispatchSoftmaxGradBlockSMemImplBlockSize(hipStream_t stream, LOAD_Y load_y,
+                                                                LOAD_DY load_dy, STORE store,
+                                                                const int64_t rows,
+                                                                const int64_t cols, bool* success) {
+  constexpr int block_size_conf_1 = 128;
+  constexpr int block_size_conf_2 = 256;
+  constexpr int block_size_conf_3 = 512;
+  constexpr int block_size_conf_4 = 1024;
+  const size_t smem = cols * sizeof(ComputeType) * 2;
+  int max_active_blocks_conf_1;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_1,
+        SoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, block_size_conf_1,
+                                 algorithm>,
+        block_size_conf_1, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_1 <= 0) {
+    *success = false;
+    return hipSuccess;
+  }
+  int max_active_blocks_conf_4;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_4,
+        SoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, block_size_conf_4,
+                                 algorithm>,
+        block_size_conf_4, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_4 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchSoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size,
+                                          block_size_conf_4, algorithm>(stream, load_y, load_dy,
+                                                                        store, smem, rows, cols);
+  }
+  int max_active_blocks_conf_3;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_3,
+        SoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, block_size_conf_3,
+                                 algorithm>,
+        block_size_conf_3, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_3 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchSoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size,
+                                          block_size_conf_3, algorithm>(stream, load_y, load_dy,
+                                                                        store, smem, rows, cols);
+  }
+  int max_active_blocks_conf_2;
+  {
+    hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_2,
+        SoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, block_size_conf_2,
+                                 algorithm>,
+        block_size_conf_2, smem);
+    if (err != hipSuccess) { return err; }
+  }
+  if (max_active_blocks_conf_2 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchSoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size,
+                                          block_size_conf_2, algorithm>(stream, load_y, load_dy,
+                                                                        store, smem, rows, cols);
+  }
+  *success = true;
+  return LaunchSoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size,
+                                        block_size_conf_1, algorithm>(stream, load_y, load_dy,
+                                                                      store, smem, rows, cols);
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType,
+         Algorithm algorithm>
+struct TryDispatchSoftmaxGradBlockSMemImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                         const int64_t rows, const int64_t cols, bool* success) {
+    if (cols % 2 == 0) {
+      return TryDispatchSoftmaxGradBlockSMemImplBlockSize<LOAD_Y, LOAD_DY, STORE, ComputeType, 2,
+                                                          algorithm>(stream, load_y, load_dy, store,
+                                                                     rows, cols, success);
+    } else {
+      return TryDispatchSoftmaxGradBlockSMemImplBlockSize<LOAD_Y, LOAD_DY, STORE, ComputeType, 1,
+                                                          algorithm>(stream, load_y, load_dy, store,
+                                                                     rows, cols, success);
+    }
+  }
+};
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType,
+         Algorithm algorithm>
+inline hipError_t TryDispatchSoftmaxGradBlockSMemImpl(hipStream_t stream, LOAD_Y load_y,
+                                                       LOAD_DY load_dy, STORE store,
+                                                       const int64_t rows, const int64_t cols,
+                                                       bool* success) {
+  return TryDispatchSoftmaxGradBlockSMemImplPackSize<LOAD_Y, LOAD_DY, STORE, ComputeType,
+                                                     algorithm>()(stream, load_y, load_dy, store,
+                                                                  rows, cols, success);
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         int block_size, Algorithm algorithm>
+__global__ void SoftmaxGradBlockUncachedImpl(LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                                             const int64_t rows, const int64_t cols) {
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = cols / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType thread_sum = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType y_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      load_y.template load<pack_size>(y_pack, row, pack_id * pack_size);
+      load_dy.template load<pack_size>(dy_pack, row, pack_id * pack_size);
+
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        if (algorithm == Algorithm::kSoftmax) {
+          thread_sum += y_pack[i] * dy_pack[i];
+        } else if (algorithm == Algorithm::kLogSoftmax) {
+          thread_sum += dy_pack[i];
+        } else {
+          __trap();
+        }
+      }
+    }
+    const ComputeType row_sum = BlockAllReduce<SumOp, ComputeType, block_size>(thread_sum);
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType y_pack[pack_size];
+      ComputeType dy_pack[pack_size];
+      load_y.template load<pack_size>(y_pack, row, pack_id * pack_size);
+      load_dy.template load<pack_size>(dy_pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        if (algorithm == Algorithm::kSoftmax) {
+          dy_pack[i] = (dy_pack[i] - row_sum) * y_pack[i];
+        } else if (algorithm == Algorithm::kLogSoftmax) {
+          dy_pack[i] -= Exp(y_pack[i]) * row_sum;
+        } else {
+          __trap();
+        }
+      }
+      store.template store<pack_size>(dy_pack, row, pack_id * pack_size);
+    }
+  }
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType, int pack_size,
+         Algorithm algorithm>
+inline hipError_t LaunchSoftmaxGradBlockUncachedImpl(hipStream_t stream, LOAD_Y load_y,
+                                                      LOAD_DY load_dy, STORE store,
+                                                      const int64_t rows, const int64_t cols) {
+  constexpr int block_size = 1024;
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    hipError_t err = GetNumBlocks(block_size, rows, waves, &grid_dim_x);
+    if (err != hipSuccess) { return err; }
+  }
+  SoftmaxGradBlockUncachedImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, pack_size, block_size,
+                               algorithm>
+      <<<grid_dim_x, block_size, 0, stream>>>(load_y, load_dy, store, rows, cols);
+  return hipPeekAtLastError();
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType,
+         Algorithm algorithm>
+struct DispatchSoftmaxGradBlockUncachedImplPackSize {
+  hipError_t operator()(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                         const int64_t rows, const int64_t cols) {
+    if (cols % 2 == 0 && cols > kWarpSize) {
+      return LaunchSoftmaxGradBlockUncachedImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, 2, algorithm>(
+          stream, load_y, load_dy, store, rows, cols);
+    } else {
+      return LaunchSoftmaxGradBlockUncachedImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, 1, algorithm>(
+          stream, load_y, load_dy, store, rows, cols);
+    }
+  }
+};
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType,
+         Algorithm algorithm>
+inline hipError_t DispatchSoftmaxGradBlockUncachedImpl(hipStream_t stream, LOAD_Y load_y,
+                                                        LOAD_DY load_dy, STORE store,
+                                                        const int64_t rows, const int64_t cols) {
+  return DispatchSoftmaxGradBlockUncachedImplPackSize<LOAD_Y, LOAD_DY, STORE, ComputeType,
+                                                      algorithm>()(stream, load_y, load_dy, store,
+                                                                   rows, cols);
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType>
+inline typename std::enable_if<!std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchSoftmaxGrad(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                    const int64_t rows, const int64_t cols) {
+  if (cols <= 1024) {
+    return DispatchSoftmaxGradWarpImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, Algorithm::kSoftmax>(
+        stream, load_y, load_dy, store, rows, cols);
+  } else {
+    bool dispatch_smem_impl_success;
+    {
+      hipError_t err = TryDispatchSoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType,
+                                                            Algorithm::kSoftmax>(
+          stream, load_y, load_dy, store, rows, cols, &dispatch_smem_impl_success);
+      if (err != hipSuccess) { return err; }
+    }
+    if (!dispatch_smem_impl_success) {
+      return DispatchSoftmaxGradBlockUncachedImpl<LOAD_Y, LOAD_DY, STORE, ComputeType,
+                                                  Algorithm::kSoftmax>(stream, load_y, load_dy,
+                                                                       store, rows, cols);
+    }
+    return hipSuccess;
+  }
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType>
+inline typename std::enable_if<std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchSoftmaxGrad(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                    const int64_t rows, const int64_t cols) {
+  return DispatchSoftmaxGradBlockUncachedImpl<LOAD_Y, LOAD_DY, STORE, ComputeType,
+                                              Algorithm::kSoftmax>(stream, load_y, load_dy, store,
+                                                                   rows, cols);
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType>
+inline typename std::enable_if<!std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchLogSoftmaxGrad(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                       const int64_t rows, const int64_t cols) {
+  if (cols <= 1024) {
+    return DispatchSoftmaxGradWarpImpl<LOAD_Y, LOAD_DY, STORE, ComputeType, Algorithm::kLogSoftmax>(
+        stream, load_y, load_dy, store, rows, cols);
+  } else {
+    bool dispatch_smem_impl_success;
+    {
+      hipError_t err = TryDispatchSoftmaxGradBlockSMemImpl<LOAD_Y, LOAD_DY, STORE, ComputeType,
+                                                            Algorithm::kLogSoftmax>(
+          stream, load_y, load_dy, store, rows, cols, &dispatch_smem_impl_success);
+      if (err != hipSuccess) { return err; }
+    }
+    if (!dispatch_smem_impl_success) {
+      return DispatchSoftmaxGradBlockUncachedImpl<LOAD_Y, LOAD_DY, STORE, ComputeType,
+                                                  Algorithm::kLogSoftmax>(stream, load_y, load_dy,
+                                                                          store, rows, cols);
+    }
+    return hipSuccess;
+  }
+}
+
+template<typename LOAD_Y, typename LOAD_DY, typename STORE, typename ComputeType>
+inline typename std::enable_if<std::is_same<ComputeType, double>::value, hipError_t>::type
+DispatchLogSoftmaxGrad(hipStream_t stream, LOAD_Y load_y, LOAD_DY load_dy, STORE store,
+                       const int64_t rows, const int64_t cols) {
+  return DispatchSoftmaxGradBlockUncachedImpl<LOAD_Y, LOAD_DY, STORE, ComputeType,
+                                              Algorithm::kLogSoftmax>(stream, load_y, load_dy,
+                                                                      store, rows, cols);
+}
+
+}  // namespace softmax
+
+}  // namespace cuda
+
+}  // namespace oneflow
+
+#endif // WITH_HIP
 
 #endif  // ONEFLOW_CORE_CUDA_SOFTMAX_H_

--- a/oneflow/core/cuda/unique.cuh
+++ b/oneflow/core/cuda/unique.cuh
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef ONEFLOW_CORE_CUDA_UNIQUE_H_
 #define ONEFLOW_CORE_CUDA_UNIQUE_H_
 
+#ifdef WITH_CUDA
+
 #include <cub/cub.cuh>
 #include <device_launch_parameters.h>
 #include "oneflow/core/common/permutation_iterator.h"
@@ -241,5 +243,239 @@ cudaError_t GetWorkspaceSize(Flag flag, size_t n, size_t* workspace_size) {
 }  // namespace cuda
 
 }  // namespace oneflow
+
+#endif // WITH_CUDA
+
+#ifdef WITH_HIP
+
+#include <hipcub/hipcub.hpp>
+#include "hip/hip_runtime.h"
+// #include <device_launch_parameters.h>
+#include "hip/hip_runtime.h"
+#include "oneflow/core/common/permutation_iterator.h"
+#include "oneflow/core/common/not_equal_to_previous_adjacent_iterator.h"
+
+namespace oneflow {
+
+namespace cuda {
+
+namespace unique {
+
+using Flag = uint32_t;
+static constexpr Flag kDefault = 0x0;
+static constexpr Flag kInputSorted = 0x1;
+static constexpr Flag kOutputInverseIndices = 0x1 << 1;
+static constexpr Flag kOutputCounts = 0x1 << 2;
+
+namespace {
+
+constexpr size_t kCudaAlignSize = 512;
+
+__device__ __host__ __forceinline__ size_t GetCudaAlignedSize(size_t size) {
+  return (size + kCudaAlignSize - 1) / kCudaAlignSize * kCudaAlignSize;
+}
+
+template<typename T>
+__device__ __host__ __forceinline__ T* PtrOffset(void* ptr, size_t offset) {
+  return reinterpret_cast<T*>(reinterpret_cast<unsigned char*>(ptr) + offset);
+}
+
+__device__ __host__ __forceinline__ size_t max(size_t a, size_t b) { return a > b ? a : b; }
+
+template<typename Key, typename Index>
+hipError_t DoUnique(size_t n, const Key* sorted_in, Key* unique, Index* num_unique,
+                     void* workspace, size_t* workspace_size, hipStream_t stream) {
+  size_t ws = *workspace_size;
+  hipError_t err = hipcub::DeviceSelect::Unique<const Key*, Key*, Index*>(
+      workspace, ws, sorted_in, unique, num_unique, n, stream);
+  if (err != hipSuccess) { return err; }
+  if (*workspace_size == 0) { *workspace_size = ws; }
+  return hipSuccess;
+}
+
+template<typename Key, typename Index>
+hipError_t DoUniqueWithCounts(size_t n, const Key* sorted_in, Key* unique, Index* num_unique,
+                               Index* counts, void* workspace, size_t* workspace_size,
+                               hipStream_t stream) {
+  size_t ws = *workspace_size;
+  hipError_t err = hipcub::DeviceRunLengthEncode::Encode<const Key*, Key*, Index*, Index*>(
+      workspace, ws, sorted_in, unique, counts, num_unique, n, stream);
+  if (err != hipSuccess) { return err; }
+  if (*workspace_size == 0) { *workspace_size = ws; }
+  return hipSuccess;
+}
+
+template<typename Key, typename Index>
+hipError_t DispatchOutputCounts(Flag flag, size_t n, const Key* sorted_in, Key* unique,
+                                 Index* num_unique, Index* counts, void* workspace,
+                                 size_t* workspace_size, hipStream_t stream) {
+  size_t ws = *workspace_size;
+  if ((flag & kOutputCounts) != 0) {
+    hipError_t err = DoUniqueWithCounts<Key, Index>(n, sorted_in, unique, num_unique, counts,
+                                                     workspace, &ws, stream);
+    if (err != hipSuccess) { return err; }
+  } else {
+    hipError_t err =
+        DoUnique<Key, Index>(n, sorted_in, unique, num_unique, workspace, &ws, stream);
+    if (err != hipSuccess) { return err; }
+  }
+  if (*workspace_size == 0) { *workspace_size = ws; }
+  return hipSuccess;
+}
+
+template<typename Key, typename Index, typename InverseIndicesIter>
+hipError_t DoGenInverseIndices(size_t n, const Key* sorted_in,
+                                InverseIndicesIter inverse_indices_iter, void* workspace,
+                                size_t* workspace_size, hipStream_t stream) {
+  size_t ws = *workspace_size;
+  NotEqualToPreviousAdjacentIterator<Index, Key> unique_counting_iter(sorted_in, 0);
+  hipError_t err =
+      hipcub::DeviceScan::InclusiveSum<decltype(unique_counting_iter), InverseIndicesIter>(
+          workspace, ws, unique_counting_iter, inverse_indices_iter, n, stream);
+  if (err != hipSuccess) { return err; }
+  if (*workspace_size == 0) { *workspace_size = ws; }
+  return hipSuccess;
+}
+
+template<typename Key, typename Index, typename InverseIndicesIter>
+hipError_t DispatchOutputInverseIndices(Flag flag, size_t n, const Key* sorted_in, Key* unique,
+                                         Index* num_unique, InverseIndicesIter inverse_indices_iter,
+                                         Index* counts, void* workspace, size_t* workspace_size,
+                                         hipStream_t stream) {
+  size_t dispatch_with_counts_ws = *workspace_size;
+  size_t do_gen_inverse_indices_ws = *workspace_size;
+  {
+    hipError_t err =
+        DispatchOutputCounts<Key, Index>(flag, n, sorted_in, unique, num_unique, counts, workspace,
+                                         &dispatch_with_counts_ws, stream);
+    if (err != hipSuccess) { return err; }
+  }
+  if ((flag & kOutputInverseIndices) != 0) {
+    hipError_t err = DoGenInverseIndices<Key, Index, InverseIndicesIter>(
+        n, sorted_in, inverse_indices_iter, workspace, &do_gen_inverse_indices_ws, stream);
+    if (err != hipSuccess) { return err; }
+  }
+  if (*workspace_size == 0) {
+    *workspace_size = max(dispatch_with_counts_ws, do_gen_inverse_indices_ws);
+  }
+  return hipSuccess;
+}
+
+template<typename T>
+__global__ void IotaKernel(size_t n, T* out) {
+  for (T i = blockIdx.x * blockDim.x + threadIdx.x, step = blockDim.x * gridDim.x; i < n;
+       i += step) {
+    out[i] = i;
+  }
+}
+
+template<typename Key, typename Index>
+hipError_t DoSort(size_t n, const Key* in, Key* sorted, Index* sorted_indices, void* workspace,
+                   size_t* workspace_size, hipStream_t stream) {
+  Index* indices;
+  const size_t indices_size = GetCudaAlignedSize(n * sizeof(Index));
+  void* sort_workspace;
+  size_t sort_ws;
+  if (*workspace_size == 0) {
+    indices = nullptr;
+    sort_workspace = nullptr;
+    sort_ws = 0;
+  } else {
+    if (*workspace_size <= indices_size) { return hipErrorInvalidValue; }
+    indices = PtrOffset<Index>(workspace, 0);
+    sort_workspace = PtrOffset<Index>(workspace, indices_size);
+    sort_ws = *workspace_size - indices_size;
+  }
+  if (*workspace_size != 0) {
+    const int block_size = 1024;
+    const int num_blocks = static_cast<int>((n + block_size - 1) / block_size);
+    IotaKernel<Index><<<num_blocks, block_size, 0, stream>>>(n, indices);
+  }
+  hipError_t err = hipcub::DeviceRadixSort::SortPairs<Key, Index>(
+      sort_workspace, sort_ws, in, sorted, indices, sorted_indices, n, 0, sizeof(Key) * 8, stream);
+  if (err != hipSuccess) { return err; }
+  if (*workspace_size == 0) { *workspace_size = indices_size + sort_ws; }
+  return hipSuccess;
+}
+
+template<typename Key, typename Index>
+hipError_t DispatchInputSorted(Flag flag, size_t n, const Key* in, Key* unique, Index* num_unique,
+                                Index* inverse_indices, Index* counts, void* workspace,
+                                size_t* workspace_size, hipStream_t stream) {
+  if ((flag & kInputSorted) != 0) {
+    return DispatchOutputInverseIndices<Key, Index, Index*>(flag, n, in, unique, num_unique,
+                                                            inverse_indices, counts, workspace,
+                                                            workspace_size, stream);
+  } else {
+    const size_t sorted_in_size = GetCudaAlignedSize(n * sizeof(Key));
+    const size_t sorted_indices_size = GetCudaAlignedSize(n * sizeof(Index));
+    const size_t sort_buffer_size = sorted_in_size + sorted_indices_size;
+    Key* sorted_in;
+    Index* sorted_indices;
+    size_t do_sort_ws;
+    void* do_sort_workspace;
+    size_t do_inverse_indices_ws;
+    void* do_inverse_indices_workspace;
+    if (*workspace_size == 0) {
+      sorted_in = nullptr;
+      sorted_indices = nullptr;
+      do_sort_ws = 0;
+      do_sort_workspace = nullptr;
+      do_inverse_indices_ws = 0;
+      do_inverse_indices_workspace = nullptr;
+    } else {
+      if (*workspace_size <= sort_buffer_size) { return hipErrorInvalidValue; }
+      sorted_in = PtrOffset<Key>(workspace, 0);
+      sorted_indices = PtrOffset<Index>(workspace, sorted_in_size);
+      do_sort_ws = *workspace_size - sort_buffer_size;
+      do_sort_workspace = PtrOffset<void>(workspace, sort_buffer_size);
+      do_inverse_indices_ws = do_sort_ws;
+      do_inverse_indices_workspace = do_sort_workspace;
+    }
+    {
+      hipError_t err = DoSort<Key, Index>(n, in, sorted_in, sorted_indices, do_sort_workspace,
+                                           &do_sort_ws, stream);
+      if (err != hipSuccess) { return err; }
+    }
+    PermutationIterator<Index, Index*, Index*> inverse_indices_iter(inverse_indices,
+                                                                    sorted_indices);
+    {
+      hipError_t err = DispatchOutputInverseIndices<Key, Index, decltype(inverse_indices_iter)>(
+          flag, n, sorted_in, unique, num_unique, inverse_indices_iter, counts,
+          do_inverse_indices_workspace, &do_inverse_indices_ws, stream);
+      if (err != hipSuccess) { return err; }
+    }
+    if (*workspace_size == 0) {
+      *workspace_size = sort_buffer_size + max(do_sort_ws, do_inverse_indices_ws);
+    }
+    return hipSuccess;
+  }
+}
+
+}  // namespace
+
+template<typename Key, typename Index>
+hipError_t Launch(Flag flag, size_t n, const Key* in, Key* unique, Index* num_unique,
+                   Index* inverse_indices, Index* counts, void* workspace, size_t workspace_size,
+                   hipStream_t stream) {
+  if (workspace_size == 0) { return hipErrorInvalidValue; }
+  return DispatchInputSorted<Key, Index>(flag, n, in, unique, num_unique, inverse_indices, counts,
+                                         workspace, &workspace_size, stream);
+}
+
+template<typename Key, typename Index>
+hipError_t GetWorkspaceSize(Flag flag, size_t n, size_t* workspace_size) {
+  *workspace_size = 0;
+  return DispatchInputSorted<Key, Index>(flag, n, nullptr, nullptr, nullptr, nullptr, nullptr,
+                                         nullptr, workspace_size, 0);
+}
+
+}  // namespace unique
+
+}  // namespace cuda
+
+}  // namespace oneflow
+
+#endif // WITH_HIP
 
 #endif  // ONEFLOW_CORE_CUDA_UNIQUE_H_

--- a/oneflow/core/device/cuda_event.cpp
+++ b/oneflow/core/device/cuda_event.cpp
@@ -34,4 +34,21 @@ bool CudaEvent::Query() const { return cudaEventQuery(event_) != cudaErrorNotRea
 
 #endif
 
+#ifdef WITH_HIP
+
+CudaEvent::CudaEvent(int device_id, unsigned int flags) : device_id_(device_id) {
+  CudaCurrentDeviceGuard guard(device_id_);
+  OF_CUDA_CHECK(hipEventCreateWithFlags(&event_, flags));
+}
+
+CudaEvent::~CudaEvent() {
+  CudaCurrentDeviceGuard guard(device_id_);
+  OF_CUDA_CHECK(hipEventDestroy(event_));
+}
+
+bool CudaEvent::Query() const { return hipEventQuery(event_) != hipErrorNotReady; }
+
+
+#endif
+
 }  // namespace oneflow

--- a/oneflow/core/device/cuda_event.h
+++ b/oneflow/core/device/cuda_event.h
@@ -100,6 +100,94 @@ class SingleThreadQueryCudaEventProvider : public QueryCudaEventProvider,
 
 }  // namespace oneflow
 
-#endif
+#endif // WITH_CUDA
+
+#ifdef WITH_HIP
+
+#include "oneflow/core/device/cuda_util.h"
+#include "oneflow/core/common/single_thread_obj_pool.h"
+
+namespace oneflow {
+
+class CudaEvent final {
+ public:
+  CudaEvent(const CudaEvent&) = delete;
+  CudaEvent(CudaEvent&&) = delete;
+
+  CudaEvent(int device_id, unsigned int flags);
+  ~CudaEvent();
+
+  int device_id() const { return device_id_; }
+  bool Query() const;
+
+  hipEvent_t* mut_event() { return &event_; }
+
+ private:
+  int device_id_;
+  hipEvent_t event_;
+};
+
+class CudaEventProvider {
+ public:
+  CudaEventProvider(const CudaEventProvider&) = delete;
+  CudaEventProvider(CudaEventProvider&&) = delete;
+  virtual ~CudaEventProvider() = default;
+
+  virtual std::shared_ptr<CudaEvent> GetCudaEventWithFlags(unsigned int flags) = 0;
+
+ protected:
+  CudaEventProvider() = default;
+};
+
+class QueryCudaEventProvider : public CudaEventProvider {
+ public:
+  QueryCudaEventProvider(const QueryCudaEventProvider&) = delete;
+  QueryCudaEventProvider(QueryCudaEventProvider&&) = delete;
+  QueryCudaEventProvider() = default;
+  virtual ~QueryCudaEventProvider() = default;
+
+  std::shared_ptr<CudaEvent> GetCudaEvent() {
+    return GetCudaEventWithFlags(hipEventBlockingSync | hipEventDisableTiming);
+  }
+};
+
+class SingleThreadReusedEventPool {
+ public:
+  SingleThreadReusedEventPool(const SingleThreadReusedEventPool&) = delete;
+  SingleThreadReusedEventPool(SingleThreadReusedEventPool&&) = delete;
+  explicit SingleThreadReusedEventPool(int device_id)
+      : events_(new SingleThreadPoolType()), device_id_(device_id) {}
+  ~SingleThreadReusedEventPool() = default;
+
+  std::shared_ptr<CudaEvent> GetReusedCudaEventWithFlags(unsigned int flags) {
+    return events_->make_shared(device_id_, flags);
+  }
+
+ private:
+  using SingleThreadPoolType =
+      obj_pool::SingleThreadObjPool<CudaEvent, obj_pool::kDisableReconstruct>;
+  std::shared_ptr<SingleThreadPoolType> events_;
+  int device_id_;
+};
+
+class SingleThreadQueryCudaEventProvider : public QueryCudaEventProvider,
+                                           public SingleThreadReusedEventPool {
+ public:
+  SingleThreadQueryCudaEventProvider(const SingleThreadQueryCudaEventProvider&) = delete;
+  SingleThreadQueryCudaEventProvider(SingleThreadQueryCudaEventProvider&&) = delete;
+  explicit SingleThreadQueryCudaEventProvider(int device_id)
+      : QueryCudaEventProvider(), SingleThreadReusedEventPool(device_id) {}
+  ~SingleThreadQueryCudaEventProvider() = default;
+
+  std::shared_ptr<CudaEvent> GetCudaEventWithFlags(unsigned int flags) override {
+    return GetReusedCudaEventWithFlags(flags);
+  }
+};
+
+}  // namespace oneflow
+
+
+#endif // WITH_HIP
+
 
 #endif  // ONEFLOW_CORE_DEVICE_CUDA_EVENT_H_

--- a/oneflow/core/device/cuda_pseudo_half.h
+++ b/oneflow/core/device/cuda_pseudo_half.h
@@ -158,4 +158,141 @@ DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(sqrt)
 
 #endif  // WITH_CUDA
 
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+#define DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_OPERATOR(op)                        \
+  __device__ __forceinline__ __half operator op(const __half& lh, const __half& rh) { \
+    return __float2half(__half2float(lh) op __half2float(rh));                        \
+  }
+
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_OPERATOR(+)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_OPERATOR(-)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_OPERATOR(*)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_OPERATOR(/)
+
+#undef DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_OPERATOR
+
+#define DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_FUNC(func)                    \
+  __device__ __forceinline__ __half __h##func(const __half a, const __half b) { \
+    return __float2half(__f##func##_rn(__half2float(a), __half2float(b)));      \
+  }
+
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_FUNC(add)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_FUNC(div)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_FUNC(mul)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_BINARY_FUNC(sub)
+
+#undef DEFINE_CUDA_PSEUDO_HALF_HALF2_ARITHMETIC_BINARY_FUNC
+
+#define DEFINE_CUDA_PSEUDO_HALF_HALF2_ARITHMETIC_BINARY_FUNC(func)                    \
+  __device__ __forceinline__ __half2 __h##func##2(const __half2 a, const __half2 b) { \
+    __half2 ret;                                                                      \
+    ret.x = __h##func(a.x, b.x);                                                      \
+    ret.y = __h##func(a.y, b.y);                                                      \
+    return ret;                                                                       \
+  }
+
+DEFINE_CUDA_PSEUDO_HALF_HALF2_ARITHMETIC_BINARY_FUNC(add)
+DEFINE_CUDA_PSEUDO_HALF_HALF2_ARITHMETIC_BINARY_FUNC(div)
+DEFINE_CUDA_PSEUDO_HALF_HALF2_ARITHMETIC_BINARY_FUNC(mul)
+DEFINE_CUDA_PSEUDO_HALF_HALF2_ARITHMETIC_BINARY_FUNC(sub)
+
+#undef DEFINE_CUDA_PSEUDO_HALF_HALF2_ARITHMETIC_BINARY_FUNC
+
+#define DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_ASSIGNMENT_OPERATOR(op)               \
+  __device__ __forceinline__ __half& operator op(__half& lh, const __half& rh) { \
+    float lhv = __half2float(lh);                                                \
+    lhv op __half2float(rh);                                                     \
+    lh = __float2half(lhv);                                                      \
+    return lh;                                                                   \
+  }
+
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_ASSIGNMENT_OPERATOR(+=)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_ASSIGNMENT_OPERATOR(-=)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_ASSIGNMENT_OPERATOR(*=)
+DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_ASSIGNMENT_OPERATOR(/=)
+
+#undef DEFINE_CUDA_PSEUDO_HALF_ARITHMETIC_ASSIGNMENT_OPERATOR
+
+__device__ __forceinline__ __half& operator++(__half& h) {
+  h = __float2half(__half2float(h) + 1);
+  return h;
+}
+
+__device__ __forceinline__ __half& operator--(__half& h) {
+  h = __float2half(__half2float(h) - 1);
+  return h;
+}
+
+__device__ __forceinline__ __half operator++(__half& h, int) {
+  __half ret = h;
+  h = __float2half(__half2float(h) + 1);
+  return ret;
+}
+
+__device__ __forceinline__ __half operator--(__half& h, int) {
+  __half ret = h;
+  h = __float2half(__half2float(h) - 1);
+  return ret;
+}
+
+__device__ __forceinline__ __half operator+(const __half& h) { return h; }
+
+__device__ __forceinline__ __half operator-(const __half& h) {
+  return __float2half(-__half2float(h));
+}
+
+__device__ __forceinline__ __half __hneg(const __half a) { return -a; }
+
+#define DEFINE_CUDA_PSEUDO_HALF_COMPARISON_BINARY_OPERATOR(op)                      \
+  __device__ __forceinline__ bool operator op(const __half& lh, const __half& rh) { \
+    return __half2float(lh) op __half2float(rh);                                    \
+  }
+
+DEFINE_CUDA_PSEUDO_HALF_COMPARISON_BINARY_OPERATOR(==)
+DEFINE_CUDA_PSEUDO_HALF_COMPARISON_BINARY_OPERATOR(!=)
+DEFINE_CUDA_PSEUDO_HALF_COMPARISON_BINARY_OPERATOR(>)
+DEFINE_CUDA_PSEUDO_HALF_COMPARISON_BINARY_OPERATOR(<)
+DEFINE_CUDA_PSEUDO_HALF_COMPARISON_BINARY_OPERATOR(>=)
+DEFINE_CUDA_PSEUDO_HALF_COMPARISON_BINARY_OPERATOR(<=)
+
+#undef DEFINE_CUDA_PSEUDO_HALF_COMPARISON_BINARY_OPERATOR
+
+__device__ __forceinline__ bool __heq(const __half a, const __half b) { return a == b; }
+__device__ __forceinline__ bool __hge(const __half a, const __half b) { return a >= b; }
+__device__ __forceinline__ bool __hgt(const __half a, const __half b) { return a > b; }
+__device__ __forceinline__ bool __hle(const __half a, const __half b) { return a <= b; }
+__device__ __forceinline__ bool __hlt(const __half a, const __half b) { return a < b; }
+__device__ __forceinline__ bool __hne(const __half a, const __half b) { return a != b; }
+__device__ __forceinline__ __half __hmax(const __half a, const __half b) { return a > b ? a : b; }
+__device__ __forceinline__ __half __hmin(const __half a, const __half b) { return a > b ? a : b; }
+
+#define DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(func)               \
+  __device__ __forceinline__ __half h##func(const __half h) { \
+    return __float2half(func##f(__half2float(h)));            \
+  }
+
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(cos)
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(exp)
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(exp10)
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(exp2)
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(log)
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(log10)
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(log2)
+
+__device__ __forceinline__ __half hrcp(const __half h) {
+  return __float2half(1.0f / __half2float(h));
+}
+
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(rsqrt)
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(sin)
+DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC(sqrt)
+
+#undef DEFINE_CUDA_PSEUDO_HALF_MATH_FUNC
+
+#endif // WITH_HIP
+
 #endif  // ONEFLOW_CORE_DEVICE_CUDA_PSEUDO_HALF_H_

--- a/oneflow/core/device/cuda_util.cpp
+++ b/oneflow/core/device/cuda_util.cpp
@@ -23,13 +23,21 @@ limitations under the License.
 #include "oneflow/core/job/lazy_mode.h"
 #include "oneflow/core/platform/include/pthread_fork.h"
 #include "oneflow/core/device/device_context.h"
-#include "oneflow/core/ep/cuda/cuda_stream.h"
 
 #ifdef WITH_CUDA
 
+#include "oneflow/core/ep/cuda/cuda_stream.h"
 #include <cuda.h>
 
 #endif  // WITH_CUDA
+
+#ifdef WITH_HIP
+
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include <hip/hip_runtime.h>
+
+#endif  // WITH_HIP
+
 
 namespace oneflow {
 
@@ -216,5 +224,190 @@ cudaError_t CudaDriverGetPrimaryCtxActive(int dev, int* active) {
 }
 
 #endif  // WITH_CUDA
+
+#ifdef WITH_HIP
+
+const char* CublasGetErrorString(hipblasStatus_t error) {
+  switch (error) {
+    case HIPBLAS_STATUS_SUCCESS: return "HIPBLAS_STATUS_SUCCESS";
+    case HIPBLAS_STATUS_NOT_INITIALIZED: return "HIPBLAS_STATUS_NOT_INITIALIZED";
+    case HIPBLAS_STATUS_ALLOC_FAILED: return "HIPBLAS_STATUS_ALLOC_FAILED";
+    case HIPBLAS_STATUS_INVALID_VALUE: return "HIPBLAS_STATUS_INVALID_VALUE";
+    case HIPBLAS_STATUS_ARCH_MISMATCH: return "HIPBLAS_STATUS_ARCH_MISMATCH";
+    case HIPBLAS_STATUS_MAPPING_ERROR: return "HIPBLAS_STATUS_MAPPING_ERROR";
+    case HIPBLAS_STATUS_EXECUTION_FAILED: return "HIPBLAS_STATUS_EXECUTION_FAILED";
+    case HIPBLAS_STATUS_INTERNAL_ERROR: return "HIPBLAS_STATUS_INTERNAL_ERROR";
+#if CUDA_VERSION >= 6000
+    case HIPBLAS_STATUS_NOT_SUPPORTED: return "HIPBLAS_STATUS_NOT_SUPPORTED";
+#endif
+#if CUDA_VERSION >= 6050
+    case CUBLAS_STATUS_LICENSE_ERROR: return "CUBLAS_STATUS_LICENSE_ERROR";
+#endif
+  }
+  return "Unknown cublas status";
+}
+
+const char* CurandGetErrorString(hiprandStatus_t error) {
+  switch (error) {
+    case HIPRAND_STATUS_SUCCESS: return "HIPRAND_STATUS_SUCCESS";
+    case HIPRAND_STATUS_VERSION_MISMATCH: return "HIPRAND_STATUS_VERSION_MISMATCH";
+    case HIPRAND_STATUS_NOT_INITIALIZED: return "HIPRAND_STATUS_NOT_INITIALIZED";
+    case HIPRAND_STATUS_ALLOCATION_FAILED: return "HIPRAND_STATUS_ALLOCATION_FAILED";
+    case HIPRAND_STATUS_TYPE_ERROR: return "HIPRAND_STATUS_TYPE_ERROR";
+    case HIPRAND_STATUS_OUT_OF_RANGE: return "HIPRAND_STATUS_OUT_OF_RANGE";
+    case HIPRAND_STATUS_LENGTH_NOT_MULTIPLE: return "HIPRAND_STATUS_LENGTH_NOT_MULTIPLE";
+    case HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED: return "HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED";
+    case HIPRAND_STATUS_LAUNCH_FAILURE: return "HIPRAND_STATUS_LAUNCH_FAILURE";
+    case HIPRAND_STATUS_PREEXISTING_FAILURE: return "HIPRAND_STATUS_PREEXISTING_FAILURE";
+    case HIPRAND_STATUS_INITIALIZATION_FAILED: return "HIPRAND_STATUS_INITIALIZATION_FAILED";
+    case HIPRAND_STATUS_ARCH_MISMATCH: return "HIPRAND_STATUS_ARCH_MISMATCH";
+    case HIPRAND_STATUS_INTERNAL_ERROR: return "HIPRAND_STATUS_INTERNAL_ERROR";
+  }
+  return "Unknown hiprand status";
+}
+
+// #if CUDA_VERSION >= 10020
+
+// const char* NvjpegGetErrorString(nvjpegStatus_t error) {
+//   switch (error) {
+//     case NVJPEG_STATUS_SUCCESS: return "NVJPEG_STATUS_SUCCESS";
+//     case NVJPEG_STATUS_NOT_INITIALIZED: return "NVJPEG_STATUS_NOT_INITIALIZED";
+//     case NVJPEG_STATUS_INVALID_PARAMETER: return "NVJPEG_STATUS_INVALID_PARAMETER";
+//     case NVJPEG_STATUS_BAD_JPEG: return "NVJPEG_STATUS_BAD_JPEG";
+//     case NVJPEG_STATUS_JPEG_NOT_SUPPORTED: return "NVJPEG_STATUS_JPEG_NOT_SUPPORTED";
+//     case NVJPEG_STATUS_ALLOCATOR_FAILURE: return "NVJPEG_STATUS_ALLOCATOR_FAILURE";
+//     case NVJPEG_STATUS_EXECUTION_FAILED: return "NVJPEG_STATUS_EXECUTION_FAILED";
+//     case NVJPEG_STATUS_ARCH_MISMATCH: return "NVJPEG_STATUS_ARCH_MISMATCH";
+//     case NVJPEG_STATUS_INTERNAL_ERROR: return "NVJPEG_STATUS_INTERNAL_ERROR";
+//     case NVJPEG_STATUS_IMPLEMENTATION_NOT_SUPPORTED:
+//       return "NVJPEG_STATUS_IMPLEMENTATION_NOT_SUPPORTED";
+//   }
+//   return "Unknown nvjpeg status";
+// }
+
+// #endif
+
+size_t GetAvailableGpuMemSize(int dev_id) {
+  hipDeviceProp_t prop{};
+  hipGetDeviceProperties(&prop, dev_id);
+  return prop.totalGlobalMem;
+}
+
+namespace {
+
+std::function<hipError_t(void**, size_t)> GetCudaMallocHostFn(int32_t dev) {
+  auto default_fn = [](void** ptr, size_t size) { return hipMallocHost(ptr, size); };
+  auto manager = Global<hardware::NodeDeviceDescriptorManager>::Get();
+  if (manager == nullptr) { return default_fn; }
+  auto node_desc = manager->GetLocalNodeDeviceDescriptor();
+  auto cuda_device = std::dynamic_pointer_cast<const hardware::CudaDeviceDescriptor>(
+      node_desc->GetDevice(hardware::kCudaDeviceDescriptorClassName, dev));
+  if (!cuda_device) { return default_fn; }
+  auto saved_affinity = node_desc->Topology()->GetMemoryAffinity();
+  if (!saved_affinity) { return default_fn; }
+  auto device_affinity =
+      node_desc->Topology()->GetMemoryAffinityByPCIBusID(cuda_device->PCIBusID());
+  if (!device_affinity) { return default_fn; }
+  return [device_affinity, saved_affinity, node_desc, default_fn](void** ptr, size_t size) {
+    node_desc->Topology()->SetMemoryAffinity(device_affinity);
+    hipError_t err = default_fn(ptr, size);
+    node_desc->Topology()->SetMemoryAffinity(saved_affinity);
+    return err;
+  };
+}
+
+}  // namespace
+
+hipError_t NumaAwareCudaMallocHost(int32_t dev, void** ptr, size_t size) {
+  auto fn = GetCudaMallocHostFn(dev);
+  return fn(ptr, size);
+}
+
+CudaCurrentDeviceGuard::CudaCurrentDeviceGuard(int32_t dev_id) {
+  CHECK(!pthread_fork::IsForkedSubProcess()) << pthread_fork::kOfCudaNotSupportInForkedSubProcess;
+  OF_CUDA_CHECK(hipGetDevice(&saved_dev_id_));
+  OF_CUDA_CHECK(hipSetDevice(dev_id));
+}
+
+CudaCurrentDeviceGuard::CudaCurrentDeviceGuard() { OF_CUDA_CHECK(hipGetDevice(&saved_dev_id_)); }
+
+CudaCurrentDeviceGuard::~CudaCurrentDeviceGuard() { OF_CUDA_CHECK(hipSetDevice(saved_dev_id_)); }
+
+// CublasMathModeGuard::CublasMathModeGuard(hipblasHandle_t handle, cublasMath_t new_mode)
+//     : CublasMathModeGuard(handle) {
+//   SetMathMode(new_mode);
+// }
+
+// CublasMathModeGuard::CublasMathModeGuard(hipblasHandle_t handle) : handle_(handle) {
+//   OF_CUBLAS_CHECK(cublasGetMathMode(handle_, &saved_mode_));
+//   new_mode_ = saved_mode_;
+// }
+
+// CublasMathModeGuard::~CublasMathModeGuard() {
+//   if (new_mode_ != saved_mode_) { OF_CUBLAS_CHECK(cublasSetMathMode(handle_, saved_mode_)); }
+// }
+
+// void CublasMathModeGuard::SetMathMode(cublasMath_t new_mode) {
+//   new_mode_ = new_mode;
+//   if (new_mode_ != saved_mode_) { OF_CUBLAS_CHECK(cublasSetMathMode(handle_, new_mode_)); }
+// }
+
+int GetCudaDeviceIndex() { return GlobalProcessCtx::LocalRank(); }
+
+int GetCudaDeviceCount() {
+  /* static */ int cuda_device_count = 0;
+  CudaCurrentDeviceGuard dev_guard(GetCudaDeviceIndex());
+  OF_CUDA_CHECK(hipGetDeviceCount(&cuda_device_count));
+  return cuda_device_count;
+}
+
+void InitCudaContextOnce(int device_id) {
+  static int device_count = GetCudaDeviceCount();
+  static std::vector<std::once_flag> init_flags = std::vector<std::once_flag>(device_count);
+  if (LazyMode::is_enabled()) { return; }
+  if (device_id == -1) { device_id = GetCudaDeviceIndex(); }
+  std::call_once(init_flags[device_id], [&]() {
+    OF_CUDA_CHECK(hipSetDevice(device_id));
+    OF_CUDA_CHECK(hipDeviceSynchronize());
+  });
+}
+
+// hipError_t CudaDriverGetPrimaryCtxActive(int dev, int* active) {
+// #if CUDA_VERSION >= 11030
+//   hipDevice_t cu_device{};
+//   {
+//     hipError_t (*fnCuDeviceGet)(hipDevice_t*, int) = nullptr;
+//     hipError_t err =
+//         cudaGetDriverEntryPoint("hipDeviceGet", (void**)&fnCuDeviceGet, cudaEnableDefault);
+//     if (err != hipSuccess) { return err; }
+//     hipError_t result = fnCuDeviceGet(&cu_device, dev);
+//     if (result == hipSuccess) {
+//       // do nothing
+//     } else if (result == hipError_t::hipErrorInvalidDevice) {
+//       return hipErrorInvalidDevice;
+//     } else {
+//       return hipErrorUnknown;
+//     }
+//   }
+//   {
+//     hipError_t (*fnCuDevicePrimaryCtxGetState)(hipDevice_t, unsigned int*, int*) = nullptr;
+//     hipError_t err = cudaGetDriverEntryPoint(
+//         "hipDevicePrimaryCtxGetState", (void**)&fnCuDevicePrimaryCtxGetState, cudaEnableDefault);
+//     if (err != hipSuccess) { return err; }
+//     unsigned int flags{};
+//     hipError_t result = fnCuDevicePrimaryCtxGetState(cu_device, &flags, active);
+//     if (result == hipSuccess) {
+//       return hipSuccess;
+//     } else {
+//       return hipErrorUnknown;
+//     }
+//   }
+// #else
+//   return hipErrorNotSupported;
+// #endif  // CUDA_VERSION < 11030
+// }
+
+#endif  // WITH_HIP
+
 
 }  // namespace oneflow

--- a/oneflow/core/device/cuda_util.cu
+++ b/oneflow/core/device/cuda_util.cu
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#ifdef WITH_CUDA
+
 #include <cub/cub.cuh>
 #include "oneflow/core/device/cuda_util.h"
 
@@ -32,3 +34,6 @@ int GetCudaPtxVersion() {
 }
 
 }  // namespace oneflow
+
+
+#endif

--- a/oneflow/core/device/cuda_util.h
+++ b/oneflow/core/device/cuda_util.h
@@ -167,4 +167,150 @@ cudaError_t CudaDriverGetPrimaryCtxActive(int dev, int* active);
 
 #endif  // WITH_CUDA
 
+#ifdef WITH_HIP
+
+#include <hipblas.h>
+#include <hip/hip_runtime.h>
+#include <miopen/miopen.h>
+#include <hiprand.h>
+#include <rccl.h>
+#include <hip/hip_fp16.h>
+#include "oneflow/core/device/cuda_pseudo_half.h"
+#include "oneflow/core/ep/hip/hip_stream.h"
+
+// #if CUDA_VERSION >= 10020
+
+// #include <nvjpeg.h>
+
+// #endif
+
+namespace oneflow {
+
+const char* CublasGetErrorString(hipblasStatus_t error);
+
+const char* CurandGetErrorString(hiprandStatus_t error);
+
+// #if CUDA_VERSION >= 10020
+
+// const char* NvjpegGetErrorString(nvjpegStatus_t error);
+
+// #endif
+
+#define OF_CUDA_CHECK(condition)                                                               \
+  for (hipError_t _of_cuda_check_status = (condition); _of_cuda_check_status != hipSuccess;) \
+  LOG(FATAL) << "Check failed: " #condition " : " << hipGetErrorString(_of_cuda_check_status) \
+             << " (" << _of_cuda_check_status << ") "
+
+#define OF_CUDNN_CHECK(condition)                                                                \
+  for (hipdnnStatus_t _of_cudnn_check_status = (condition);                                       \
+       _of_cudnn_check_status != HIPDNN_STATUS_SUCCESS;)                                          \
+  LOG(FATAL) << "Check failed: " #condition " : " << miopenGetErrorString(_of_cudnn_check_status) \
+             << " (" << _of_cudnn_check_status << ") "
+
+#define OF_CUBLAS_CHECK(condition)                                                                 \
+  for (hipblasStatus_t _of_cublas_check_status = (condition);                                       \
+       _of_cublas_check_status != HIPBLAS_STATUS_SUCCESS;)                                          \
+  LOG(FATAL) << "Check failed: " #condition " : " << CublasGetErrorString(_of_cublas_check_status) \
+             << " (" << _of_cublas_check_status << ") "
+
+#define OF_CURAND_CHECK(condition)                                                                 \
+  for (hiprandStatus_t _of_curand_check_status = (condition);                                       \
+       _of_curand_check_status != HIPRAND_STATUS_SUCCESS;)                                          \
+  LOG(FATAL) << "Check failed: " #condition " : " << CurandGetErrorString(_of_curand_check_status) \
+             << " (" << _of_curand_check_status << ") "
+
+#define OF_NCCL_CHECK(condition)                                                                \
+  for (ncclResult_t _of_nccl_check_status = (condition); _of_nccl_check_status != ncclSuccess;) \
+  LOG(FATAL) << "Check failed: " #condition " : " << ncclGetErrorString(_of_nccl_check_status)  \
+             << " (" << _of_nccl_check_status << "). "                                          \
+             << "To see more detail, please run OneFlow with system variable NCCL_DEBUG=INFO"
+
+#define OF_NCCL_CHECK_OR_RETURN(condition)                                                         \
+  for (ncclResult_t _of_nccl_check_status = (condition); _of_nccl_check_status != ncclSuccess;)    \
+  return Error::CheckFailedError().AddStackFrame(__FILE__, __LINE__, __FUNCTION__)                 \
+         << "Check failed: " #condition " : " << ncclGetErrorString(_of_nccl_check_status) << " (" \
+         << _of_nccl_check_status << ") "
+
+// #if CUDA_VERSION >= 10020
+
+// #define OF_NVJPEG_CHECK(condition)                                                                 \
+//   for (nvjpegStatus_t _of_nvjpeg_check_status = (condition);                                       \
+//        _of_nvjpeg_check_status != NVJPEG_STATUS_SUCCESS;)                                          \
+//   LOG(FATAL) << "Check failed: " #condition " : " << NvjpegGetErrorString(_of_nvjpeg_check_status) \
+//              << " (" << _of_nvjpeg_check_status << ") "
+
+// #endif
+
+// CUDA: grid stride looping
+#define CUDA_1D_KERNEL_LOOP(i, n)                                                                 \
+  for (int32_t i = blockIdx.x * blockDim.x + threadIdx.x, step = blockDim.x * gridDim.x; i < (n); \
+       i += step)
+
+#define CUDA_1D_KERNEL_LOOP_T(type, i, n)                                                      \
+  for (type i = blockIdx.x * blockDim.x + threadIdx.x, step = blockDim.x * gridDim.x; i < (n); \
+       i += step)
+
+const int32_t kCudaThreadsNumPerBlock = 512;
+const int32_t kCudaMaxBlocksNum = 8192;
+const int32_t kCudaWarpSize = 32;
+
+// 48KB, max byte size of shared memroy per thread block
+// TODO: limit of shared memory should be different for different arch
+const int32_t kCudaMaxSharedMemoryByteSize = 48 << 10;
+
+inline int32_t BlocksNum4ThreadsNum(const int32_t n) {
+  CHECK_GT(n, 0);
+  return std::min((n + kCudaThreadsNumPerBlock - 1) / kCudaThreadsNumPerBlock, kCudaMaxBlocksNum);
+}
+
+#define RUN_CUDA_KERNEL(func, stream, elem_cnt, ...) \
+  stream->As<ep::CudaStream>()->LaunchKernel(func, elem_cnt, 1, __VA_ARGS__)
+
+size_t GetAvailableGpuMemSize(int dev_id);
+
+hipError_t NumaAwareCudaMallocHost(int32_t dev, void** ptr, size_t size);
+
+class CudaCurrentDeviceGuard final {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaCurrentDeviceGuard);
+  explicit CudaCurrentDeviceGuard(int32_t dev_id);
+  CudaCurrentDeviceGuard();
+  ~CudaCurrentDeviceGuard();
+
+ private:
+  int32_t saved_dev_id_ = -1;
+};
+
+// class CublasMathModeGuard final {
+//  public:
+//   OF_DISALLOW_COPY_AND_MOVE(CublasMathModeGuard);
+//   CublasMathModeGuard(hipblasHandle_t handle, cublasMath_t new_mode);
+//   explicit CublasMathModeGuard(hipblasHandle_t handle);
+//   ~CublasMathModeGuard();
+
+//   void SetMathMode(cublasMath_t new_mode);
+
+//  private:
+//   hipblasHandle_t handle_{};
+//   cublasMath_t saved_mode_{};
+//   cublasMath_t new_mode_{};
+// };
+
+// int GetCudaSmVersion();
+
+// int GetCudaPtxVersion();
+
+int GetCudaDeviceIndex();
+
+int GetCudaDeviceCount();
+
+void InitCudaContextOnce(int device_id);
+
+// hipError_t CudaDriverGetPrimaryCtxActive(int dev, int* active);
+
+}  // namespace oneflow
+
+
+#endif // WITH_HIP
+
 #endif  // ONEFLOW_CORE_DEVICE_CUDA_UTIL_H_

--- a/oneflow/core/device/nccl_util.cpp
+++ b/oneflow/core/device/nccl_util.cpp
@@ -30,4 +30,17 @@ void NcclUniqueIdFromString(const std::string& str, ncclUniqueId* unique_id) {
 
 #endif  // WITH_CUDA
 
+#ifdef WITH_HIP
+
+std::string NcclUniqueIdToString(const ncclUniqueId& unique_id) {
+  return std::string(unique_id.internal, NCCL_UNIQUE_ID_BYTES);
+}
+
+void NcclUniqueIdFromString(const std::string& str, ncclUniqueId* unique_id) {
+  CHECK_EQ(str.size(), NCCL_UNIQUE_ID_BYTES);
+  memcpy(unique_id->internal, str.data(), NCCL_UNIQUE_ID_BYTES);
+}
+
+#endif  // WITH_HIP
+
 }  // namespace oneflow

--- a/oneflow/core/device/nccl_util.h
+++ b/oneflow/core/device/nccl_util.h
@@ -30,6 +30,12 @@ limitations under the License.
 
 #endif  // WITH_CUDA
 
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+
+#endif  // WITH_HIP
+
 namespace oneflow {
 
 #ifdef WITH_CUDA
@@ -64,6 +70,39 @@ void NcclUniqueIdFromString(const std::string& str, ncclUniqueId* unique_id);
 #define HAS_NCCL_SEND_RECV NCCL_VERSION_CODE > 2700
 
 #endif  // WITH_CUDA
+
+#ifdef WITH_HIP
+
+inline ncclDataType_t GetNcclDataType(const DataType& dt) {
+  switch (dt) {
+#define NCCL_DATA_TYPE_CASE(dtype) \
+  case DataType::k##dtype: return ncclDataType_t::nccl##dtype
+    NCCL_DATA_TYPE_CASE(Char);
+    NCCL_DATA_TYPE_CASE(Float);
+    NCCL_DATA_TYPE_CASE(Double);
+    NCCL_DATA_TYPE_CASE(Int8);
+    NCCL_DATA_TYPE_CASE(Int32);
+    NCCL_DATA_TYPE_CASE(Int64);
+    NCCL_DATA_TYPE_CASE(Float16);
+    case DataType::kBool: return ncclDataType_t::ncclUint8;
+// #if defined(__CUDA_BF16_TYPES_EXIST__) && NCCL_VERSION_CODE >= 21003
+//     case DataType::kBFloat16: return ncclBfloat16;
+// #endif
+    case DataType::kUInt8: return ncclUint8;
+    case DataType::kUInt32: return ncclUint32;
+    case DataType::kUInt64: return ncclUint64;
+    default: UNIMPLEMENTED();
+  }
+  return ncclDataType_t::ncclFloat;
+}
+
+std::string NcclUniqueIdToString(const ncclUniqueId& unique_id);
+
+void NcclUniqueIdFromString(const std::string& str, ncclUniqueId* unique_id);
+
+#define HAS_NCCL_SEND_RECV NCCL_VERSION_CODE > 2700
+
+#endif  // WITH_HIP
 
 }  // namespace oneflow
 

--- a/oneflow/core/ep/hip/cuda_device.cpp
+++ b/oneflow/core/ep/hip/cuda_device.cpp
@@ -1,0 +1,179 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/hip/cuda_device.h"
+#include "oneflow/core/ep/hip/cuda_event.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// #if CUDA_VERSION >= 11000
+// #include <cuda_bf16.h>
+// #endif
+
+namespace oneflow {
+
+namespace ep {
+
+namespace {
+
+constexpr size_t kDefaultConstBufElementCount = 1024 * 1024;
+
+template<typename T>
+void CreateConstBuffer(void** buf, T value, size_t n) {
+  OF_CUDA_CHECK(hipMalloc(buf, n * sizeof(T)));
+  std::vector<T> host(n, value);
+  OF_CUDA_CHECK(hipMemcpy(*buf, host.data(), n * sizeof(T), hipMemcpyDefault));
+}
+
+}  // namespace
+
+CudaDevice::CudaDevice(int device_index, DeviceManager* device_manager)
+    : device_index_(device_index),
+      event_flags_{},
+      properties_{},
+      device_manager_(device_manager),
+      const_buf_elem_cnt_(0),
+      const_zeros_buffer_(nullptr),
+      const_ones_buffer_fp32_(nullptr),
+      const_ones_buffer_fp16_(nullptr),
+      const_ones_buffer_bf16_(nullptr) {
+  CudaCurrentDeviceGuard guard(device_index_);
+  OF_CUDA_CHECK(hipGetDeviceProperties(&properties_, device_index_));
+  event_flags_ = hipEventDisableTiming;
+  if (ParseBooleanFromEnv("ONEFLOW_STREAM_CUDA_EVENT_FLAG_BLOCKING_SYNC", false)) {
+    event_flags_ |= hipEventBlockingSync;
+  }
+  const_buf_elem_cnt_ = ParseIntegerFromEnv("ONEFLOW_EP_CUDA_CONST_BUFFER_ELEMENT_COUNT",
+                                            kDefaultConstBufElementCount);
+  if (const_buf_elem_cnt_ > 0) {
+    CreateConstBuffer<float>(&const_zeros_buffer_, static_cast<float>(0), const_buf_elem_cnt_);
+    CreateConstBuffer<float>(&const_ones_buffer_fp32_, static_cast<float>(1.0),
+                             const_buf_elem_cnt_);
+    CreateConstBuffer<half>(&const_ones_buffer_fp16_, static_cast<half>(1.0), const_buf_elem_cnt_);
+// #if CUDA_VERSION >= 11000
+//     CreateConstBuffer<nv_bfloat16>(&const_ones_buffer_bf16_, static_cast<nv_bfloat16>(1.0),
+//                                    const_buf_elem_cnt_);
+// #endif
+  }
+}
+
+CudaDevice::~CudaDevice() {
+  CudaCurrentDeviceGuard guard(device_index_);
+  for (auto* event : events_) { delete event; }
+  OF_CUDA_CHECK(hipFree(const_zeros_buffer_));
+  OF_CUDA_CHECK(hipFree(const_ones_buffer_fp32_));
+  OF_CUDA_CHECK(hipFree(const_ones_buffer_fp16_));
+  OF_CUDA_CHECK(hipFree(const_ones_buffer_bf16_));
+}
+
+void CudaDevice::SetAsActiveDevice() { OF_CUDA_CHECK(hipSetDevice(device_index_)); }
+
+Stream* CudaDevice::CreateStream() {
+  CudaCurrentDeviceGuard guard(device_index_);
+  return new CudaStream(this);
+}
+
+void CudaDevice::DestroyStream(Stream* stream) {
+  CudaCurrentDeviceGuard guard(device_index_);
+  delete stream;
+}
+
+void CudaDevice::CreateEvents(Event** events, size_t count) {
+  size_t copied = 0;
+  {
+    std::lock_guard<std::mutex> lock(events_mutex_);
+    copied = std::min(count, events_.size());
+    size_t offset = events_.size() - copied;
+    std::copy(events_.begin() + offset, events_.end(), events);
+    events_.resize(offset);
+  }
+  if (copied != count) {
+    CudaCurrentDeviceGuard guard(device_index_);
+    for (size_t i = copied; i < count; ++i) { events[i] = new CudaEvent(event_flags_); }
+  }
+}
+
+void CudaDevice::DestroyEvents(Event** events, size_t count) {
+  std::lock_guard<std::mutex> lock(events_mutex_);
+  events_.insert(events_.end(), events, events + count);
+}
+
+Maybe<void> CudaDevice::Alloc(const AllocationOptions& options, void** ptr, size_t size) {
+  CudaCurrentDeviceGuard guard(device_index_);
+  CHECK(!options.HasPinnedDevice());
+  hipError_t err = hipMalloc(ptr, size);
+  if (err != hipSuccess) {
+    return Error::RuntimeError() << hipGetErrorString(err);
+  } else {
+    return Maybe<void>::Ok();
+  }
+}
+
+void CudaDevice::Free(const AllocationOptions& attr, void* ptr) {
+  CudaCurrentDeviceGuard guard(device_index_);
+  OF_CUDA_CHECK(hipFree(ptr));
+}
+
+Maybe<void> CudaDevice::AllocPinned(const AllocationOptions& options, void** ptr, size_t size) {
+  CudaCurrentDeviceGuard guard(device_index_);
+  hipError_t err = NumaAwareCudaMallocHost(device_index_, ptr, size);
+  if (err != hipSuccess) {
+    return Error::RuntimeError() << hipGetErrorString(err);
+  } else {
+    return Maybe<void>::Ok();
+  }
+}
+
+void CudaDevice::FreePinned(const AllocationOptions& options, void* ptr) {
+  CudaCurrentDeviceGuard guard(device_index_);
+  OF_CUDA_CHECK(hipHostFree(ptr));
+}
+
+const hipDeviceProp_t& CudaDevice::properties() const { return properties_; }
+
+const void* CudaDevice::GetConstZeros(DataType data_type, size_t n) const {
+  if (GetSizeOfDataType(data_type) * n
+      <= GetSizeOfDataType(DataType::kFloat) * const_buf_elem_cnt_) {
+    return const_zeros_buffer_;
+  } else {
+    return nullptr;
+  }
+}
+
+const void* CudaDevice::GetConstOnes(DataType data_type, size_t n) const {
+  if (n <= const_buf_elem_cnt_) {
+    if (data_type == DataType::kFloat) {
+      return const_ones_buffer_fp32_;
+    } else if (data_type == DataType::kFloat16) {
+      return const_ones_buffer_fp16_;
+    } else if (data_type == DataType::kBFloat16) {
+      return const_ones_buffer_bf16_;
+    } else {
+      return nullptr;
+    }
+  } else {
+    return nullptr;
+  }
+}
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP

--- a/oneflow/core/ep/hip/cuda_device.h
+++ b/oneflow/core/ep/hip/cuda_device.h
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_EP_CUDA_CUDA_DEVICE_H_
+#define ONEFLOW_CORE_EP_CUDA_CUDA_DEVICE_H_
+
+#include "oneflow/core/ep/include/device.h"
+#include "oneflow/core/common/data_type.h"
+
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+
+namespace oneflow {
+
+namespace ep {
+
+class CudaDevice : public Device {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaDevice);
+  explicit CudaDevice(int device_index, DeviceManager* device_manager);
+  ~CudaDevice() override;
+
+  void SetAsActiveDevice() override;
+
+  DeviceType device_type() const override { return DeviceType::kCUDA; }
+  size_t device_index() const override { return device_index_; }
+  DeviceManager* device_manager() const override { return device_manager_; }
+
+  Stream* CreateStream() override;
+  void DestroyStream(Stream* stream) override;
+
+  void CreateEvents(Event** events, size_t count) override;
+  void DestroyEvents(Event** events, size_t count) override;
+
+  Maybe<void> Alloc(const AllocationOptions& options, void** ptr, size_t size) override;
+  void Free(const AllocationOptions& options, void* ptr) override;
+  Maybe<void> AllocPinned(const AllocationOptions& options, void** ptr, size_t size) override;
+  void FreePinned(const AllocationOptions& options, void* ptr) override;
+
+  const hipDeviceProp_t& properties() const;
+
+  const void* GetConstZeros(DataType data_type, size_t n) const;
+  const void* GetConstOnes(DataType data_type, size_t n) const;
+
+ private:
+  int device_index_;
+  std::mutex events_mutex_;
+  std::vector<Event*> events_;
+  unsigned int event_flags_;
+  hipDeviceProp_t properties_;
+  DeviceManager* device_manager_;
+  int64_t const_buf_elem_cnt_;
+  void* const_zeros_buffer_;
+  void* const_ones_buffer_fp32_;
+  void* const_ones_buffer_fp16_;
+  void* const_ones_buffer_bf16_;
+};
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP
+
+#endif  // ONEFLOW_CORE_EP_CUDA_CUDA_DEVICE_H_

--- a/oneflow/core/ep/hip/cuda_device_manager.cpp
+++ b/oneflow/core/ep/hip/cuda_device_manager.cpp
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/hip/cuda_device_manager.h"
+#include "oneflow/core/device/cuda_util.h"
+
+#ifdef WITH_HIP
+
+namespace oneflow {
+
+namespace ep {
+
+CudaDeviceManager::CudaDeviceManager(DeviceManagerRegistry* registry) : registry_(registry) {}
+CudaDeviceManager::~CudaDeviceManager() = default;
+
+DeviceManagerRegistry* CudaDeviceManager::registry() const { return registry_; }
+
+std::shared_ptr<Device> CudaDeviceManager::GetDevice(size_t device_index) {
+  std::lock_guard<std::mutex> lock(devices_mutex_);
+  if (device_index < devices_.size() && devices_.at(device_index)) {
+    return devices_.at(device_index);
+  }
+  auto device = std::make_shared<CudaDevice>(device_index, this);
+  if (device_index >= devices_.size()) { devices_.resize(device_index + 1); }
+  devices_.at(device_index) = device;
+  return device;
+}
+
+size_t CudaDeviceManager::GetDeviceCount(size_t primary_device_index) {
+  CudaCurrentDeviceGuard guard(primary_device_index);
+  return this->GetDeviceCount();
+}
+
+size_t CudaDeviceManager::GetDeviceCount() {
+  int count = 0;
+  OF_CUDA_CHECK(hipGetDeviceCount(&count));
+  return count;
+}
+
+size_t CudaDeviceManager::GetActiveDeviceIndex() {
+  int device = 0;
+  OF_CUDA_CHECK(hipGetDevice(&device));
+  return static_cast<size_t>(device);
+}
+
+void CudaDeviceManager::SetActiveDeviceByIndex(size_t device_index) {
+  OF_CUDA_CHECK(hipSetDevice(static_cast<int>(device_index)));
+}
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP

--- a/oneflow/core/ep/hip/cuda_device_manager.h
+++ b/oneflow/core/ep/hip/cuda_device_manager.h
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_EP_CUDA_CUDA_DEVICE_MANAGER_H_
+#define ONEFLOW_CORE_EP_CUDA_CUDA_DEVICE_MANAGER_H_
+
+#include "oneflow/core/ep/include/device_manager.h"
+
+#ifdef WITH_HIP
+
+namespace oneflow {
+namespace ep {
+
+class CudaDevice;
+
+class CudaDeviceManager : public DeviceManager {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaDeviceManager);
+  CudaDeviceManager(DeviceManagerRegistry* registry);
+  ~CudaDeviceManager() override;
+
+  DeviceManagerRegistry* registry() const override;
+  std::shared_ptr<Device> GetDevice(size_t device_index) override;
+  size_t GetDeviceCount(size_t primary_device_index) override;
+  size_t GetDeviceCount() override;
+  size_t GetActiveDeviceIndex() override;
+  void SetActiveDeviceByIndex(size_t device_index) override;
+
+ private:
+  std::mutex devices_mutex_;
+  std::vector<std::shared_ptr<CudaDevice>> devices_;
+  DeviceManagerRegistry* registry_;
+};
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP
+
+#endif  // ONEFLOW_CORE_EP_CUDA_CUDA_DEVICE_MANAGER_H_

--- a/oneflow/core/ep/hip/cuda_device_manager_factory.cpp
+++ b/oneflow/core/ep/hip/cuda_device_manager_factory.cpp
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/device_manager_factory.h"
+#include "oneflow/core/ep/include/device_manager_registry.h"
+#include "oneflow/core/ep/hip/cuda_device_manager.h"
+
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+#include <miopen/miopen.h>
+#include <rccl.h>
+
+namespace oneflow {
+
+namespace ep {
+
+namespace {
+
+std::string GetCudaVersionString(int version) {
+  return std::to_string(version / 1000) + "." + std::to_string((version % 1000) / 10);
+}
+
+bool GetCudnnVersion(size_t* major, size_t* minor, size_t* patch) {
+  miopenStatus_t status = miopenGetVersion(major, minor, patch);
+  if (status == miopenStatusSuccess) {
+    return true;
+  } else {
+    LOG(ERROR) << "Failed to get cuDNN version: " << miopenGetErrorString(status);
+    return false;
+  }
+}
+
+bool GetCudnnVersionString(std::string* version) {
+  int version_major = 0;
+  int version_minor = 0;
+  int version_patch = 0;
+  if (!GetCudnnVersion(version_major, version_minor, version_patch)) { return false; }
+  *version = std::to_string(version_major) + "." + std::to_string(version_minor) + "."
+             + std::to_string(version_patch);
+  return true;
+}
+
+void CudaDumpVersionInfo() {
+  {
+    int cuda_runtime_version = 0;
+    hipError_t err = hipRuntimeGetVersion(&cuda_runtime_version);
+    if (err == hipSuccess) {
+      LOG(INFO) << "CUDA runtime version: " << GetCudaVersionString(cuda_runtime_version);
+    } else {
+      LOG(ERROR) << "Failed to get cuda runtime version: " << hipGetErrorString(err);
+    }
+  }
+
+  {
+    std::string cudnn_version_string;
+    if (GetCudnnVersionString(&cudnn_version_string)) {
+      LOG(INFO) << "cuDNN version: " << cudnn_version_string;
+    }
+  }
+
+  {
+    int nccl_version = 0;
+    ncclResult_t result = ncclGetVersion(&nccl_version);
+    if (result == ncclSuccess) {
+      int nccl_version_major =
+          (nccl_version >= 20900) ? (nccl_version / 10000) : (nccl_version / 1000);
+      int nccl_version_minor =
+          (nccl_version >= 20900) ? (nccl_version % 10000) / 100 : (nccl_version % 1000) / 100;
+      int nccl_version_patch = (nccl_version % 100);
+      LOG(INFO) << "NCCL version: " << nccl_version_major << "." << nccl_version_minor << "."
+                << nccl_version_patch;
+    } else {
+      LOG(ERROR) << "Failed to get NCCL version: " << ncclGetErrorString(result);
+    }
+  }
+}
+
+class CudaDeviceManagerFactory : public DeviceManagerFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaDeviceManagerFactory);
+  CudaDeviceManagerFactory() = default;
+  ~CudaDeviceManagerFactory() override = default;
+
+  std::unique_ptr<DeviceManager> NewDeviceManager(DeviceManagerRegistry* registry) override {
+    return std::make_unique<CudaDeviceManager>(registry);
+  }
+
+  DeviceType device_type() const override { return DeviceType::kCUDA; }
+
+  std::string device_type_name() const override { return "cuda"; }
+
+  void DumpVersionInfo() const override { CudaDumpVersionInfo(); }
+};
+
+COMMAND(DeviceManagerRegistry::RegisterDeviceManagerFactory(
+    std::make_unique<CudaDeviceManagerFactory>()))
+
+}  // namespace
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP

--- a/oneflow/core/ep/hip/cuda_event.cpp
+++ b/oneflow/core/ep/hip/cuda_event.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/hip/cuda_event.h"
+
+#ifdef WITH_HIP
+
+namespace oneflow {
+
+namespace ep {
+
+CudaEvent::CudaEvent(unsigned int flags) : cuda_event_{} {
+  OF_CUDA_CHECK(hipEventCreateWithFlags(&cuda_event_, flags));
+}
+
+CudaEvent::~CudaEvent() { OF_CUDA_CHECK(hipEventDestroy(cuda_event_)); }
+
+Maybe<bool> CudaEvent::QueryDone() {
+  hipError_t err = hipEventQuery(cuda_event_);
+  if (err == hipSuccess) {
+    return Maybe<bool>(true);
+  } else if (err == hipErrorNotReady) {
+    return Maybe<bool>(false);
+  } else {
+    return Error::RuntimeError() << hipGetErrorString(err);
+  }
+}
+
+Maybe<void> CudaEvent::Sync() {
+  hipError_t err = hipEventSynchronize(cuda_event_);
+  if (err == hipSuccess) {
+    return Maybe<void>::Ok();
+  } else {
+    return Error::RuntimeError() << hipGetErrorString(err);
+  }
+}
+
+hipEvent_t CudaEvent::cuda_event() { return cuda_event_; }
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP

--- a/oneflow/core/ep/hip/cuda_event.h
+++ b/oneflow/core/ep/hip/cuda_event.h
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_EP_CUDA_CUDA_EVENT_H_
+#define ONEFLOW_CORE_EP_CUDA_CUDA_EVENT_H_
+
+#include "oneflow/core/ep/include/event.h"
+
+#ifdef WITH_HIP
+
+#include "oneflow/core/device/cuda_util.h"
+
+namespace oneflow {
+
+namespace ep {
+
+class CudaEvent : public Event {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaEvent);
+  explicit CudaEvent(unsigned int flags);
+  ~CudaEvent() override;
+
+  Maybe<bool> QueryDone() override;
+  Maybe<void> Sync() override;
+
+  hipEvent_t cuda_event();
+
+ private:
+  hipEvent_t cuda_event_;
+};
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP
+
+#endif  // ONEFLOW_CORE_EP_CUDA_CUDA_EVENT_H_

--- a/oneflow/core/ep/hip/cuda_stream.cpp
+++ b/oneflow/core/ep/hip/cuda_stream.cpp
@@ -1,0 +1,209 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include "oneflow/core/job/global_for.h"
+#include "oneflow/core/job/resource_desc.h"
+#include "oneflow/core/hardware/node_device_descriptor_manager.h"
+#include "oneflow/core/hardware/cuda_device_descriptor.h"
+#include "oneflow/core/ep/hip/cuda_event.h"
+#include "oneflow/core/ep/hip/cuda_device.h"
+
+#ifdef WITH_HIP
+
+namespace oneflow {
+
+namespace ep {
+
+namespace {
+
+constexpr size_t kDefaultWorkspaceSize = 4 * 1024 * 1024;  // 4M
+
+void SetAffinityByDevice(int dev_id) {
+  auto node_device_desc_mgr = Global<hardware::NodeDeviceDescriptorManager>::Get();
+  if (node_device_desc_mgr == nullptr) { return; }
+  auto node_device_desc = node_device_desc_mgr->GetLocalNodeDeviceDescriptor();
+  auto cuda_device = std::dynamic_pointer_cast<const hardware::CudaDeviceDescriptor>(
+      node_device_desc->GetDevice(hardware::kCudaDeviceDescriptorClassName, dev_id));
+  if (!cuda_device) { return; }
+  node_device_desc->Topology()->SetCPUAffinityByPCIBusID(cuda_device->PCIBusID());
+  node_device_desc->Topology()->SetMemoryAffinityByPCIBusID(cuda_device->PCIBusID());
+}
+
+bool IsCuda9OnTuringDevice(const hipDeviceProp_t& prop) {
+  // return CUDA_VERSION >= 9000 && CUDA_VERSION < 9020 && prop.major == 7 && prop.minor == 5;
+  return false;
+}
+
+}  // namespace
+
+#ifdef WITH_HIP_GRAPHS
+
+CudaGraphExecutable::CudaGraphExecutable() : graph_exec_(nullptr), dev_(-1) {}
+
+CudaGraphExecutable::~CudaGraphExecutable() { Reset(); }
+
+void CudaGraphExecutable::Update(hipGraph_t graph) {
+  int dev = -1;
+  OF_CUDA_CHECK(hipGetDevice(&dev));
+  if (dev != dev_) { Reset(); }
+  dev_ = dev;
+  if (graph_exec_ != nullptr) {
+    hipGraphExecUpdateResult update_result{};
+    hipGraphNode_t error_node = nullptr;
+    OF_CUDA_CHECK(hipGraphExecUpdate(graph_exec_, graph, &error_node, &update_result));
+    if (update_result == hipGraphExecUpdateSuccess) { return; }
+  }
+  Reset();
+  OF_CUDA_CHECK(hipGraphInstantiate(&graph_exec_, graph, NULL, NULL, 0));
+}
+
+void CudaGraphExecutable::Launch(hipStream_t stream) const {
+  OF_CUDA_CHECK(hipGraphLaunch(graph_exec_, stream));
+}
+
+bool CudaGraphExecutable::IsInstantiated() const { return graph_exec_ != nullptr; }
+
+void CudaGraphExecutable::Reset() {
+  if (graph_exec_ != nullptr) {
+    CudaCurrentDeviceGuard guard(dev_);
+    OF_CUDA_CHECK(hipGraphExecDestroy(graph_exec_));
+  }
+}
+
+#endif  // WITH_HIP_GRAPHS
+
+CudaStream::CudaStream(CudaDevice* device)
+    : device_index_(device->device_index()), device_(device) {
+  CudaCurrentDeviceGuard guard(device_index_);
+  // cuda_stream
+  OF_CUDA_CHECK(hipStreamCreate(&cuda_stream_));
+  // cublas_handle
+  OF_CUBLAS_CHECK(hipblasCreate(&cublas_handle_));
+  OF_CUBLAS_CHECK(hipblasSetStream(cublas_handle_, cuda_stream_));
+// #if CUDA_VERSION >= 10010
+//   // cublas_lt_handle
+//   OF_CUBLAS_CHECK(cublasLtCreate(&cublas_lt_handle_));
+// #endif
+// #if CUBLAS_VERSION >= 11000
+//   if (ParseBooleanFromEnv("ONEFLOW_EP_CUDA_ENABLE_TF32_EXECUTION", true)) {
+//     OF_CUBLAS_CHECK(cublasSetMathMode(cublas_handle_, CUBLAS_TF32_TENSOR_OP_MATH));
+//   }
+// #endif  // CUBLAS_VERSION >= 11000
+  workspace_size_ = kDefaultWorkspaceSize;
+  OF_CUDA_CHECK(hipMalloc(&workspace_, workspace_size_));
+// #if CUBLAS_VERSION >= 11200
+//   OF_CUBLAS_CHECK(cublasSetWorkspace(cublas_handle_, workspace_, workspace_size_));
+// #endif  // CUBLAS_VERSION >= 11200
+  // cudnn_handle
+  // if (IsCuda9OnTuringDevice(device_properties())) {
+  //   OF_CUDA_CHECK(hipDeviceSynchronize());
+  //   OF_CUDA_CHECK(hipGetLastError());
+  // }
+  OF_CUDNN_CHECK(miopenCreate(&cudnn_handle_));
+  // if (IsCuda9OnTuringDevice(device_properties())) {
+  //   OF_CUDA_CHECK(hipDeviceSynchronize());
+  //   hipGetLastError();
+  // }
+  OF_CUDNN_CHECK(miopenSetStream(cudnn_handle_, cuda_stream_));
+}
+
+CudaStream::~CudaStream() {
+  CudaCurrentDeviceGuard guard(device_index_);
+  OF_CUDA_CHECK(hipStreamSynchronize(cuda_stream_));
+  OF_CUDNN_CHECK(miopenDestroy(cudnn_handle_));
+  OF_CUBLAS_CHECK(hipblasDestroy(cublas_handle_));
+// #if CUDA_VERSION >= 10010
+//   OF_CUBLAS_CHECK(cublasLtDestroy(cublas_lt_handle_));
+// #endif
+  OF_CUDA_CHECK(hipStreamDestroy(cuda_stream_));
+  OF_CUDA_CHECK(hipFree(workspace_));
+}
+
+Maybe<void> CudaStream::OnExecutionContextSetup() {
+  OF_CUDA_CHECK(hipSetDevice(device_index_));
+  SetAffinityByDevice(device_index_);
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> CudaStream::OnExecutionContextTeardown() { return Maybe<void>::Ok(); }
+
+DeviceType CudaStream::device_type() const { return DeviceType::kCUDA; }
+
+CudaDevice* CudaStream::device() const { return device_; }
+
+Maybe<void> CudaStream::Sync() {
+  hipError_t err = hipStreamSynchronize(cuda_stream_);
+  if (err == hipSuccess) {
+    return Maybe<void>::Ok();
+  } else {
+    return Error::RuntimeError() << hipGetErrorString(err) << " (" << err << ") ";
+  }
+}
+
+void CudaStream::RecordEvent(Event* event) {
+  auto* cuda_event = static_cast<CudaEvent*>(event);  // NOLINT
+  OF_CUDA_CHECK(hipEventRecord(cuda_event->cuda_event(), cuda_stream_));
+}
+
+hipStream_t CudaStream::cuda_stream() const { return cuda_stream_; }
+
+hipblasHandle_t CudaStream::cublas_handle() const { return cublas_handle_; }
+
+// #if CUDA_VERSION >= 10010
+// cublasLtHandle_t CudaStream::cublas_lt_handle() const { return cublas_lt_handle_; }
+// #endif
+
+void* CudaStream::cublas_workspace() const { return workspace_; }
+
+size_t CudaStream::cublas_workspace_size() const { return workspace_size_; }
+
+miopenHandle_t CudaStream::cudnn_handle() const { return cudnn_handle_; }
+
+const hipDeviceProp_t& CudaStream::device_properties() const { return device_->properties(); }
+
+int CudaStream::cuda_arch() const {
+  return device_->properties().major * 100 + device_->properties().minor * 10;
+}
+
+#ifdef WITH_HIP_GRAPHS
+
+void CudaStream::BeginGraphCapture() {
+  CHECK(!is_graph_capturing_);
+  is_graph_capturing_ = true;
+  OF_CUDA_CHECK(hipStreamBeginCapture(cuda_stream_, hipStreamCaptureModeThreadLocal));
+}
+
+void CudaStream::EndGraphCapture(CudaGraphExecutable* executable) {
+  hipGraph_t graph = nullptr;
+  OF_CUDA_CHECK(hipStreamEndCapture(cuda_stream_, &graph));
+  executable->Update(graph);
+  OF_CUDA_CHECK(hipGraphDestroy(graph));
+  is_graph_capturing_ = false;
+}
+
+bool CudaStream::IsGraphCapturing() const { return is_graph_capturing_; }
+
+void CudaStream::LaunchGraph(const CudaGraphExecutable* executable) {
+  executable->Launch(cuda_stream_);
+}
+
+#endif  // WITH_HIP_GRAPHS
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP

--- a/oneflow/core/ep/hip/cuda_stream.h
+++ b/oneflow/core/ep/hip/cuda_stream.h
@@ -1,0 +1,167 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_EP_CUDA_CUDA_STREAM_H_
+#define ONEFLOW_CORE_EP_CUDA_CUDA_STREAM_H_
+
+#include "oneflow/core/ep/include/stream.h"
+#include "oneflow/core/ep/hip/cuda_device.h"
+
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+
+// #if CUDA_VERSION >= 11000
+#define WITH_HIP_GRAPHS
+// #endif  // CUDA_VERSION >= 11000
+
+#include "oneflow/core/device/cuda_util.h"
+
+namespace oneflow {
+
+namespace ep {
+
+class CudaDevice;
+
+#ifdef WITH_HIP_GRAPHS
+
+class CudaGraphExecutable {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaGraphExecutable);
+  CudaGraphExecutable();
+  ~CudaGraphExecutable();
+
+  void Update(hipGraph_t graph);
+  void Launch(hipStream_t stream) const;
+  bool IsInstantiated() const;
+
+ private:
+  void Reset();
+
+  hipGraphExec_t graph_exec_;
+  int dev_;
+};
+
+#endif  // WITH_HIP_GRAPHS
+
+struct CudaLaunchConfig {
+  dim3 grid_dim;
+  dim3 block_dim;
+  size_t shared_mem_size;
+  CudaLaunchConfig() : grid_dim{}, block_dim{}, shared_mem_size(0) {}
+
+  CudaLaunchConfig(unsigned int grid_size, unsigned int block_size, size_t shared_mem_size)
+      : grid_dim(grid_size), block_dim(block_size), shared_mem_size(shared_mem_size) {}
+};
+
+class CudaStream : public Stream {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaStream);
+  explicit CudaStream(CudaDevice* device);
+  ~CudaStream() override;
+
+  static constexpr uint32_t kDefaultBlockSize = 256;
+
+  DeviceType device_type() const override;
+  CudaDevice* device() const override;
+  Maybe<void> Sync() override;
+  void RecordEvent(Event* event) override;
+
+  Maybe<void> OnExecutionContextSetup() override;
+  Maybe<void> OnExecutionContextTeardown() override;
+
+  hipStream_t cuda_stream() const;
+  hipblasHandle_t cublas_handle() const;
+
+// #if CUDA_VERSION >= 10010
+
+//   cublasLtHandle_t cublas_lt_handle() const;
+
+// #endif
+
+  miopenHandle_t cudnn_handle() const;
+  void* cublas_workspace() const;
+  size_t cublas_workspace_size() const;
+  const hipDeviceProp_t& device_properties() const;
+  int cuda_arch() const;
+
+  void InitLaunchConfigWithWaves(CudaLaunchConfig* config, size_t elem_cnt, size_t block_size,
+                                 size_t max_waves) const {
+    const uint32_t max_grid_size = max_waves * device_properties().multiProcessorCount
+                                   * (device_properties().maxThreadsPerMultiProcessor / block_size);
+    const uint32_t grid_size =
+        std::min<uint32_t>(max_grid_size, (elem_cnt + block_size - 1) / block_size);
+    config->grid_dim = dim3(grid_size);
+    config->block_dim = dim3(block_size);
+    config->shared_mem_size = 0;
+  }
+
+#ifdef __HIPCC__
+  template<typename... Params, typename... Args>
+  void LaunchKernel(void (*kernel)(Params...), const CudaLaunchConfig& launch_config,
+                    Args... args) {
+    kernel<<<launch_config.grid_dim, launch_config.block_dim, launch_config.shared_mem_size,
+             cuda_stream()>>>(args...);
+  }
+
+  template<typename... Params, typename... Args>
+  void LaunchKernel(void (*kernel)(Params...), size_t elem_cnt, size_t max_waves, Args... args) {
+    constexpr uint32_t block_size = kDefaultBlockSize;
+    CudaLaunchConfig config{};
+    InitLaunchConfigWithWaves(&config, elem_cnt, block_size, max_waves);
+    LaunchKernel(kernel, config, args...);
+  }
+
+  template<typename... Params, typename... Args>
+  void LaunchKernelDefaultWaves(void (*kernel)(Params...), size_t elem_cnt, Args... args) {
+    const size_t default_waves = 32;
+    LaunchKernel(kernel, elem_cnt, default_waves, args...);
+  }
+#endif  // __HIPCC__
+
+#ifdef WITH_HIP_GRAPHS
+  void BeginGraphCapture();
+  void EndGraphCapture(CudaGraphExecutable* executable);
+  bool IsGraphCapturing() const;
+  void LaunchGraph(const CudaGraphExecutable* executable);
+#endif  // WITH_HIP_GRAPHS
+
+ private:
+  hipStream_t cuda_stream_{};
+  hipblasHandle_t cublas_handle_{};
+
+// #if CUDA_VERSION >= 10010
+
+//   cublasLtHandle_t cublas_lt_handle_{};
+
+// #endif
+
+  miopenHandle_t cudnn_handle_{};
+  int device_index_;
+  void* workspace_{};
+  size_t workspace_size_{};
+#ifdef WITH_HIP_GRAPHS
+  bool is_graph_capturing_{};
+#endif  // WITH_HIP_GRAPHS
+  CudaDevice* device_;
+};
+
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP
+
+#endif  // ONEFLOW_CORE_EP_CUDA_CUDA_STREAM_H_

--- a/oneflow/core/ep/hip/primitive/add.cu
+++ b/oneflow/core/ep/hip/primitive/add.cu
@@ -1,0 +1,139 @@
+#include "hip/hip_runtime.h"
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/primitive/add.h"
+#include "oneflow/core/ep/hip/primitive/type_seq.h"
+#include "oneflow/core/cuda/elementwise.cuh"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include "oneflow/core/device/cuda_pseudo_bfloat16.h"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+template<typename... Args>
+struct AddFunctor;
+
+template<typename T>
+struct AddFunctor<T> {
+  __device__ T operator()(T x) const { return x; }
+};
+
+template<typename T, typename U, typename... Args>
+struct AddFunctor<T, U, Args...> {
+  __device__ T operator()(T x0, U x1, Args... xs) const {
+    return x0 + AddFunctor<U, Args...>()(x1, xs...);
+  }
+};
+
+template<typename T, typename... Args>
+__global__ void AddGpu(const Args*... srcs, T* dst, size_t count) {
+  CUDA_1D_KERNEL_LOOP_T(size_t, i, count) { dst[i] = AddFunctor<Args...>()(srcs[i]...); }
+}
+
+template<typename T, typename... Args>
+void LaunchAddGpu(hipStream_t stream, const Args*... srcs, T* dst, size_t count) {
+  AddGpu<T, Args...>
+      <<<BlocksNum4ThreadsNum(count), kCudaThreadsNumPerBlock, 0, stream>>>(srcs..., dst, count);
+}
+
+template<typename T>
+void DispatchLaunch(hipStream_t stream, const T* const* srcs, size_t arity, T* dst, size_t count) {
+  if (arity == 0) {
+    OF_CUDA_CHECK(hipMemsetAsync(dst, 0, count * sizeof(T), stream));
+  } else if (arity == 1) {
+    OF_CUDA_CHECK(hipMemcpyAsync(dst, srcs[0], count * sizeof(T), hipMemcpyDefault, stream));
+  } else if (arity == 2) {
+    OF_CUDA_CHECK((cuda::elementwise::Binary<AddFunctor<T, T>, T, T, T>(
+        AddFunctor<T, T>(), count, dst, srcs[0], srcs[1], stream)));
+  } else if (arity == 3) {
+    OF_CUDA_CHECK((cuda::elementwise::Ternary<AddFunctor<T, T, T>, T, T, T, T>(
+        AddFunctor<T, T, T>(), count, dst, srcs[0], srcs[1], srcs[2], stream)));
+  } else if (arity == 4) {
+    LaunchAddGpu<T, T, T, T, T>(stream, srcs[0], srcs[1], srcs[2], srcs[3], dst, count);
+  } else if (arity == 5) {
+    LaunchAddGpu<T, T, T, T, T, T>(stream, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4], dst, count);
+  } else if (arity == 6) {
+    LaunchAddGpu<T, T, T, T, T, T, T>(stream, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4], srcs[5],
+                                      dst, count);
+  } else if (arity == 7) {
+    LaunchAddGpu<T, T, T, T, T, T, T, T>(stream, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4],
+                                         srcs[5], srcs[6], dst, count);
+  } else if (arity == 8) {
+    LaunchAddGpu<T, T, T, T, T, T, T, T, T>(stream, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4],
+                                            srcs[5], srcs[6], srcs[7], dst, count);
+  } else {
+    DispatchLaunch(stream, srcs + 7, arity - 7, dst, count);
+    LaunchAddGpu<T, T, T, T, T, T, T, T, T>(stream, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4],
+                                            srcs[5], srcs[6], dst, dst, count);
+  }
+}
+
+template<typename T>
+class AddImpl : public Add {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(AddImpl);
+  AddImpl() = default;
+  ~AddImpl() override = default;
+
+  using Add::Launch;
+  void Launch(Stream* stream, const void* const* srcs, size_t arity, void* dst,
+              size_t count) override {
+    hipStream_t cuda_stream = stream->As<CudaStream>()->cuda_stream();
+    DispatchLaunch(cuda_stream, reinterpret_cast<const T* const*>(srcs), arity,
+                   reinterpret_cast<T*>(dst), count);
+  }
+};
+
+template<typename T>
+std::unique_ptr<Add> NewAdd() {
+  return std::unique_ptr<Add>(new AddImpl<T>());
+}
+
+class AddFactoryImpl : public AddFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(AddFactoryImpl);
+  AddFactoryImpl() = default;
+  ~AddFactoryImpl() override = default;
+
+  std::unique_ptr<Add> New(DataType data_type) override {
+#define MAKE_NEW_ADD_ENTRY(type_cpp, type_proto) {type_proto, NewAdd<type_cpp>},
+
+    static const std::map<DataType, std::function<std::unique_ptr<Add>()>> new_add_handle{
+        OF_PP_FOR_EACH_TUPLE(MAKE_NEW_ADD_ENTRY, CUDA_PRIMITIVE_ALL_TYPE_SEQ)};
+
+#undef MAKE_NEW_ADD_ENTRY
+
+    const auto it = new_add_handle.find(data_type);
+    if (it != new_add_handle.end()) {
+      return it->second();
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, AddFactory, AddFactoryImpl);
+
+}  // namespace
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/binary_functor.cuh
+++ b/oneflow/core/ep/hip/primitive/binary_functor.cuh
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "oneflow/core/ep/common/primitive/binary_functor.h"
+
+namespace oneflow {
+namespace ep {
+namespace primitive {
+namespace broadcast_elementwise_binary {
+
+template<typename Src, typename Dst>
+struct BinaryFunctor<DeviceType::kCUDA, BinaryOp::kPow, Src, Dst> {
+  OF_DEVICE_FUNC Dst operator()(Src src0, Src src1) const { return pow(src0, src1); }
+};
+
+template<>
+struct BinaryFunctor<DeviceType::kCUDA, BinaryOp::kPow, bool, bool> {
+  OF_DEVICE_FUNC bool operator()(bool src0, bool src1) const {
+    return static_cast<bool>(pow(static_cast<double>(src0), static_cast<double>(src1)));
+  }
+};
+
+template<>
+struct BinaryFunctor<DeviceType::kCUDA, BinaryOp::kPow, half, half> {
+  OF_DEVICE_FUNC half operator()(half src0, half src1) const {
+    return static_cast<half>(pow(static_cast<float>(src0), static_cast<float>(src1)));
+  }
+};
+
+// #if CUDA_VERSION >= 11000
+
+// template<>
+// struct BinaryFunctor<DeviceType::kCUDA, BinaryOp::kPow, nv_bfloat16, nv_bfloat16> {
+//   OF_DEVICE_FUNC nv_bfloat16 operator()(nv_bfloat16 src0, nv_bfloat16 src1) const {
+//     return static_cast<nv_bfloat16>(pow(static_cast<float>(src0), static_cast<float>(src1)));
+//   }
+// };
+
+// #endif  // CUDA_VERSION >= 11000
+
+}  // namespace broadcast_elementwise_binary
+}  // namespace primitive
+}  // namespace ep
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary.cu
+++ b/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary.cu
@@ -1,0 +1,86 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/primitive//broadcast_elementwise_binary.h"
+#include "oneflow/core/ep/common/primitive/broadcast_elementwise_binary.h"
+#include "oneflow/core/ep/hip/primitive/type_seq.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include "oneflow/core/cuda/elementwise.cuh"
+#include "oneflow/core/ep/hip/primitive/binary_functor.cuh"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+namespace broadcast_elementwise_binary {
+
+template<BinaryOp binary_op, typename Src, typename Dst>
+std::unique_ptr<BroadcastElementwiseBinary> NewBroadcastElementwiseBinary();
+
+namespace {
+
+class BroadcastElementwiseBinaryFactoryImpl : public BroadcastElementwiseBinaryFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(BroadcastElementwiseBinaryFactoryImpl);
+  BroadcastElementwiseBinaryFactoryImpl() = default;
+  ~BroadcastElementwiseBinaryFactoryImpl() override = default;
+
+  std::unique_ptr<BroadcastElementwiseBinary> New(BinaryOp binary_op, DataType src_type,
+                                                  DataType dst_type, size_t max_num_dims) override {
+    if (max_num_dims > kMaxNumDims) { return nullptr; }
+#define MAKE_NEW_BROADCAST_ELEMENTWISE_BINARY_MATH_ENTRY(binary_op, data_type_pair) \
+  {std::make_tuple(binary_op, OF_PP_PAIR_SECOND(data_type_pair),                    \
+                   OF_PP_PAIR_SECOND(data_type_pair)),                              \
+   NewBroadcastElementwiseBinary<binary_op, OF_PP_PAIR_FIRST(data_type_pair),       \
+                                 OF_PP_PAIR_FIRST(data_type_pair)>},
+
+#define MAKE_NEW_BROADCAST_ELEMENTWISE_BINARY_COMPARASION_AND_LOGICAL_ENTRY(      \
+    binary_op, src_data_type_pair, dst_data_type_pair)                            \
+  {std::make_tuple(binary_op, OF_PP_PAIR_SECOND(src_data_type_pair),              \
+                   OF_PP_PAIR_SECOND(dst_data_type_pair)),                        \
+   NewBroadcastElementwiseBinary<binary_op, OF_PP_PAIR_FIRST(src_data_type_pair), \
+                                 OF_PP_PAIR_FIRST(dst_data_type_pair)>},
+
+    static const std::map<std::tuple<BinaryOp, DataType, DataType>,
+                          std::function<std::unique_ptr<BroadcastElementwiseBinary>()>>
+        new_broadcast_elementwise_binary_handle{
+            OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(MAKE_NEW_BROADCAST_ELEMENTWISE_BINARY_MATH_ENTRY,
+                                             BINARY_MATH_OP_SEQ, CUDA_PRIMITIVE_ALL_TYPE_SEQ)
+                OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(
+                    MAKE_NEW_BROADCAST_ELEMENTWISE_BINARY_COMPARASION_AND_LOGICAL_ENTRY,
+                    BINARY_COMPARISION_OP_SEQ BINARY_LOGICAL_OP_SEQ, CUDA_PRIMITIVE_ALL_TYPE_SEQ,
+                    CUDA_PRIMITIVE_BOOL_TYPE_SEQ)};
+
+#undef MAKE_NEW_BROADCAST_ELEMENTWISE_BINARY_COMPARASION_AND_LOGICAL_ENTRY
+#undef MAKE_NEW_BROADCAST_ELEMENTWISE_BINARY_MATH_ENTRY
+
+    const auto it = new_broadcast_elementwise_binary_handle.find(
+        std::make_tuple(binary_op, src_type, dst_type));
+    if (it != new_broadcast_elementwise_binary_handle.end()) {
+      return it->second();
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, BroadcastElementwiseBinaryFactory,
+                           BroadcastElementwiseBinaryFactoryImpl);
+}  // namespace
+}  // namespace broadcast_elementwise_binary
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary.cuh
+++ b/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary.cuh
@@ -1,0 +1,378 @@
+
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/primitive//broadcast_elementwise_binary.h"
+#include "oneflow/core/ep/common/primitive/broadcast_elementwise_binary.h"
+#include "oneflow/core/ep/hip/primitive/type_seq.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include "oneflow/core/cuda/elementwise.cuh"
+#include "oneflow/core/ep/hip/primitive/binary_functor.cuh"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+namespace broadcast_elementwise_binary {
+
+namespace {
+
+template<typename T, int N>
+struct GetPackType {
+  using type = typename std::aligned_storage<N * sizeof(T), N * sizeof(T)>::type;
+};
+
+template<typename T, int N>
+using PackType = typename GetPackType<T, N>::type;
+
+template<typename T, int N>
+union Pack {
+  static_assert(sizeof(PackType<T, N>) == sizeof(T) * N, "");
+  OF_DEVICE_FUNC Pack() {
+    // do nothing
+  }
+  PackType<T, N> storage;
+  T elem[N];
+};
+
+template<size_t max_dims, typename IndexType>
+struct BroadcastElementwiseBinaryParams {
+  NdIndexOffsetHelper<IndexType, max_dims> src0_index_helper;
+  NdIndexOffsetHelper<IndexType, max_dims> src1_index_helper;
+  NdIndexOffsetHelper<IndexType, max_dims> dst_index_helper;
+  size_t num_dims;
+  IndexType src0_index_mask[max_dims];
+  IndexType src1_index_mask[max_dims];
+  IndexType count{};
+  const void* src0{};
+  const void* src1{};
+  void* dst{};
+};
+
+template<BinaryOp binary_op, typename Src, typename Dst, size_t max_dims, size_t src0_pack_size,
+         size_t src1_pack_size, typename IndexType>
+__global__ void BroadcastElementwiseBinaryGpu(
+    BroadcastElementwiseBinaryParams<max_dims, IndexType> params) {
+  constexpr size_t dst_pack_size =
+      src0_pack_size > src1_pack_size ? src0_pack_size : src1_pack_size;
+  static_assert(src0_pack_size == dst_pack_size || src0_pack_size == 1, "");
+  static_assert(src1_pack_size == dst_pack_size || src1_pack_size == 1, "");
+
+  const PackType<Src, src0_pack_size>* src0 =
+      reinterpret_cast<const PackType<Src, src0_pack_size>*>(params.src0);
+  const PackType<Src, src1_pack_size>* src1 =
+      reinterpret_cast<const PackType<Src, src1_pack_size>*>(params.src1);
+  PackType<Dst, dst_pack_size>* dst = reinterpret_cast<PackType<Dst, dst_pack_size>*>(params.dst);
+
+  IndexType src0_index[max_dims];
+  IndexType src1_index[max_dims];
+  IndexType dst_index[max_dims];
+  size_t num_dims = params.num_dims;
+  CUDA_1D_KERNEL_LOOP_T(IndexType, offset, params.count) {
+    params.dst_index_helper.OffsetToNdIndex(offset, dst_index, num_dims);
+#pragma unroll
+    for (int i = 0; i < max_dims; ++i) {
+      if (i < num_dims) {
+        src0_index[i] = params.src0_index_mask[i] * dst_index[i];
+        src1_index[i] = params.src1_index_mask[i] * dst_index[i];
+      }
+    }
+    const IndexType src0_offset = params.src0_index_helper.NdIndexToOffset(src0_index, num_dims);
+    const IndexType src1_offset = params.src1_index_helper.NdIndexToOffset(src1_index, num_dims);
+    Pack<Src, src0_pack_size> src0_pack;
+    src0_pack.storage = src0[src0_offset];
+    Pack<Src, src1_pack_size> src1_pack;
+    src1_pack.storage = src1[src1_offset];
+    Pack<Dst, dst_pack_size> dst_pack;
+#pragma unroll
+    for (int j = 0; j < dst_pack_size; ++j) {
+      const Src src0_val =
+          (src0_pack_size == dst_pack_size) ? src0_pack.elem[j] : src0_pack.elem[0];
+      const Src src1_val =
+          (src1_pack_size == dst_pack_size) ? src1_pack.elem[j] : src1_pack.elem[0];
+      dst_pack.elem[j] =
+          BinaryFunctor<DeviceType::kCUDA, binary_op, Src, Dst>()(src0_val, src1_val);
+    }
+    dst[offset] = dst_pack.storage;
+  }
+}
+
+template<BinaryOp op, typename T, typename R, size_t max_dims, size_t src0_pack_size,
+         size_t src1_pack_size, typename IndexType>
+void LaunchKernel(Stream* stream, int num_dims, const int64_t* src0_dims, const void* src0,
+                  const int64_t* src1_dims, const void* src1, const int64_t* dst_dims, void* dst,
+                  size_t count) {
+  BroadcastElementwiseBinaryParams<max_dims, IndexType> params;
+  for (size_t i = 0; i < num_dims; ++i) {
+    params.src0_index_mask[i] = (src0_dims[i] == 1) ? 0 : 1;
+    params.src1_index_mask[i] = (src1_dims[i] == 1) ? 0 : 1;
+  }
+  params.src0_index_helper = NdIndexOffsetHelper<IndexType, max_dims>(src0_dims, num_dims);
+  params.src1_index_helper = NdIndexOffsetHelper<IndexType, max_dims>(src1_dims, num_dims);
+  params.dst_index_helper = NdIndexOffsetHelper<IndexType, max_dims>(dst_dims, num_dims);
+  params.num_dims = num_dims;
+  params.src0 = src0;
+  params.src1 = src1;
+  params.dst = dst;
+  params.count = static_cast<IndexType>(count);
+  auto* cuda_stream = stream->As<CudaStream>();
+  BroadcastElementwiseBinaryGpu<op, T, R, max_dims, src0_pack_size, src1_pack_size, IndexType>
+      <<<BlocksNum4ThreadsNum(params.count), kCudaThreadsNumPerBlock, 0,
+         cuda_stream->cuda_stream()>>>(params);
+}
+
+template<BinaryOp op, typename T, typename R, size_t max_dims, size_t src0_pack_size,
+         size_t src1_pack_size>
+void DispatchIndexType(Stream* stream, size_t num_dims, const int64_t* src0_dims, const void* src0,
+                       const int64_t* src1_dims, const void* src1, const int64_t* dst_dims,
+                       void* dst) {
+  size_t count = GetElementCount(num_dims, dst_dims);
+  if (count < GetMaxVal<int32_t>()) {
+    LaunchKernel<op, T, R, max_dims, src0_pack_size, src1_pack_size, int32_t>(
+        stream, num_dims, src0_dims, src0, src1_dims, src1, dst_dims, dst, count);
+  } else {
+    LaunchKernel<op, T, R, max_dims, src0_pack_size, src1_pack_size, int64_t>(
+        stream, num_dims, src0_dims, src0, src1_dims, src1, dst_dims, dst, count);
+  }
+}
+
+template<BinaryOp op, typename T, typename R, size_t max_dims>
+void DispatchPackSize(Stream* stream, size_t src0_pack_size, size_t src1_pack_size, size_t num_dims,
+                      const int64_t* src0_dims, const void* src0, const int64_t* src1_dims,
+                      const void* src1, const int64_t* dst_dims, void* dst) {
+  void (*func)(Stream* /*stream*/, size_t /*num_dims*/, const int64_t* /*src0_dims*/,
+               const void* /*src0*/, const int64_t* /*src1_dims*/, const void* /*src1*/,
+               const int64_t* /*dst_dims*/, void* /*dst*/) = nullptr;
+  if (src0_pack_size == 1 && src1_pack_size == 1) {
+    func = DispatchIndexType<op, T, R, max_dims, 1, 1>;
+  } else if (src0_pack_size == 4 && src1_pack_size == 4) {
+    func = DispatchIndexType<op, T, R, max_dims, 4, 4>;
+  } else if (src0_pack_size == 1 && src1_pack_size == 4) {
+    func = DispatchIndexType<op, T, R, max_dims, 1, 4>;
+  } else if (src0_pack_size == 4 && src1_pack_size == 1) {
+    func = DispatchIndexType<op, T, R, max_dims, 4, 1>;
+  } else {
+    UNIMPLEMENTED();
+  }
+  func(stream, num_dims, src0_dims, src0, src1_dims, src1, dst_dims, dst);
+}
+
+template<BinaryOp op, typename T, typename R>
+void DispatchNumDims(Stream* stream, size_t src0_pack_size, size_t src1_pack_size, size_t num_dims,
+                     const int64_t* src0_dims, const void* src0, const int64_t* src1_dims,
+                     const void* src1, const int64_t* dst_dims, void* dst) {
+  void (*func)(Stream* /*stream*/, size_t /*src0_pack_size*/, size_t /*src1_pack_size*/,
+               size_t /*num_dims*/, const int64_t* /*src0_dims*/, const void* /*src0*/,
+               const int64_t* /*src1_dims*/, const void* /*src1*/, const int64_t* /*dst_dims*/,
+               void* /*dst*/) = nullptr;
+  CHECK_NE(num_dims, 1);
+  if (num_dims == 2) {
+    func = DispatchPackSize<op, T, R, 2>;
+  } else if (num_dims == 3) {
+    func = DispatchPackSize<op, T, R, 3>;
+  } else if (num_dims == 4) {
+    func = DispatchPackSize<op, T, R, 4>;
+  } else if (num_dims <= 8) {
+    func = DispatchPackSize<op, T, R, 8>;
+  } else {
+    UNIMPLEMENTED();
+  }
+  func(stream, src0_pack_size, src1_pack_size, num_dims, src0_dims, src0, src1_dims, src1, dst_dims,
+       dst);
+}
+
+template<size_t max_pack_size, typename T, typename R>
+size_t GetPackSize(size_t num_src_dims, const int64_t* src0_dims, const void* src0,
+                   const int64_t* src1_dims, const void* src1, void* dst) {
+  static_assert(max_pack_size > 0 && (max_pack_size & (max_pack_size - 1)) == 0, "");
+  CHECK(src0_dims[num_src_dims - 1] != 1 || src1_dims[num_src_dims - 1] != 1);
+  auto dst_ptr = reinterpret_cast<std::uintptr_t>(dst);
+  for (size_t pack_size = max_pack_size; pack_size > 2; pack_size /= 2) {
+    bool is_src0_supported = (src0_dims[num_src_dims - 1] == 1)
+                             || IsPackSizeSupported<T>(pack_size, num_src_dims, src0_dims, src0);
+    bool is_src1_supported = (src1_dims[num_src_dims - 1] == 1)
+                             || IsPackSizeSupported<T>(pack_size, num_src_dims, src1_dims, src1);
+    if (is_src0_supported && is_src1_supported && (dst_ptr % (pack_size * sizeof(R))) == 0) {
+      return pack_size;
+    }
+  }
+  return 1;
+}
+
+constexpr size_t kMaxPackSize = 4;
+
+template<BinaryOp op, typename T, typename R>
+void LaunchWithSimplified(Stream* stream, size_t simplified_num_dims, int64_t* simplified_src0_dims,
+                          const void* src0, int64_t* simplified_src1_dims, const void* src1,
+                          int64_t* simplified_dst_dims, void* dst) {
+  CHECK_LE(simplified_num_dims, kMaxNumDims);
+  size_t pack_size = GetPackSize<kMaxPackSize, T, R>(simplified_num_dims, simplified_src0_dims,
+                                                     src0, simplified_src1_dims, src1, dst);
+  size_t src0_pack_size = 1;
+  size_t src1_pack_size = 1;
+  if (simplified_src0_dims[simplified_num_dims - 1] != 1) {
+    simplified_src0_dims[simplified_num_dims - 1] /= pack_size;
+    src0_pack_size = pack_size;
+  }
+  if (simplified_src1_dims[simplified_num_dims - 1] != 1) {
+    simplified_src1_dims[simplified_num_dims - 1] /= pack_size;
+    src1_pack_size = pack_size;
+  }
+  simplified_dst_dims[simplified_num_dims - 1] /= pack_size;
+  DispatchNumDims<op, T, R>(stream, src0_pack_size, src1_pack_size, simplified_num_dims,
+                            simplified_src0_dims, src0, simplified_src1_dims, src1,
+                            simplified_dst_dims, dst);
+}
+
+template<BinaryOp binary_op, typename Src, typename Dst>
+struct BinaryLhsScalarFunctor {
+  __host__ __device__ explicit BinaryLhsScalarFunctor(Src scalar) : scalar(scalar) {}
+  __device__ Dst operator()(Src src) const {
+    return BinaryFunctor<DeviceType::kCUDA, binary_op, Src, Dst>()(scalar, src);
+  }
+  const Src scalar;
+};
+
+template<BinaryOp binary_op, typename Src, typename Dst>
+struct BinaryRhsScalarFunctor {
+  __host__ __device__ explicit BinaryRhsScalarFunctor(Src scalar) : scalar(scalar) {}
+  __device__ Dst operator()(Src src) const {
+    return BinaryFunctor<DeviceType::kCUDA, binary_op, Src, Dst>()(src, scalar);
+  }
+  const Src scalar;
+};
+
+template<BinaryOp binary_op, typename Src, typename Dst>
+struct BinaryLhsScalarPtrFunctorFactory {
+  __host__ __device__ explicit BinaryLhsScalarPtrFunctorFactory(const Src* scalar_ptr)
+      : scalar_ptr(scalar_ptr) {}
+  __device__ BinaryLhsScalarFunctor<binary_op, Src, Dst> operator()() const {
+    return BinaryLhsScalarFunctor<binary_op, Src, Dst>(*scalar_ptr);
+  }
+  const Src* scalar_ptr;
+};
+
+template<BinaryOp binary_op, typename Src, typename Dst>
+struct BinaryRhsScalarPtrFunctorFactory {
+  __host__ __device__ explicit BinaryRhsScalarPtrFunctorFactory(const Src* scalar_ptr)
+      : scalar_ptr(scalar_ptr) {}
+  __device__ BinaryRhsScalarFunctor<binary_op, Src, Dst> operator()() const {
+    return BinaryRhsScalarFunctor<binary_op, Src, Dst>(*scalar_ptr);
+  }
+  const Src* scalar_ptr;
+};
+
+template<BinaryOp binary_op, typename Src, typename Dst>
+void DispatchLaunch(Stream* stream, size_t num_src0_dims, const int64_t* src0_dims, const Src* src0,
+                    size_t num_src1_dims, const int64_t* src1_dims, const Src* src1, Dst* dst) {
+  auto* cuda_stream = stream->As<CudaStream>();
+  size_t simplified_num_dims = 0;
+  int64_t simplified_src0_dims[kMaxNumDims];
+  int64_t simplified_src1_dims[kMaxNumDims];
+  int64_t simplified_dst_dims[kMaxNumDims];
+  SimplifyBroadcastDims<kMaxNumDims>(num_src0_dims, src0_dims, num_src1_dims, src1_dims,
+                                     &simplified_num_dims, simplified_src0_dims,
+                                     simplified_src1_dims, simplified_dst_dims);
+  CheckInplace(simplified_num_dims, simplified_src0_dims, src0, simplified_src1_dims, src1,
+               simplified_dst_dims, dst);
+  if (IsDimsEquals(simplified_num_dims, simplified_src0_dims, simplified_num_dims,
+                   simplified_src1_dims)) {
+    const int64_t elem_cnt = GetElementCount(simplified_num_dims, simplified_src0_dims);
+    OF_CUDA_CHECK(
+        (cuda::elementwise::Binary(BinaryFunctor<DeviceType::kCUDA, binary_op, Src, Dst>(),
+                                   elem_cnt, dst, src0, src1, cuda_stream->cuda_stream())));
+  } else {
+    if (simplified_num_dims == 1 && simplified_src0_dims[0] == 1) {
+      OF_CUDA_CHECK((cuda::elementwise::UnaryWithFactory(
+          BinaryLhsScalarPtrFunctorFactory<binary_op, Src, Dst>(src0), simplified_src1_dims[0], dst,
+          src1, cuda_stream->cuda_stream())));
+    } else if (simplified_num_dims == 1 && simplified_src1_dims[0] == 1) {
+      OF_CUDA_CHECK((cuda::elementwise::UnaryWithFactory(
+          BinaryRhsScalarPtrFunctorFactory<binary_op, Src, Dst>(src1), simplified_src0_dims[0], dst,
+          src0, cuda_stream->cuda_stream())));
+    } else {
+      LaunchWithSimplified<binary_op, Src, Dst>(stream, simplified_num_dims, simplified_src0_dims,
+                                                src0, simplified_src1_dims, src1,
+                                                simplified_dst_dims, dst);
+    }
+  }
+}
+
+template<typename T>
+T GetValue(Scalar value) {
+  return value.Value<T>();
+}
+
+template<>
+half GetValue<half>(Scalar value) {
+  return static_cast<half>(GetValue<float>(value));
+}
+
+// #if CUDA_VERSION >= 11000
+
+// template<>
+// nv_bfloat16 GetValue<nv_bfloat16>(Scalar value) {
+//   return static_cast<nv_bfloat16>(GetValue<float>(value));
+// }
+
+// #endif  // CUDA_VERSION >= 11000
+
+template<BinaryOp binary_op, typename Src, typename Dst>
+class BroadcastElementwiseBinaryImpl : public BroadcastElementwiseBinary {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(BroadcastElementwiseBinaryImpl);
+  BroadcastElementwiseBinaryImpl() = default;
+  ~BroadcastElementwiseBinaryImpl() override = default;
+
+  void Launch(Stream* stream, Scalar src0, size_t num_src1_dims, const int64_t* src1_dims,
+              const void* src1, void* dst) override {
+    auto* cuda_stream = stream->As<CudaStream>();
+    const size_t elem_cnt = GetElementCount(num_src1_dims, src1_dims);
+    OF_CUDA_CHECK(
+        (cuda::elementwise::Unary(BinaryLhsScalarFunctor<binary_op, Src, Dst>(GetValue<Src>(src0)),
+                                  elem_cnt, reinterpret_cast<Dst*>(dst),
+                                  reinterpret_cast<const Src*>(src1), cuda_stream->cuda_stream())));
+  }
+  void Launch(Stream* stream, size_t num_src0_dims, const int64_t* src0_dims, const void* src0,
+              Scalar src1, void* dst) override {
+    auto* cuda_stream = stream->As<CudaStream>();
+    const size_t elem_cnt = GetElementCount(num_src0_dims, src0_dims);
+    OF_CUDA_CHECK(
+        (cuda::elementwise::Unary(BinaryRhsScalarFunctor<binary_op, Src, Dst>(GetValue<Src>(src1)),
+                                  elem_cnt, reinterpret_cast<Dst*>(dst),
+                                  reinterpret_cast<const Src*>(src0), cuda_stream->cuda_stream())));
+  }
+  void Launch(Stream* stream, size_t num_src0_dims, const int64_t* src0_dims, const void* src0,
+              size_t num_src1_dims, const int64_t* src1_dims, const void* src1,
+              void* dst) override {
+    DispatchLaunch<binary_op, Src, Dst>(
+        stream, num_src0_dims, src0_dims, reinterpret_cast<const Src*>(src0), num_src1_dims,
+        src1_dims, reinterpret_cast<const Src*>(src1), reinterpret_cast<Dst*>(dst));
+  }
+};
+
+}  // namespace
+
+template<BinaryOp binary_op, typename Src, typename Dst>
+std::unique_ptr<BroadcastElementwiseBinary> NewBroadcastElementwiseBinary() {
+  return std::unique_ptr<BroadcastElementwiseBinary>(
+      new BroadcastElementwiseBinaryImpl<binary_op, Src, Dst>());
+}
+
+}  // namespace broadcast_elementwise_binary
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary_comparision.cu
+++ b/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary_comparision.cu
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/hip/primitive/broadcast_elementwise_binary.cuh"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+namespace broadcast_elementwise_binary {
+
+#define INSTANTIATE_NEW_BROADCAST_ELEMENTWISE_BINARY_COMPARASION_ENTRY(               \
+    binary_op, src_data_type_pair, dst_data_type_pair)                                \
+  template std::unique_ptr<BroadcastElementwiseBinary> NewBroadcastElementwiseBinary< \
+      binary_op, OF_PP_PAIR_FIRST(src_data_type_pair), OF_PP_PAIR_FIRST(dst_data_type_pair)>();
+
+OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(INSTANTIATE_NEW_BROADCAST_ELEMENTWISE_BINARY_COMPARASION_ENTRY,
+                                 BINARY_COMPARISION_OP_SEQ, CUDA_PRIMITIVE_ALL_TYPE_SEQ,
+                                 CUDA_PRIMITIVE_BOOL_TYPE_SEQ);
+
+}  // namespace broadcast_elementwise_binary
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary_logical.cu
+++ b/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary_logical.cu
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/hip/primitive/broadcast_elementwise_binary.cuh"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+namespace broadcast_elementwise_binary {
+
+#define INSTANTIATE_NEW_BROADCAST_ELEMENTWISE_BINARY_LOGICAL_ENTRY(binary_op, src_data_type_pair, \
+                                                                   dst_data_type_pair)            \
+  template std::unique_ptr<BroadcastElementwiseBinary> NewBroadcastElementwiseBinary<             \
+      binary_op, OF_PP_PAIR_FIRST(src_data_type_pair), OF_PP_PAIR_FIRST(dst_data_type_pair)>();
+
+OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(INSTANTIATE_NEW_BROADCAST_ELEMENTWISE_BINARY_LOGICAL_ENTRY,
+                                 BINARY_COMPARISION_OP_SEQ BINARY_LOGICAL_OP_SEQ,
+                                 CUDA_PRIMITIVE_ALL_TYPE_SEQ, CUDA_PRIMITIVE_BOOL_TYPE_SEQ);
+
+}  // namespace broadcast_elementwise_binary
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary_math.cu
+++ b/oneflow/core/ep/hip/primitive/broadcast_elementwise_binary_math.cu
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/hip/primitive/broadcast_elementwise_binary.cuh"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+namespace broadcast_elementwise_binary {
+
+#define INSTANTIATE_NEW_BROADCAST_ELEMENTWISE_BINARY_MATH_ENTRY(binary_op, data_type_pair) \
+  template std::unique_ptr<BroadcastElementwiseBinary> NewBroadcastElementwiseBinary<      \
+      binary_op, OF_PP_PAIR_FIRST(data_type_pair), OF_PP_PAIR_FIRST(data_type_pair)>();
+
+OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(INSTANTIATE_NEW_BROADCAST_ELEMENTWISE_BINARY_MATH_ENTRY,
+                                 BINARY_MATH_OP_SEQ, CUDA_PRIMITIVE_ALL_TYPE_SEQ);
+
+}  // namespace broadcast_elementwise_binary
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/broadcast_matmul.cpp
+++ b/oneflow/core/ep/hip/primitive/broadcast_matmul.cpp
@@ -1,0 +1,210 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifdef WITH_HIP
+
+#include "oneflow/core/ep/include/primitive/primitive.h"
+#include "oneflow/core/ep/include/primitive/broadcast_matmul.h"
+#include "oneflow/core/ep/common/primitive/broadcast_matmul.h"
+#include "oneflow/core/common/optional.h"
+#include "oneflow/core/device/cuda_util.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include <hip/hip_runtime.h>
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace broadcast_matmul {
+
+namespace internal {
+
+namespace {
+
+constexpr size_t kMaxNumDims = 8;
+
+Optional<hipblasDatatype_t> OptCudaDataType(DataType data_type) {
+  switch (data_type) {
+    case kFloat: return HIPBLAS_R_32F;
+    case kDouble: return HIPBLAS_R_64F;
+    case kFloat16: return HIPBLAS_R_16F;
+// #if CUDA_VERSION >= 11000
+//     case kBFloat16: return CUDA_R_16BF;
+// #endif  // CUDA_VERSION >= 11000
+    default: return NullOpt;
+  }
+}
+
+hipblasDatatype_t GetCudaDataType(DataType data_type) {
+  auto cuda_data_type = OptCudaDataType(data_type);
+  CHECK(cuda_data_type.has_value());
+  return cuda_data_type.value_or(HIPBLAS_R_32F);
+}
+
+union CublasScalarParameter {
+  double d;
+  float s;
+};
+
+CublasScalarParameter GetCublasScalarParameter(Scalar scalar, hipblasDatatype_t compute_type) {
+  CublasScalarParameter sp{};
+  if (compute_type == HIPBLAS_R_64F) {
+    sp.d = scalar.Value<double>();
+  } else if (compute_type == HIPBLAS_R_32F) {
+    sp.s = scalar.Value<float>();
+  } else {
+    UNIMPLEMENTED();
+  }
+  return sp;
+}
+
+hipblasDatatype_t GetComputeType(DataType data_type) {
+  switch (data_type) {
+    case kFloat: return HIPBLAS_R_32F;
+    case kDouble: return HIPBLAS_R_64F;
+    case kFloat16: return HIPBLAS_R_16F;
+// #if CUDA_VERSION >= 11000
+//     case kBFloat16: return HIPBLAS_R_32F;
+// #endif  // CUDA_VERSION >= 11000
+    default: UNIMPLEMENTED(); return HIPBLAS_R_32F;
+  }
+}
+
+void LaunchBroadcastMatmul(Stream* stream, DataType data_type, BlasTransposeType transpose_a,
+                           BlasTransposeType transpose_b, int64_t num_batch_dims,
+                           const int64_t* broadcast_batch_dims, const int64_t* a_batch_dims,
+                           const int64_t* b_batch_dims, const int64_t* c_batch_dims, int64_t m,
+                           int64_t n, int64_t k, Scalar alpha, const void* a, const void* b,
+                           Scalar beta, void* c) {
+  auto* cuda_stream = stream->As<CudaStream>();
+  const auto cuda_data_type = GetCudaDataType(data_type);
+  const auto compute_type = GetComputeType(data_type);
+  const auto sp_alpha = GetCublasScalarParameter(alpha, compute_type);
+  const auto GetCublasOperation = [](BlasTransposeType transpose_type) {
+    if (transpose_type == BlasTransposeType::N) {
+      return HIPBLAS_OP_N;
+    } else if (transpose_type == BlasTransposeType::T) {
+      return HIPBLAS_OP_T;
+    } else {
+      UNIMPLEMENTED();
+      return HIPBLAS_OP_N;
+    }
+  };
+  const hipblasOperation_t cublas_trans_a = GetCublasOperation(transpose_b);
+  const hipblasOperation_t cublas_trans_b = GetCublasOperation(transpose_a);
+  const int cublas_m = n;
+  const int cublas_n = m;
+  const int cublas_k = k;
+  int cublas_lda = 0;
+  if (transpose_b == BlasTransposeType::N) {
+    cublas_lda = n;
+  } else if (transpose_b == BlasTransposeType::T) {
+    cublas_lda = k;
+  } else {
+    UNIMPLEMENTED();
+  }
+  int cublas_ldb = 0;
+  if (transpose_a == BlasTransposeType::N) {
+    cublas_ldb = k;
+  } else if (transpose_a == BlasTransposeType::T) {
+    cublas_ldb = m;
+  } else {
+    UNIMPLEMENTED();
+  }
+  const int cublas_ldc = n;
+  // CublasMathModeGuard guard(cuda_stream->cublas_handle());
+//   if (data_type == DataType::kFloat16) {
+// #if CUDA_VERSION < 11000
+//     guard.SetMathMode(CUBLAS_TENSOR_OP_MATH);
+// #else
+//     guard.SetMathMode(CUBLAS_DEFAULT_MATH);
+// #endif  // CUDA_VERSION < 11000
+//   }
+// #if CUDA_VERSION >= 11000
+//   hipblasGemmAlgo_t algo = HIPBLAS_GEMM_DEFAULT;
+  hipblasGemmAlgo_t algo = HIPBLAS_GEMM_DEFAULT;  
+// #else
+//   hipblasGemmAlgo_t algo =
+//       (data_type == DataType::kFloat16) ? CUBLAS_GEMM_DFALT_TENSOR_OP : HIPBLAS_GEMM_DEFAULT;
+// #endif
+  if (num_batch_dims == 1 && c_batch_dims[0] != 1) {
+    const void* cublas_a = b;
+    const void* cublas_b = a;
+    void* cublas_c = c;
+    const int64_t a_batch_count = a_batch_dims[0];
+    const int64_t b_batch_count = b_batch_dims[0];
+    CHECK(a_batch_count == 1 || b_batch_count == 1 || a_batch_count == b_batch_count);
+    CHECK_GT(a_batch_count, 0);
+    CHECK_GT(b_batch_count, 0);
+    const int batch_count = std::max(a_batch_count, b_batch_count);
+    const long long int cublas_stride_a = b_batch_count == 1 ? 0 : cublas_m * cublas_k;
+    const long long int cublas_stride_b = a_batch_count == 1 ? 0 : cublas_k * cublas_n;
+    const long long int cublas_stride_c = cublas_m * cublas_n;
+    const auto sp_beta = GetCublasScalarParameter(beta, compute_type);
+    OF_CUBLAS_CHECK(hipblasGemmStridedBatchedEx(
+        cuda_stream->cublas_handle(), cublas_trans_a, cublas_trans_b, cublas_m, cublas_n, cublas_k,
+        &sp_alpha, cublas_a, cuda_data_type, cublas_lda, cublas_stride_a, cublas_b, cuda_data_type,
+        cublas_ldb, cublas_stride_b, &sp_beta, cublas_c, cuda_data_type, cublas_ldc,
+        cublas_stride_c, batch_count, compute_type, algo));
+  } else {
+    auto func = [&](const void* batch_a, const void* batch_b, void* batch_c, Scalar batch_beta) {
+      const auto sp_beta = GetCublasScalarParameter(batch_beta, compute_type);
+      const void* cublas_a = batch_b;
+      const void* cublas_b = batch_a;
+      void* cublas_c = batch_c;
+      OF_CUBLAS_CHECK(hipblasGemmEx(
+          cuda_stream->cublas_handle(), cublas_trans_a, cublas_trans_b, cublas_m, cublas_n,
+          cublas_k, &sp_alpha, cublas_a, cuda_data_type, cublas_lda, cublas_b, cuda_data_type,
+          cublas_ldb, &sp_beta, cublas_c, cuda_data_type, cublas_ldc, compute_type, algo));
+    };
+    ForEachMatmul<kMaxNumDims>(data_type, m, n, k, beta, num_batch_dims, broadcast_batch_dims,
+                               a_batch_dims, b_batch_dims, c_batch_dims, a, b, c, func);
+  }
+}
+
+class BroadcastMatmulFactoryImpl : public BroadcastMatmulFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(BroadcastMatmulFactoryImpl);
+  BroadcastMatmulFactoryImpl() = default;
+  ~BroadcastMatmulFactoryImpl() override = default;
+
+  std::unique_ptr<BroadcastMatmul> New(DataType data_type, BlasTransposeType transpose_a,
+                                       BlasTransposeType transpose_b,
+                                       size_t max_num_dims) override {
+    auto cuda_data_type = OptCudaDataType(data_type);
+    if (max_num_dims <= kMaxNumDims && cuda_data_type.has_value()) {
+      return std::make_unique<BroadcastMatmulImpl<kMaxNumDims>>(data_type, transpose_a,
+                                                                transpose_b);
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, BroadcastMatmulFactory, BroadcastMatmulFactoryImpl);
+
+}  // namespace
+
+}  // namespace internal
+
+}  // namespace broadcast_matmul
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP

--- a/oneflow/core/ep/hip/primitive/cast.cu
+++ b/oneflow/core/ep/hip/primitive/cast.cu
@@ -1,0 +1,147 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/primitive/cast.h"
+#include "oneflow/core/ep/hip/primitive/type_seq.h"
+#include "oneflow/core/cuda/elementwise.cuh"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+template<typename To, typename From, typename = void>
+struct CastFunctor {
+  __device__ To operator()(From from) const { return static_cast<To>(from); }
+};
+
+template<typename To>
+struct CastFunctor<To, half, typename std::enable_if<!std::is_same<To, half>::value>::type> {
+  __device__ To operator()(half from) const { return static_cast<To>(static_cast<float>(from)); }
+
+  __device__ void Apply2(To* to, const half* from) const {
+    const float2 f2 = __half22float2(*reinterpret_cast<const half2*>(from));
+    to[0] = static_cast<To>(f2.x);
+    to[1] = static_cast<To>(f2.y);
+  }
+};
+
+template<typename From>
+struct CastFunctor<half, From, typename std::enable_if<!std::is_same<From, half>::value>::type> {
+  __device__ half operator()(From from) const {
+    return static_cast<half>(static_cast<float>(from));
+  }
+
+  __device__ void Apply2(half* to, const From* from) const {
+    float2 f2;
+    f2.x = static_cast<float>(from[0]);
+    f2.y = static_cast<float>(from[1]);
+    *reinterpret_cast<half2*>(to) = __float22half2_rn(f2);
+  }
+};
+
+// #if CUDA_VERSION >= 11000
+
+// template<typename To>
+// struct CastFunctor<To, nv_bfloat16,
+//                    typename std::enable_if<!(std::is_same<To, nv_bfloat16>::value
+//                                              || std::is_same<To, half>::value)>::type> {
+//   __device__ To operator()(nv_bfloat16 from) const {
+//     return static_cast<To>(static_cast<float>(from));
+//   }
+// };
+
+// template<typename From>
+// struct CastFunctor<nv_bfloat16, From,
+//                    typename std::enable_if<!(std::is_same<From, nv_bfloat16>::value
+//                                              || std::is_same<From, half>::value)>::type> {
+//   __device__ nv_bfloat16 operator()(From from) const {
+//     return static_cast<nv_bfloat16>(static_cast<float>(from));
+//   }
+// };
+
+// #endif  // CUDA_VERSION >= 11000
+
+template<typename From, typename To>
+class CastImpl : public Cast {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CastImpl);
+  explicit CastImpl() = default;
+  ~CastImpl() override = default;
+
+  void Launch(Stream* stream, const void* from, void* to, size_t count) override {
+    auto* cuda_stream = stream->As<CudaStream>();
+    OF_CUDA_CHECK((cuda::elementwise::Unary<CastFunctor<To, From>, To, From>(
+        CastFunctor<To, From>(), count, reinterpret_cast<To*>(to),
+        reinterpret_cast<const From*>(from), cuda_stream->cuda_stream())));
+  }
+};
+
+template<typename From, typename To>
+std::unique_ptr<Cast> NewCast() {
+  return std::unique_ptr<Cast>(new CastImpl<From, To>());
+}
+
+#define CUDA_PRIMITIVE_CAST_TYPE_SEQ \
+  CUDA_PRIMITIVE_BOOL_TYPE_SEQ       \
+  CUDA_PRIMITIVE_CHAR_TYPE_SEQ       \
+  CUDA_PRIMITIVE_INT8_TYPE_SEQ       \
+  CUDA_PRIMITIVE_UINT8_TYPE_SEQ      \
+  CUDA_PRIMITIVE_INT32_TYPE_SEQ      \
+  CUDA_PRIMITIVE_UINT32_TYPE_SEQ     \
+  CUDA_PRIMITIVE_INT64_TYPE_SEQ      \
+  CUDA_PRIMITIVE_UINT64_TYPE_SEQ     \
+  CUDA_PRIMITIVE_FLOAT_TYPE_SEQ      \
+  CUDA_PRIMITIVE_DOUBLE_TYPE_SEQ     \
+  CUDA_PRIMITIVE_FLOAT16_TYPE_SEQ    \
+  CUDA_PRIMITIVE_BFLOAT16_TYPE_SEQ
+
+class CastFactoryImpl : public CastFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CastFactoryImpl);
+  CastFactoryImpl() = default;
+  ~CastFactoryImpl() override = default;
+
+  std::unique_ptr<Cast> New(DataType from, DataType to) override {
+#define MAKE_NEW_CAST_ENTRY(from_pair, to_pair)                              \
+  {std::make_pair(OF_PP_PAIR_SECOND(from_pair), OF_PP_PAIR_SECOND(to_pair)), \
+   NewCast<OF_PP_PAIR_FIRST(from_pair), OF_PP_PAIR_FIRST(to_pair)>},
+
+    static const std::map<std::pair<DataType, DataType>, std::function<std::unique_ptr<Cast>()>>
+        new_cast_handle{OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(
+            MAKE_NEW_CAST_ENTRY, CUDA_PRIMITIVE_CAST_TYPE_SEQ, CUDA_PRIMITIVE_CAST_TYPE_SEQ)};
+
+#undef MAKE_NEW_CAST_ENTRY
+
+    const auto it = new_cast_handle.find(std::make_pair(from, to));
+    if (it != new_cast_handle.end()) {
+      return it->second();
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, CastFactory, CastFactoryImpl);
+
+}  // namespace
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/copy_nd.cu
+++ b/oneflow/core/ep/hip/primitive/copy_nd.cu
@@ -1,0 +1,95 @@
+#include "hip/hip_runtime.h"
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "oneflow/core/ep/include/primitive/copy_nd.h"
+#include "oneflow/core/ep/common/primitive/copy_nd.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include <hip/hip_runtime.h>
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+template<size_t num_dims, size_t movement_size, typename IndexType>
+__global__ void CopyNdKernel(CopyNdKernelParams<num_dims, IndexType> params) {
+  using T = typename std::aligned_storage<movement_size, movement_size>::type;
+  const T* src = reinterpret_cast<const T*>(params.src);
+  T* dst = reinterpret_cast<T*>(params.dst);
+  IndexType copy_index[num_dims];
+  IndexType src_index[num_dims];
+  IndexType dst_index[num_dims];
+  CUDA_1D_KERNEL_LOOP_T(IndexType, i, params.count) {
+    params.copy_index_helper.OffsetToNdIndex(i, copy_index);
+#pragma unroll
+    for (size_t j = 0; j < num_dims; ++j) {
+      src_index[j] = params.src_pos[j] + copy_index[j];
+      dst_index[j] = params.dst_pos[j] + copy_index[j];
+    }
+    const IndexType src_offset = params.src_index_helper.NdIndexToOffset(src_index);
+    const IndexType dst_offset = params.dst_index_helper.NdIndexToOffset(dst_index);
+    dst[dst_offset] = src[src_offset];
+  }
+}
+
+template<size_t num_dims, size_t movement_size, typename IndexType>
+void LaunchKernel(Stream* stream, CopyNdKernelParams<num_dims, IndexType> params) {
+  hipStream_t cuda_stream = stream->As<CudaStream>()->cuda_stream();
+  CopyNdKernel<num_dims, movement_size, IndexType>
+      <<<BlocksNum4ThreadsNum(params.count), kCudaThreadsNumPerBlock, 0, cuda_stream>>>(params);
+}
+
+class CopyNdImpl : public CopyNd {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CopyNdImpl);
+  CopyNdImpl() = default;
+  ~CopyNdImpl() override = default;
+
+  void Launch(Stream* stream, DataType data_type, size_t num_dims, void* dst,
+              const int64_t* dst_dims, const int64_t* dst_pos, const void* src,
+              const int64_t* src_dims, const int64_t* src_pos,
+              const int64_t* extent) const override {
+    SimplifyThenLaunch(stream, data_type, num_dims, dst, dst_dims, dst_pos, src, src_dims, src_pos,
+                       extent);
+  }
+};
+
+class CopyNdFactoryImpl : public CopyNdFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CopyNdFactoryImpl);
+  CopyNdFactoryImpl() = default;
+  ~CopyNdFactoryImpl() override = default;
+
+  std::unique_ptr<CopyNd> New(size_t max_num_dims) override {
+    if (max_num_dims <= kMaxNumDims) {
+      return std::unique_ptr<CopyNd>(new CopyNdImpl());
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, CopyNdFactory, CopyNdFactoryImpl);
+
+}  // namespace
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/elementwise_unary.cu
+++ b/oneflow/core/ep/hip/primitive/elementwise_unary.cu
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/common/primitive/elementwise_unary.h"
+#include "oneflow/core/ep/hip/primitive/unary_functor.cuh"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+template<UnaryOp unary_op, typename Src, typename Dst>
+class ElementwiseUnaryImpl : public ElementwiseUnary {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(ElementwiseUnaryImpl);
+  ElementwiseUnaryImpl() = default;
+  ~ElementwiseUnaryImpl() override = default;
+
+  void Launch(Stream* stream, const void* src, void* dst, size_t count) override {
+    auto* cuda_stream = stream->As<CudaStream>();
+    OF_CUDA_CHECK(
+        (cuda::elementwise::Unary<UnaryFunctor<DeviceType::kCUDA, unary_op, Dst, Src>, Dst, Src>(
+            UnaryFunctor<DeviceType::kCUDA, unary_op, Dst, Src>(), count,
+            reinterpret_cast<Dst*>(dst), reinterpret_cast<const Src*>(src),
+            cuda_stream->cuda_stream())));
+  }
+};
+
+template<UnaryOp unary_op, typename Src, typename Dst>
+std::unique_ptr<ElementwiseUnary> NewElementwiseUnary() {
+  return std::unique_ptr<ElementwiseUnary>(new ElementwiseUnaryImpl<unary_op, Src, Dst>());
+}
+
+class ElementwiseUnaryFactoryImpl : public ElementwiseUnaryFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(ElementwiseUnaryFactoryImpl);
+  ElementwiseUnaryFactoryImpl() = default;
+  ~ElementwiseUnaryFactoryImpl() override = default;
+
+  std::unique_ptr<ElementwiseUnary> New(UnaryOp unary_op, DataType src_type,
+                                        DataType dst_dtype) override {
+#define MAKE_NEW_SAME_DTYPE_ELEMENTWISE_UNARY_ENTRY(unary_op, dtype_pair)                   \
+  {std::make_tuple(unary_op, OF_PP_PAIR_SECOND(dtype_pair), OF_PP_PAIR_SECOND(dtype_pair)), \
+   NewElementwiseUnary<unary_op, OF_PP_PAIR_FIRST(dtype_pair), OF_PP_PAIR_FIRST(dtype_pair)>},
+
+#define MAKE_NEW_DIFFERENT_DTYPE_ELEMENTWISE_UNARY_ENTRY(unary_op, src_type_pair, dst_dtype_pair)  \
+  {std::make_tuple(unary_op, OF_PP_PAIR_SECOND(src_type_pair), OF_PP_PAIR_SECOND(dst_dtype_pair)), \
+   NewElementwiseUnary<unary_op, OF_PP_PAIR_FIRST(src_type_pair),                                  \
+                       OF_PP_PAIR_FIRST(dst_dtype_pair)>},
+
+    static const std::map<std::tuple<UnaryOp, DataType, DataType>,
+                          std::function<std::unique_ptr<ElementwiseUnary>()>>
+        new_elementwise_unary_handle{
+            // For All Type OP
+            OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(MAKE_NEW_SAME_DTYPE_ELEMENTWISE_UNARY_ENTRY,
+                                             UNARY_MATH_OP_SEQ, CUDA_PRIMITIVE_ALL_TYPE_SEQ)
+            // For Float Type OP
+            OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(MAKE_NEW_SAME_DTYPE_ELEMENTWISE_UNARY_ENTRY,
+                                             UNARY_FLOATING_MATH_OP_SEQ,
+                                             CUDA_PRIMITIVE_FLOATING_TYPE_SEQ)
+            // For Logical OP
+            OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(MAKE_NEW_DIFFERENT_DTYPE_ELEMENTWISE_UNARY_ENTRY,
+                                             UNARY_LOGICAL_OP_SEQ, CUDA_PRIMITIVE_ALL_TYPE_SEQ,
+                                             CUDA_PRIMITIVE_BOOL_TYPE_SEQ)};
+
+#undef MAKE_NEW_DIFFERENT_DTYPE_ELEMENTWISE_UNARY_ENTRY
+
+#undef MAKE_NEW_SAME_DTYPE_ELEMENTWISE_UNARY_ENTRY
+    const auto it =
+        new_elementwise_unary_handle.find(std::make_tuple(unary_op, src_type, dst_dtype));
+    if (it != new_elementwise_unary_handle.end()) {
+      return it->second();
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, ElementwiseUnaryFactory, ElementwiseUnaryFactoryImpl);
+
+}  // namespace
+}  // namespace primitive
+}  // namespace ep
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/fill.cu
+++ b/oneflow/core/ep/hip/primitive/fill.cu
@@ -1,0 +1,151 @@
+#include "hip/hip_runtime.h"
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/primitive/fill.h"
+#include "oneflow/core/ep/hip/primitive/type_seq.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+template<size_t size>
+using Storage = typename std::aligned_storage<size, size>::type;
+
+template<typename T, size_t pack>
+union Pack {
+  static constexpr size_t size = sizeof(T) * pack;
+  explicit __device__ __host__ Pack(T value) {
+    static_assert(sizeof(Pack) == size, "");
+    static_assert(alignof(Pack) == size, "");
+#pragma unroll
+    for (size_t i = 0; i < pack; ++i) { elem[i] = value; }
+  }
+  T elem[pack];
+  Storage<size> storage;
+};
+
+template<typename T, size_t pack>
+__global__ void FillGpu(T* dst, T value, size_t count) {
+  const size_t pack_count = count / pack;
+  Pack<T, pack> pack_value(value);
+  auto* pack_dst = reinterpret_cast<decltype(pack_value.storage)*>(dst);
+  CUDA_1D_KERNEL_LOOP_T(size_t, i, pack_count) { pack_dst[i] = pack_value.storage; }
+  T* tail_dst = dst + pack_count * pack;
+  const size_t tail_count = count - pack_count * pack;
+  CUDA_1D_KERNEL_LOOP_T(size_t, i, tail_count) { tail_dst[i] = value; }
+}
+
+template<typename T>
+T GetValue(Scalar value) {
+  return value.Value<T>();
+}
+
+template<>
+half GetValue<half>(Scalar value) {
+  return static_cast<half>(GetValue<float>(value));
+}
+
+// #if CUDA_VERSION >= 11000
+
+// template<>
+// nv_bfloat16 GetValue<nv_bfloat16>(Scalar value) {
+//   return static_cast<nv_bfloat16>(GetValue<float>(value));
+// }
+
+// #endif  // CUDA_VERSION >= 11000
+
+template<typename T, size_t pack>
+typename std::enable_if<(pack != 0), void>::type LaunchPackFill(hipStream_t stream, T* dst,
+                                                                T value, size_t count) {
+  FillGpu<T, pack>
+      <<<BlocksNum4ThreadsNum(count), kCudaThreadsNumPerBlock, 0, stream>>>(dst, value, count);
+}
+
+template<typename T, size_t pack>
+typename std::enable_if<(pack == 0), void>::type LaunchPackFill(hipStream_t stream, T* dst,
+                                                                T value, size_t count) {
+  LOG(FATAL) << "wrong alignment";
+}
+
+template<typename T>
+void LaunchFill(hipStream_t stream, T* dst, T value, size_t count) {
+  auto uintptr = reinterpret_cast<std::uintptr_t>(dst);
+  if (uintptr % 16 == 0) {
+    LaunchPackFill<T, 16 / sizeof(T)>(stream, dst, value, count);
+  } else if (uintptr % 8 == 0) {
+    LaunchPackFill<T, 8 / sizeof(T)>(stream, dst, value, count);
+  } else if (uintptr % 4 == 0) {
+    LaunchPackFill<T, 4 / sizeof(T)>(stream, dst, value, count);
+  } else if (uintptr % 2 == 0) {
+    LaunchPackFill<T, 2 / sizeof(T)>(stream, dst, value, count);
+  } else {
+    LaunchPackFill<T, 1 / sizeof(T)>(stream, dst, value, count);
+  }
+}
+
+template<typename T>
+class FillImpl : public Fill {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(FillImpl);
+  FillImpl() = default;
+  ~FillImpl() override = default;
+
+  void Launch(Stream* stream, void* dst, Scalar value, size_t count) override {
+    hipStream_t cuda_stream = stream->As<CudaStream>()->cuda_stream();
+    LaunchFill<T>(cuda_stream, reinterpret_cast<T*>(dst), GetValue<T>(value), count);
+  }
+};
+
+template<typename T>
+std::unique_ptr<Fill> NewFill() {
+  return std::unique_ptr<Fill>(new FillImpl<T>());
+}
+
+class FillFactoryImpl : public FillFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(FillFactoryImpl);
+  FillFactoryImpl() = default;
+  ~FillFactoryImpl() override = default;
+
+  std::unique_ptr<Fill> New(DataType data_type) override {
+#define MAKE_NEW_FILL_ENTRY(type_cpp, type_proto) {type_proto, NewFill<type_cpp>},
+
+    static const std::map<DataType, std::function<std::unique_ptr<Fill>()>> new_fill_handle{
+        OF_PP_FOR_EACH_TUPLE(MAKE_NEW_FILL_ENTRY, CUDA_PRIMITIVE_ALL_TYPE_SEQ)};
+
+#undef MAKE_NEW_FILL_ENTRY
+
+    const auto it = new_fill_handle.find(data_type);
+    if (it != new_fill_handle.end()) {
+      return it->second();
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, FillFactory, FillFactoryImpl);
+
+}  // namespace
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/memcpy.cpp
+++ b/oneflow/core/ep/hip/primitive/memcpy.cpp
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifdef WITH_HIP
+
+#include "oneflow/core/ep/include/primitive/memcpy.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include <hip/hip_runtime.h>
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+class MemcpyImpl : public Memcpy {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(MemcpyImpl);
+  MemcpyImpl() = default;
+  ~MemcpyImpl() override = default;
+
+  void Launch(Stream* stream, void* dst, const void* src, size_t count) override {
+    if (dst == src) { return; }
+    auto* cuda_stream = stream->As<CudaStream>();
+    OF_CUDA_CHECK(hipMemcpyAsync(dst, src, count, hipMemcpyDefault, cuda_stream->cuda_stream()));
+  }
+};
+
+class MemcpyFactoryImpl : public MemcpyFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(MemcpyFactoryImpl);
+  MemcpyFactoryImpl() = default;
+  ~MemcpyFactoryImpl() override = default;
+
+  std::unique_ptr<Memcpy> New(MemcpyKind kind) override {
+    return std::unique_ptr<Memcpy>(new MemcpyImpl());
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, MemcpyFactory, MemcpyFactoryImpl);
+
+}  // namespace
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif

--- a/oneflow/core/ep/hip/primitive/memset.cpp
+++ b/oneflow/core/ep/hip/primitive/memset.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifdef WITH_HIP
+
+#include "oneflow/core/ep/include/primitive/memset.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include <hip/hip_runtime.h>
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+class MemsetImpl : public Memset {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(MemsetImpl);
+  MemsetImpl() = default;
+  ~MemsetImpl() override = default;
+
+  void Launch(Stream* stream, void* ptr, int value, size_t count) override {
+    auto* cuda_stream = stream->As<CudaStream>();
+    OF_CUDA_CHECK(hipMemsetAsync(ptr, value, count, cuda_stream->cuda_stream()));
+  }
+};
+
+class MemsetFactoryImpl : public MemsetFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(MemsetFactoryImpl);
+  MemsetFactoryImpl() = default;
+  ~MemsetFactoryImpl() override = default;
+
+  std::unique_ptr<Memset> New() override { return std::unique_ptr<Memset>(new MemsetImpl()); }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, MemsetFactory, MemsetFactoryImpl);
+
+}  // namespace
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow
+
+#endif

--- a/oneflow/core/ep/hip/primitive/permute.cu
+++ b/oneflow/core/ep/hip/primitive/permute.cu
@@ -1,0 +1,333 @@
+#include "hip/hip_runtime.h"
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/primitive/permute.h"
+#include "oneflow/core/ep/common/primitive/permute_impl.h"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+#include <hip/hip_runtime.h>
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace permute {
+
+namespace internal {
+
+namespace {
+
+constexpr int32_t kMov4TileSize = 32;
+constexpr int32_t kMov2TileSize = 64;
+constexpr int32_t kBlockRows = 8;
+
+template<size_t num_dims, size_t movement_size, typename IndexType>
+__global__ void PermuteKernel(PermuteKernelParams<num_dims, IndexType> params) {
+  using T = typename std::aligned_storage<movement_size, movement_size>::type;
+  const T* src = reinterpret_cast<const T*>(params.src);
+  T* dst = reinterpret_cast<T*>(params.dst);
+  IndexType src_index[num_dims];
+  IndexType dst_index[num_dims];
+  CUDA_1D_KERNEL_LOOP_T(IndexType, i, params.count) {
+    params.dst_index_helper.OffsetToNdIndex(i, dst_index);
+#pragma unroll
+    for (size_t dim = 0; dim < num_dims; ++dim) {
+      src_index[params.permutation[dim]] = dst_index[dim];
+    }
+    IndexType src_offset = params.src_index_helper.NdIndexToOffset(src_index);
+    dst[i] = src[src_offset];
+  }
+}
+
+// (B, X, Y) -> (B, Y, X)
+// refer from https://developer.nvidia.com/blog/efficient-matrix-transpose-cuda-cc/
+template<size_t num_dims, size_t movement_size, size_t tile_size, typename IndexType>
+__global__ void BatchTransposeKernel(const void* src_ptr, void* dst_ptr, IndexType rows,
+                                     IndexType cols, IndexType num_tile_rows,
+                                     IndexType num_tile_cols, int32_t block_nums) {
+  const IndexType src_rows = rows;
+  const IndexType src_cols = cols;
+  const IndexType dst_rows = cols;
+  const IndexType dst_cols = rows;
+
+  using T = typename std::aligned_storage<movement_size, movement_size>::type;
+  __shared__ T tile[tile_size][tile_size + 1];  // To avoid bank conflict.
+
+  const T* src = reinterpret_cast<const T*>(src_ptr);
+  T* dst = reinterpret_cast<T*>(dst_ptr);
+
+  IndexType batch_num_tile = num_tile_rows * num_tile_cols;
+  for (int i = blockIdx.x, step = gridDim.x; i < block_nums; i += step) {
+    const IndexType batch_index = i / batch_num_tile;  // the index of batch.
+    const IndexType tile_index =
+        i - batch_index * batch_num_tile;  // equal to i % (num_tile_rows*num_tile_cols). the
+                                           // flatten index of tile in a batch.
+
+    const IndexType tile_row_index =
+        tile_index / num_tile_cols;  // the row index of tile in a batch.
+    const IndexType tile_col_index =
+        tile_index
+        - tile_row_index
+              * num_tile_cols;  // equal to k % num_tile_cols. the col index of tile in a batch.
+
+    const IndexType offset = batch_index * src_rows * src_cols;
+    {
+      IndexType col_in_tile = threadIdx.x;
+      IndexType col_in_matrix = tile_col_index * tile_size + threadIdx.x;
+#pragma unroll
+      for (IndexType row_in_tile = threadIdx.y; row_in_tile < tile_size;
+           row_in_tile += kBlockRows) {
+        IndexType row_in_matrix = row_in_tile + tile_row_index * tile_size;
+        if (col_in_matrix < src_cols && row_in_matrix < src_rows) {
+          tile[row_in_tile][col_in_tile] = src[offset + row_in_matrix * src_cols + col_in_matrix];
+        }
+      }
+    }
+    __syncthreads();
+    {
+      IndexType col_in_tile = threadIdx.x;
+      IndexType col_in_matrix = tile_row_index * tile_size + threadIdx.x;
+#pragma unroll
+      for (IndexType row_in_tile = threadIdx.y; row_in_tile < tile_size;
+           row_in_tile += kBlockRows) {
+        IndexType row_in_matrix = row_in_tile + tile_col_index * tile_size;
+        if (col_in_matrix < dst_cols && row_in_matrix < dst_rows) {
+          dst[offset + row_in_matrix * dst_cols + col_in_matrix] = tile[col_in_tile][row_in_tile];
+        }
+      }
+    }
+    __syncthreads();
+  }
+}
+
+/*
+Here is a Movementsie=2 version of Batch Transpose.
+When the H W can be divided by 2. we can read data use movementsize=4, and write back as
+movementsize=4.
+*/
+template<size_t num_dims, size_t tile_size, typename IndexType>
+__global__ void BatchTransposeMovement2Kernel(const void* src_ptr, void* dst_ptr, IndexType rows,
+                                              IndexType cols, IndexType num_tile_rows,
+                                              IndexType num_tile_cols, int32_t block_nums) {
+  const IndexType src_rows = rows;
+  const IndexType src_cols = cols;
+  const IndexType dst_rows = cols;
+  const IndexType dst_cols = rows;
+
+  static_assert(tile_size % 2 == 0, "");
+  using T_MOV2 = typename std::aligned_storage<2, 2>::type;
+  using T_MOV4 = typename std::aligned_storage<4, 4>::type;
+
+  const T_MOV4* src = reinterpret_cast<const T_MOV4*>(src_ptr);
+  T_MOV4* dst = reinterpret_cast<T_MOV4*>(dst_ptr);
+
+  // Use union structure to process Load and Store.
+  __shared__ union {
+    T_MOV2 tile_m2[tile_size][tile_size + 2];      // half [64][66]
+    T_MOV4 tile_m4[tile_size][tile_size / 2 + 1];  // half2 [64][33]
+  } tile_mem;
+
+  IndexType batch_num_tile = num_tile_rows * num_tile_cols;
+  for (int i = blockIdx.x, step = gridDim.x; i < block_nums; i += step) {
+    const IndexType batch_index = i / batch_num_tile;  // the index of batch.
+    const IndexType tile_index =
+        i - batch_index * batch_num_tile;  // equal to i % (num_tile_rows*num_tile_cols). the
+                                           // flatten index of tile in a batch.
+
+    const IndexType tile_row_index =
+        tile_index / num_tile_cols;  // the row index of tile in a batch.
+    const IndexType tile_col_index =
+        tile_index
+        - tile_row_index
+              * num_tile_cols;  // equal to k % num_tile_cols. the col index of tile in a batch.
+
+    const IndexType offset = batch_index * src_rows * src_cols;
+    {
+      IndexType col_in_tile = threadIdx.x;
+      IndexType col_in_matrix = tile_col_index * tile_size + threadIdx.x * 2;
+#pragma unroll
+      for (IndexType row_in_tile = threadIdx.y; row_in_tile < tile_size;
+           row_in_tile += kBlockRows) {
+        IndexType row_in_matrix = row_in_tile + tile_row_index * tile_size;
+        if (col_in_matrix < src_cols && row_in_matrix < src_rows) {
+          tile_mem.tile_m4[row_in_tile][col_in_tile] =
+              src[(offset + row_in_matrix * src_cols + col_in_matrix) / 2];
+        }
+      }
+    }
+    __syncthreads();
+    {
+      IndexType col_in_tile = threadIdx.x;
+      IndexType col_in_matrix = tile_row_index * tile_size + threadIdx.x * 2;
+#pragma unroll
+      for (IndexType row_in_tile = threadIdx.y; row_in_tile < tile_size;
+           row_in_tile += kBlockRows) {
+        IndexType row_in_matrix = row_in_tile + tile_col_index * tile_size;
+        union {
+          T_MOV4 m4;
+          T_MOV2 m2[2];
+        } tmp_storage;
+
+        if (col_in_matrix < dst_cols && row_in_matrix < dst_rows) {
+          tmp_storage.m2[0] = tile_mem.tile_m2[col_in_tile * 2][row_in_tile];
+          tmp_storage.m2[1] = tile_mem.tile_m2[col_in_tile * 2 + 1][row_in_tile];
+          dst[(offset + row_in_matrix * dst_cols + col_in_matrix) / 2] = tmp_storage.m4;
+        }
+      }
+    }
+    __syncthreads();
+  }
+}
+
+template<size_t num_dims, size_t movement_size, size_t tile_size, typename IndexType>
+void LaunchBatchTransposeKernel(hipStream_t& cuda_stream,
+                                const PermuteKernelParams<num_dims, IndexType>& params,
+                                const IndexType& num_batches, const IndexType& rows,
+                                const IndexType& cols) {
+  IndexType num_tile_rows = (rows + tile_size - 1) / tile_size;
+  IndexType num_tile_cols = (cols + tile_size - 1) / tile_size;
+  const int32_t block_nums = num_batches * num_tile_rows * num_tile_cols;
+  int32_t launched_block_nums = std::min(block_nums, kCudaMaxBlocksNum);
+  if (tile_size == kMov2TileSize) {
+    const int32_t half2_thread = tile_size / 2;  // cause each thread process two half elements.
+    BatchTransposeMovement2Kernel<num_dims, kMov2TileSize, IndexType>
+        <<<launched_block_nums, dim3(half2_thread, kBlockRows), 0, cuda_stream>>>(
+            params.src, params.dst, rows, cols, num_tile_rows, num_tile_cols,
+            block_nums);  // Set threads num as 32x8 cause each threads
+                          // process 4 elements to 64x66 half share memory.
+  } else {
+    BatchTransposeKernel<num_dims, movement_size, tile_size, IndexType>
+        <<<launched_block_nums, dim3(tile_size, kBlockRows), 0, cuda_stream>>>(
+            params.src, params.dst, rows, cols, num_tile_rows, num_tile_cols, block_nums);
+  }
+}
+
+template<size_t tile_size, typename IndexType>
+bool CheckIfGreaterEqualThanTileSize(const IndexType& rows, const IndexType& cols) {
+  if (rows < tile_size || cols < tile_size) { return false; }
+  return true;
+}
+
+template<size_t num_dims, size_t tile_size, typename IndexType>
+bool CheckLaunchBatchTranspose(const int* permutation, const IndexType& num_batches,
+                               const IndexType& rows, const IndexType& cols) {
+  if (CheckIfGreaterEqualThanTileSize<tile_size, IndexType>(rows, cols)) {
+    if (num_batches == 1 && permutation[1] == 0 && permutation[0] == 1) {
+      // 2d tensor case: (0, 1) -> (1, 0)
+      return true;
+    } else if (num_dims == 3 && permutation[2] == 1 && permutation[1] == 2) {
+      // 3d tensor case: (0, 1, 2) -> (0, 2, 1)
+      return true;
+    } else {
+      return false;
+    }
+  }
+  return false;
+}
+
+template<typename IndexType, size_t movement_size>
+bool CheckUseMov2(const IndexType& rows, const IndexType& cols, const void* src, void* dst) {
+  auto src_ptr = reinterpret_cast<std::uintptr_t>(src);
+  auto dst_ptr = reinterpret_cast<std::uintptr_t>(dst);
+  return (movement_size == 2) && (rows % 2 == 0) && (cols % 2 == 0) && (src_ptr % 4 == 0)
+         && (dst_ptr % 4 == 0);
+}
+
+template<size_t num_dims, typename IndexType>
+void InferBatchTransposeShape(const int64_t* src_dims, IndexType* num_batches, IndexType* rows,
+                              IndexType* cols) {
+  if (num_dims == 2) {
+    *num_batches = 1;
+    *rows = src_dims[0];
+    *cols = src_dims[1];
+  } else {
+    *num_batches = src_dims[0];
+    *rows = src_dims[1];
+    *cols = src_dims[2];
+  }
+}
+
+template<size_t num_dims, size_t movement_size, typename IndexType>
+void LaunchKernel(Stream* stream, const int64_t* src_dims, const void* src, const int* permutation,
+                  void* dst, size_t count) {
+  PermuteKernelParams<num_dims, IndexType> params =
+      MakePermuteParams<num_dims, IndexType>(src_dims, src, permutation, dst, count);
+  hipStream_t cuda_stream = stream->As<CudaStream>()->cuda_stream();
+
+  if (num_dims == 2 || num_dims == 3) {
+    IndexType num_batches;
+    IndexType rows;
+    IndexType cols;
+    InferBatchTransposeShape<num_dims, IndexType>(src_dims, &num_batches, &rows, &cols);
+    if (CheckLaunchBatchTranspose<num_dims, kMov4TileSize>(params.permutation, num_batches, rows,
+                                                           cols)) {
+      if (CheckUseMov2<IndexType, movement_size>(rows, cols, src, dst)) {
+        LaunchBatchTransposeKernel<num_dims, 2, kMov2TileSize, IndexType>(cuda_stream, params,
+                                                                          num_batches, rows, cols);
+      } else {
+        LaunchBatchTransposeKernel<num_dims, movement_size, kMov4TileSize, IndexType>(
+            cuda_stream, params, num_batches, rows, cols);
+      }
+    } else {
+      PermuteKernel<num_dims, movement_size, IndexType>
+          <<<BlocksNum4ThreadsNum(params.count), kCudaThreadsNumPerBlock, 0, cuda_stream>>>(params);
+    }
+  } else {
+    PermuteKernel<num_dims, movement_size, IndexType>
+        <<<BlocksNum4ThreadsNum(params.count), kCudaThreadsNumPerBlock, 0, cuda_stream>>>(params);
+  }
+}
+
+class PermuteImpl : public Permute {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(PermuteImpl);
+  PermuteImpl() = default;
+  ~PermuteImpl() override = default;
+
+  using Permute::Launch;
+  void Launch(Stream* stream, DataType data_type, size_t num_dims, const int64_t* src_dims,
+              const void* src, const int* permutation, void* dst) override {
+    SimplifyThenLaunch(stream, data_type, num_dims, src_dims, src, permutation, dst);
+  }
+};
+
+class PermuteFactoryImpl : public PermuteFactory {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(PermuteFactoryImpl);
+  PermuteFactoryImpl() = default;
+  ~PermuteFactoryImpl() override = default;
+
+  std::unique_ptr<Permute> New(size_t max_num_dims) override {
+    if (max_num_dims <= kMaxNumDims) {
+      return std::unique_ptr<Permute>(new PermuteImpl());
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, PermuteFactory, PermuteFactoryImpl);
+
+}  // namespace
+
+}  // namespace internal
+
+}  // namespace permute
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/softmax.cu
+++ b/oneflow/core/ep/hip/primitive/softmax.cu
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/primitive/softmax.h"
+#include "oneflow/core/ep/include/primitive/log_softmax.h"
+#include "oneflow/core/ep/hip/primitive/type_seq.h"
+#include "oneflow/core/cuda/softmax.cuh"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+enum class Algorithm {
+  kSoftmax,
+  kLogSoftmax,
+};
+
+template<Algorithm algorithm, typename T>
+void SoftmaxGpu(hipStream_t cuda_stream, size_t rows, size_t cols, const T* x, T* y) {
+  using ComputeType = typename cuda::softmax::DefaultComputeType<T>::type;
+  oneflow::cuda::softmax::DirectLoad<T, ComputeType> load(x, cols);
+  oneflow::cuda::softmax::DirectStore<ComputeType, T> store(y, cols);
+  if (algorithm == Algorithm::kSoftmax) {
+    OF_CUDA_CHECK((cuda::softmax::DispatchSoftmax<decltype(load), decltype(store), ComputeType>(
+        cuda_stream, load, store, rows, cols)));
+  } else if (algorithm == Algorithm::kLogSoftmax) {
+    OF_CUDA_CHECK((cuda::softmax::DispatchLogSoftmax<decltype(load), decltype(store), ComputeType>(
+        cuda_stream, load, store, rows, cols)));
+  } else {
+    UNIMPLEMENTED();
+  }
+}
+
+template<typename SoftmaxBase, Algorithm algorithm, typename T>
+class SoftmaxImpl : public SoftmaxBase {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(SoftmaxImpl);
+  SoftmaxImpl() = default;
+  ~SoftmaxImpl() override = default;
+
+  void Launch(Stream* stream, size_t rows, size_t cols, const void* x, void* y) override {
+    hipStream_t cuda_stream = stream->As<CudaStream>()->cuda_stream();
+    SoftmaxGpu<algorithm, T>(cuda_stream, rows, cols, reinterpret_cast<const T*>(x),
+                             reinterpret_cast<T*>(y));
+  }
+};
+
+template<typename SoftmaxBase, Algorithm algorithm, typename T>
+std::unique_ptr<SoftmaxBase> NewSoftmax() {
+  return std::unique_ptr<SoftmaxBase>(new SoftmaxImpl<SoftmaxBase, algorithm, T>());
+}
+
+template<typename FactoryBase, typename SoftmaxBase, Algorithm algorithm>
+class GenericSoftmaxFactoryImpl : public FactoryBase {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(GenericSoftmaxFactoryImpl);
+  GenericSoftmaxFactoryImpl() = default;
+  ~GenericSoftmaxFactoryImpl() override = default;
+
+  std::unique_ptr<SoftmaxBase> New(DataType data_type) override {
+#define MAKE_NEW_SOFTMAX_ENTRY(type_cpp, type_proto) \
+  {type_proto, NewSoftmax<SoftmaxBase, algorithm, type_cpp>},
+
+    static const std::map<DataType, std::function<std::unique_ptr<SoftmaxBase>()>>
+        new_softmax_handle{
+            OF_PP_FOR_EACH_TUPLE(MAKE_NEW_SOFTMAX_ENTRY, CUDA_PRIMITIVE_FLOATING_TYPE_SEQ)};
+
+#undef MAKE_NEW_SOFTMAX_ENTRY
+
+    const auto it = new_softmax_handle.find(data_type);
+    if (it != new_softmax_handle.end()) {
+      return it->second();
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+using SoftmaxFactoryImpl = GenericSoftmaxFactoryImpl<SoftmaxFactory, Softmax, Algorithm::kSoftmax>;
+using LogSoftmaxFactoryImpl =
+    GenericSoftmaxFactoryImpl<LogSoftmaxFactory, LogSoftmax, Algorithm::kLogSoftmax>;
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, SoftmaxFactory, SoftmaxFactoryImpl);
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, LogSoftmaxFactory, LogSoftmaxFactoryImpl);
+
+}  // namespace
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/softmax_backward.cu
+++ b/oneflow/core/ep/hip/primitive/softmax_backward.cu
@@ -1,0 +1,115 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/include/primitive/softmax_backward.h"
+#include "oneflow/core/ep/include/primitive/log_softmax_backward.h"
+#include "oneflow/core/ep/hip/primitive/type_seq.h"
+#include "oneflow/core/cuda/softmax.cuh"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+
+namespace oneflow {
+
+namespace ep {
+namespace primitive {
+
+namespace {
+
+enum class Algorithm {
+  kSoftmax,
+  kLogSoftmax,
+};
+
+template<Algorithm algorithm, typename T>
+void SoftmaxBackwardGpu(hipStream_t cuda_stream, size_t rows, size_t cols, const T* y, const T* dy,
+                        T* dx) {
+  using ComputeType = typename cuda::softmax::DefaultComputeType<T>::type;
+  cuda::softmax::DirectLoad<T, ComputeType> load_y(y, cols);
+  cuda::softmax::DirectLoad<T, ComputeType> load_dy(dy, cols);
+  cuda::softmax::DirectStore<ComputeType, T> store(dx, cols);
+  if (algorithm == Algorithm::kSoftmax) {
+    OF_CUDA_CHECK((cuda::softmax::DispatchSoftmaxGrad<decltype(load_y), decltype(load_dy),
+                                                      decltype(store), ComputeType>(
+        cuda_stream, load_y, load_dy, store, rows, cols)));
+  } else if (algorithm == Algorithm::kLogSoftmax) {
+    OF_CUDA_CHECK((cuda::softmax::DispatchLogSoftmaxGrad<decltype(load_y), decltype(load_dy),
+                                                         decltype(store), ComputeType>(
+        cuda_stream, load_y, load_dy, store, rows, cols)));
+  } else {
+    UNIMPLEMENTED();
+  }
+}
+
+template<typename SoftmaxBackwardBase, Algorithm algorithm, typename T>
+class SoftmaxBackwardImpl : public SoftmaxBackwardBase {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(SoftmaxBackwardImpl);
+  SoftmaxBackwardImpl() = default;
+  ~SoftmaxBackwardImpl() override = default;
+
+  void Launch(Stream* stream, size_t rows, size_t cols, const void* y, const void* dy,
+              void* dx) override {
+    hipStream_t cuda_stream = stream->As<CudaStream>()->cuda_stream();
+    SoftmaxBackwardGpu<algorithm, T>(cuda_stream, rows, cols, reinterpret_cast<const T*>(y),
+                                     reinterpret_cast<const T*>(dy), reinterpret_cast<T*>(dx));
+  }
+};
+
+template<typename SoftmaxBackwardBase, Algorithm algorithm, typename T>
+std::unique_ptr<SoftmaxBackwardBase> NewSoftmaxBackward() {
+  return std::unique_ptr<SoftmaxBackwardBase>(
+      new SoftmaxBackwardImpl<SoftmaxBackwardBase, algorithm, T>());
+}
+
+template<typename BackwardFactoryBase, typename SoftmaxBackwardBase, Algorithm algorithm>
+class GenericSoftmaxBackwardFactoryImpl : public BackwardFactoryBase {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(GenericSoftmaxBackwardFactoryImpl);
+  GenericSoftmaxBackwardFactoryImpl() = default;
+  ~GenericSoftmaxBackwardFactoryImpl() override = default;
+
+  std::unique_ptr<SoftmaxBackwardBase> New(DataType data_type) override {
+#define MAKE_NEW_SOFTMAX_ENTRY(type_cpp, type_proto) \
+  {type_proto, NewSoftmaxBackward<SoftmaxBackwardBase, algorithm, type_cpp>},
+
+    static const std::map<DataType, std::function<std::unique_ptr<SoftmaxBackwardBase>()>>
+        new_softmax_backward_handle{
+            OF_PP_FOR_EACH_TUPLE(MAKE_NEW_SOFTMAX_ENTRY, CUDA_PRIMITIVE_FLOATING_TYPE_SEQ)};
+
+#undef MAKE_NEW_SOFTMAX_ENTRY
+
+    const auto it = new_softmax_backward_handle.find(data_type);
+    if (it != new_softmax_backward_handle.end()) {
+      return it->second();
+    } else {
+      return nullptr;
+    }
+  }
+};
+
+using SoftmaxBackwardFactoryImpl =
+    GenericSoftmaxBackwardFactoryImpl<SoftmaxBackwardFactory, SoftmaxBackward, Algorithm::kSoftmax>;
+using LogSoftmaxBackwardFactoryImpl =
+    GenericSoftmaxBackwardFactoryImpl<LogSoftmaxBackwardFactory, LogSoftmaxBackward,
+                                      Algorithm::kLogSoftmax>;
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, SoftmaxBackwardFactory, SoftmaxBackwardFactoryImpl);
+REGISTER_PRIMITIVE_FACTORY(DeviceType::kCUDA, LogSoftmaxBackwardFactory,
+                           LogSoftmaxBackwardFactoryImpl);
+
+}  // namespace
+
+}  // namespace primitive
+}  // namespace ep
+
+}  // namespace oneflow

--- a/oneflow/core/ep/hip/primitive/type_seq.h
+++ b/oneflow/core/ep/hip/primitive/type_seq.h
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_EP_CUDA_PRIMITIVE_TYPE_SEQ_H_
+#define ONEFLOW_CORE_EP_CUDA_PRIMITIVE_TYPE_SEQ_H_
+
+#include "oneflow/core/common/preprocessor.h"
+#include "oneflow/core/common/data_type.h"
+
+#ifdef WITH_HIP
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// #if CUDA_VERSION >= 11000
+// #include <cuda_bf16.h>
+// #endif  // CUDA_VERSION >= 11000
+
+#define CUDA_PRIMITIVE_BOOL_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(bool, DataType::kBool)
+#define CUDA_PRIMITIVE_CHAR_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(char, DataType::kChar)
+#define CUDA_PRIMITIVE_INT8_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(int8_t, DataType::kInt8)
+#define CUDA_PRIMITIVE_UINT8_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(uint8_t, DataType::kUInt8)
+#define CUDA_PRIMITIVE_INT32_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(int32_t, DataType::kInt32)
+#define CUDA_PRIMITIVE_UINT32_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(uint32_t, DataType::kUInt32)
+#define CUDA_PRIMITIVE_INT64_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(int64_t, DataType::kInt64)
+#define CUDA_PRIMITIVE_UINT64_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(uint64_t, DataType::kUInt64)
+#define CUDA_PRIMITIVE_FLOAT_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(float, DataType::kFloat)
+#define CUDA_PRIMITIVE_DOUBLE_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(double, DataType::kDouble)
+#define CUDA_PRIMITIVE_FLOAT16_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(half, DataType::kFloat16)
+
+// #if CUDA_VERSION >= 11000
+// #define CUDA_PRIMITIVE_BFLOAT16_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(nv_bfloat16, DataType::kBFloat16)
+// #else
+// #define CUDA_PRIMITIVE_BFLOAT16_TYPE_SEQ
+// #endif  // CUDA_VERSION >= 11000
+
+#define CUDA_PRIMITIVE_ALL_TYPE_SEQ \
+  CUDA_PRIMITIVE_BOOL_TYPE_SEQ      \
+  CUDA_PRIMITIVE_CHAR_TYPE_SEQ      \
+  CUDA_PRIMITIVE_INT8_TYPE_SEQ      \
+  CUDA_PRIMITIVE_UINT8_TYPE_SEQ     \
+  CUDA_PRIMITIVE_INT32_TYPE_SEQ     \
+  CUDA_PRIMITIVE_INT64_TYPE_SEQ     \
+  CUDA_PRIMITIVE_FLOAT_TYPE_SEQ     \
+  CUDA_PRIMITIVE_DOUBLE_TYPE_SEQ    \
+  CUDA_PRIMITIVE_FLOAT16_TYPE_SEQ   \
+  CUDA_PRIMITIVE_BFLOAT16_TYPE_SEQ
+
+#define CUDA_PRIMITIVE_FLOATING_TYPE_SEQ \
+  CUDA_PRIMITIVE_FLOAT_TYPE_SEQ          \
+  CUDA_PRIMITIVE_DOUBLE_TYPE_SEQ         \
+  CUDA_PRIMITIVE_FLOAT16_TYPE_SEQ        \
+  CUDA_PRIMITIVE_BFLOAT16_TYPE_SEQ
+
+#endif  // WITH_HIP
+
+#endif  // ONEFLOW_CORE_EP_CUDA_PRIMITIVE_TYPE_SEQ_H_

--- a/oneflow/core/ep/hip/primitive/unary_functor.cuh
+++ b/oneflow/core/ep/hip/primitive/unary_functor.cuh
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/ep/common/primitive/unary_functor.h"
+#include "oneflow/core/ep/hip/primitive/type_seq.h"
+#include "oneflow/core/cuda/elementwise.cuh"
+#include "oneflow/core/ep/hip/cuda_stream.h"
+
+namespace oneflow {
+namespace ep {
+namespace primitive {
+
+template<typename Dst, typename Src>
+struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kGelu, Dst, Src> {
+  OF_DEVICE_FUNC Dst operator()(Src src) const {
+    return static_cast<Src>(0.5) * src
+           * (static_cast<Src>(1.0) + erf(static_cast<Src>(M_SQRT1_2) * src));
+  }
+};
+
+template<>
+struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kGelu, half, half> {
+  UnaryFunctor<DeviceType::kCUDA, UnaryOp::kGelu, float, float> float_functor;
+  OF_DEVICE_FUNC half operator()(half src) const {
+    return __float2half(float_functor(__half2float(src)));
+  }
+};
+
+// #if CUDA_VERSION >= 11000
+// template<>
+// struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kGelu, nv_bfloat16, nv_bfloat16> {
+//   UnaryFunctor<DeviceType::kCUDA, UnaryOp::kGelu, float, float> float_functor;
+//   OF_DEVICE_FUNC nv_bfloat16 operator()(nv_bfloat16 src) const {
+//     return __float2bfloat16(float_functor(__bfloat162float(src)));
+//   }
+// };
+// #endif
+
+template<>
+struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kTanh, float, float> {
+  OF_DEVICE_FUNC float operator()(float src) const { return tanhf(src); }
+};
+
+template<>
+struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kTanh, double, double> {
+  OF_DEVICE_FUNC double operator()(double src) const { return tanh(src); }
+};
+
+template<>
+struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kTanh, half, half> {
+  OF_DEVICE_FUNC half operator()(half src) const { return __float2half(tanhf(__half2float(src))); }
+};
+
+// #if CUDA_VERSION >= 11000
+// template<>
+// struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kTanh, nv_bfloat16, nv_bfloat16> {
+//   UnaryFunctor<DeviceType::kCUDA, UnaryOp::kTanh, float, float> float_functor;
+//   OF_DEVICE_FUNC nv_bfloat16 operator()(nv_bfloat16 src) const {
+//     return __float2bfloat16(float_functor(__bfloat162float(src)));
+//   }
+// };
+// #endif
+
+}  // namespace primitive
+}  // namespace ep
+}  // namespace oneflow

--- a/oneflow/core/hardware/cuda_device_descriptor.cpp
+++ b/oneflow/core/hardware/cuda_device_descriptor.cpp
@@ -140,3 +140,130 @@ std::shared_ptr<const CudaDeviceDescriptor> CudaDeviceDescriptor::Deserialize(
 }  // namespace oneflow
 
 #endif  // WITH_CUDA
+
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+#include "nlohmann/json.hpp"
+
+namespace oneflow {
+
+namespace hardware {
+
+namespace {
+
+constexpr char kJsonKeyOrdinal[] = "ordinal";
+constexpr char kJsonKeyName[] = "name";
+constexpr char kJsonKeyTotalGlobalMemory[] = "total_global_memory_bytes";
+constexpr char kJsonKeyClockRate[] = "clock_rate_khz";
+constexpr char kJsonKeyComputeCapabilityMajor[] = "compute_capability_major";
+constexpr char kJsonKeyComputeCapabilityMinor[] = "compute_capability_minor";
+constexpr char kJsonKeyMemoryClockRate[] = "memory_clock_rate_khz";
+constexpr char kJsonKeyMemoryBusWidth[] = "memory_bus_width_bit";
+constexpr char kJsonKeyPCIBusID[] = "pci_bus_id";
+
+}  // namespace
+
+struct CudaDeviceDescriptor::Impl {
+  int32_t ordinal{};
+  std::string name;
+  size_t total_global_memory_bytes{};
+  int32_t clock_rate_khz{};
+  int32_t compute_capability_major{};
+  int32_t compute_capability_minor{};
+  int32_t memory_clock_rate_khz{};
+  int32_t memory_bus_width_bit{};
+  std::string pci_bus_id;
+};
+
+CudaDeviceDescriptor::CudaDeviceDescriptor() { impl_.reset(new Impl()); }
+
+CudaDeviceDescriptor::~CudaDeviceDescriptor() = default;
+
+int32_t CudaDeviceDescriptor::Ordinal() const { return impl_->ordinal; }
+
+const std::string& CudaDeviceDescriptor::Name() const { return impl_->name; }
+
+size_t CudaDeviceDescriptor::GlobalMemorySizeBytes() const {
+  return impl_->total_global_memory_bytes;
+}
+
+int32_t CudaDeviceDescriptor::ClockRateKHz() const { return impl_->clock_rate_khz; }
+
+int32_t CudaDeviceDescriptor::ComputeCapabilityMajor() const {
+  return impl_->compute_capability_major;
+}
+
+int32_t CudaDeviceDescriptor::ComputeCapabilityMinor() const {
+  return impl_->compute_capability_minor;
+}
+
+int32_t CudaDeviceDescriptor::MemoryClockRateKHz() const { return impl_->memory_clock_rate_khz; }
+
+int32_t CudaDeviceDescriptor::MemoryBusWidthBit() const { return impl_->memory_bus_width_bit; }
+
+const std::string& CudaDeviceDescriptor::PCIBusID() const { return impl_->pci_bus_id; }
+
+std::shared_ptr<const CudaDeviceDescriptor> CudaDeviceDescriptor::Query(int32_t ordinal) {
+  hipDeviceProp_t prop{};
+  const hipError_t err = hipGetDeviceProperties(&prop, ordinal);
+  CHECK(err == hipSuccess);
+  auto* desc = new CudaDeviceDescriptor();
+  desc->impl_->ordinal = ordinal;
+  desc->impl_->name = prop.name;
+  desc->impl_->total_global_memory_bytes = prop.totalGlobalMem;
+  desc->impl_->clock_rate_khz = prop.clockRate;
+  desc->impl_->compute_capability_major = prop.major;
+  desc->impl_->compute_capability_minor = prop.minor;
+  desc->impl_->memory_clock_rate_khz = prop.memoryClockRate;
+  desc->impl_->memory_bus_width_bit = prop.memoryBusWidth;
+  char pci_bus_id_buf[sizeof("00000000:00:00.0")];
+  if (
+    // CUDA_VERSION >= 11000 && 
+    hipDeviceGetPCIBusId(pci_bus_id_buf, sizeof(pci_bus_id_buf), ordinal) == hipSuccess) {
+    for (int i = 0; i < sizeof(pci_bus_id_buf) - 1; ++i) {
+      pci_bus_id_buf[i] = static_cast<char>(std::tolower(pci_bus_id_buf[i]));
+    }
+    desc->impl_->pci_bus_id = pci_bus_id_buf;
+  } else {
+    desc->impl_->pci_bus_id = "";
+  }
+  return std::shared_ptr<const CudaDeviceDescriptor>(desc);
+}
+
+void CudaDeviceDescriptor::Serialize(std::string* serialized) const {
+  nlohmann::json json_object;
+  json_object[kJsonKeyOrdinal] = impl_->ordinal;
+  json_object[kJsonKeyName] = impl_->name;
+  json_object[kJsonKeyTotalGlobalMemory] = impl_->total_global_memory_bytes;
+  json_object[kJsonKeyClockRate] = impl_->clock_rate_khz;
+  json_object[kJsonKeyComputeCapabilityMajor] = impl_->compute_capability_major;
+  json_object[kJsonKeyComputeCapabilityMinor] = impl_->compute_capability_minor;
+  json_object[kJsonKeyMemoryClockRate] = impl_->memory_clock_rate_khz;
+  json_object[kJsonKeyMemoryBusWidth] = impl_->memory_bus_width_bit;
+  json_object[kJsonKeyPCIBusID] = impl_->pci_bus_id;
+  *serialized = json_object.dump(2);
+}
+
+std::shared_ptr<const CudaDeviceDescriptor> CudaDeviceDescriptor::Deserialize(
+    const std::string& serialized) {
+  auto json_object = nlohmann::json::parse(serialized);
+  auto* desc = new CudaDeviceDescriptor();
+  desc->impl_->ordinal = json_object[kJsonKeyOrdinal];
+  desc->impl_->name = json_object[kJsonKeyName];
+  desc->impl_->total_global_memory_bytes = json_object[kJsonKeyTotalGlobalMemory];
+  desc->impl_->clock_rate_khz = json_object[kJsonKeyClockRate];
+  desc->impl_->compute_capability_major = json_object[kJsonKeyComputeCapabilityMajor];
+  desc->impl_->compute_capability_minor = json_object[kJsonKeyComputeCapabilityMinor];
+  desc->impl_->memory_clock_rate_khz = json_object[kJsonKeyMemoryClockRate];
+  desc->impl_->memory_bus_width_bit = json_object[kJsonKeyMemoryBusWidth];
+  desc->impl_->pci_bus_id = json_object[kJsonKeyPCIBusID];
+  return std::shared_ptr<const CudaDeviceDescriptor>(desc);
+}
+
+}  // namespace hardware
+
+}  // namespace oneflow
+
+
+#endif // WITH_HIP

--- a/oneflow/core/hardware/cuda_device_descriptor.h
+++ b/oneflow/core/hardware/cuda_device_descriptor.h
@@ -60,4 +60,43 @@ class CudaDeviceDescriptor : public DeviceDescriptor {
 
 #endif  // WITH_CUDA
 
+#ifdef WITH_HIP
+
+namespace oneflow {
+
+namespace hardware {
+
+constexpr char kCudaDeviceDescriptorClassName[] = "cuda";
+
+class CudaDeviceDescriptor : public DeviceDescriptor {
+ public:
+  OF_DISALLOW_COPY_AND_MOVE(CudaDeviceDescriptor);
+  ~CudaDeviceDescriptor() override;
+
+  int32_t Ordinal() const;
+  const std::string& Name() const;
+  size_t GlobalMemorySizeBytes() const;
+  int32_t ClockRateKHz() const;
+  int32_t ComputeCapabilityMajor() const;
+  int32_t ComputeCapabilityMinor() const;
+  int32_t MemoryClockRateKHz() const;
+  int32_t MemoryBusWidthBit() const;
+  const std::string& PCIBusID() const;
+  void Serialize(std::string* serialized) const;
+  static std::shared_ptr<const CudaDeviceDescriptor> Query(int32_t ordinal);
+  static std::shared_ptr<const CudaDeviceDescriptor> Deserialize(const std::string& serialized);
+
+ private:
+  CudaDeviceDescriptor();
+
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace hardware
+
+}  // namespace oneflow
+
+#endif  // WITH_HIP
+
 #endif  // ONEFLOW_CORE_HARDWARE_CUDA_DEVICE_DESCRIPTOR_H_

--- a/oneflow/core/hardware/cuda_device_descriptor_class.cpp
+++ b/oneflow/core/hardware/cuda_device_descriptor_class.cpp
@@ -103,3 +103,86 @@ COMMAND(DeviceDescriptorClass::RegisterClass(std::make_shared<CudaDeviceDescript
 }  // namespace oneflow
 
 #endif  // WITH_CUDA
+
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime.h>
+
+namespace oneflow {
+
+namespace hardware {
+
+namespace {
+
+constexpr char kJsonKeyDevices[] = "devices";
+
+}  // namespace
+
+class CudaDeviceDescriptorClass : public DeviceDescriptorClass {
+ public:
+  CudaDeviceDescriptorClass() = default;
+  ~CudaDeviceDescriptorClass() override = default;
+
+  std::shared_ptr<const DeviceDescriptorList> QueryDeviceDescriptorList() const override {
+    int n_dev = 0;
+    hipError_t err = hipGetDeviceCount(&n_dev);
+    if (err != hipSuccess) {
+      LOG(WARNING) << hipGetErrorString(err);
+      return std::make_shared<const BasicDeviceDescriptorList>(
+          std::vector<std::shared_ptr<const DeviceDescriptor>>());
+    }
+    std::vector<std::shared_ptr<const DeviceDescriptor>> devices(n_dev);
+    for (int dev = 0; dev < n_dev; ++dev) { devices.at(dev) = CudaDeviceDescriptor::Query(dev); }
+    return std::make_shared<const BasicDeviceDescriptorList>(devices);
+  }
+
+  std::string Name() const override { return kCudaDeviceDescriptorClassName; }
+
+  void SerializeDeviceDescriptorList(const std::shared_ptr<const DeviceDescriptorList>& list,
+                                     std::string* serialized) const override {
+    std::vector<std::string> serialized_devices;
+    serialized_devices.reserve(list->DeviceCount());
+    for (size_t i = 0; i < list->DeviceCount(); ++i) {
+      auto cuda_device = std::dynamic_pointer_cast<const CudaDeviceDescriptor>(list->GetDevice(i));
+      CHECK(cuda_device);
+      std::string serialized_device;
+      cuda_device->Serialize(&serialized_device);
+      serialized_devices.emplace_back(std::move(serialized_device));
+    }
+    nlohmann::json json_object;
+    json_object[kJsonKeyDevices] = serialized_devices;
+    *serialized = json_object.dump();
+  }
+
+  std::shared_ptr<const DeviceDescriptorList> DeserializeDeviceDescriptorList(
+      const std::string& serialized) const override {
+    auto json_object = nlohmann::json::parse(serialized);
+    std::vector<std::string> serialized_devices = json_object[kJsonKeyDevices];
+    std::vector<std::shared_ptr<const DeviceDescriptor>> devices(serialized_devices.size());
+    for (int i = 0; i < serialized_devices.size(); ++i) {
+      devices.at(i) = CudaDeviceDescriptor::Deserialize(serialized_devices.at(i));
+    }
+    return std::make_shared<const BasicDeviceDescriptorList>(devices);
+  }
+
+  void DumpDeviceDescriptorListSummary(const std::shared_ptr<const DeviceDescriptorList>& list,
+                                       const std::string& path) const override {
+    for (size_t i = 0; i < list->DeviceCount(); ++i) {
+      auto cuda_device = std::dynamic_pointer_cast<const CudaDeviceDescriptor>(list->GetDevice(i));
+      CHECK(cuda_device);
+      auto stream = TeePersistentLogStream::Create(JoinPath(path, std::to_string(i) + ".json"));
+      std::string serialized;
+      cuda_device->Serialize(&serialized);
+      stream << serialized;
+    }
+  }
+};
+
+COMMAND(DeviceDescriptorClass::RegisterClass(std::make_shared<CudaDeviceDescriptorClass>()));
+
+}  // namespace hardware
+
+}  // namespace oneflow
+
+
+#endif  // WITH_HIP

--- a/oneflow/core/hipdnn/hipdnn.h
+++ b/oneflow/core/hipdnn/hipdnn.h
@@ -1,0 +1,1472 @@
+/*
+ Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#ifndef HIPDNN_H
+#define HIPDNN_H
+
+#ifdef WITH_HIP
+
+#define HIPDNN_BN_MIN_EPSILON 1e-05
+
+#include <hip/hip_runtime_api.h>
+
+#define HIPDNN_VERSION 7000
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CHECK_HIP(expression)                                                   \
+    {                                                                           \
+        hipError_t error = (expression);                                        \
+        if (error != hipSuccess) {                                              \
+            fprintf(stderr, "HIP error: %s (%d) at %s:%d\n",                    \
+                    hipGetErrorString(error), error, __FILE__, __LINE__);       \
+            exit(EXIT_FAILURE);                                                 \
+        }                                                                       \
+    }
+
+#define CHECK_HIPDNN(expression)                                                \
+    {                                                                           \
+        hipdnnStatus_t error = (expression);                                    \
+        if (error != HIPDNN_STATUS_SUCCESS) {                                   \
+            fprintf(stderr, "HIPDNN error: %s (%d) at %s:%d\n",                 \
+                    hipdnnGetErrorString(error), error, __FILE__, __LINE__);    \
+            return error;                                                       \
+        }                                                                       \
+    }
+
+#define CHECK_MALLOC(pointer)                                                   \
+    {                                                                           \
+        if ( (pointer) == 0) {   /*if Null pointer*/                            \
+            fprintf(stderr, "Malloc failed error:%s:%d\n", __FILE__, __LINE__); \
+            std::exit(EXIT_FAILURE);                                            \
+        }                                                                       \
+    }
+
+//============================ Datatypes =======================================
+
+typedef enum {
+    HIPDNN_STATUS_SUCCESS = 0,
+    HIPDNN_STATUS_NOT_INITIALIZED = 1,
+    HIPDNN_STATUS_ALLOC_FAILED = 2,
+    HIPDNN_STATUS_BAD_PARAM = 3,
+    HIPDNN_STATUS_INTERNAL_ERROR = 4,
+    HIPDNN_STATUS_INVALID_VALUE = 5,
+    HIPDNN_STATUS_ARCH_MISMATCH = 6,
+    HIPDNN_STATUS_MAPPING_ERROR = 7,
+    HIPDNN_STATUS_EXECUTION_FAILED = 8,
+    HIPDNN_STATUS_NOT_SUPPORTED = 9,
+    HIPDNN_STATUS_LICENSE_ERROR = 10,
+    HIPDNN_STATUS_RUNTIME_PREREQUISITE_MISSING = 11,
+} hipdnnStatus_t;
+
+typedef enum {
+    HIPDNN_DATA_FLOAT = 0,
+    HIPDNN_DATA_DOUBLE = 1,
+    HIPDNN_DATA_HALF = 2,
+    HIPDNN_DATA_INT8 = 3,
+    HIPDNN_DATA_INT32 = 4,
+    HIPDNN_DATA_INT8x4 = 5
+} hipdnnDataType_t;
+
+typedef enum {
+    HIPDNN_NOT_PROPAGATE_NAN = 0,
+    HIPDNN_PROPAGATE_NAN = 1,
+} hipdnnNanPropagation_t;
+
+//------------------------- Tensors datatypes ----------------------------------
+
+typedef enum {
+    HIPDNN_DEFAULT_MATH = 0,
+    HIPDNN_TENSOR_OP_MATH = 1,
+} hipdnnMathType_t;
+
+typedef enum {
+    HIPDNN_TENSOR_NCHW = 0, /* row major (wStride = 1, hStride = w) */
+    HIPDNN_TENSOR_NHWC = 1, /* feature maps interleaved ( cStride = 1 )*/
+    HIPDNN_TENSOR_NCHW_VECT_C = 2 /* each image point is vector of element of C:
+                          the length of the vector is carried by the data type*/
+} hipdnnTensorFormat_t;
+
+typedef enum {
+    HIPDNN_OP_TENSOR_ADD = 0,
+    HIPDNN_OP_TENSOR_MUL = 1,
+    HIPDNN_OP_TENSOR_MIN = 2,
+    HIPDNN_OP_TENSOR_MAX = 3,
+    HIPDNN_OP_TENSOR_SQRT = 4,
+    HIPDNN_OP_TENSOR_NOT  = 5,
+} hipdnnOpTensorOp_t;
+
+// CNTK 2.4
+
+typedef enum {
+    HIPDNN_REDUCE_TENSOR_ADD = 0,
+    HIPDNN_REDUCE_TENSOR_MUL = 1,
+    HIPDNN_REDUCE_TENSOR_MIN = 2,
+    HIPDNN_REDUCE_TENSOR_MAX = 3,
+    HIPDNN_REDUCE_TENSOR_AMAX = 4,
+    HIPDNN_REDUCE_TENSOR_AVG = 5,
+    HIPDNN_REDUCE_TENSOR_NORM1 = 6,
+    HIPDNN_REDUCE_TENSOR_NORM2 = 7,
+    HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS = 8,
+} hipdnnReduceTensorOp_t;
+
+typedef enum {
+    HIPDNN_REDUCE_TENSOR_NO_INDICES = 0,
+    HIPDNN_REDUCE_TENSOR_FLATTENED_INDICES = 1,
+} hipdnnReduceTensorIndices_t;
+
+typedef enum {
+    HIPDNN_32BIT_INDICES = 0,
+    HIPDNN_64BIT_INDICES = 1,
+    HIPDNN_16BIT_INDICES = 2,
+    HIPDNN_8BIT_INDICES = 3,
+} hipdnnIndicesType_t;
+
+//------------------------- Convolutional datatypes ----------------------------
+
+typedef enum {
+    HIPDNN_CONVOLUTION = 0,         //Not supported in MIopen
+    HIPDNN_CROSS_CORRELATION = 1,   //MIopen's Convolution
+    HIPDNN_TRANSPOSE = 2,           //Not supported in CUDNN
+    HIPDNN_GROUP_CONVOLUTION = 3,   //Not supported in CUDNN
+    HIPDNN_DEPTHWISE = 4,           //Not supported in CUDNN
+} hipdnnConvolutionMode_t;
+
+typedef enum {
+    HIPDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM = 0,
+    HIPDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM = 1,
+    HIPDNN_CONVOLUTION_FWD_ALGO_GEMM = 2,
+    HIPDNN_CONVOLUTION_FWD_ALGO_DIRECT = 3,
+    HIPDNN_CONVOLUTION_FWD_ALGO_FFT = 4,
+    HIPDNN_CONVOLUTION_FWD_ALGO_FFT_TILING = 5,
+    HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD = 6,
+    HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED = 7,
+    HIPDNN_CONVOLUTION_FWD_ALGO_COUNT = 8,
+} hipdnnConvolutionFwdAlgo_t;
+
+int ConvolutionFwdAlgoCount();
+
+// call ConvolutionFwdAlgoCount first, caller's responsibility to
+// make sure that i is not too large!
+//
+hipdnnConvolutionFwdAlgo_t GetConvolutionFwdAlgo(int i);
+
+
+typedef enum {
+    HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_0 = 0,  // non-deterministic
+    HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_1 = 1,
+    HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT = 2,
+    HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_3 =
+        3,  // non-deterministic, algo0 with workspace
+    HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD = 4,  // not implemented
+    HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD_NONFUSED = 5,
+    HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT_TILING = 6,
+    HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT = 7,
+} hipdnnConvolutionBwdFilterAlgo_t;
+
+int ConvolutionBwdFilterAlgoCount();
+
+// call ConvolutionBwdFilterAlgoCount first, caller's responsibility to
+// make sure that i is not too large!
+//
+hipdnnConvolutionBwdFilterAlgo_t GetConvolutionBwdFilterAlgo(int i);
+
+
+typedef enum {
+    HIPDNN_CONVOLUTION_BWD_DATA_ALGO_0 = 0,  // non-deterministic
+    HIPDNN_CONVOLUTION_BWD_DATA_ALGO_1 = 1,
+    HIPDNN_CONVOLUTION_BWD_DATA_ALGO_FFT = 2,
+    HIPDNN_CONVOLUTION_BWD_DATA_ALGO_FFT_TILING = 3,
+    HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD = 4,
+    HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED = 5,
+    HIPDNN_CONVOLUTION_BWD_DATA_ALGO_TRANSPOSE_GEMM = 6,
+    HIPDNN_CONVOLUTION_BWD_DATA_ALGO_COUNT = 7,
+} hipdnnConvolutionBwdDataAlgo_t;
+
+int ConvolutionBwdDataAlgoCount();
+
+// call ConvolutionBwdDataAlgoCount first, caller's responsibility to
+// make sure that i is not too large!
+//
+hipdnnConvolutionBwdDataAlgo_t GetConvolutionBwdDataAlgo(int i);
+
+
+typedef enum {
+    HIPDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE = 0,
+    HIPDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST = 1,
+    HIPDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT = 2,
+} hipdnnConvolutionBwdDataPreference_t;
+
+typedef enum {
+    HIPDNN_CONVOLUTION_FWD_NO_WORKSPACE = 0,
+    HIPDNN_CONVOLUTION_FWD_PREFER_FASTEST = 1,
+    HIPDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT = 2,
+} hipdnnConvolutionFwdPreference_t;
+
+typedef enum {
+    HIPDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE = 0,
+    HIPDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST = 1,
+    HIPDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT = 2,
+} hipdnnConvolutionBwdFilterPreference_t;
+
+struct hipdnnConvolutionFwdAlgoPerf_t {
+    hipdnnConvolutionFwdAlgo_t algo;
+    hipdnnStatus_t status;
+    float time;
+    size_t memory;
+    hipdnnMathType_t mathType;
+    long reserved[3];
+};
+
+struct hipdnnConvolutionBwdDataAlgoPerf_t {
+    hipdnnConvolutionBwdDataAlgo_t algo;
+    hipdnnStatus_t status;
+    float time;
+    size_t memory;
+    hipdnnMathType_t mathType;
+    long reserved[3];
+};
+
+struct hipdnnConvolutionBwdFilterAlgoPerf_t {
+    hipdnnConvolutionBwdFilterAlgo_t algo;
+    hipdnnStatus_t status;
+    float time;
+    size_t memory;
+    hipdnnMathType_t mathType;
+    long reserved[3];
+};
+
+//-------------------------- Pooling datatypes ---------------------------------
+
+typedef enum {
+    HIPDNN_POOLING_MAX = 0,
+    HIPDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING =
+        1,  // count for average includes padded values
+    HIPDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING =
+        2,  // count for average does not include padded values
+    HIPDNN_POOLING_MAX_DETERMINISTIC = 3
+} hipdnnPoolingMode_t;
+
+//--------------------------- LRN datatypes ------------------------------------
+
+typedef enum {
+    HIPDNN_LRN_WITHIN_CHANNEL = 0,
+    HIPDNN_LRN_CROSS_CHANNEL = 1,
+} hipdnnLRNMode_t;
+
+//--------------------------- BN datatypes ------------------------------------
+
+typedef enum {
+    /* bnScale, bnBias tensor dims are 1xCxHxWx.. (one value per CHW...-slice,
+     * normalized over N slice)
+     */
+    HIPDNN_BATCHNORM_PER_ACTIVATION = 0,
+
+    /* bnScale, bnBias tensor dims are 1xCx1x1 (one value per C-dim normalized
+     * over Nx1xHxW subtensors)
+     */
+    HIPDNN_BATCHNORM_SPATIAL = 1,
+
+    /* bnScale, bnBias tensor dims are 1xCx1x1 (one value per C-dim normalized
+     * over Nx1xHxW subtensors). May be faster than CUDNN_BATCHNORM_SPATIAL but
+     * imposes some limits on the range of values
+     */
+    HIPDNN_BATCHNORM_SPATIAL_PERSISTENT = 2,
+} hipdnnBatchNormMode_t;
+
+//--------------------------- Activation datatypes -----------------------------
+
+typedef enum {
+    HIPDNN_ACTIVATION_SIGMOID = 0,
+    HIPDNN_ACTIVATION_RELU,
+    HIPDNN_ACTIVATION_TANH,
+    HIPDNN_ACTIVATION_CLIPPED_RELU,
+    HIPDNN_ACTIVATION_ELU,
+    HIPDNN_ACTIVATION_PATHTRU,
+    HIPDNN_ACTIVATION_SOFTRELU,
+    HIPDNN_ACTIVATION_ABS,
+    HIPDNN_ACTIVATION_POWER
+} hipdnnActivationMode_t;
+
+//--------------------------- Softmax datatypes -----------------------------
+
+typedef enum {
+    HIPDNN_SOFTMAX_FAST = 0, /* straightforward implementation */
+    HIPDNN_SOFTMAX_ACCURATE =
+        1, /* subtract max from every point to avoid overflow */
+    HIPDNN_SOFTMAX_LOG = 2
+} hipdnnSoftmaxAlgorithm_t;
+
+typedef enum {
+    HIPDNN_SOFTMAX_MODE_INSTANCE =
+        0, /* compute the softmax over all C, H, W for each N */
+    HIPDNN_SOFTMAX_MODE_CHANNEL =
+        1 /* compute the softmax over all C for each H, W, N */
+} hipdnnSoftmaxMode_t;
+
+//--------------------------- RNN datatypes -----------------------------
+
+typedef enum {
+    HIPDNN_RNN_RELU = 0,  // Stock RNN with ReLu activation
+    HIPDNN_RNN_TANH = 1,  // Stock RNN with tanh activation
+    HIPDNN_LSTM = 2,      // LSTM with no peephole connections
+    HIPDNN_GRU =
+        3  // Using h' = tanh(r * Uh(t-1) + Wx) and h = (1 - z) * h' + z
+           // * h(t-1);
+} hipdnnRNNMode_t;
+
+typedef enum {
+    HIPDNN_UNIDIRECTIONAL = 0,
+    HIPDNN_BIDIRECTIONAL = 1  // Using output concatination at each step.
+                              // HGSOS: Do we also want to support output sum?
+} hipdnnDirectionMode_t;
+
+typedef enum {
+    HIPDNN_LINEAR_INPUT = 0,
+    HIPDNN_SKIP_INPUT = 1
+} hipdnnRNNInputMode_t;
+
+typedef enum {
+    HIPDNN_RNN_ALGO_STANDARD = 0,
+    HIPDNN_RNN_ALGO_PERSIST_STATIC = 1,
+    HIPDNN_RNN_ALGO_PERSIST_DYNAMIC = 2
+} hipdnnRNNAlgo_t;
+
+typedef enum {
+    HIPDNN_RNN_NO_BIAS = 0,
+    HIPDNN_RNN_WITH_BIAS = 1
+} hipdnnRNNBiasMode_t;
+
+typedef enum {
+    HIPDNN_RNN_ALGO_GEMM = 0
+}hipdnnRNNGEMMalgoMode_t;
+
+//--------------------------- Fusion datatypes ---------------------------------
+
+typedef enum {
+    HIPDNN_VERTICAL_FUSION = 0,
+    HIPDNN_HORIZONTAL_FUSION = 1,
+} hipdnnFusionDirection_t;
+
+//------------------------------- Opaque Pointers ------------------------------
+
+typedef void *hipdnnHandle_t;
+
+typedef void *hipdnnStream_t;
+
+typedef void *hipdnnTensorDescriptor_t;
+
+typedef void *hipdnnReduceTensorDescriptor_t;
+
+typedef void *hipdnnFilterDescriptor_t;
+
+typedef void *hipdnnConvolutionDescriptor_t;
+
+typedef void *hipdnnLRNDescriptor_t;
+
+typedef void *hipdnnActivationDescriptor_t;
+
+typedef void *hipdnnPoolingDescriptor_t;
+
+typedef void *hipdnnOpTensorDescriptor_t;
+
+typedef void *hipdnnDropoutDescriptor_t;
+
+typedef void *hipdnnRNNDescriptor_t;
+
+typedef void *hipdnnPersistentRNNPlan_t;
+
+typedef void *hipdnnDeterminism_t;
+
+typedef void *hipdnnFusionPlanDescriptor_t;
+
+typedef void *hipdnnFusionOpDescriptor_t;
+
+typedef void *hipdnnOperatorArgs_t;
+
+//==============================================================================
+
+hipdnnStatus_t hipdnnCreate(hipdnnHandle_t *handle);
+
+hipdnnStatus_t hipdnnDestroy(hipdnnHandle_t handle);
+
+hipdnnStatus_t hipdnnSetStream(hipdnnHandle_t handle, hipdnnStream_t streamId);
+
+hipdnnStatus_t hipdnnGetStream(hipdnnHandle_t handle, hipdnnStream_t *streamId);
+
+size_t hipdnnGetVersion(void);
+
+//=============================== Tensors ======================================
+
+hipdnnStatus_t
+hipdnnCreateTensorDescriptor( hipdnnTensorDescriptor_t *tensorDesc);
+
+hipdnnStatus_t
+hipdnnSetTensor4dDescriptor( hipdnnTensorDescriptor_t tensorDesc,
+                             hipdnnTensorFormat_t format,
+                             hipdnnDataType_t dataType,
+                             int n, int c, int h, int w);
+
+hipdnnStatus_t
+hipdnnGetTensor4dDescriptor( hipdnnTensorDescriptor_t tensorDesc,
+                             hipdnnDataType_t *dataType,
+                             int *n, int *c, int *h, int *w,
+                             int *nStride, int *cStride,
+                             int *hStride, int *wStride);
+
+hipdnnStatus_t
+hipdnnSetTensor4dDescriptorEx( hipdnnTensorDescriptor_t tensorDesc,
+                               hipdnnDataType_t dataType, /* image data type */
+                               int n,                     /* number of inputs (batch size) */
+                               int c,                     /* number of input feature maps */
+                               int h,                     /* height of input section */
+                               int w,                     /* width of input section */
+                               int nStride, int cStride, int hStride, int wStride);
+
+hipdnnStatus_t
+hipdnnSetTensorNdDescriptor( hipdnnTensorDescriptor_t tensorDesc,
+                             hipdnnDataType_t dataType,
+                             int nbDims,
+                             const int dimA[],
+                             const int strideA[]);
+
+hipdnnStatus_t
+hipdnnGetTensorNdDescriptor( const hipdnnTensorDescriptor_t tensorDesc,
+                             int nbDimsRequested,
+                             hipdnnDataType_t *dataType,
+                             int *nbDims,
+                             int dimA[],
+                             int strideA[]);
+
+hipdnnStatus_t
+hipdnnDestroyTensorDescriptor( hipdnnTensorDescriptor_t tensorDesc);
+
+hipdnnStatus_t hipdnnSetTensor( hipdnnHandle_t handle,
+                                const hipdnnTensorDescriptor_t yDesc,
+                                void *y,
+                                const void *valuePtr );
+
+hipdnnStatus_t hipdnnAddTensor( hipdnnHandle_t handle,
+                                const void *alpha,
+                                const hipdnnTensorDescriptor_t aDesc,
+                                const void *A,
+                                const void *beta,
+                                const hipdnnTensorDescriptor_t cDesc,
+                                void *C);
+
+hipdnnStatus_t hipdnnScaleTensor( hipdnnHandle_t handle,
+                                  const hipdnnTensorDescriptor_t yDesc,
+                                  void *y,
+                                  const void *alpha);
+
+//-------------------------- Tensor Operation -----------------------------------
+hipdnnStatus_t
+hipdnnCreateOpTensorDescriptor( hipdnnOpTensorDescriptor_t *opTensorDesc);
+
+hipdnnStatus_t
+hipdnnSetOpTensorDescriptor( hipdnnOpTensorDescriptor_t opTensorDesc,
+                             hipdnnOpTensorOp_t opTensorOp,
+                             hipdnnDataType_t opTensorCompType,
+                             hipdnnNanPropagation_t opTensorNanOpt);
+
+hipdnnStatus_t
+hipdnnGetOpTensorDescriptor( const hipdnnOpTensorDescriptor_t opTensorDesc,
+                             hipdnnOpTensorOp_t *opTensorOp,
+                             hipdnnDataType_t *opTensorCompType,
+                             hipdnnNanPropagation_t *opTensorNanOpt);
+
+hipdnnStatus_t
+hipdnnDestroyOpTensorDescriptor( hipdnnOpTensorDescriptor_t opTensorDesc);
+
+hipdnnStatus_t hipdnnOpTensor( hipdnnHandle_t handle,
+                               const hipdnnOpTensorDescriptor_t opTensorDesc,
+                               const void *alpha1,
+                               const hipdnnTensorDescriptor_t aDesc,
+                               const void *A,
+                               const void *alpha2,
+                               const hipdnnTensorDescriptor_t bDesc,
+                               const void *B,
+                               const void *beta,
+                               const hipdnnTensorDescriptor_t cDesc,
+                               void *C);
+
+//--------------------------- Tensor Reduction ---------------------------------
+
+hipdnnStatus_t
+hipdnnCreateReduceTensorDescriptor( hipdnnReduceTensorDescriptor_t *reduceTensorDesc);
+
+hipdnnStatus_t
+hipdnnSetReduceTensorDescriptor( hipdnnReduceTensorDescriptor_t reduceTensorDesc,
+                                 hipdnnReduceTensorOp_t reduceTensorOp,
+                                 hipdnnDataType_t reduceTensorCompType,
+                                 hipdnnNanPropagation_t reduceTensorNanOpt,
+                                 hipdnnReduceTensorIndices_t reduceTensorIndices,
+                                 hipdnnIndicesType_t reduceTensorIndicesType);
+
+hipdnnStatus_t
+hipdnnGetReductionWorkspaceSize( hipdnnHandle_t handle,
+                         const hipdnnReduceTensorDescriptor_t reduceTensorDesc,
+                         const hipdnnTensorDescriptor_t aDesc,
+                         const hipdnnTensorDescriptor_t cDesc,
+                         size_t *sizeInBytes);
+
+hipdnnStatus_t
+hipdnnReduceTensor( hipdnnHandle_t handle,
+                    const hipdnnReduceTensorDescriptor_t reduceTensorDesc,
+                    void *indices,   size_t indicesSizeInBytes,
+                    void *workspace, size_t workspaceSizeInBytes,
+                    const void *alpha,
+                    const hipdnnTensorDescriptor_t aDesc, const void *A,
+                    const void *beta,
+                    const hipdnnTensorDescriptor_t cDesc, void *C);
+
+hipdnnStatus_t
+hipdnnDestroyReduceTensorDescriptor( hipdnnReduceTensorDescriptor_t reduceTensorDesc);
+
+//=============================== Filter =======================================
+// In MIOpen Filter data and descriptor is same as tensor data and decriptor
+
+hipdnnStatus_t
+hipdnnCreateFilterDescriptor( hipdnnFilterDescriptor_t *filterDesc);
+
+hipdnnStatus_t
+hipdnnSetFilter4dDescriptor( hipdnnFilterDescriptor_t filterDesc,
+                             hipdnnTensorFormat_t format,
+                             hipdnnDataType_t dataType,
+                             int k, int c, int h, int w);
+
+hipdnnStatus_t
+hipdnnSetFilterNdDescriptor( hipdnnFilterDescriptor_t filterDesc,
+                             hipdnnDataType_t dataType,  /* image data type */
+                             hipdnnTensorFormat_t format,
+                             int nbDims,
+                             const int filterDimA[]);
+
+hipdnnStatus_t
+hipdnnGetFilterNdDescriptor( const hipdnnFilterDescriptor_t filterDesc,
+                             int nbDimsRequested,
+                             hipdnnDataType_t *dataType,  /* image data type */
+                             hipdnnTensorFormat_t *format,
+                             int *nbDims,
+                             int filterDimA[]);
+
+hipdnnStatus_t
+hipdnnGetFilter4dDescriptor( const hipdnnFilterDescriptor_t filterDesc,
+                             hipdnnDataType_t *dataType,
+                             hipdnnTensorFormat_t *format,
+                             int *k, int *c, int *h, int *w);
+
+hipdnnStatus_t
+hipdnnDestroyFilterDescriptor( hipdnnFilterDescriptor_t filterDesc);
+
+//========================== Convolutional =====================================
+
+hipdnnStatus_t
+hipdnnCreateConvolutionDescriptor( hipdnnConvolutionDescriptor_t *convDesc);
+
+hipdnnStatus_t
+hipdnnSetConvolution2dDescriptor( hipdnnConvolutionDescriptor_t convDesc,
+                                  int pad_h, int pad_w, int u, int v,
+                                  int upscalex, int upscaley,
+                                  hipdnnConvolutionMode_t mode,
+                                  hipdnnDataType_t computeType);
+
+hipdnnStatus_t
+hipdnnGetConvolution2dDescriptor( const hipdnnConvolutionDescriptor_t convDesc,
+                                  int *pad_h, int *pad_y, int *u, int *v,
+                                  int *upscalex, int *upscaley,
+                                  hipdnnConvolutionMode_t *mode,
+                                  hipdnnDataType_t *computeType);
+
+hipdnnStatus_t
+hipdnnGetConvolution2dForwardOutputDim(
+                                const hipdnnConvolutionDescriptor_t convDesc,
+                                const hipdnnTensorDescriptor_t inputTensorDesc,
+                                const hipdnnFilterDescriptor_t filterDesc,
+                                int *n, int *c, int *h, int *w);
+
+
+hipdnnStatus_t
+hipdnnSetConvolutionNdDescriptor( hipdnnConvolutionDescriptor_t convDesc,
+                                  int arrayLength, /* nbDims-2 size */
+                                  const int padA[],
+                                  const int filterStrideA[],
+                                  const int dilationA[],
+                                  hipdnnConvolutionMode_t mode,
+                                  hipdnnDataType_t computeType);  /* convolution data type */
+
+hipdnnStatus_t
+hipdnnDestroyConvolutionDescriptor( hipdnnConvolutionDescriptor_t convDesc);
+
+hipdnnStatus_t
+hipdnnFindConvolutionForwardAlgorithm( hipdnnHandle_t handle,
+                                    const hipdnnTensorDescriptor_t xDesc,
+                                    const hipdnnFilterDescriptor_t wDesc,
+                                    const hipdnnConvolutionDescriptor_t convDesc,
+                                    const hipdnnTensorDescriptor_t yDesc,
+                                    const int requestedAlgoCount,
+                                    int *returnedAlgoCount,
+                                    hipdnnConvolutionFwdAlgoPerf_t *perfResults);
+
+hipdnnStatus_t
+hipdnnGetConvolutionForwardAlgorithm( hipdnnHandle_t handle,
+                                    const hipdnnTensorDescriptor_t xDesc,
+                                    const hipdnnFilterDescriptor_t wDesc,
+                                    const hipdnnConvolutionDescriptor_t convDesc,
+                                    const hipdnnTensorDescriptor_t yDesc,
+                                    hipdnnConvolutionFwdPreference_t preference,
+                                    size_t memoryLimitInBytes,
+                                    hipdnnConvolutionFwdAlgo_t *algo);
+
+hipdnnStatus_t
+hipdnnFindConvolutionForwardAlgorithmEx( hipdnnHandle_t handle,
+                                    const hipdnnTensorDescriptor_t xDesc,
+                                    const void *x,
+                                    const hipdnnFilterDescriptor_t wDesc,
+                                    const void *w,
+                                    const hipdnnConvolutionDescriptor_t convDesc,
+                                    const hipdnnTensorDescriptor_t yDesc,
+                                    void *y,
+                                    const int requestedAlgoCount,
+                                    int *returnedAlgoCount,
+                                    hipdnnConvolutionFwdAlgoPerf_t *perfResults,
+                                    void *workSpace,
+                                    size_t workSpaceSizeInBytes);
+
+hipdnnStatus_t
+hipdnnGetConvolutionForwardWorkspaceSize( hipdnnHandle_t handle,
+                                    const hipdnnTensorDescriptor_t xDesc,
+                                    const hipdnnFilterDescriptor_t wDesc,
+                                    const hipdnnConvolutionDescriptor_t convDesc,
+                                    const hipdnnTensorDescriptor_t yDesc,
+                                    hipdnnConvolutionFwdAlgo_t algo,
+                                    size_t *sizeInBytes);
+
+hipdnnStatus_t
+hipdnnConvolutionForward( hipdnnHandle_t handle,
+                         const void *alpha,
+                         const hipdnnTensorDescriptor_t xDesc,
+                         const void *x,
+                         const hipdnnFilterDescriptor_t wDesc,
+                         const void *w,
+                         const hipdnnConvolutionDescriptor_t convDesc,
+                         hipdnnConvolutionFwdAlgo_t algo,
+                         void *workSpace,
+                         size_t workSpaceSizeInBytes,
+                         const void *beta,
+                         const hipdnnTensorDescriptor_t yDesc,
+                         void *y);
+
+hipdnnStatus_t
+hipdnnConvolutionBackwardBias( hipdnnHandle_t handle,
+                                const void *alpha,
+                                const hipdnnTensorDescriptor_t dyDesc,
+                                const void *dy,
+                                const void *beta,
+                                const hipdnnTensorDescriptor_t dbDesc,
+                                void *db);
+
+hipdnnStatus_t
+hipdnnFindConvolutionBackwardFilterAlgorithm( hipdnnHandle_t handle,
+                            const hipdnnTensorDescriptor_t xDesc,
+                            const hipdnnTensorDescriptor_t dyDesc,
+                            const hipdnnConvolutionDescriptor_t convDesc,
+                            const hipdnnFilterDescriptor_t dwDesc,
+                            const int requestedAlgoCount,
+                            int *returnedAlgoCount,
+                            hipdnnConvolutionBwdFilterAlgoPerf_t *perfResults);
+
+hipdnnStatus_t
+hipdnnGetConvolutionBackwardFilterAlgorithm( hipdnnHandle_t handle,
+                              const hipdnnTensorDescriptor_t xDesc,
+                              const hipdnnTensorDescriptor_t dyDesc,
+                              const hipdnnConvolutionDescriptor_t convDesc,
+                              const hipdnnFilterDescriptor_t dwDesc,
+                              hipdnnConvolutionBwdFilterPreference_t preference,
+                              size_t memoryLimitInBytes,
+                              hipdnnConvolutionBwdFilterAlgo_t *algo);
+
+hipdnnStatus_t
+hipdnnFindConvolutionBackwardFilterAlgorithmEx( hipdnnHandle_t handle,
+                                const hipdnnTensorDescriptor_t xDesc,
+                                const void *x,
+                                const hipdnnTensorDescriptor_t dyDesc,
+                                const void *dy,
+                                const hipdnnConvolutionDescriptor_t convDesc,
+                                const hipdnnFilterDescriptor_t dwDesc,
+                                void *dw,
+                                const int requestedAlgoCount,
+                                int *returnedAlgoCount,
+                                hipdnnConvolutionBwdFilterAlgoPerf_t *perfResults,
+                                void *workSpace,
+                                size_t workSpaceSizeInBytes);
+
+hipdnnStatus_t
+hipdnnGetConvolutionBackwardFilterWorkspaceSize( hipdnnHandle_t handle,
+                                    const hipdnnTensorDescriptor_t xDesc,
+                                    const hipdnnTensorDescriptor_t dyDesc,
+                                    const hipdnnConvolutionDescriptor_t convDesc,
+                                    const hipdnnFilterDescriptor_t dwDesc,
+                                    hipdnnConvolutionBwdFilterAlgo_t algo,
+                                    size_t *sizeInBytes);
+
+hipdnnStatus_t
+hipdnnConvolutionBackwardFilter( hipdnnHandle_t handle,
+                                  const void *alpha,
+                                  const hipdnnTensorDescriptor_t xDesc,
+                                  const void *x,
+                                  const hipdnnTensorDescriptor_t dyDesc,
+                                  const void *dy,
+                                  const hipdnnConvolutionDescriptor_t convDesc,
+                                  hipdnnConvolutionBwdFilterAlgo_t algo,
+                                  void *workSpace,
+                                  size_t workSpaceSizeInBytes,
+                                  const void *beta,
+                                  const hipdnnFilterDescriptor_t dwDesc,
+                                  void *dw);
+
+hipdnnStatus_t
+hipdnnGetConvolutionBackwardDataWorkspaceSize( hipdnnHandle_t handle,
+                                    const hipdnnFilterDescriptor_t wDesc,
+                                    const hipdnnTensorDescriptor_t dyDesc,
+                                    const hipdnnConvolutionDescriptor_t convDesc,
+                                    const hipdnnTensorDescriptor_t dxDesc,
+                                    hipdnnConvolutionBwdDataAlgo_t algo,
+                                    size_t *sizeInBytes);
+
+hipdnnStatus_t
+hipdnnFindConvolutionBackwardDataAlgorithm( hipdnnHandle_t handle,
+                                const hipdnnFilterDescriptor_t wDesc,
+                                const hipdnnTensorDescriptor_t dyDesc,
+                                const hipdnnConvolutionDescriptor_t convDesc,
+                                const hipdnnTensorDescriptor_t dxDesc,
+                                const int requestedAlgoCount,
+                                int *returnedAlgoCount,
+                                hipdnnConvolutionBwdDataAlgoPerf_t *perfResults);
+
+hipdnnStatus_t
+hipdnnGetConvolutionBackwardDataAlgorithm( hipdnnHandle_t handle,
+                                const hipdnnFilterDescriptor_t wDesc,
+                                const hipdnnTensorDescriptor_t dyDesc,
+                                const hipdnnConvolutionDescriptor_t convDesc,
+                                const hipdnnTensorDescriptor_t dxDesc,
+                                hipdnnConvolutionBwdDataPreference_t preference,
+                                size_t memoryLimitInBytes,
+                                hipdnnConvolutionBwdDataAlgo_t *algo);
+
+hipdnnStatus_t
+hipdnnFindConvolutionBackwardDataAlgorithmEx( hipdnnHandle_t handle,
+                               const hipdnnFilterDescriptor_t wDesc,
+                               const void *w,
+                               const hipdnnTensorDescriptor_t dyDesc,
+                               const void *dy,
+                               const hipdnnConvolutionDescriptor_t convDesc,
+                               const hipdnnTensorDescriptor_t dxDesc,
+                               void *dx,
+                               const int requestedAlgoCount,
+                               int *returnedAlgoCount,
+                               hipdnnConvolutionBwdDataAlgoPerf_t *perfResults,
+                               void *workSpace,
+                               size_t workSpaceSizeInBytes);
+hipdnnStatus_t
+hipdnnConvolutionBackwardData( hipdnnHandle_t handle,
+                               const void *alpha,
+                               const hipdnnFilterDescriptor_t wDesc,
+                               const void *w,
+                               const hipdnnTensorDescriptor_t dyDesc,
+                               const void *dy,
+                               const hipdnnConvolutionDescriptor_t convDesc,
+                               hipdnnConvolutionBwdDataAlgo_t algo,
+                               void *workSpace,
+                               size_t workSpaceSizeInBytes,
+                               const void *beta,
+                               const hipdnnTensorDescriptor_t dxDesc,
+                               void *dx);
+
+hipdnnStatus_t hipdnnSetConvolutionMathType(
+    hipdnnConvolutionDescriptor_t convDesc, hipdnnMathType_t mathType);
+
+hipdnnStatus_t
+hipdnnSetConvolutionGroupCount( hipdnnConvolutionDescriptor_t convDesc,
+                                int groupCount );
+
+//============================== SoftMax =======================================
+
+hipdnnStatus_t hipdnnSoftmaxForward( hipdnnHandle_t handle,
+                                     hipdnnSoftmaxAlgorithm_t algo,
+                                     hipdnnSoftmaxMode_t mode,
+                                     const void *alpha,
+                                     const hipdnnTensorDescriptor_t xDesc,
+                                     const void *x,
+                                     const void *beta,
+                                     const hipdnnTensorDescriptor_t yDesc,
+                                     void *y);
+
+ hipdnnStatus_t hipdnnSoftmaxBackward( hipdnnHandle_t handle,
+                                       hipdnnSoftmaxAlgorithm_t algo,
+                                       hipdnnSoftmaxMode_t mode,
+                                       const void *alpha,
+                                       const hipdnnTensorDescriptor_t yDesc,
+                                       const void *y,
+                                       const hipdnnTensorDescriptor_t dyDesc,
+                                       const void *dy,
+                                       const void *beta,
+                                       const hipdnnTensorDescriptor_t dxDesc,
+                                       void *dx);
+
+//================================ Pooling =====================================
+
+hipdnnStatus_t
+hipdnnCreatePoolingDescriptor(hipdnnPoolingDescriptor_t *poolingDesc);
+
+hipdnnStatus_t
+hipdnnSetPooling2dDescriptor( hipdnnPoolingDescriptor_t poolingDesc,
+                              hipdnnPoolingMode_t mode,
+                              hipdnnNanPropagation_t maxpoolingNanOpt,
+                              int windowHeight,
+                              int windowWidth,
+                              int verticalPadding,
+                              int horizontalPadding,
+                              int verticalStride,
+                              int horizontalStride);
+
+hipdnnStatus_t
+hipdnnSetPoolingNdDescriptor( hipdnnPoolingDescriptor_t poolingDesc,
+                              const hipdnnPoolingMode_t mode,
+                              const hipdnnNanPropagation_t maxpoolingNanOpt,
+                              int nbDims,
+                              const int windowDimA[],
+                              const int paddingA[],
+                              const int strideA[]);
+hipdnnStatus_t
+hipdnnGetPooling2dDescriptor( const hipdnnPoolingDescriptor_t poolingDesc,
+                               hipdnnPoolingMode_t *mode,
+                               hipdnnNanPropagation_t *maxpoolingNanOpt,
+                               int *windowHeight,    int *windowWidth,
+                               int *verticalPadding, int *horizontalPadding,
+                               int *verticalStride,  int *horizontalStride);
+
+hipdnnStatus_t
+hipdnnGetPooling2dForwardOutputDim( const hipdnnPoolingDescriptor_t poolingDesc,
+                                const hipdnnTensorDescriptor_t inputTensorDesc,
+                                int *n, int *c, int *h, int *w);
+
+hipdnnStatus_t
+hipdnnDestroyPoolingDescriptor( hipdnnPoolingDescriptor_t poolingDesc);
+
+hipdnnStatus_t hipdnnPoolingForward( hipdnnHandle_t handle,
+                                    const hipdnnPoolingDescriptor_t poolingDesc,
+                                    const void *alpha,
+                                    const hipdnnTensorDescriptor_t xDesc,
+                                    const void *x,
+                                    const void *beta,
+                                    const hipdnnTensorDescriptor_t yDesc,
+                                    void *y, bool do_backward);
+
+hipdnnStatus_t hipdnnPoolingBackward( hipdnnHandle_t handle,
+                                    const hipdnnPoolingDescriptor_t poolingDesc,
+                                    const void *alpha,
+                                    const hipdnnTensorDescriptor_t yDesc,
+                                    const void *y,
+                                    const hipdnnTensorDescriptor_t dyDesc,
+                                    const void *dy,
+                                    const hipdnnTensorDescriptor_t xDesc,
+                                    const void *x,
+                                    const void *beta,
+                                    const hipdnnTensorDescriptor_t dxDesc,
+                                    void *dx);
+
+//============================ Activation ======================================
+
+hipdnnStatus_t
+hipdnnCreateActivationDescriptor(hipdnnActivationDescriptor_t *activationDesc);
+
+/* cudnn uses only one coeff param - for clipping threashold or alpha coefficient.
+ * MIOpen supports three - Alpha, Beta and Gamma
+ * The first parameter reluCeilingOrAlpha is the common denominator.
+ * unless MIOpen specific mode used, zeros can be passed for activBeta and activExp
+ */
+hipdnnStatus_t
+hipdnnSetActivationDescriptor( hipdnnActivationDescriptor_t activationDesc,
+                                hipdnnActivationMode_t mode,
+                                hipdnnNanPropagation_t reluNanOpt,
+                                double reluCeilingOrAlpha,
+                                double activBeta,
+                                double activExp);
+
+hipdnnStatus_t
+hipdnnGetActivationDescriptor( const hipdnnActivationDescriptor_t activationDesc,
+                                hipdnnActivationMode_t *mode,
+                                hipdnnNanPropagation_t *reluNanOpt,
+                                double *reluCeilingOrAlpha,
+                                double *activBeta,
+                                double *activExp);
+
+hipdnnStatus_t
+hipdnnDestroyActivationDescriptor(hipdnnActivationDescriptor_t activationDesc);
+
+hipdnnStatus_t
+hipdnnActivationForward( hipdnnHandle_t handle,
+                         hipdnnActivationDescriptor_t activationDesc,
+                         const void *alpha,
+                         const hipdnnTensorDescriptor_t xDesc,
+                         const void *x,
+                         const void *beta,
+                         const hipdnnTensorDescriptor_t yDesc,
+                         void *y);
+
+hipdnnStatus_t
+hipdnnActivationBackward( hipdnnHandle_t handle,
+                           hipdnnActivationDescriptor_t activationDesc,
+                           const void *alpha,
+                           const hipdnnTensorDescriptor_t yDesc,
+                           const void *y,
+                           const hipdnnTensorDescriptor_t dyDesc,
+                           const void *dy,
+                           const hipdnnTensorDescriptor_t xDesc,
+                           const void *x,
+                           const void *beta,
+                           const hipdnnTensorDescriptor_t dxDesc,
+                           void *dx);
+
+//=======================Local Responce Normalization ==========================
+
+hipdnnStatus_t
+hipdnnCreateLRNDescriptor(hipdnnLRNDescriptor_t *normDesc);
+
+hipdnnStatus_t
+hipdnnSetLRNDescriptor( hipdnnLRNDescriptor_t normDesc,
+                        hipdnnLRNMode_t mode,
+                        unsigned lrnN,
+                        double lrnAlpha,
+                        double lrnBeta,
+                        double lrnK);
+
+hipdnnStatus_t
+hipdnnGetLRNDescriptor( hipdnnLRNDescriptor_t normDesc,
+                        hipdnnLRNMode_t *mode,
+                        unsigned *lrnN,
+                        double *lrnAlpha,
+                        double *lrnBeta,
+                        double *lrnK);
+
+hipdnnStatus_t
+hipdnnDestroyLRNDescriptor(hipdnnLRNDescriptor_t lrnDesc);
+
+hipdnnStatus_t
+hipdnnLRNCrossChannelForward( hipdnnHandle_t handle,
+                              hipdnnLRNDescriptor_t normDesc,
+                              hipdnnLRNMode_t lrnMode,
+                              const void *alpha,
+                              const hipdnnTensorDescriptor_t xDesc,
+                              const void *x,
+                              const void *beta,
+                              const hipdnnTensorDescriptor_t yDesc,
+                              void *y,
+                              bool do_backward);
+
+hipdnnStatus_t
+hipdnnLRNCrossChannelForwardEx( hipdnnHandle_t handle,
+                                hipdnnLRNDescriptor_t normDesc,
+                                hipdnnLRNMode_t lrnMode,
+                                const void *alpha,
+                                const hipdnnTensorDescriptor_t xDesc,
+                                const void *x,
+                                const void *beta,
+                                const hipdnnTensorDescriptor_t yDesc,
+                                void *y,
+                                size_t workspacesize,
+                                void *workspace,
+                                bool do_backward);
+
+hipdnnStatus_t
+hipdnnLRNCrossChannelBackward( hipdnnHandle_t handle,
+                               hipdnnLRNDescriptor_t normDesc,
+                               hipdnnLRNMode_t lrnMode,
+                               const void *alpha,
+                               const hipdnnTensorDescriptor_t yDesc,
+                               const void *y,
+                               const hipdnnTensorDescriptor_t dyDesc,
+                               const void *dy,
+                               const hipdnnTensorDescriptor_t xDesc,
+                               const void *x,
+                               const void *beta,
+                               const hipdnnTensorDescriptor_t dxDesc,
+                               void *dx);
+
+hipdnnStatus_t
+hipdnnLRNCrossChannelBackwardEx( hipdnnHandle_t handle,
+                                  hipdnnLRNDescriptor_t normDesc,
+                                  hipdnnLRNMode_t lrnMode,
+                                  const void *alpha,
+                                  const hipdnnTensorDescriptor_t yDesc,
+                                  const void *y,
+                                  const hipdnnTensorDescriptor_t dyDesc,
+                                  const void *dy,
+                                  const hipdnnTensorDescriptor_t xDesc,
+                                  const void *x, const void *beta,
+                                  const hipdnnTensorDescriptor_t dxDesc,
+                                  void *dx,
+                                  size_t workspacesize,
+                                  void *workspace);
+
+//============================ Batch Normalization =============================
+
+hipdnnStatus_t hipdnnDeriveBNTensorDescriptor(
+                                         hipdnnTensorDescriptor_t derivedBnDesc,
+                                         const hipdnnTensorDescriptor_t xDesc,
+                                         hipdnnBatchNormMode_t mode);
+
+hipdnnStatus_t
+hipdnnBatchNormalizationForwardTraining( hipdnnHandle_t handle,
+                          hipdnnBatchNormMode_t mode,
+                          void *alpha, void *beta,
+                          const hipdnnTensorDescriptor_t xDesc,
+                          const void *x,
+                          const hipdnnTensorDescriptor_t yDesc,
+                          void *y,
+                          const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc,
+                          void *bnScale, void *bnBias,
+                          double exponentialAverageFactor,
+                          void *resultRunningMean,
+                          void *resultRunningVariance,
+                          double epsilon,
+                          void *resultSaveMean,
+                          void *resultSaveInvVariance);
+
+hipdnnStatus_t
+hipdnnnBatchNormalizationForwardInference( hipdnnHandle_t handle,
+                           hipdnnBatchNormMode_t mode,
+                           void *alpha, void *beta,
+                           const hipdnnTensorDescriptor_t xDesc,
+                           const void *x,
+                           const hipdnnTensorDescriptor_t yDesc,
+                           void *y,
+                           const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc,
+                           const void *bnScale, const void *bnBias,
+                           const void *estimatedMean,
+                           const void *estimatedVariance,
+                           double epsilon);
+
+hipdnnStatus_t
+hipdnnBatchNormalizationBackward( hipdnnHandle_t handle,
+                             hipdnnBatchNormMode_t mode,
+                             const void *alphaDataDiff,
+                             const void *betaDataDiff,
+                             const void *alphaParamDiff,
+                             const void *betaParamDiff,
+                             const hipdnnTensorDescriptor_t xDesc,
+                             const void *x,
+                             const hipdnnTensorDescriptor_t dyDesc,
+                             const void *dy,
+                             const hipdnnTensorDescriptor_t dxDesc,
+                             void *dx,
+                             const hipdnnTensorDescriptor_t bnScaleBiasDiffDesc,
+                             const void *bnScale,
+                             void *resultBnScaleDiff,
+                             void *resultBnBiasDiff,
+                             double epsilon,
+                             const void *savedMean,
+                             const void *savedInvVariance);
+
+hipdnnStatus_t
+hipdnnBatchNormalizationForwardInference( hipdnnHandle_t handle,
+                          hipdnnBatchNormMode_t mode,
+                          const void *alpha,  // alpha[0] = result blend factor
+                          const void *beta,   // beta[0] = dest layer blend factor
+                          const hipdnnTensorDescriptor_t xDesc,
+                          const void *x,  // NxCxHxW
+                          const hipdnnTensorDescriptor_t yDesc,
+                          void *y,  // NxCxHxW
+                          const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc,
+                          const void *bnScale, const void *bnBias,
+                          const void *estimatedMean,
+                          const void *estimatedVariance,
+                          double epsilon);
+
+//======================== Drop out Layer ======================================
+
+hipdnnStatus_t
+hipdnnCreateDropoutDescriptor( hipdnnDropoutDescriptor_t *dropoutDesc);
+
+hipdnnStatus_t
+hipdnnDropoutGetStatesSize(hipdnnHandle_t handle, size_t *sizeInBytes);
+
+hipdnnStatus_t
+hipdnnSetDropoutDescriptor( hipdnnDropoutDescriptor_t dropoutDesc,
+                            hipdnnHandle_t handle,
+                            float dropout,
+                            void *states,
+                            size_t stateSizeInBytes,
+                            unsigned long long seed);
+
+hipdnnStatus_t
+hipdnnDestroyDropoutDescriptor( hipdnnDropoutDescriptor_t dropoutDesc);
+
+//======================= Recurrent Neural Net =================================
+
+hipdnnStatus_t hipdnnCreateRNNDescriptor(hipdnnRNNDescriptor_t *rnnDesc);
+
+hipdnnStatus_t hipdnnDestroyRNNDescriptor(hipdnnRNNDescriptor_t rnnDesc);
+
+// Expensive. Creates the plan for the specific settings.
+hipdnnStatus_t hipdnnCreatePersistentRNNPlan(hipdnnRNNDescriptor_t rnnDesc,
+                                             const int minibatch,
+                                             const hipdnnDataType_t dataType,
+                                             hipdnnPersistentRNNPlan_t *plan);
+
+// Attaches the plan to the descriptor.
+hipdnnStatus_t hipdnnSetPersistentRNNPlan(hipdnnRNNDescriptor_t rnnDesc,
+                                          hipdnnPersistentRNNPlan_t plan);
+
+hipdnnStatus_t hipdnnDestroyPersistentRNNPlan(hipdnnPersistentRNNPlan_t plan);
+
+/* DataType in the RNN descriptor is used to determine math precision
+ * DataType in weight descriptors and input descriptors is used to describe storage
+ */
+
+hipdnnStatus_t
+hipdnnSetRNNDescriptor_v6( hipdnnHandle_t handle,
+            hipdnnRNNDescriptor_t rnnDesc,
+            const int hiddenSize,
+            const int numLayers,
+            hipdnnDropoutDescriptor_t dropoutDesc, /*Between layers, not between recurrent steps*/
+            hipdnnRNNInputMode_t inputMode,
+            hipdnnDirectionMode_t direction,
+            hipdnnRNNMode_t mode,
+            hipdnnRNNAlgo_t algo,
+            hipdnnDataType_t dataType);
+
+hipdnnStatus_t
+hipdnnSetRNNDescriptor( hipdnnHandle_t handle,
+            hipdnnRNNDescriptor_t rnnDesc,
+            int hiddenSize,
+            int numLayers,
+            hipdnnDropoutDescriptor_t dropoutDesc,/*Between layers, not between recurrent steps*/
+            hipdnnRNNInputMode_t inputMode,
+            hipdnnDirectionMode_t direction,
+            hipdnnRNNMode_t mode,
+            hipdnnRNNAlgo_t algo,
+            hipdnnDataType_t dataType,
+            hipdnnRNNBiasMode_t biasMode);
+
+hipdnnStatus_t
+hipdnnSetRNNDescriptor_v5( hipdnnRNNDescriptor_t rnnDesc,
+            int hiddenSize,
+            int numLayers,
+            hipdnnDropoutDescriptor_t dropoutDesc, /* Between layers, not between recurrent steps. */
+            hipdnnRNNInputMode_t inputMode,
+            hipdnnDirectionMode_t direction,
+            hipdnnRNNMode_t mode,
+            hipdnnDataType_t dataType);
+
+hipdnnStatus_t
+hipdnnGetRNNDescriptor(hipdnnHandle_t handle,
+           hipdnnRNNDescriptor_t rnnDesc,
+           int* hiddenSize, int* numLayers,
+           hipdnnDropoutDescriptor_t *dropoutDesc,
+           hipdnnRNNInputMode_t *inputMode,
+           hipdnnDirectionMode_t *direction,
+           hipdnnRNNMode_t *mode,
+           hipdnnRNNAlgo_t *algo,
+           hipdnnDataType_t *dataType,
+           hipdnnRNNBiasMode_t *biasMode);
+
+hipdnnStatus_t
+hipdnnGetRNNParamsSize(hipdnnHandle_t handle,
+            const hipdnnRNNDescriptor_t rnnDesc,
+            const hipdnnTensorDescriptor_t xDesc,
+            size_t *sizeInBytes,
+            hipdnnDataType_t dataType);
+
+hipdnnStatus_t
+hipdnnGetRNNLayerParamSize(hipdnnHandle_t handle,
+                hipdnnRNNDescriptor_t rnnDesc,
+                const int layer,
+                hipdnnTensorDescriptor_t xDesc,
+                const int paramID,
+                size_t *numBytes);
+
+hipdnnStatus_t
+hipdnnGetRNNLayerBiasSize(hipdnnHandle_t handle,
+                    hipdnnRNNDescriptor_t rnnDesc,
+                    const int layer,
+                    const int biasID,
+                    size_t *numBytes);
+
+hipdnnStatus_t hipdnnGetRNNWorkspaceSize(hipdnnHandle_t handle,
+                                         const hipdnnRNNDescriptor_t rnnDesc,
+                                         const int seqLength,
+                                         const hipdnnTensorDescriptor_t *xDesc,
+                                         size_t *sizeInBytes);
+
+hipdnnStatus_t
+hipdnnGetRNNTrainingReserveSize( hipdnnHandle_t handle,
+                                 const hipdnnRNNDescriptor_t rnnDesc,
+                                 const int seqLength,
+                                 const hipdnnTensorDescriptor_t *xDesc,
+                                 size_t *sizeInBytes);
+
+hipdnnStatus_t hipdnnGetRNNParamsSize(hipdnnHandle_t handle,
+                                      const hipdnnRNNDescriptor_t rnnDesc,
+                                      const hipdnnTensorDescriptor_t xDesc,
+                                      size_t *sizeInBytes,
+                                      hipdnnDataType_t dataType);
+
+hipdnnStatus_t
+hipdnnGetRNNLinLayerMatrixParams( hipdnnHandle_t handle,
+                                  const hipdnnRNNDescriptor_t rnnDesc,
+                                  const int layer,
+                                  const hipdnnTensorDescriptor_t xDesc,
+                                  const hipdnnFilterDescriptor_t wDesc,
+                                  const void *w,
+                                  const int linLayerID,
+                                  hipdnnFilterDescriptor_t linLayerMatDesc,
+                                  void **linLayerMat);
+
+hipdnnStatus_t
+hipdnnGetRNNLinLayerBiasParams( hipdnnHandle_t handle,
+                                const hipdnnRNNDescriptor_t rnnDesc,
+                                const int layer,
+                                const hipdnnTensorDescriptor_t xDesc,
+                                const hipdnnFilterDescriptor_t wDesc,
+                                const void *w,
+                                const int linLayerID,
+                                hipdnnFilterDescriptor_t linLayerBiasDesc,
+                                void **linLayerBias);
+
+hipdnnStatus_t
+hipdnnGetRNNParamsDescriptor(hipdnnHandle_t handle,
+                             hipdnnRNNDescriptor_t rnnDesc,
+                             hipdnnTensorDescriptor_t xDesc,
+                             hipdnnTensorDescriptor_t wDesc,
+                             hipdnnDataType_t dtype);
+
+hipdnnStatus_t
+hipdnnGetRNNInputTensorSize(hipdnnHandle_t handle,
+                            hipdnnRNNDescriptor_t rnnDesc,
+                            const int seqLen,
+                            hipdnnTensorDescriptor_t *xDesc,
+                            size_t *numBytes);
+
+hipdnnStatus_t
+hipdnnGetRNNHiddenTensorSize(hipdnnHandle_t handle,
+                             hipdnnRNNDescriptor_t rnnDesc,
+                             const int seqLen,
+                             hipdnnTensorDescriptor_t *xDesc,
+                             size_t *numBytes);
+
+hipdnnStatus_t
+hipdnnSetRNNLayerParam(hipdnnHandle_t handle,
+                       hipdnnRNNDescriptor_t rnnDesc,
+                       const int layer,
+                       hipdnnTensorDescriptor_t xDesc,
+                       hipdnnTensorDescriptor_t wDesc,
+                       void *w,
+                       const int paramID,
+                       hipdnnTensorDescriptor_t paramDesc,
+                       const void *layerParam);
+
+hipdnnStatus_t
+hipdnnSetRNNLayerBias(hipdnnHandle_t handle,
+                      hipdnnRNNDescriptor_t rnnDesc,
+                      const int layer,
+                      hipdnnTensorDescriptor_t xDesc,
+                      hipdnnTensorDescriptor_t wDesc,
+                      void *w,
+                      const int biasID,
+                      hipdnnTensorDescriptor_t biasDesc,
+                      const void *layerBias);
+
+hipdnnStatus_t
+hipdnnRNNForwardInference( hipdnnHandle_t handle,
+                           const hipdnnRNNDescriptor_t rnnDesc,
+                           const int seqLength,
+                           const hipdnnTensorDescriptor_t *xDesc, const void *x,
+                           const hipdnnTensorDescriptor_t hxDesc, const void *hx,
+                           const hipdnnTensorDescriptor_t cxDesc, const void *cx,
+                           const hipdnnFilterDescriptor_t wDesc,  const void *w,
+                           const hipdnnTensorDescriptor_t *yDesc, void *y,
+                           const hipdnnTensorDescriptor_t hyDesc, void *hy,
+                           const hipdnnTensorDescriptor_t cyDesc, void *cy,
+                           void *workspace,
+                           size_t workSpaceSizeInBytes);
+
+hipdnnStatus_t
+hipdnnRNNForwardTraining( hipdnnHandle_t handle,
+                          const hipdnnRNNDescriptor_t rnnDesc,
+                          const int seqLength,
+                          const hipdnnTensorDescriptor_t *xDesc, const void *x,
+                          const hipdnnTensorDescriptor_t hxDesc, const void *hx,
+                          const hipdnnTensorDescriptor_t cxDesc, const void *cx,
+                          const hipdnnFilterDescriptor_t wDesc,  const void *w,
+                          const hipdnnTensorDescriptor_t *yDesc, void *y,
+                          const hipdnnTensorDescriptor_t hyDesc, void *hy,
+                          const hipdnnTensorDescriptor_t cyDesc, void *cy,
+                          void *workspace, size_t workSpaceSizeInBytes,
+                          void *reserveSpace, size_t reserveSpaceSizeInBytes);
+
+hipdnnStatus_t
+hipdnnRNNBackwardData( hipdnnHandle_t handle,
+                       const hipdnnRNNDescriptor_t rnnDesc,
+                       const int seqLength,
+                       const hipdnnTensorDescriptor_t *yDesc,  const void *y,
+                       const hipdnnTensorDescriptor_t *dyDesc, const void *dy,
+                       const hipdnnTensorDescriptor_t dhyDesc, const void *dhy,
+                       const hipdnnTensorDescriptor_t dcyDesc, const void *dcy,
+                       const hipdnnFilterDescriptor_t wDesc,   const void *w,
+                       const hipdnnTensorDescriptor_t hxDesc,  const void *hx,
+                       const hipdnnTensorDescriptor_t cxDesc,  const void *cx,
+                       const hipdnnTensorDescriptor_t *dxDesc, void *dx,
+                       const hipdnnTensorDescriptor_t dhxDesc, void *dhx,
+                       const hipdnnTensorDescriptor_t dcxDesc, void *dcx,
+                       void *workspace, size_t workSpaceSizeInBytes,
+                       void *reserveSpace, size_t reserveSpaceSizeInBytes);
+
+hipdnnStatus_t
+hipdnnRNNBackwardWeights( hipdnnHandle_t handle,
+                          const hipdnnRNNDescriptor_t rnnDesc,
+                          const int seqLength,
+                          const hipdnnTensorDescriptor_t *xDesc, const void *x,
+                          const hipdnnTensorDescriptor_t hxDesc, const void *hx,
+                          const hipdnnTensorDescriptor_t *yDesc, const void *y,
+                          const void *workspace, size_t workSpaceSizeInBytes,
+                          const hipdnnFilterDescriptor_t dwDesc, void *dw,
+                          const void *reserveSpace, size_t reserveSpaceSizeInBytes);
+
+//========================== Fusion API ========================================
+
+hipdnnStatus_t
+hipdnnCreateFusionPlan( hipdnnFusionPlanDescriptor_t *fusePlanDesc,
+                        const hipdnnFusionDirection_t fuseDirection,
+                        const hipdnnTensorDescriptor_t inputDesc);
+
+
+hipdnnStatus_t
+hipdnnCreateOpConvForward( hipdnnFusionPlanDescriptor_t    fusePlanDesc,
+                           hipdnnFusionOpDescriptor_t*     convOp,
+                           hipdnnConvolutionDescriptor_t   convDesc,
+                           const hipdnnTensorDescriptor_t  wDesc );
+
+hipdnnStatus_t
+hipdnnCreateOpBiasForward( hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                           hipdnnFusionOpDescriptor_t *biasOp,
+                           const hipdnnTensorDescriptor_t bDesc);
+
+hipdnnStatus_t
+hipdnnCreateOpActivationForward( hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                                 hipdnnFusionOpDescriptor_t *activOp,
+                                 hipdnnActivationMode_t mode);
+
+hipdnnStatus_t
+hipdnnCreateOpBatchNormInference(
+                 hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                 hipdnnFusionOpDescriptor_t *bnOp,
+                 const hipdnnBatchNormMode_t bn_mode,
+                 const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc);
+
+hipdnnStatus_t
+hipdnnCompileFusionPlan( hipdnnHandle_t handle,
+                         hipdnnFusionPlanDescriptor_t fusePlanDesc);
+
+hipdnnStatus_t
+hipdnnFusionPlanGetOp( hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                       const int op_idx,
+                       hipdnnFusionOpDescriptor_t *op);
+
+hipdnnStatus_t
+hipdnnFusionPlanGetWorkSpaceSize( hipdnnHandle_t handle,
+                                  hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                                  size_t *workSpaceSize,
+                                  hipdnnConvolutionFwdAlgo_t algo);
+
+hipdnnStatus_t
+hipdnnFusionPlanConvolutionGetAlgo(
+                        hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                        const int requestAlgoCount,
+                        int* returnedAlgoCount,
+                        hipdnnConvolutionFwdAlgo_t* returnedAlgos);
+
+hipdnnStatus_t hipdnnCreateOperatorArgs( hipdnnOperatorArgs_t* args);
+
+hipdnnStatus_t
+hipdnnSetOpArgsConvForward( hipdnnOperatorArgs_t args,
+                            const hipdnnFusionOpDescriptor_t convOp,
+                            const void *alpha,
+                            const void *beta,
+                            const void *w );
+
+hipdnnStatus_t
+hipdnnSetOpArgsBiasForward( hipdnnOperatorArgs_t args,
+                            const hipdnnFusionOpDescriptor_t biasOp,
+                            const void *alpha,
+                            const void *beta,
+                            const void *bias );
+
+hipdnnStatus_t
+hipdnnSetOpArgsActivForward( hipdnnOperatorArgs_t args,
+                             const hipdnnFusionOpDescriptor_t activOp,
+                             const void *alpha,
+                             const void *beta,
+                             double activAlpha,
+                             double activBeta,
+                             double activGamma);
+
+hipdnnStatus_t
+hipdnnSetOpArgsBatchNormInference( hipdnnOperatorArgs_t args,
+                                   const hipdnnFusionOpDescriptor_t bnOp,
+                                   const void* alpha,
+                                   const void* beta,
+                                   const void* bnScale,
+                                   const void* bnBias,
+                                   const void* estimatedMean,
+                                   const void* estimatedVariance,
+                                   double epsilon);
+
+
+hipdnnStatus_t
+hipdnnExecuteFusionPlan( const hipdnnHandle_t handle,
+                         const hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                         const hipdnnTensorDescriptor_t inputDesc,
+                         const void *input,
+                         const hipdnnTensorDescriptor_t outputDesc, void *output,
+                         hipdnnOperatorArgs_t args);
+
+hipdnnStatus_t hipdnnDestroyOperatorArgs( hipdnnOperatorArgs_t args);
+
+hipdnnStatus_t
+hipdnnDestroyFusionPlan( hipdnnFusionPlanDescriptor_t fusePlanDesc);
+
+//==============================================================================
+
+const char *hipdnnGetErrorString(hipdnnStatus_t status);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //WITH_HIP
+
+#endif  // HIPDNN_H

--- a/oneflow/core/hipdnn/hipdnn_miopen.cpp
+++ b/oneflow/core/hipdnn/hipdnn_miopen.cpp
@@ -1,0 +1,3770 @@
+/*
+ Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+#ifdef WITH_HIP
+
+#include <assert.h>
+#include <hipdnn_miopen.h>
+#include <hipdnn.h>
+#include <logger.h>
+#include <stdint.h>
+#include <exception>
+#include <iterator>
+#include <map>
+#include "hip/hip_runtime.h"
+
+#define CHECK_MIO(expression)                                                   \
+    {                                                                           \
+        hipdnnStatus_t status = miopenTohipdnnStatus(expression);               \
+        if (status != HIPDNN_STATUS_SUCCESS) {                                  \
+            fprintf(stderr, "HIPDNN error: %s (%d) at %s:%d\n",                 \
+                    hipdnnGetErrorString(status), status, __FILE__, __LINE__);  \
+            return status;                                                      \
+        }                                                                       \
+    }
+
+#define CHECK_HIPDNN_NO_RET(expression)                                         \
+    {                                                                           \
+        hipdnnStatus_t error = (expression);                                    \
+        if (error != HIPDNN_STATUS_SUCCESS) {                                   \
+            fprintf(stderr, "HIPDNN error: '%s'(%d) at %s:%d\n",                \
+                    hipdnnGetErrorString(error), error, __FILE__, __LINE__);    \
+        }                                                                       \
+    }
+
+#define HIPDNNFLUSH << std::flush;
+#define PROMOTE_TO_SUPPORTED
+
+#ifndef thread_local
+#if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#define thread_local _Thread_local
+#elif defined _WIN32 && (defined _MSC_VER || defined __ICL || \
+                         defined __DMC__ || defined __BORLANDC__)
+#define thread_local __declspec(thread)
+/* note that ICC (linux) and Clang are covered by __GNUC__ */
+#elif defined __GNUC__ || defined __SUNPRO_C || defined __xlC__
+#define thread_local __thread
+#else
+//#error "Cannot define thread_local"
+// NOT THREAD SAFE.
+#define thread_local
+#endif
+#endif
+
+// std::map<miopenPoolingDescriptor_t, void *>  sPoolingDescToWorkspace;  ????
+
+static std::map<miopenTensorDescriptor_t, std::pair<int8_t *, size_t>>
+    sDescToWorkspacePooling;  // device pointers
+
+static std::map<miopenTensorDescriptor_t, std::pair<int8_t *, size_t>>
+    sDescToWorkspaceLRN;  // device pointers
+
+static std::map<miopenConvolutionDescriptor_t, int *>
+    sDescTo3DConvolution;  // To bookkeep 3D depth information
+
+
+// Custom TensorAdd Kernel
+
+/*
+ * dst= dst + beta * prior
+ */
+template <typename T>
+__global__ void TensorAdd(T *C_d, T *A_d, T beta, int N) {
+    size_t offset = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x);
+    size_t stride = hipBlockDim_x * hipGridDim_x;
+    for (size_t i = offset; i < N; i += stride) {
+        C_d[i] = beta * A_d[i] + C_d[i];
+    }
+}
+
+// SaveAsPriorBuffer routine to book keep and return priorData before any
+// activation or convolution
+
+// Returns the hipMalloc'ed PriorData to be used for accumalation when
+// the scaling factor beta is non zero
+void *SaveAsPriorBuffer(void *dData) {
+    void *dPrior = NULL;    // Pointer to keep track of priorDst value
+    size_t dPriorSize = 0;  // PriorDstSize
+    CHECK_HIP(hipMemPtrGetInfo(
+        dData, &dPriorSize));  // Get the info of the gradient dx size
+    CHECK_HIP(hipMalloc(&dPrior, dPriorSize));  // Allocate priorDst
+    CHECK_HIP(hipMemcpy(
+        dPrior, dData, dPriorSize,
+        hipMemcpyDeviceToDevice));  // Copy gradient to prior Destination
+    return dPrior;
+}
+
+// Revoke the PriorBuffer
+void deallocPrior(void *dData) {
+    size_t dPriorSize = 0;  // PriorDstSize
+    CHECK_HIP(hipMemPtrGetInfo(dData, &dPriorSize));
+    if (dPriorSize > 0) CHECK_HIP(hipFree(dData));
+}
+
+//=============================================================================
+
+hipdnnStatus_t miopenTohipdnnStatus(miopenStatus_t cStatus) {
+    switch (cStatus) {
+        case miopenStatusSuccess:
+            return HIPDNN_STATUS_SUCCESS;
+            break;
+        case miopenStatusNotInitialized:
+            return HIPDNN_STATUS_NOT_INITIALIZED;
+            break;
+        case miopenStatusAllocFailed:
+            return HIPDNN_STATUS_ALLOC_FAILED;
+            break;
+        case miopenStatusBadParm:
+            return HIPDNN_STATUS_BAD_PARAM;
+            break;
+        case miopenStatusInternalError:
+            return HIPDNN_STATUS_INTERNAL_ERROR;
+            break;
+        case miopenStatusInvalidValue:
+            return HIPDNN_STATUS_INVALID_VALUE;
+            break;
+        case miopenStatusUnknownError:
+            return HIPDNN_STATUS_EXECUTION_FAILED;
+            break;
+        case miopenStatusNotImplemented:
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+            break;
+        default:
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipTomiopenDataType(hipdnnDataType_t in, miopenDataType_t *out) {
+    switch (in) {
+        case HIPDNN_DATA_FLOAT:
+            *out = miopenFloat;
+            break;
+        case HIPDNN_DATA_HALF:
+            *out = miopenHalf;
+            break;
+        case HIPDNN_DATA_DOUBLE:
+        case HIPDNN_DATA_INT8:
+        case HIPDNN_DATA_INT32:
+        case HIPDNN_DATA_INT8x4:
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenDataType " << in << ": NOT SUPPORTED."
+                                                     << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipDataType(miopenDataType_t in, hipdnnDataType_t *out) {
+    switch (in) {
+        case miopenFloat:
+            *out = HIPDNN_DATA_FLOAT;
+            break;
+        case miopenHalf:
+            *out = HIPDNN_DATA_HALF;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipDataType " << in << ": NOT SUPPORTED."
+                                                     << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t miopenTohipdnnConvolutionMode(miopenConvolutionMode_t in,
+                                                hipdnnConvolutionMode_t* out) {
+    if (in == miopenConvolution) //MIOpen's convolution is cudnn's corss corelation equivalent
+        *out = HIPDNN_CROSS_CORRELATION;
+    else if( in == miopenTranspose)
+        *out = HIPDNN_TRANSPOSE;
+    else if( in == miopenGroupConv)
+        *out = HIPDNN_GROUP_CONVOLUTION;
+    else if( in == miopenDepthwise)
+        *out = HIPDNN_DEPTHWISE;
+    else
+        return HIPDNN_STATUS_NOT_SUPPORTED;
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipTomiopenConvolutionMode(hipdnnConvolutionMode_t in,
+                                                miopenConvolutionMode_t* out) {
+    if (in == HIPDNN_CROSS_CORRELATION)
+        *out = miopenConvolution;
+    else if( in == HIPDNN_TRANSPOSE)
+        *out = miopenTranspose;
+    else if( in == HIPDNN_GROUP_CONVOLUTION)
+        *out = miopenGroupConv;
+    else if( in == HIPDNN_DEPTHWISE)
+        *out = miopenDepthwise;
+
+    else if( in == HIPDNN_CONVOLUTION) {
+        std::cerr << "CONVOLUTION is Not supported in MIOpen."
+                  <<"CROSS_CORRELATION can be used instead for (Train+Inference)";
+        return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    else
+        return HIPDNN_STATUS_NOT_SUPPORTED;
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipTomiopenPoolingMode(hipdnnPoolingMode_t in,
+                                      miopenPoolingMode_t *out) {
+    switch (in) {
+        case HIPDNN_POOLING_MAX:
+            *out = miopenPoolingMax;
+            break;
+        case HIPDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING:
+            *out = miopenPoolingAverageInclusive;
+            break;
+        case HIPDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING:
+            *out = miopenPoolingAverage;
+            break;
+        case HIPDNN_POOLING_MAX_DETERMINISTIC:
+            *out = miopenPoolingMax;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenPoolingMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipPoolingMode(miopenPoolingMode_t in,
+                                      hipdnnPoolingMode_t *out) {
+    switch (in) {
+        case miopenPoolingMax:
+            *out = HIPDNN_POOLING_MAX;
+            break;
+        case miopenPoolingAverageInclusive:
+            *out = HIPDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
+            break;
+        case miopenPoolingAverage:
+            *out = HIPDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING;
+            break;
+            // HGSOS     *out = HIPDNN_POOLING_MAX_DETERMINISTIC;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipPoolingMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipTomiopenLRNMode(hipdnnLRNMode_t in, miopenLRNMode_t *out) {
+    switch (in) {
+        case HIPDNN_LRN_WITHIN_CHANNEL:
+            *out = miopenLRNWithinChannel;
+            break;
+        case HIPDNN_LRN_CROSS_CHANNEL:
+            *out = miopenLRNCrossChannel;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenLRNMode" << in << ": NOT SUPPORTED."
+                                                   << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipLRNMode(miopenLRNMode_t in, hipdnnLRNMode_t *out) {
+    switch (in) {
+        case miopenLRNWithinChannel:
+            *out = HIPDNN_LRN_WITHIN_CHANNEL;
+            break;
+        case miopenLRNCrossChannel:
+            *out = HIPDNN_LRN_CROSS_CHANNEL;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipLRNMode " << in << ": NOT SUPPORTED."
+                                                    << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipTomiopenBatchNormMode(hipdnnBatchNormMode_t in,
+                                        miopenBatchNormMode_t *out) {
+    switch (in) {
+        case HIPDNN_BATCHNORM_PER_ACTIVATION:
+            *out = miopenBNPerActivation;
+            break;
+        case HIPDNN_BATCHNORM_SPATIAL:
+            *out = miopenBNSpatial;
+            break;
+        case HIPDNN_BATCHNORM_SPATIAL_PERSISTENT:
+            *out = miopenBNSpatial;  // TODO: Change when Spatial persistent is
+                                     // supported on MIOPEN
+            break;
+        default:
+            HIPDNN_OPEN_LOG_E("Invalid HIPDNN_BATCHNORM_MODE" << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t miopenTohipActivationMode(miopenActivationMode_t in,
+                                         hipdnnActivationMode_t *out) {
+    switch (in) {
+        case miopenActivationLOGISTIC:
+            *out = HIPDNN_ACTIVATION_SIGMOID;
+            break;
+
+        case miopenActivationRELU:
+            *out = HIPDNN_ACTIVATION_RELU;
+            break;
+
+        case miopenActivationTANH:
+            *out = HIPDNN_ACTIVATION_TANH;
+            break;
+
+        case miopenActivationPASTHRU:
+            *out = HIPDNN_ACTIVATION_PATHTRU;
+            break;
+
+        case miopenActivationSOFTRELU:
+            *out = HIPDNN_ACTIVATION_SOFTRELU;
+            break;
+
+        case miopenActivationABS:
+            *out = HIPDNN_ACTIVATION_ABS;
+            break;
+
+        case miopenActivationPOWER:
+            *out = HIPDNN_ACTIVATION_POWER;
+            break;
+
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipActivationMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipTomiopenActivationMode(hipdnnActivationMode_t in,
+                                         miopenActivationMode_t *out) {
+    switch (in) {
+        case HIPDNN_ACTIVATION_SIGMOID:
+            HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_SIGMOID" << std::flush);
+            *out = miopenActivationLOGISTIC;
+            break;
+
+        case HIPDNN_ACTIVATION_RELU:
+            HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_RELU" << std::flush);
+            *out = miopenActivationRELU;
+            break;
+
+        case HIPDNN_ACTIVATION_TANH:
+            HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_TANH" << std::flush);
+            *out = miopenActivationTANH;
+            break;
+
+        case HIPDNN_ACTIVATION_PATHTRU:
+            HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_PATHTRU" << std::flush);
+            *out = miopenActivationPASTHRU;
+            break;
+
+        case HIPDNN_ACTIVATION_SOFTRELU:
+            HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_SOFTRELU" << std::flush);
+            *out = miopenActivationSOFTRELU;
+            break;
+
+        case HIPDNN_ACTIVATION_ABS:
+            HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_ABS" << std::flush);
+            *out = miopenActivationABS;
+            break;
+
+        case HIPDNN_ACTIVATION_POWER:
+            HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_POWER" << std::flush);
+            *out = miopenActivationPOWER;
+            break;
+
+        case HIPDNN_ACTIVATION_ELU:
+            HIPDNN_OPEN_LOG_E("HIPDNN_ACTIVATION_ELU" << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+
+        case HIPDNN_ACTIVATION_CLIPPED_RELU:
+            HIPDNN_OPEN_LOG_E("HIPDNN_ACTIVATION_CLIPPED_RELU" << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipPoolingMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipTomiopenConvolutionFwdAlgo(hipdnnConvolutionFwdAlgo_t in,
+                                             miopenConvFwdAlgorithm_t *out) {
+    switch (in) {
+        case HIPDNN_CONVOLUTION_FWD_ALGO_GEMM:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_FWD_ALGO_GEMM" << std::flush);
+            *out = miopenConvolutionFwdAlgoGEMM;
+            break;
+
+        case HIPDNN_CONVOLUTION_FWD_ALGO_DIRECT:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_FWD_ALGO_DIRECT"
+                              << std::flush);
+            *out = miopenConvolutionFwdAlgoDirect;
+            break;
+
+        case HIPDNN_CONVOLUTION_FWD_ALGO_FFT:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_FWD_ALGO_FFT" << std::flush);
+            *out = miopenConvolutionFwdAlgoFFT;
+            break;
+
+        case HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD"
+                              << std::flush);
+            *out = miopenConvolutionFwdAlgoWinograd;
+            break;
+
+        case HIPDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM"
+                              << std::flush);
+            *out = miopenConvolutionFwdAlgoGEMM;
+            break;
+
+        default:
+            HIPDNN_OPEN_LOG_E("hipdnnConvolutionFwdAlgo_t: "
+                              << in << " NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipConvolutionFwdAlgo(miopenConvFwdAlgorithm_t in,
+                                             hipdnnConvolutionFwdAlgo_t *out) {
+    switch (in) {
+        case miopenConvolutionFwdAlgoGEMM:
+            *out = HIPDNN_CONVOLUTION_FWD_ALGO_GEMM;
+            break;
+        case miopenConvolutionFwdAlgoDirect:
+            *out = HIPDNN_CONVOLUTION_FWD_ALGO_DIRECT;
+            break;
+        case miopenConvolutionFwdAlgoFFT:
+            *out = HIPDNN_CONVOLUTION_FWD_ALGO_FFT;
+            break;
+        case miopenConvolutionFwdAlgoWinograd:
+            *out = HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipConvolutionFwdAlgo "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+            break;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+int ConvolutionFwdAlgoCount() { return 4; }
+
+// call ConvolutionFwdAlgoCount first, caller's responsibility to
+// make sure that i is not too large!
+//
+hipdnnConvolutionFwdAlgo_t GetConvolutionFwdAlgo(int i) {
+    hipdnnConvolutionFwdAlgo_t retVal;
+    miopenConvFwdAlgorithm_t mialgo;
+
+    if (i < ConvolutionFwdAlgoCount()) {
+        mialgo = (miopenConvFwdAlgorithm_t)i;
+    } else {
+        // for protection
+        mialgo = (miopenConvFwdAlgorithm_t)miopenConvolutionFwdAlgoWinograd;
+    }
+    CHECK_HIPDNN_NO_RET( miopenTohipConvolutionFwdAlgo(mialgo, &retVal));
+    return retVal;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipTomiopenConvolutionBwdFilterAlgo(
+    hipdnnConvolutionBwdFilterAlgo_t in, miopenConvBwdWeightsAlgorithm_t *out) {
+    switch (in) {
+        case HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_0:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_0"
+                              << std::flush);
+            *out = miopenConvolutionBwdWeightsAlgoGEMM;
+            break;
+
+        case HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_1:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_1"
+                              << std::flush);
+            *out = miopenConvolutionBwdWeightsAlgoDirect;
+            break;
+
+        case HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD"
+                              << std::flush);
+            *out = miopenConvolutionBwdWeightsAlgoWinograd;
+            break;
+
+            // TODO NEEL: Add other BwdFilter algorithms
+            /*case HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT:
+             case HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_3:
+             case HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD_NONFUSED:
+             case HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT_TILING:
+             case HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT:*/ //TODO: will be added in future
+        default:
+            HIPDNN_OPEN_LOG_E("hipdnnConvolutionBwdFilterAlgo_t: "
+                              << in << " NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+            break;
+    }
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipConvolutionBwdFilterAlgo(
+    miopenConvBwdWeightsAlgorithm_t in, hipdnnConvolutionBwdFilterAlgo_t *out) {
+    switch (in) {
+        case miopenConvolutionBwdWeightsAlgoGEMM:
+            *out = HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
+            break;
+        case miopenConvolutionBwdWeightsAlgoDirect:
+            *out = HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_1;
+            break;
+        case miopenConvolutionBwdWeightsAlgoWinograd:
+            *out = HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_E("miopenTohipConvolutionBwdFilterAlgo: "
+                              << in << " NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+int ConvolutionBwdFilterAlgoCount() { return (int)2; }
+
+// call ConvolutionBwdFilterAlgoCount first, caller's responsibility to
+// make sure that i is not too large!
+//
+hipdnnConvolutionBwdFilterAlgo_t GetConvolutionBwdFilterAlgo(int i) {
+    hipdnnConvolutionBwdFilterAlgo_t retVal;
+    miopenConvBwdWeightsAlgorithm_t mialgo;
+
+    if (i < ConvolutionBwdFilterAlgoCount()) {
+        mialgo = (miopenConvBwdWeightsAlgorithm_t)i;
+    } else {
+        // for protection
+        mialgo = (miopenConvBwdWeightsAlgorithm_t)
+            miopenConvolutionBwdWeightsAlgoGEMM;
+    }
+    CHECK_HIPDNN_NO_RET(miopenTohipConvolutionBwdFilterAlgo(mialgo, &retVal));
+
+    return retVal;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipTomiopenConvolutionBwdDataAlgo(
+    hipdnnConvolutionBwdDataAlgo_t in, miopenConvBwdDataAlgorithm_t *out) {
+    switch (in) {
+        case HIPDNN_CONVOLUTION_BWD_DATA_ALGO_0:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_BWD_DATA_ALGO_0"
+                              << std::flush);
+            *out = miopenConvolutionBwdDataAlgoGEMM;
+            break;
+
+        case HIPDNN_CONVOLUTION_BWD_DATA_ALGO_1:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_BWD_DATA_ALGO_1"
+                              << std::flush);
+            *out = miopenConvolutionBwdDataAlgoDirect;
+            break;
+
+        case HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD"
+                              << std::flush);
+            *out = miopenConvolutionBwdDataAlgoWinograd;
+            break;
+
+        case HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED:
+            HIPDNN_OPEN_LOG_M(
+                "HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED"
+                << std::flush);
+            *out = miopenConvolutionBwdDataAlgoWinograd;
+            break;
+
+        case HIPDNN_CONVOLUTION_BWD_DATA_ALGO_FFT:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_BWD_DATA_ALGO_FFT"
+                              << std::flush);
+            *out = miopenConvolutionBwdDataAlgoFFT;
+            break;
+
+        case HIPDNN_CONVOLUTION_BWD_DATA_ALGO_TRANSPOSE_GEMM:
+            HIPDNN_OPEN_LOG_M("HIPDNN_CONVOLUTION_BWD_DATA_ALGO_TRANSPOSE_GEMM"
+                              << std::flush);
+            *out = miopenTransposeBwdDataAlgoGEMM;
+            break;
+
+        default:
+            HIPDNN_OPEN_LOG_E("hipdnnConvolutionBwdDataAlgo_t: "
+                              << in << " NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipConvolutionBwdDataAlgo(
+    miopenConvBwdDataAlgorithm_t in, hipdnnConvolutionBwdDataAlgo_t *out) {
+    switch (in) {
+        case miopenConvolutionBwdDataAlgoGEMM:
+            *out = HIPDNN_CONVOLUTION_BWD_DATA_ALGO_0;
+            break;
+        case miopenConvolutionBwdDataAlgoDirect:
+            *out = HIPDNN_CONVOLUTION_BWD_DATA_ALGO_1;
+            break;
+        case miopenConvolutionBwdDataAlgoFFT:
+            *out = HIPDNN_CONVOLUTION_BWD_DATA_ALGO_FFT;
+            break;
+        case miopenConvolutionBwdDataAlgoWinograd:
+            *out = HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD;
+            break;
+        case miopenTransposeBwdDataAlgoGEMM:
+            *out = HIPDNN_CONVOLUTION_BWD_DATA_ALGO_TRANSPOSE_GEMM;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_E("miopenTohipConvolutionBwdDataAlgo: "
+                              << in << " NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+int ConvolutionBwdDataAlgoCount() { return (int)2; }
+
+// call ConvolutionBwdDataAlgoCount first, caller's responsibility to
+// make sure that i is not too large!
+//
+hipdnnConvolutionBwdDataAlgo_t GetConvolutionBwdDataAlgo(int i) {
+    hipdnnConvolutionBwdDataAlgo_t retVal;
+    miopenConvBwdDataAlgorithm_t mialgo;
+
+    if (i < ConvolutionBwdDataAlgoCount()) {
+        mialgo = (miopenConvBwdDataAlgorithm_t)i;
+    } else {
+        // for protection
+        mialgo =
+            (miopenConvBwdDataAlgorithm_t)miopenConvolutionBwdDataAlgoWinograd;
+    }
+    CHECK_HIPDNN_NO_RET(miopenTohipConvolutionBwdDataAlgo(mialgo, &retVal));
+
+    return retVal;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipSoftmaxModeSupported(hipdnnSoftmaxMode_t in) {
+    switch (in) {
+        // PRNSOS: MAX mode need to check
+        case HIPDNN_SOFTMAX_MODE_INSTANCE:
+            HIPDNN_OPEN_LOG_E("HIPDNN_SOFTMAX_MODE_INSTANCE NOT SUPPORTED."
+                              << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+
+        case HIPDNN_SOFTMAX_MODE_CHANNEL:
+            break;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t SoftmaxAlgorithmSupported(hipdnnSoftmaxAlgorithm_t in) {
+    switch (in) {
+        case HIPDNN_SOFTMAX_FAST:
+        case HIPDNN_SOFTMAX_ACCURATE:
+            break;
+        case HIPDNN_SOFTMAX_LOG:
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+            break;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+// miopen does not define tensor format,
+// implicitly HIPDNN_TENSOR_NCHW only
+hipdnnStatus_t hipTensorFormatSupported(hipdnnTensorFormat_t in) {
+    if (in == HIPDNN_TENSOR_NCHW) {
+        HIPDNN_OPEN_LOG_M("HIPDNN_TENSOR_NCHW" << std::flush);
+        return HIPDNN_STATUS_SUCCESS;
+    } else {
+        HIPDNN_OPEN_LOG_E("hipdnnTensorFormat_t " << in << " NOT SUPPORTED."
+                                                  << std::flush);
+        return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+}
+
+hipdnnStatus_t ConvolutionFwdPreferenceSupported(
+    hipdnnConvolutionFwdPreference_t in) {
+    switch (in) {
+        case HIPDNN_CONVOLUTION_FWD_NO_WORKSPACE:
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+
+        case HIPDNN_CONVOLUTION_FWD_PREFER_FASTEST:
+            break;
+        case HIPDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT:
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t ConvolutionBwdFilterPreferenceSupported(
+    hipdnnConvolutionBwdFilterPreference_t in) {
+    switch (in) {
+        case HIPDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE:
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+        case HIPDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST:
+            break;
+        case HIPDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT:
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//==================================RNN Operations =============================
+
+hipdnnStatus_t hipTomiopenRNNInputMode(hipdnnRNNInputMode_t in,
+                                      miopenRNNInputMode_t *out) {
+    switch (in) {
+        case HIPDNN_LINEAR_INPUT:
+            *out = miopenRNNlinear;
+            break;
+        case HIPDNN_SKIP_INPUT:
+            *out = miopenRNNskip;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenRNNInputMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipRNNInputMode(miopenRNNInputMode_t in,
+                                      hipdnnRNNInputMode_t *out) {
+    switch (in) {
+        case miopenRNNlinear:
+            *out = HIPDNN_LINEAR_INPUT;
+            break;
+        case miopenRNNskip:
+            *out = HIPDNN_SKIP_INPUT;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipRNNInputMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//====================================================================================
+
+hipdnnStatus_t hipTomiopenRNNDirectionMode(hipdnnDirectionMode_t in,
+                                       miopenRNNDirectionMode_t *out) {
+    switch (in) {
+        case HIPDNN_UNIDIRECTIONAL:
+            *out = miopenRNNunidirection;
+            break;
+        case HIPDNN_BIDIRECTIONAL:
+            *out = miopenRNNbidirection;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenRNNDirectionMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipRNNDirectionMode(miopenRNNDirectionMode_t in,
+                                        hipdnnDirectionMode_t *out) {
+    switch (in) {
+        case miopenRNNunidirection:
+            *out = HIPDNN_UNIDIRECTIONAL ;
+            break;
+        case miopenRNNbidirection:
+            *out = HIPDNN_BIDIRECTIONAL;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipRNNDirectionMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=====================================================================================
+
+hipdnnStatus_t hipTomiopenRNNMode(hipdnnRNNMode_t in,
+                                miopenRNNMode_t *out) {
+    switch (in) {
+        case HIPDNN_RNN_RELU:
+            *out = miopenRNNRELU;
+            break;
+        case HIPDNN_RNN_TANH:
+            *out = miopenRNNTANH;
+            break;
+        case HIPDNN_LSTM:
+            *out = miopenLSTM;
+            break;
+        case HIPDNN_GRU:
+            *out = miopenGRU;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenRNNMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipRNNMode(miopenRNNMode_t in,
+                                hipdnnRNNMode_t *out) {
+    switch (in) {
+        case miopenRNNRELU:
+            *out = HIPDNN_RNN_RELU ;
+            break;
+        case miopenRNNTANH:
+            *out = HIPDNN_RNN_TANH ;
+            break;
+        case miopenLSTM:
+            *out = HIPDNN_LSTM ;
+            break;
+        case miopenGRU:
+            *out = HIPDNN_GRU ;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipRNNMode "
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//==========================================================================================
+
+hipdnnStatus_t hipTomiopenRNNAlgo(hipdnnRNNAlgo_t in,
+                                        miopenRNNAlgo_t *out) {
+    switch (in) {
+        case HIPDNN_RNN_ALGO_STANDARD:
+            *out = miopenRNNdefault;
+            break;
+        case HIPDNN_RNN_ALGO_PERSIST_STATIC:
+        case HIPDNN_RNN_ALGO_PERSIST_DYNAMIC:
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenRNNAlgo"
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipRNNAlgo(miopenRNNAlgo_t in,
+                                hipdnnRNNAlgo_t *out) {
+    switch (in) {
+        case miopenRNNdefault:
+            *out = HIPDNN_RNN_ALGO_STANDARD;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipRNNAlgo"
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//============================================================================================================
+
+hipdnnStatus_t hipTomiopenRNNBias(hipdnnRNNBiasMode_t in,
+                                        miopenRNNBiasMode_t *out) {
+
+    switch (in) {
+        case HIPDNN_RNN_NO_BIAS:
+            *out = miopenRNNNoBias;
+            break;
+        case HIPDNN_RNN_WITH_BIAS:
+            *out = miopenRNNwithBias;
+             break;
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenRNNBias"
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t miopenTohipRNNBias(miopenRNNBiasMode_t in,
+                                hipdnnRNNBiasMode_t *out) {
+
+    switch (in) {
+        case miopenRNNNoBias:
+            *out = HIPDNN_RNN_NO_BIAS;
+            break;
+        case miopenRNNwithBias:
+            *out = HIPDNN_RNN_WITH_BIAS ;
+             break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipRNNBias"
+                              << in << ": NOT SUPPORTED." << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=======================================================================================
+
+// Accumulate Gradients Method to accumulate the dst and Prior with scaling
+// factor beta
+
+hipdnnStatus_t accumulateGradients(void *gradient, void *gradientPrior,
+                                   hipdnnTensorDescriptor_t gradientDesc,
+                                   const void *beta, hipdnnDataType_t *dataType) {
+    // Trying to get the individual planes info
+
+    int gradientArray[5];
+    int gradientStride[5];
+
+    CHECK_MIO(miopenGetTensorDescriptor((miopenTensorDescriptor_t)gradientDesc,
+                                        (miopenDataType_t*)dataType, gradientArray,
+                                        gradientStride));
+
+
+    int totalElements = gradientArray[0] * gradientArray[1] * gradientArray[2] *
+                        gradientArray[3];
+    const unsigned blocks = 512;
+    const unsigned threadsPerBlock = 256;
+
+   if(*dataType == miopenFloat) {
+
+    float betaVal = *(static_cast<const float *>(beta));
+    float *gradientF = static_cast<float *>(gradient);
+    float *gradientPriorF = static_cast<float *>(gradientPrior);
+    hipLaunchKernelGGL((TensorAdd<float>), dim3(blocks), dim3(threadsPerBlock),
+                       0, 0, gradientF, gradientPriorF, betaVal, totalElements);
+    CHECK_HIP(hipDeviceSynchronize());
+    }
+    else if (*dataType == miopenHalf){
+
+    hc::half betaVal = *(static_cast<const hc::half *>(beta));
+    hc::half *gradientF = static_cast<hc::half *>(gradient);
+    hc::half *gradientPriorF = static_cast<hc::half *>(gradientPrior);
+    hipLaunchKernelGGL((TensorAdd<hc::half>), dim3(blocks), dim3(threadsPerBlock),
+                       0, 0, gradientF, gradientPriorF, betaVal, totalElements);
+    CHECK_HIP(hipDeviceSynchronize());
+    }
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnCreate(hipdnnHandle_t *handle) {
+    CHECK_MIO(miopenCreate((miopenHandle_t *)handle));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnDestroy(hipdnnHandle_t handle) {
+    CHECK_MIO(miopenDestroy((miopenHandle_t)handle));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnSetStream(hipdnnHandle_t handle, hipdnnStream_t streamId) {
+    CHECK_MIO(miopenSetStream((miopenHandle_t)handle,
+                              (miopenAcceleratorQueue_t)streamId));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetStream(hipdnnHandle_t handle,
+                               hipdnnStream_t *streamId) {
+    CHECK_MIO(miopenGetStream((miopenHandle_t)handle,
+                              (miopenAcceleratorQueue_t *)streamId));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+size_t hipdnnGetVersion() { return 6000; }
+
+//======================== Tensor and Operations ==============================
+
+hipdnnStatus_t
+hipdnnCreateTensorDescriptor( hipdnnTensorDescriptor_t *tensorDesc) {
+
+    CHECK_MIO(miopenCreateTensorDescriptor((miopenTensorDescriptor_t*)tensorDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetTensor4dDescriptor(hipdnnTensorDescriptor_t tensorDesc,
+                                           hipdnnTensorFormat_t format,
+                                           hipdnnDataType_t dataType, int n,
+                                           int c, int h, int w) {
+
+    miopenDataType_t miDT;
+    CHECK_HIPDNN(hipTensorFormatSupported(format));
+    CHECK_HIPDNN(hipTomiopenDataType(dataType, &miDT));
+    CHECK_MIO(miopenSet4dTensorDescriptor((miopenTensorDescriptor_t)tensorDesc,
+                                          miDT, n, c, h, w));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnGetTensor4dDescriptor(hipdnnTensorDescriptor_t tensorDesc,
+                                           hipdnnDataType_t *dataType, int *n,
+                                           int *c, int *h, int *w, int *nStride,
+                                           int *cStride, int *hStride,
+                                           int *wStride) {
+    miopenDataType_t midT;
+    CHECK_MIO(miopenGet4dTensorDescriptor((miopenTensorDescriptor_t)tensorDesc,
+                                          &midT, n, c, h, w,
+                                          nStride, cStride, hStride, wStride));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t
+hipdnnDestroyTensorDescriptor( hipdnnTensorDescriptor_t tensorDesc) {
+
+    CHECK_MIO(miopenDestroyTensorDescriptor((miopenTensorDescriptor_t)tensorDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetTensor(hipdnnHandle_t handle,
+                               const hipdnnTensorDescriptor_t yDesc, void *y,
+                               const void *valuePtr) {
+
+    CHECK_MIO(miopenSetTensor((miopenHandle_t)handle,
+                              (miopenTensorDescriptor_t)yDesc, y, valuePtr));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// dstValue = alpha[0]*srcValue + beta[0]*priorDstValue
+
+hipdnnStatus_t hipdnnAddTensor(hipdnnHandle_t handle, const void *alpha,
+                               const hipdnnTensorDescriptor_t aDesc,
+                               const void *A, const void *beta,
+                               const hipdnnTensorDescriptor_t cDesc, void *C) {
+
+    miopenTensorOp_t tensorOp = miopenTensorOpAdd;
+    int alpha2 = 0;
+    CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, tensorOp, alpha,
+                             (miopenTensorDescriptor_t)cDesc, C, alpha,
+                             (miopenTensorDescriptor_t)aDesc, A, beta,
+                             (miopenTensorDescriptor_t)cDesc, C));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnScaleTensor(hipdnnHandle_t handle,
+                                 const hipdnnTensorDescriptor_t yDesc, void *y,
+                                 const void *alpha) {
+
+    CHECK_MIO(miopenScaleTensor((miopenHandle_t)handle,
+                                (miopenTensorDescriptor_t)yDesc, y, alpha));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//============================ Tensor Operations ===============================
+
+miopenTensorOp_t hipToMIOpenTensorOp(hipdnnOpTensorDescriptor_t opTensorDesc) {
+    //TODO: Not needed, can be removed
+    // int *result = reinterpret_cast<int *>(opTensorDesc);
+    uintptr_t result = (uintptr_t)opTensorDesc;
+    switch (result) {
+        case 1:
+            return miopenTensorOpAdd;
+        case 2:
+            return miopenTensorOpMul;
+        case 3:
+            return miopenTensorOpMin;
+        case 4:
+            return miopenTensorOpMax;
+        default:
+            return miopenTensorOpAdd;
+    }
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t miopenTohipOpTensorOp(miopenTensorOp_t in,
+                                     hipdnnOpTensorOp_t *out) {
+    switch (in) {
+        case miopenTensorOpAdd:
+            *out = HIPDNN_OP_TENSOR_ADD;
+            break;
+        case miopenTensorOpMul:
+            *out = HIPDNN_OP_TENSOR_MUL;
+            break;
+        case miopenTensorOpMin:
+            *out = HIPDNN_OP_TENSOR_MIN;
+            break;
+        case miopenTensorOpMax:
+            *out = HIPDNN_OP_TENSOR_MAX;
+            break;
+        default:
+            HIPDNN_OPEN_LOG_M("miopenTohipTensorOp " << in << ": NOT SUPPORTED."
+                                                     << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipTomiopenOpTensorOp(hipdnnOpTensorOp_t in,
+                                     miopenTensorOp_t *out) {
+    switch (in) {
+        case HIPDNN_OP_TENSOR_ADD:
+            *out = miopenTensorOpAdd;
+            break;
+        case HIPDNN_OP_TENSOR_MUL:
+            *out = miopenTensorOpMul;
+            break;
+        case HIPDNN_OP_TENSOR_MIN:
+            *out = miopenTensorOpMin;
+            break;
+        case HIPDNN_OP_TENSOR_MAX:
+            *out = miopenTensorOpMax;
+            break;
+        case HIPDNN_OP_TENSOR_SQRT:
+        default:
+            HIPDNN_OPEN_LOG_M("hipTomiopenTensorOp " << in << ": NOT SUPPORTED."
+                                                     << std::flush);
+            return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+typedef struct {
+    hipdnnOpTensorOp_t opTensorOp;
+    hipdnnDataType_t opTensorCompType;
+    hipdnnNanPropagation_t opTensorNanOpt;
+}structOpTensorDesc_t;
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t
+hipdnnCreateOpTensorDescriptor(hipdnnOpTensorDescriptor_t *opTensorDesc) {
+
+    *opTensorDesc = (void*)malloc(sizeof(structOpTensorDesc_t));
+    CHECK_MALLOC(*opTensorDesc);
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t
+hipdnnSetOpTensorDescriptor(hipdnnOpTensorDescriptor_t opTensorDesc,
+                            hipdnnOpTensorOp_t opTensorOp,
+                            hipdnnDataType_t opTensorCompType,
+                            hipdnnNanPropagation_t opTensorNanOpt) {
+
+    ((structOpTensorDesc_t*)opTensorDesc)->opTensorOp = opTensorOp;
+    ((structOpTensorDesc_t*)opTensorDesc)->opTensorCompType = opTensorCompType;
+    ((structOpTensorDesc_t*)opTensorDesc)->opTensorNanOpt = opTensorNanOpt;
+
+    return HIPDNN_STATUS_SUCCESS;
+
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t
+hipdnnGetOpTensorDescriptor(const hipdnnOpTensorDescriptor_t opTensorDesc,
+                            hipdnnOpTensorOp_t *opTensorOp,
+                            hipdnnDataType_t *opTensorCompType,
+                            hipdnnNanPropagation_t *opTensorNanOpt) {
+
+    *opTensorOp = ((structOpTensorDesc_t*)opTensorDesc)->opTensorOp;
+    *opTensorCompType = ((structOpTensorDesc_t*)opTensorDesc)->opTensorCompType;
+    *opTensorNanOpt = ((structOpTensorDesc_t*)opTensorDesc)->opTensorNanOpt;
+
+    return HIPDNN_STATUS_SUCCESS;
+
+}
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t
+hipdnnDestroyOpTensorDescriptor(hipdnnOpTensorDescriptor_t opTensorDesc) {
+
+    free(opTensorDesc);
+    return HIPDNN_STATUS_SUCCESS;
+
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnOpTensor(
+    hipdnnHandle_t handle, const hipdnnOpTensorDescriptor_t opTensorDesc,
+    const void *alpha1, const hipdnnTensorDescriptor_t aDesc, const void *A,
+    const void *alpha2, const hipdnnTensorDescriptor_t bDesc, const void *B,
+    const void *beta, const hipdnnTensorDescriptor_t cDesc, void *C) {
+
+    miopenTensorOp_t miOpType;
+    CHECK_HIPDNN( hipTomiopenOpTensorOp(
+            ((structOpTensorDesc_t*)opTensorDesc)->opTensorOp, &miOpType ));
+
+    CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, miOpType, alpha1,
+                (miopenTensorDescriptor_t)aDesc, A, alpha2,
+                (miopenTensorDescriptor_t)bDesc, B, beta,
+                (miopenTensorDescriptor_t)cDesc, C));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnSetFilter4dDescriptor(hipdnnFilterDescriptor_t filterDesc,
+                                           hipdnnTensorFormat_t format,
+                                           hipdnnDataType_t dataType, int k,
+                                           int c, int h, int w) {
+    miopenDataType_t miDT;
+    CHECK_HIPDNN(hipTensorFormatSupported(format));
+    CHECK_HIPDNN(hipTomiopenDataType(dataType, &miDT));
+    CHECK_MIO(miopenSet4dTensorDescriptor((miopenTensorDescriptor_t)filterDesc,
+                                          miDT, k, c, h, w));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnCreateFilterDescriptor(
+    hipdnnFilterDescriptor_t *filterDesc) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnCreateFilterDescriptor, " << filterDesc
+                                                              << std::flush);
+    // in miopen a filter descriptor is just a typedef to a tensor descriptor
+    CHECK_HIPDNN(hipdnnCreateTensorDescriptor(filterDesc));
+    HIPDNN_OPEN_LOG_C("Inside hipdnnCreateFilterDescriptor, " << filterDesc
+                                                              << std::flush);
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//============================= Convolution ====================================
+
+/*
+ * structConvDesc_t is used to contain cudnn-conv desc information that are not in miopenConvolutionDescriptor
+ * hipdnnConvolutionDescriptor_t is just opaque pointer void*
+ * Thus pointer structure `structConvDesc_t` is assigned in hipdnnConvolutionDescriptor_t
+ * Structure also conatin hipdnnConvolutionDescriptor_t to hold descriptor
+ * Use descriptor in structure with proper typecastings for MIopen API
+ */
+
+// structure to be used in place of convolution descriptor
+typedef struct {
+    hipdnnConvolutionDescriptor_t descriptor;
+    hipdnnDataType_t convDataType;
+    hipdnnMathType_t convMathType;
+}structConvDesc_t;
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnCreateConvolutionDescriptor(
+    hipdnnConvolutionDescriptor_t *convDesc) {
+
+    *convDesc = (void*)malloc(sizeof(structConvDesc_t));
+    CHECK_MALLOC(*convDesc);
+    hipdnnConvolutionDescriptor_t* convDesc_cast =
+                            &( ((structConvDesc_t*)(*convDesc))->descriptor );
+    CHECK_MIO(miopenCreateConvolutionDescriptor(
+        (miopenConvolutionDescriptor_t *)convDesc_cast));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetConvolutionMathType(
+    hipdnnConvolutionDescriptor_t convDesc, hipdnnMathType_t mathType) {
+
+    HIPDNN_OPEN_LOG_I2( "Setting MathType by user is not supported in MIOpen."
+                      << "Internally set based on datatype of input.");
+
+    HIPDNN_OPEN_LOG_E("hipdnnSetConvolutionMathType"
+                      << mathType << " NOT SUPPORTED in MIOpen"
+                      << std::flush);
+
+    ((structConvDesc_t*)(convDesc))->convMathType = mathType;
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetConvolution2dDescriptor(
+    hipdnnConvolutionDescriptor_t convDesc, int pad_h, int pad_w, int u, int v,
+    int upscalex, int upscaley, hipdnnConvolutionMode_t mode,
+    hipdnnDataType_t computeType) {
+
+    miopenConvolutionMode_t miConvMode;
+    CHECK_HIPDNN(hipTomiopenConvolutionMode(mode,&miConvMode));
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO( miopenInitConvolutionDescriptor(
+                                    (miopenConvolutionDescriptor_t)convDesc_cast,
+                                    miConvMode, pad_h,
+                                    pad_w, u, v, upscalex, upscaley));
+
+    HIPDNN_OPEN_LOG_I2( "Setting MathType by user is not supported in MIOpen."
+                      << "Internally set based on datatype of input.");
+
+    ((structConvDesc_t*)(convDesc))->convDataType = computeType;
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetConvolutionNdDescriptor(
+    hipdnnConvolutionDescriptor_t convDesc, int arrayLength, /* nbDims-2 size */
+    const int padA[], const int filterStrideA[], const int dilationA[],
+    hipdnnConvolutionMode_t mode,
+    hipdnnDataType_t computeType)  // convolution data type
+{
+    HIPDNN_OPEN_LOG_C("Inside hipdnnSetConvolutionNdDescriptor with arrayLength:"
+                        << arrayLength << std::flush);
+
+    int pad_h, pad_w, u, v, d_h, d_w;
+
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+
+    if (arrayLength == 2) {
+        pad_h = padA[0];
+        pad_w = padA[1];
+        u = filterStrideA[0];
+        v = filterStrideA[1];
+        d_h = dilationA[0];
+        d_w = dilationA[1];
+
+        CHECK_MIO(miopenInitConvolutionDescriptor(
+                                    (miopenConvolutionDescriptor_t)convDesc_cast,
+                                    miopenConvolution, pad_h,
+                                    pad_w, u, v, d_h, d_w) );
+    }
+    else if (arrayLength == 3) {
+        // 3D convolution Scenario
+        // Got to book keep additional padding, stride and dilation info along
+        //  depth direction
+        // Book keeping using global static std::map container
+        // But first lets initialize the 2D Description
+        pad_h = padA[0];
+        pad_w = padA[1];
+        u = filterStrideA[0];
+        v = filterStrideA[1];
+        d_h = dilationA[0];
+        d_w = dilationA[1];
+        CHECK_MIO(miopenInitConvolutionDescriptor(
+                                    (miopenConvolutionDescriptor_t)convDesc_cast,
+                                    miopenConvolution, pad_h,
+                                    pad_w, u, v, d_h, d_w) );
+        // Populate the map container with key being newly created 2Ddescriptor
+        // and value a 3 dim array with index mapping as
+        // 0-pad, 1-stride and 2-dilation
+        int depthDesc[3];
+        depthDesc[0] = padA[2];
+        depthDesc[1] = filterStrideA[2];
+        depthDesc[2] = dilationA[2];
+        sDescTo3DConvolution[(miopenConvolutionDescriptor_t)convDesc_cast] =
+            depthDesc;
+
+    }
+    else {
+        HIPDNN_OPEN_LOG_E(
+            "Inside hipdnnSetConvolutionNdDescriptor NOT SUPPORTED"
+            << std::flush);
+        return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnGetConvolution2dDescriptor(
+    const hipdnnConvolutionDescriptor_t convDesc, int *pad_h, int *pad_y,
+    int *u, int *v, int *upscalex, int *upscaley, hipdnnConvolutionMode_t *mode,
+    hipdnnDataType_t *computeType) {
+
+    miopenConvolutionMode_t miMode;
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO(miopenGetConvolutionDescriptor(
+        (miopenConvolutionDescriptor_t)convDesc_cast, &miMode, pad_h, pad_y, u, v,
+        upscalex, upscaley));
+
+    CHECK_HIPDNN( miopenTohipdnnConvolutionMode(miMode, mode) );
+    *computeType = ((structConvDesc_t*)(convDesc))->convDataType;
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnGetConvolution2dForwardOutputDim(
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t inputTensorDesc,
+    const hipdnnFilterDescriptor_t filterDesc, int *n, int *c, int *h, int *w) {
+
+    HIPDNN_OPEN_LOG_C("HIPDNN_SOFTMAX_MODE_INSTANCE NOT SUPPORTED."
+                      << std::flush);
+
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO(miopenGetConvolutionForwardOutputDim(
+        (miopenConvolutionDescriptor_t)(convDesc_cast), // should be const in miopen.
+        (miopenTensorDescriptor_t)inputTensorDesc,
+        (miopenTensorDescriptor_t)filterDesc, n, c, h, w));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t
+hipdnnDestroyConvolutionDescriptor(hipdnnConvolutionDescriptor_t convDesc) {
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO(miopenDestroyConvolutionDescriptor(
+        (miopenConvolutionDescriptor_t)convDesc_cast));
+    free(convDesc);
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//-------------------------- Conv Forward --------------------------------------
+
+hipdnnStatus_t hipdnnFindConvolutionForwardAlgorithm(
+    hipdnnHandle_t handle, const hipdnnTensorDescriptor_t xDesc,
+    const hipdnnFilterDescriptor_t wDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t yDesc, const int requestedAlgoCount,
+    int *returnedAlgoCount, hipdnnConvolutionFwdAlgoPerf_t *perfResults) {
+
+    size_t sizeInBytes = 0;
+    void *sConvolutionForwardAlgorithmWorkspace;
+    miopenConvFwdAlgorithm_t mialgo;
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    // in miopen, workspace size does not depend on algo.
+    CHECK_MIO(miopenConvolutionForwardGetWorkSpaceSize(
+        (miopenHandle_t)handle, (miopenTensorDescriptor_t)wDesc,
+        (miopenTensorDescriptor_t)xDesc,
+        (miopenConvolutionDescriptor_t)convDesc_cast,
+        (miopenTensorDescriptor_t)yDesc, &sizeInBytes));
+
+    HIPDNN_OPEN_LOG_I("INTERNAL_ALLOC hipdnnFindConvolutionForwardAlgorithm");
+
+    CHECK_HIP(hipMalloc((void **)&sConvolutionForwardAlgorithmWorkspace,
+                        sizeInBytes));
+
+    size_t numBytes;
+    void *x;
+    void *y;
+    void *w;
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)xDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&x, numBytes));
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)wDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&w, numBytes));
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)yDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&y, numBytes));
+
+    CHECK_HIPDNN(hipdnnFindConvolutionForwardAlgorithmEx(
+        handle, xDesc, x, wDesc, w, convDesc, yDesc,
+        y, requestedAlgoCount, returnedAlgoCount, perfResults,
+        sConvolutionForwardAlgorithmWorkspace, sizeInBytes));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnGetConvolutionForwardAlgorithm(
+    hipdnnHandle_t handle, const hipdnnTensorDescriptor_t xDesc,
+    const hipdnnFilterDescriptor_t wDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t yDesc,
+    hipdnnConvolutionFwdPreference_t preference, size_t memoryLimitInBytes,
+    hipdnnConvolutionFwdAlgo_t *algo) {
+    miopenConvFwdAlgorithm_t mialgo;
+    size_t sizeInBytes = 0;
+    void *sConvolutionForwardAlgorithmWorkspace;
+    // in miopen, workspace size does not depend on algo.
+
+    if(preference == HIPDNN_CONVOLUTION_FWD_PREFER_FASTEST)
+        CHECK_HIPDNN(hipdnnGetConvolutionForwardWorkspaceSize(
+            handle, xDesc, wDesc, convDesc, yDesc, *algo, &sizeInBytes));
+
+    if(preference == HIPDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT)
+        sizeInBytes = memoryLimitInBytes;
+
+    hipMalloc((void **)&sConvolutionForwardAlgorithmWorkspace, sizeInBytes);
+
+    size_t numBytes;
+    void *x;
+    void *y;
+    void *w;
+    const int requestedAlgoCount = 1;
+    int returnedAlgoCount;
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)xDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&x, numBytes));
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)wDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&w, numBytes));
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)yDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&y, numBytes));
+
+    hipdnnConvolutionFwdAlgoPerf_t *perfResults =
+        new hipdnnConvolutionFwdAlgoPerf_t[requestedAlgoCount];
+
+    CHECK_HIPDNN(hipdnnFindConvolutionForwardAlgorithmEx(
+        handle, xDesc, x, wDesc, w, convDesc, yDesc, y, requestedAlgoCount,
+        &returnedAlgoCount, perfResults, sConvolutionForwardAlgorithmWorkspace,
+        sizeInBytes));
+
+    *algo = perfResults[0].algo;
+
+    CHECK_HIP(hipFree(x));
+    CHECK_HIP(hipFree(w));
+    CHECK_HIP(hipFree(y));
+    delete[] perfResults;
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnFindConvolutionForwardAlgorithmEx(
+    hipdnnHandle_t handle, const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const hipdnnFilterDescriptor_t wDesc, const void *w,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t yDesc, void *y, const int requestedAlgoCount,
+    int *returnedAlgoCount, hipdnnConvolutionFwdAlgoPerf_t *perfResults,
+    void *workSpace, size_t workSpaceSizeInBytes) {
+    HIPDNN_OPEN_LOG_C("ENTER hipdnnFindConvolutionForwardAlgorithmEx: WS PTR"
+                      << workSpace << ", " << workSpaceSizeInBytes
+                      << std::flush);
+    assert(x);
+    assert(w);
+    assert(y);
+    miopenConvAlgoPerf_t *miopenPerfResults =
+        new miopenConvAlgoPerf_t[requestedAlgoCount];
+
+    HIPDNN_OPEN_LOG_C("Invoking miopenConvolutionForwardGetWorkSpaceSize"
+                      << std::flush);
+    size_t expectedWorkSpaceSize = 0, infoWorkSpaceSize = 0;
+    void *workSpaceInternal = NULL;
+
+    workSpaceInternal = workSpace;
+    expectedWorkSpaceSize = workSpaceSizeInBytes;
+
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO(miopenFindConvolutionForwardAlgorithm(
+        (miopenHandle_t)handle, (miopenTensorDescriptor_t)xDesc, x,
+        (miopenTensorDescriptor_t)wDesc, w,
+        (miopenConvolutionDescriptor_t)convDesc_cast,
+        (miopenTensorDescriptor_t)yDesc, y, requestedAlgoCount,
+        returnedAlgoCount, miopenPerfResults, workSpaceInternal,
+        expectedWorkSpaceSize, false  // exhaustiveSearch
+        ));
+
+
+    HIPDNN_OPEN_LOG_C("Invoked miopenFindConvolutionForwardAlgorithm");
+
+    for (int i = 0; i < *returnedAlgoCount; i++) {
+        CHECK_HIPDNN(miopenTohipConvolutionFwdAlgo(
+            miopenPerfResults[i].fwd_algo, &(perfResults[i].algo)));
+        perfResults[i].status =
+            HIPDNN_STATUS_SUCCESS;  // TODO: miopen doesn't contain a 'status'
+                                    // member variable , setting it to success
+                                    // as of now.
+        perfResults[i].time = miopenPerfResults[i].time;
+        perfResults[i].memory = miopenPerfResults[i].memory;
+    }
+
+    delete[] miopenPerfResults;
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnGetConvolutionForwardWorkspaceSize(
+    hipdnnHandle_t handle, const hipdnnTensorDescriptor_t xDesc,
+    const hipdnnFilterDescriptor_t wDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t yDesc, hipdnnConvolutionFwdAlgo_t algo,
+    size_t *sizeInBytes) {
+    *sizeInBytes = 0;
+
+    HIPDNN_OPEN_LOG_C(
+        "HIPDNN ENTER hipdnnGetConvolutionForwardWorkspaceSize, algo ="
+        << algo << std::flush);
+
+    miopenConvFwdAlgorithm_t mialgo;
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    // in miopen, workspace size does not depend on algo.
+    CHECK_MIO(miopenConvolutionForwardGetWorkSpaceSize(
+        (miopenHandle_t)handle, (miopenTensorDescriptor_t)wDesc,
+        (miopenTensorDescriptor_t)xDesc,
+        (miopenConvolutionDescriptor_t)convDesc_cast,
+        (miopenTensorDescriptor_t)yDesc, sizeInBytes));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnConvolutionForward(
+    hipdnnHandle_t handle, const void *alpha,
+    const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const hipdnnFilterDescriptor_t wDesc, const void *w,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    hipdnnConvolutionFwdAlgo_t algo, void *workSpace,
+    size_t workSpaceSizeInBytes, const void *beta,
+    const hipdnnTensorDescriptor_t yDesc, void *y) {
+    HIPDNN_OPEN_LOG_C("calling hipdnnConvolutionForward." << std::flush);
+
+    size_t expectedWorkSpaceSize = 0, infoWorkSpaceSize = 0;
+    void *workSpaceInternal = NULL;
+
+        workSpaceInternal = workSpace;
+        expectedWorkSpaceSize = workSpaceSizeInBytes;
+
+    miopenConvFwdAlgorithm_t mialgo;
+    CHECK_HIPDNN(hipTomiopenConvolutionFwdAlgo(algo, &mialgo));
+    HIPDNN_OPEN_LOG_C("Invoked hipToMopenConvolutionFwdAlgo" << std::flush);
+    HIPDNN_OPEN_LOG_C("Invoking MiopenConvolutionFwd" << std::flush);
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+
+    if((*static_cast<const float *>(alpha)) == 1 && (*static_cast<const float *>(beta)) == 0) {
+
+     CHECK_MIO(miopenConvolutionForward(
+	    (miopenHandle_t)handle, alpha, (miopenTensorDescriptor_t)xDesc, x,
+        (miopenTensorDescriptor_t)wDesc, w,
+        (miopenConvolutionDescriptor_t)convDesc_cast, mialgo, beta,
+        (miopenTensorDescriptor_t)yDesc, y, workSpaceInternal,
+        expectedWorkSpaceSize));
+
+    } else {
+     void *dwPrior = SaveAsPriorBuffer(y);
+     const float alpha1 = 1;
+     const float beta1 = 0;
+
+     CHECK_MIO(miopenConvolutionForward(
+         (miopenHandle_t)handle, &alpha1, (miopenTensorDescriptor_t)xDesc, x,
+         (miopenTensorDescriptor_t)wDesc, w,
+         (miopenConvolutionDescriptor_t)convDesc_cast, mialgo, &beta1,
+         (miopenTensorDescriptor_t)yDesc, y, workSpaceInternal,
+         expectedWorkSpaceSize));
+
+     int alpha2 =0;
+     CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, miopenTensorOpAdd, alpha,
+                              (miopenTensorDescriptor_t)yDesc, y, beta,
+                              (miopenTensorDescriptor_t)yDesc, dwPrior, &alpha2,
+                              (miopenTensorDescriptor_t)yDesc, y));
+     deallocPrior(dwPrior);
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------ Conv Backward ---------------------------------------
+
+hipdnnStatus_t hipdnnConvolutionBackwardBias(
+    hipdnnHandle_t handle, const void *alpha,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy, const void *beta,
+    const hipdnnTensorDescriptor_t dbDesc, void *db) {
+    HIPDNN_OPEN_LOG_C("calling hipdnnConvolutionBackwardBias." << std::flush);
+
+    CHECK_MIO(miopenConvolutionBackwardBias(
+        (miopenHandle_t)handle, alpha, (miopenTensorDescriptor_t)dyDesc, dy,
+        beta, (miopenTensorDescriptor_t)dbDesc, db));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnFindConvolutionBackwardFilterAlgorithm(
+    hipdnnHandle_t handle, const hipdnnTensorDescriptor_t xDesc,
+    const hipdnnTensorDescriptor_t dyDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnFilterDescriptor_t dwDesc, const int requestedAlgoCount,
+    int *returnedAlgoCount, hipdnnConvolutionBwdFilterAlgoPerf_t *perfResults) {
+
+    size_t sizeInBytes = 0;
+    void *sConvolutionBackwardFilterAlgorithmWorkspace;
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    // in miopen, workspace size does not depend on algo.
+    CHECK_MIO(miopenConvolutionBackwardWeightsGetWorkSpaceSize(
+        (miopenHandle_t)handle, (miopenTensorDescriptor_t)dyDesc,
+        (miopenTensorDescriptor_t)xDesc,
+        (miopenConvolutionDescriptor_t)convDesc_cast,
+        (miopenTensorDescriptor_t)dwDesc, &sizeInBytes));
+
+    HIPDNN_OPEN_LOG_I("INTERNAL_ALLOC hipdnnFindConvolutionBackwardFilterAlgorithm");
+
+    CHECK_HIP(hipMalloc((void **)&sConvolutionBackwardFilterAlgorithmWorkspace,
+                        sizeInBytes));
+
+    size_t numBytes;
+    void *x;
+    void *dy;
+    void *dw;
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)xDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&x, numBytes));
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)dwDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&dw, numBytes));
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)dyDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&dy, numBytes));
+
+    CHECK_HIPDNN(hipdnnFindConvolutionBackwardFilterAlgorithmEx(
+        handle, xDesc, x, dyDesc, dy, convDesc, dwDesc, dw, requestedAlgoCount,
+        returnedAlgoCount, perfResults, sConvolutionBackwardFilterAlgorithmWorkspace,
+        sizeInBytes));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnGetConvolutionBackwardFilterAlgorithm(
+    hipdnnHandle_t handle, const hipdnnTensorDescriptor_t xDesc,
+    const hipdnnTensorDescriptor_t dyDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnFilterDescriptor_t dwDesc,
+    hipdnnConvolutionBwdFilterPreference_t preference,
+    size_t memoryLimitInBytes, hipdnnConvolutionBwdFilterAlgo_t *algo) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnGetConvolutionBackwardFilterAlgorithm ");
+
+    size_t sizeInBytes = 0;
+    void *sConvolutionBackwardFilterAlgorithmWorkspace;
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    if(preference == HIPDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST)
+        CHECK_MIO(miopenConvolutionBackwardWeightsGetWorkSpaceSize(
+        (miopenHandle_t)handle, (miopenTensorDescriptor_t)dyDesc,
+        (miopenTensorDescriptor_t)xDesc,
+        (miopenConvolutionDescriptor_t)convDesc_cast,
+        (miopenTensorDescriptor_t)dwDesc, &sizeInBytes));
+
+    if(preference == HIPDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT)
+        sizeInBytes = memoryLimitInBytes;
+
+    HIPDNN_OPEN_LOG_I("INTERNAL_ALLOC hipdnnGetConvolutionBackwardFilterAlgorithm");
+    hipMalloc((void **)&sConvolutionBackwardFilterAlgorithmWorkspace, sizeInBytes);
+
+    size_t numBytes;
+    void *x;
+    void *dy;
+    void *dw;
+    const int requestedAlgoCount = 1;
+    int returnedAlgoCount;
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)xDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&x, numBytes));
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)dwDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&dw, numBytes));
+
+    CHECK_MIO(
+        miopenGetTensorNumBytes((miopenTensorDescriptor_t)dyDesc, &numBytes));
+    CHECK_HIP(hipMalloc((void **)&dy, numBytes));
+
+    hipdnnConvolutionBwdFilterAlgoPerf_t *perfResults =
+        new hipdnnConvolutionBwdFilterAlgoPerf_t[requestedAlgoCount];
+
+    CHECK_HIPDNN(hipdnnFindConvolutionBackwardFilterAlgorithmEx(
+        handle, xDesc, x, dyDesc, dy, convDesc, dwDesc, dw, requestedAlgoCount,
+        &returnedAlgoCount, perfResults, sConvolutionBackwardFilterAlgorithmWorkspace,
+        0));
+
+    *algo = perfResults[0].algo;
+
+    CHECK_HIP(hipFree(x));
+    CHECK_HIP(hipFree(dw));
+    CHECK_HIP(hipFree(dy));
+    delete[] perfResults;
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnFindConvolutionBackwardFilterAlgorithmEx(
+    hipdnnHandle_t handle, const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnFilterDescriptor_t dwDesc, void *dw,
+    const int requestedAlgoCount, int *returnedAlgoCount,
+    hipdnnConvolutionBwdFilterAlgoPerf_t *perfResults, void *workSpace,
+    size_t workSpaceSizeInBytes) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnFindConvolutionBackwardFilterAlgorithmEx");
+    assert(x);
+    assert(dy);
+    assert(dw);
+
+    miopenConvAlgoPerf_t *miopenPerfResults =
+        new miopenConvAlgoPerf_t[requestedAlgoCount];
+
+    size_t expectedWorkSpaceSize = 0;
+    void *workSpaceInternal = NULL;
+    size_t infoWorkSpaceSize = 0;
+
+    workSpaceInternal = workSpace;
+    expectedWorkSpaceSize = workSpaceSizeInBytes;
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    try {
+        CHECK_MIO(miopenFindConvolutionBackwardWeightsAlgorithm(
+            (miopenHandle_t)handle, (miopenTensorDescriptor_t)dyDesc, dy,
+            (miopenTensorDescriptor_t)xDesc, x,
+            (miopenConvolutionDescriptor_t)convDesc_cast,
+            (miopenTensorDescriptor_t)dwDesc, dw, requestedAlgoCount,
+            returnedAlgoCount, miopenPerfResults, workSpaceInternal,
+            expectedWorkSpaceSize,
+            false  // exhaustiveSearch
+            ));
+
+    } catch (std::exception &e) {
+        std::cout << "EXCEPTION: hipdnnFindConvolutionBackwardFilterAlgorithmEx"
+                  << e.what() << std::endl HIPDNNFLUSH
+    }
+
+    for (int i = 0; i < *returnedAlgoCount; i++) {
+        CHECK_HIPDNN(miopenTohipConvolutionBwdFilterAlgo(
+            miopenPerfResults[i].bwd_weights_algo, &(perfResults[i].algo)));
+        perfResults[i].status =
+            HIPDNN_STATUS_SUCCESS;  // TODO: miopen doesn't contain a 'status'
+                                    // member variable , setting it to success
+                                    // as of now.
+        perfResults[i].time = miopenPerfResults[i].time;
+        perfResults[i].memory = miopenPerfResults[i].memory;
+    }
+    delete[] miopenPerfResults;
+
+    HIPDNN_OPEN_LOG_C("EXIT: hipdnnFindConvolutionBackwardFilterAlgorithmEx");
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnGetConvolutionBackwardFilterWorkspaceSize(
+    hipdnnHandle_t handle, const hipdnnTensorDescriptor_t xDesc,
+    const hipdnnTensorDescriptor_t dyDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnFilterDescriptor_t dwDesc,
+    hipdnnConvolutionBwdFilterAlgo_t algo, size_t *sizeInBytes) {
+    *sizeInBytes = 0;
+
+    HIPDNN_OPEN_LOG_C(
+        "ENTER hipdnnGetConvolutionBackwardFilterWorkspaceSize algo:"
+        << algo << std::flush);
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO(miopenConvolutionBackwardWeightsGetWorkSpaceSize(
+        (miopenHandle_t)handle, (miopenTensorDescriptor_t)dyDesc,
+        (miopenTensorDescriptor_t)xDesc,
+        (miopenConvolutionDescriptor_t)convDesc_cast,
+        (miopenTensorDescriptor_t)dwDesc, sizeInBytes));
+
+    HIPDNN_OPEN_LOG_C("EXIT hipdnnGetConvolutionBackwardFilterWorkspaceSize:"
+                      << *sizeInBytes << std::flush);
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnConvolutionBackwardFilter(
+    hipdnnHandle_t handle, const void *alpha,
+    const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    hipdnnConvolutionBwdFilterAlgo_t algo, void *workSpace,
+    size_t workSpaceSizeInBytes, const void *beta,
+    const hipdnnFilterDescriptor_t dwDesc, void *dw) {
+
+    HIPDNN_OPEN_LOG_C("CALL_STACK: Inside hipdnnConvolutionBackwardFilter");
+    size_t expectedWorkSpaceSize;
+    void *workSpaceInternal = NULL;
+    size_t infoWorkSpaceSize;
+
+
+    workSpaceInternal = workSpace;
+    expectedWorkSpaceSize = workSpaceSizeInBytes;
+
+    int nbDimsRequested =1;
+    int nbDims,dimA[1],strideA[1];
+    hipdnnDataType_t dataType;
+    hipdnnTensorFormat_t format = HIPDNN_TENSOR_NCHW;
+    int filterDimA[1];
+
+    hipdnnGetFilterNdDescriptor(dwDesc, nbDimsRequested, &dataType,
+                                             &format, &nbDims, filterDimA);
+
+    miopenConvBwdWeightsAlgorithm_t mialgo;
+    CHECK_HIPDNN(hipTomiopenConvolutionBwdFilterAlgo(algo, &mialgo));
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    if (*static_cast<const float *>(beta) == 0) {
+        CHECK_MIO(miopenConvolutionBackwardWeights(
+            (miopenHandle_t)handle, alpha, (miopenTensorDescriptor_t)dyDesc, dy,
+            (miopenTensorDescriptor_t)xDesc, x,
+            (miopenConvolutionDescriptor_t)convDesc_cast, mialgo, beta,
+            (miopenTensorDescriptor_t)dwDesc, dw, workSpaceInternal,
+            expectedWorkSpaceSize));
+    } else {
+        const float tempBeta = 0;
+        void *dwPrior = SaveAsPriorBuffer(dw);
+        CHECK_MIO(miopenConvolutionBackwardWeights(
+            (miopenHandle_t)handle, alpha, (miopenTensorDescriptor_t)dyDesc, dy,
+            (miopenTensorDescriptor_t)xDesc, x,
+            (miopenConvolutionDescriptor_t)convDesc_cast, mialgo, &tempBeta,
+            (miopenTensorDescriptor_t)dwDesc, dw, workSpaceInternal,
+            expectedWorkSpaceSize));
+        accumulateGradients(dw, dwPrior, dwDesc, beta, &dataType);
+        deallocPrior(dwPrior);
+    }
+
+    HIPDNN_OPEN_LOG_C("miopenConvolutionBackwardWeights "
+                      << ",handle= " << handle << ",alpha=" << alpha
+                      << ",xDesc=" << xDesc << ",x=" << x << ",dyDesc="
+                      << dyDesc << ",dy=" << dy << ",convDesc=" << convDesc
+                      << ",algo=" << algo << ",workSpace=" << workSpace
+                      << ",workSpaceSizeInBytes = " << workSpaceSizeInBytes
+                      << ",beta=" << beta << ",dwDesc=" << dwDesc
+                      << ",dw=" << dw << std::flush);
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnGetConvolutionBackwardDataWorkspaceSize(
+    hipdnnHandle_t handle, const hipdnnFilterDescriptor_t wDesc,
+    const hipdnnTensorDescriptor_t dyDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t dxDesc, hipdnnConvolutionBwdDataAlgo_t algo,
+    size_t *sizeInBytes) {
+
+    *sizeInBytes = 0;
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    // does not depend on algo in miopen
+    try {
+        CHECK_MIO(miopenConvolutionBackwardDataGetWorkSpaceSize(
+            (miopenHandle_t)handle, (miopenTensorDescriptor_t)dyDesc,
+            (miopenTensorDescriptor_t)wDesc,
+            (miopenConvolutionDescriptor_t)convDesc_cast,
+            (miopenTensorDescriptor_t)dxDesc, sizeInBytes));
+    } catch (std::exception &e) {
+        std::cout
+            << "Exception in hipdnnGetConvolutionBackwardDataWorkspaceSize: "
+            << e.what() << std::endl HIPDNNFLUSH;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnFindConvolutionBackwardDataAlgorithm(
+    hipdnnHandle_t handle, const hipdnnFilterDescriptor_t wDesc,
+    const hipdnnTensorDescriptor_t dyDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t dxDesc, const int requestedAlgoCount,
+    int *returnedAlgoCount, hipdnnConvolutionBwdDataAlgoPerf_t *perfResults) {
+    try {
+        HIPDNN_OPEN_LOG_E(
+            "ERROR: hipdnnFindConvolutionBackwardDataAlgorithm NOT IMPLEMENTED"
+            << std::flush);
+
+        return HIPDNN_STATUS_NOT_SUPPORTED;
+
+    } catch (std::exception &e) {
+        std::cout
+            << "Exception in hipdnnGetConvolutionBackwardDataWorkspaceSize: "
+            << e.what() << std::endl HIPDNNFLUSH;
+    }
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnGetConvolutionBackwardDataAlgorithm(
+    hipdnnHandle_t handle, const hipdnnFilterDescriptor_t wDesc,
+    const hipdnnTensorDescriptor_t dyDesc,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t dxDesc,
+    hipdnnConvolutionBwdDataPreference_t preference, size_t memoryLimitInBytes,
+    hipdnnConvolutionBwdDataAlgo_t *algo) {
+    try {
+        HIPDNN_OPEN_LOG_C("Inside hipdnnGetConvolutionBackwardDataAlgorithm "
+                          << std::flush);
+        size_t numBytes;
+        void *dx;
+        void *dy;
+        void *w;
+        const int requestedAlgoCount = 1;
+        int returnedAlgoCount;
+        void *sConvolutionBackwardDataAlgorithmWorkspace = NULL;
+
+        CHECK_MIO(miopenGetTensorNumBytes((miopenTensorDescriptor_t)dxDesc,
+                                          &numBytes));
+        CHECK_HIP(hipMalloc((void **)&dx, numBytes));
+
+        CHECK_MIO(miopenGetTensorNumBytes((miopenTensorDescriptor_t)wDesc,
+                                          &numBytes));
+        CHECK_HIP(hipMalloc((void **)&w, numBytes));
+
+        CHECK_MIO(miopenGetTensorNumBytes((miopenTensorDescriptor_t)dyDesc,
+                                          &numBytes));
+        CHECK_HIP(hipMalloc((void **)&dy, numBytes));
+
+        hipdnnConvolutionBwdDataAlgoPerf_t *perfResults =
+            new hipdnnConvolutionBwdDataAlgoPerf_t[requestedAlgoCount];
+
+        CHECK_HIPDNN(hipdnnFindConvolutionBackwardDataAlgorithmEx(
+            handle, wDesc, w, dyDesc, dy, convDesc, dxDesc, dx,
+            requestedAlgoCount, &returnedAlgoCount, perfResults,
+            sConvolutionBackwardDataAlgorithmWorkspace, 0));
+
+        *algo = perfResults[0].algo;
+
+        CHECK_HIP(hipFree(dx));
+        CHECK_HIP(hipFree(w));
+        CHECK_HIP(hipFree(dy));
+        delete[] perfResults;
+
+    } catch (std::exception &e) {
+        std::cout
+            << "Exception in hipdnnGetConvolutionBackwardDataWorkspaceSize: "
+            << e.what() << std::endl HIPDNNFLUSH;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnFindConvolutionBackwardDataAlgorithmEx(
+    hipdnnHandle_t handle, const hipdnnFilterDescriptor_t wDesc, const void *w,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t dxDesc, void *dx,
+    const int requestedAlgoCount, int *returnedAlgoCount,
+    hipdnnConvolutionBwdDataAlgoPerf_t *perfResults, void *workSpace,
+    size_t workSpaceSizeInBytes) {
+    HIPDNN_OPEN_LOG_C(
+        "Inside hipdnnFindConvolutionBackwardDataAlgorithmEx: input ws size="
+        << workSpaceSizeInBytes << ", requestedAlgoCount=" << requestedAlgoCount
+        << ", WS PTR=" << workSpace << std::flush);
+
+    size_t expectedWorkSpaceSize, infoWorkSpaceSize;
+    void *workSpaceInternal = NULL;
+
+    miopenConvAlgoPerf_t *miopenPerfResults =
+        new miopenConvAlgoPerf_t[requestedAlgoCount];
+
+        workSpaceInternal = workSpace;
+        expectedWorkSpaceSize = workSpaceSizeInBytes;
+
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO(miopenConvolutionBackwardDataGetWorkSpaceSize(
+        (miopenHandle_t)handle, (miopenTensorDescriptor_t)dyDesc,
+        (miopenTensorDescriptor_t)wDesc,
+        (miopenConvolutionDescriptor_t)convDesc_cast,
+        (miopenTensorDescriptor_t)dxDesc, &infoWorkSpaceSize));
+
+    try {
+        CHECK_MIO(miopenFindConvolutionBackwardDataAlgorithm(
+            (miopenHandle_t)handle, (miopenTensorDescriptor_t)dyDesc, dy,
+            (miopenTensorDescriptor_t)wDesc, w,
+            (miopenConvolutionDescriptor_t)convDesc_cast,
+            (miopenTensorDescriptor_t)dxDesc, dx, requestedAlgoCount,
+            returnedAlgoCount, miopenPerfResults, workSpaceInternal,
+            expectedWorkSpaceSize,
+            false  // exhaustiveSearch
+            ));
+
+        HIPDNN_OPEN_LOG_C(
+            "...miopenFindConvolutionBackwardDataAlgorithm OK, "
+            "returnedAlgoCount:"
+            << *returnedAlgoCount << std::flush);
+    } catch (std::exception &e) {
+        std::cout
+            << "Exception in hipdnnGetConvolutionBackwardDataWorkspaceSize: "
+            << e.what() << std::endl HIPDNNFLUSH;
+    }
+
+    for (int i = 0; i < *returnedAlgoCount; i++) {
+        CHECK_HIPDNN(miopenTohipConvolutionBwdDataAlgo(
+            miopenPerfResults[i].bwd_data_algo, &(perfResults[i].algo)));
+
+        perfResults[i].status =
+            HIPDNN_STATUS_SUCCESS;  // TODO: miopen doesn't contain a 'status'
+                                    // member variable , setting it to success
+                                    // as of now.
+        perfResults[i].time = miopenPerfResults[i].time;
+        perfResults[i].memory = miopenPerfResults[i].memory;
+    }
+
+    delete[] miopenPerfResults;
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnConvolutionBackwardData(
+    hipdnnHandle_t handle, const void *alpha,
+    const hipdnnFilterDescriptor_t wDesc, const void *w,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnConvolutionDescriptor_t convDesc,
+    hipdnnConvolutionBwdDataAlgo_t algo, void *workSpace,
+    size_t workSpaceSizeInBytes, const void *beta,
+    const hipdnnTensorDescriptor_t dxDesc, void *dx) {
+    HIPDNN_OPEN_LOG_C("ConvolutionBackwardData: WS PTR="
+                      << workSpace << ", WS size = " << workSpaceSizeInBytes
+                      << std::flush);
+
+    size_t expectedWorkSpaceSize = 0;
+    void *workSpaceInternal = NULL;
+    size_t infoWorkSpaceSize = 0;
+
+        workSpaceInternal = workSpace;
+        expectedWorkSpaceSize = workSpaceSizeInBytes;
+
+    int nbDimsRequested=1;
+    int nbDims,dimA[1],strideA[1];
+    hipdnnDataType_t dataType;
+    hipdnnGetTensorNdDescriptor(dxDesc, nbDimsRequested, &dataType, &nbDims, dimA,strideA);
+
+    try {
+        // Allocate sConvolutionBackwardDataAlgorithmWorkspace to gather work
+        // space value
+        miopenConvBwdDataAlgorithm_t mialgo;
+        CHECK_HIPDNN(hipTomiopenConvolutionBwdDataAlgo(algo, &mialgo));
+
+        HIPDNN_OPEN_LOG_C(
+            "ConvolutionBackwardData:  hipTomiopenConvolutionBwdDataAlgo OK."
+            << std::flush);
+        HIPDNN_OPEN_LOG_C(
+            "ConvolutionBackwardData: about to invoke "
+            "miopenConvolutionBackwardData."
+            << ", WS PTR = " << workSpaceInternal
+            << ", WS size =" << expectedWorkSpaceSize << std::flush);
+
+        hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+        if (*static_cast<const float *>(beta) == 0) {
+            CHECK_MIO(miopenConvolutionBackwardData(
+                (miopenHandle_t)handle, alpha, (miopenTensorDescriptor_t)dyDesc,
+                dy, (miopenTensorDescriptor_t)wDesc, w,
+                (miopenConvolutionDescriptor_t)convDesc_cast, mialgo, beta,
+                (miopenTensorDescriptor_t)dxDesc, dx, workSpaceInternal,
+                expectedWorkSpaceSize));
+        } else {
+            HIPDNN_OPEN_LOG_C("Case Beta !=0." << std::flush);
+            const float tempBeta = 0;
+            void *dxPrior = SaveAsPriorBuffer(dx);
+            CHECK_MIO(miopenConvolutionBackwardData(
+                (miopenHandle_t)handle, alpha, (miopenTensorDescriptor_t)dyDesc,
+                dy, (miopenTensorDescriptor_t)wDesc, w,
+                (miopenConvolutionDescriptor_t)convDesc_cast, mialgo, &tempBeta,
+                (miopenTensorDescriptor_t)dxDesc, dx, workSpaceInternal,
+                expectedWorkSpaceSize));
+            accumulateGradients(dx, dxPrior, dxDesc, beta, &dataType);
+            deallocPrior(dxPrior);
+        }
+
+    } catch (std::exception &e) {
+        std::cout
+            << "Exception in hipdnnGetConvolutionBackwardDataWorkspaceSize: "
+            << e.what() << std::endl HIPDNNFLUSH;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//============================ Softmax layer ===================================
+
+hipdnnStatus_t hipdnnSoftmaxForward(hipdnnHandle_t handle,
+                                    hipdnnSoftmaxAlgorithm_t algo,
+                                    hipdnnSoftmaxMode_t mode, const void *alpha,
+                                    const hipdnnTensorDescriptor_t xDesc,
+                                    const void *x, const void *beta,
+                                    const hipdnnTensorDescriptor_t yDesc,
+                                    void *y) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnSoftmaxForward");
+
+    CHECK_HIPDNN(SoftmaxAlgorithmSupported(algo));
+    CHECK_HIPDNN(hipSoftmaxModeSupported(mode));
+    CHECK_MIO(miopenSoftmaxForward((miopenHandle_t)handle, alpha,
+                                   (miopenTensorDescriptor_t)xDesc, x, beta,
+                                   (miopenTensorDescriptor_t)yDesc, y));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSoftmaxBackward(
+    hipdnnHandle_t handle, hipdnnSoftmaxAlgorithm_t algo,
+    hipdnnSoftmaxMode_t mode, const void *alpha,
+    const hipdnnTensorDescriptor_t yDesc, const void *y,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy, const void *beta,
+    const hipdnnTensorDescriptor_t dxDesc, void *dx) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnSoftmaxBackward");
+
+    CHECK_HIPDNN(SoftmaxAlgorithmSupported(algo));
+    CHECK_HIPDNN(hipSoftmaxModeSupported(mode));
+    CHECK_MIO(miopenSoftmaxBackward((miopenHandle_t)handle, alpha,
+                                    (miopenTensorDescriptor_t)yDesc, y,
+                                    (miopenTensorDescriptor_t)dyDesc, dy, beta,
+                                    (miopenTensorDescriptor_t)dxDesc, dx));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnCreatePoolingDescriptor(
+    hipdnnPoolingDescriptor_t *poolingDesc) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnCreatePoolingDescriptor");
+
+    CHECK_MIO(miopenCreatePoolingDescriptor(
+        (miopenPoolingDescriptor_t *)poolingDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=============================================================================
+
+hipdnnStatus_t hipdnnSetPooling2dDescriptor(
+    hipdnnPoolingDescriptor_t poolingDesc, hipdnnPoolingMode_t mode,
+    hipdnnNanPropagation_t maxpoolingNanOpt, int windowHeight, int windowWidth,
+    int verticalPadding, int horizontalPadding, int verticalStride,
+    int horizontalStride) {
+    miopenPoolingMode_t miPMode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnSetPooling2dDescriptor");
+
+    CHECK_HIPDNN(hipTomiopenPoolingMode(mode, &miPMode));
+    CHECK_MIO(miopenSet2dPoolingDescriptor(
+        (miopenPoolingDescriptor_t)poolingDesc, miPMode, windowHeight,
+        windowWidth, horizontalPadding, verticalPadding, horizontalStride,
+        verticalStride));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnGetPooling2dDescriptor(
+    const hipdnnPoolingDescriptor_t poolingDesc, hipdnnPoolingMode_t *mode,
+    hipdnnNanPropagation_t *maxpoolingNanOpt, int *windowHeight,
+    int *windowWidth, int *verticalPadding, int *horizontalPadding,
+    int *verticalStride, int *horizontalStride) {
+    miopenPoolingMode_t mipmmode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnGetPooling2dDescriptor");
+
+    CHECK_MIO(miopenGet2dPoolingDescriptor(
+        (miopenPoolingDescriptor_t)poolingDesc, &mipmmode, windowHeight,
+        windowWidth, horizontalPadding, horizontalPadding, horizontalStride,
+        verticalStride));
+    *maxpoolingNanOpt = HIPDNN_PROPAGATE_NAN;
+
+    CHECK_HIPDNN(miopenTohipPoolingMode(mipmmode, mode));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnGetPooling2dForwardOutputDim(
+    const hipdnnPoolingDescriptor_t poolingDesc,
+    const hipdnnTensorDescriptor_t inputTensorDesc, int *n, int *c, int *h,
+    int *w) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnGetPooling2dDescriptor");
+
+    CHECK_MIO(miopenGetPoolingForwardOutputDim(
+        (miopenPoolingDescriptor_t)poolingDesc,
+        (miopenTensorDescriptor_t)inputTensorDesc, n, c, h, w));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnDestroyPoolingDescriptor(
+    hipdnnPoolingDescriptor_t poolingDesc) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnDestroyPoolingDescriptor");
+
+    CHECK_MIO(
+        miopenDestroyPoolingDescriptor((miopenPoolingDescriptor_t)poolingDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnPoolingForward(
+    hipdnnHandle_t handle, const hipdnnPoolingDescriptor_t poolingDesc,
+    const void *alpha, const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const void *beta, const hipdnnTensorDescriptor_t yDesc, void *y,
+    bool do_backward) {
+
+    int8_t *devptr = 0;
+
+    size_t workSpaceSize = 0;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnPoolingForward");
+
+    if (sDescToWorkspacePooling.find((miopenTensorDescriptor_t)yDesc) ==
+        sDescToWorkspacePooling.end()) {
+        // If the descriptor is not present in the bookkept map container,
+        // create one and add to the container
+        HIPDNN_OPEN_LOG_I("INTERNAL_ALLOC: hipdnnPoolingForward");
+
+        // the yDesc is used for the workspace, not the
+        // poolingDesc
+        CHECK_MIO(miopenPoolingGetWorkSpaceSize((miopenTensorDescriptor_t)yDesc,
+                                                &workSpaceSize));
+        CHECK_HIP(hipMalloc((void **)&devptr, workSpaceSize));
+        sDescToWorkspacePooling[(miopenTensorDescriptor_t)yDesc] = std::make_pair(devptr, workSpaceSize);
+
+    } else {
+        // Reuse the preallocated workspace
+        devptr = sDescToWorkspacePooling[(miopenTensorDescriptor_t)yDesc].first;
+        workSpaceSize =
+            sDescToWorkspacePooling[(miopenTensorDescriptor_t)yDesc].second;
+    }
+
+    if((*static_cast<const float *>(alpha)) == 1 && (*static_cast<const float *>(beta)) == 0) {
+
+        CHECK_MIO(miopenPoolingForward((miopenHandle_t)handle,
+                                      (miopenPoolingDescriptor_t)poolingDesc,
+                                      alpha, (miopenTensorDescriptor_t)xDesc, x,
+                                      beta, (miopenTensorDescriptor_t)yDesc, y,
+                                      do_backward,
+                                      (void *)devptr, workSpaceSize));
+	} else {
+
+        void *dwPrior = SaveAsPriorBuffer(y);
+        const float alpha1 = 1;
+        const float beta1 = 0;
+        CHECK_MIO(miopenPoolingForward((miopenHandle_t)handle,
+                                       (miopenPoolingDescriptor_t)poolingDesc,
+                                       &alpha1, (miopenTensorDescriptor_t)xDesc, x,
+                                       &beta1, (miopenTensorDescriptor_t)yDesc, y,
+                                       do_backward,
+                                       (void *)devptr, workSpaceSize));
+        int alpha2 =0;
+        CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, miopenTensorOpAdd, alpha,
+                                 (miopenTensorDescriptor_t)yDesc, y, beta,
+                                 (miopenTensorDescriptor_t)yDesc, dwPrior, &alpha2,
+                                 (miopenTensorDescriptor_t)yDesc, y));
+        deallocPrior(dwPrior);
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=================================!
+
+hipdnnStatus_t hipdnnPoolingBackward(
+    hipdnnHandle_t handle, const hipdnnPoolingDescriptor_t poolingDesc,
+    const void *alpha, const hipdnnTensorDescriptor_t yDesc, const void *y,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnTensorDescriptor_t xDesc, const void *x, const void *beta,
+    const hipdnnTensorDescriptor_t dxDesc, void *dx) {
+    int8_t *devptr = 0;
+    size_t workSpaceSize = 0;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnPoolingBackward");
+
+    // forward and backward pooling can reuse tha same
+    // map.
+
+    if (sDescToWorkspacePooling.find((miopenTensorDescriptor_t)yDesc) ==
+        sDescToWorkspacePooling.end()) {
+        // yDesc is used for the workspace, not the
+        // poolingDesc
+
+        HIPDNN_OPEN_LOG_I("INTERNAL_ALLOC: hipdnnPoolingBackward");
+
+        CHECK_MIO(miopenPoolingGetWorkSpaceSize((miopenTensorDescriptor_t)yDesc,
+                                                &workSpaceSize));
+
+        CHECK_HIP(hipMalloc((void **)&devptr, workSpaceSize));
+        sDescToWorkspacePooling[(miopenTensorDescriptor_t)yDesc] = std::make_pair(devptr, workSpaceSize);
+
+    } else {
+        devptr = sDescToWorkspacePooling[(miopenTensorDescriptor_t)yDesc].first;
+        workSpaceSize =
+            sDescToWorkspacePooling[(miopenTensorDescriptor_t)yDesc].second;
+    }
+
+    if((*static_cast<const float *>(alpha)) == 1 && (*static_cast<const float *>(beta)) == 0) {
+
+        CHECK_MIO(miopenPoolingBackward(
+            (miopenHandle_t)handle, (miopenPoolingDescriptor_t)poolingDesc, alpha,
+            (miopenTensorDescriptor_t)yDesc, y, (miopenTensorDescriptor_t)dyDesc,
+            dy, (miopenTensorDescriptor_t)xDesc, x, beta,
+            (miopenTensorDescriptor_t)dxDesc, dx,
+            devptr));
+    } else {
+
+        void *dwPrior = SaveAsPriorBuffer(dx);
+        const float alpha1 = 1;
+        const float beta1 = 0;
+
+        CHECK_MIO(miopenPoolingBackward(
+            (miopenHandle_t)handle, (miopenPoolingDescriptor_t)poolingDesc, &alpha1,
+            (miopenTensorDescriptor_t)yDesc, y, (miopenTensorDescriptor_t)dyDesc,
+            dy, (miopenTensorDescriptor_t)xDesc, x, &beta1,
+            (miopenTensorDescriptor_t)dxDesc, dx,
+            devptr));
+
+        int alpha2 =0;
+        CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, miopenTensorOpAdd, alpha,
+                                (miopenTensorDescriptor_t)dxDesc, dx, beta,
+                                (miopenTensorDescriptor_t)dxDesc, dwPrior, &alpha2,
+                                (miopenTensorDescriptor_t)dxDesc, dx));
+        deallocPrior(dwPrior);
+}
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=============================================================================
+
+hipdnnStatus_t hipdnnCreateActivationDescriptor(
+    hipdnnActivationDescriptor_t *activationDesc) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnCreateActivationDescriptor");
+
+    CHECK_MIO(miopenCreateActivationDescriptor(
+        (miopenActivationDescriptor_t *)activationDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=============================================================================
+
+hipdnnStatus_t hipdnnSetActivationDescriptor(
+    hipdnnActivationDescriptor_t activationDesc, // not const in cudnn
+    hipdnnActivationMode_t mode,
+    hipdnnNanPropagation_t reluNanOpt, double reluCeilingOrAlpha,
+    double activBeta, double activExp) {
+    miopenActivationMode_t mimode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnSetActivationDescriptor");
+
+    CHECK_HIPDNN(hipTomiopenActivationMode(mode, &mimode));
+
+    CHECK_MIO(miopenSetActivationDescriptor(
+        static_cast<const miopenActivationDescriptor_t>(activationDesc), mimode,
+        reluCeilingOrAlpha, activBeta, activExp));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnGetActivationDescriptor(
+    const hipdnnActivationDescriptor_t activationDesc,
+    hipdnnActivationMode_t *mode, hipdnnNanPropagation_t *reluNanOpt,
+    double *reluCeilingOrAlpha, double *activBeta, double *activExp) {
+    HIPDNN_OPEN_LOG_E("ENTER hipdnnGetActivationDescriptor");
+
+    miopenActivationMode_t miactmode;
+
+    CHECK_MIO(miopenGetActivationDescriptor(
+        (miopenActivationDescriptor_t)activationDesc, &miactmode,
+        reluCeilingOrAlpha, activBeta, activExp));
+
+    CHECK_HIPDNN(miopenTohipActivationMode(miactmode, mode));
+    *reluNanOpt = HIPDNN_PROPAGATE_NAN;
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnDestroyActivationDescriptor(
+    hipdnnActivationDescriptor_t activationDesc) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnDestroyActivationDescriptor");
+    CHECK_MIO(miopenDestroyActivationDescriptor(
+        (miopenActivationDescriptor_t)activationDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=================
+
+hipdnnStatus_t hipdnnActivationForward(
+    hipdnnHandle_t handle,
+    hipdnnActivationDescriptor_t activationDesc,  // not const in cudnn
+    const void *alpha, const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const void *beta, const hipdnnTensorDescriptor_t yDesc, void *y) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnActivationForward");
+
+    void *dwPrior = SaveAsPriorBuffer(y);
+    const float alpha1 = 1;
+    const float beta1 = 0;
+    CHECK_MIO(miopenActivationForward(
+        (miopenHandle_t)handle, static_cast<const miopenActivationDescriptor_t>(activationDesc),
+        &alpha1, (miopenTensorDescriptor_t)xDesc, x, &beta1,
+        (miopenTensorDescriptor_t)yDesc, y));
+    int alpha2 =0;
+    CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, miopenTensorOpAdd, alpha,
+                             (miopenTensorDescriptor_t)yDesc, y, beta,
+                             (miopenTensorDescriptor_t)yDesc, dwPrior, &alpha2,
+                             (miopenTensorDescriptor_t)yDesc, y));
+    deallocPrior(dwPrior);
+    return HIPDNN_STATUS_SUCCESS;
+}
+//======================
+
+hipdnnStatus_t hipdnnActivationBackward(
+    hipdnnHandle_t handle,
+    hipdnnActivationDescriptor_t activationDesc,  // const missing in cuda
+    const void *alpha, const hipdnnTensorDescriptor_t yDesc, const void *y,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnTensorDescriptor_t xDesc, const void *x, const void *beta,
+    const hipdnnTensorDescriptor_t dxDesc, void *dx) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnActivationBackward");
+
+    void *dwPrior = SaveAsPriorBuffer(dx);
+    const float alpha1 = 1;
+    const float beta1 = 0;
+    CHECK_MIO(miopenActivationBackward(
+        (miopenHandle_t)handle, static_cast<const miopenActivationDescriptor_t>(activationDesc),
+        &alpha1, (miopenTensorDescriptor_t)yDesc, y,
+        (miopenTensorDescriptor_t)dyDesc, dy, (miopenTensorDescriptor_t)xDesc,
+        x, &beta1, (miopenTensorDescriptor_t)dxDesc, dx));
+    int alpha2 =0;
+    CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, miopenTensorOpAdd, alpha,
+                             (miopenTensorDescriptor_t)dxDesc, dx, beta,
+                             (miopenTensorDescriptor_t)dxDesc, dwPrior, &alpha2,
+                             (miopenTensorDescriptor_t)dxDesc, dx));
+    deallocPrior(dwPrior);
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=============================================================================
+
+hipdnnStatus_t hipdnnCreateLRNDescriptor(hipdnnLRNDescriptor_t *normDesc) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnCreateLRNDescriptor");
+
+    CHECK_MIO(miopenCreateLRNDescriptor((miopenLRNDescriptor_t *)normDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=============================================================================
+
+hipdnnStatus_t hipdnnSetLRNDescriptor(hipdnnLRNDescriptor_t normDesc,
+                                      hipdnnLRNMode_t mode, unsigned lrnN,
+                                      double lrnAlpha, double lrnBeta,
+                                      double lrnK) {
+    miopenLRNMode_t mimode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnCreateLRNDescriptor");
+
+    CHECK_HIPDNN(hipTomiopenLRNMode(mode, &mimode));
+    CHECK_MIO(miopenSetLRNDescriptor((miopenLRNDescriptor_t)normDesc, mimode,
+                                     lrnN, lrnAlpha, lrnBeta, lrnK));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//================
+
+hipdnnStatus_t hipdnnGetLRNDescriptor(hipdnnLRNDescriptor_t normDesc,
+                                      hipdnnLRNMode_t *mode, unsigned *lrnN,
+                                      double *lrnAlpha, double *lrnBeta,
+                                      double *lrnK) {
+    miopenLRNMode_t mimode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnCreateLRNDescriptor");
+
+    CHECK_MIO(miopenGetLRNDescriptor((miopenLRNDescriptor_t)normDesc, &mimode,
+                                     lrnN, lrnAlpha, lrnBeta, lrnK));
+
+    CHECK_HIPDNN(miopenTohipLRNMode(mimode, mode));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnDestroyLRNDescriptor(hipdnnLRNDescriptor_t normDesc) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnDestroyLRNDescriptor");
+
+    CHECK_MIO(miopenDestroyLRNDescriptor((miopenLRNDescriptor_t)normDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnLRNCrossChannelForward(
+    hipdnnHandle_t handle, hipdnnLRNDescriptor_t normDesc,
+    hipdnnLRNMode_t lrnMode, const void *alpha,
+    const hipdnnTensorDescriptor_t xDesc, const void *x, const void *beta,
+    const hipdnnTensorDescriptor_t yDesc, void *y, bool do_backward) {
+
+    int8_t *devptr = 0;
+
+    size_t workSpaceSize = 0;
+    miopenStatus_t miStat;
+    miopenLRNMode_t mimode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnLRNCrossChannelForward");
+
+    CHECK_HIPDNN(hipTomiopenLRNMode(lrnMode, &mimode));
+
+	if( do_backward == 1) {
+        if (sDescToWorkspaceLRN.find((miopenTensorDescriptor_t)yDesc) ==
+            sDescToWorkspaceLRN.end()) {
+            //yDesc is used for the workspace, not the
+			//hipdnnLRNDescriptor_t
+
+            CHECK_MIO(miopenLRNGetWorkSpaceSize((miopenTensorDescriptor_t)yDesc,
+                                                &workSpaceSize));
+            CHECK_HIP(hipMalloc((void **)&devptr, workSpaceSize));
+            sDescToWorkspaceLRN[(miopenTensorDescriptor_t)yDesc] = std::make_pair(devptr, workSpaceSize);
+
+        } else {
+            devptr = sDescToWorkspaceLRN[(miopenTensorDescriptor_t)yDesc].first;
+            workSpaceSize =
+             sDescToWorkspaceLRN[(miopenTensorDescriptor_t)yDesc].second;
+        }
+	}
+
+    void *dwPrior = SaveAsPriorBuffer(y);
+    const float alpha1 = 1;
+    const float beta1 = 0;
+
+    CHECK_MIO(miopenLRNForward((miopenHandle_t)handle,
+                               (miopenLRNDescriptor_t)normDesc, &alpha1,
+                               (miopenTensorDescriptor_t)xDesc, x, &beta1,
+                               (miopenTensorDescriptor_t)yDesc, y,
+                               do_backward,
+                               devptr));
+
+    int alpha2 =0;
+    CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, miopenTensorOpAdd, alpha,
+                             (miopenTensorDescriptor_t)yDesc, y, beta,
+                             (miopenTensorDescriptor_t)yDesc, dwPrior, &alpha2,
+                             (miopenTensorDescriptor_t)yDesc, y));
+    deallocPrior(dwPrior);
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnLRNCrossChannelForwardEx(
+    hipdnnHandle_t handle, hipdnnLRNDescriptor_t normDesc,
+    hipdnnLRNMode_t lrnMode, const void *alpha,
+    const hipdnnTensorDescriptor_t xDesc, const void *x, const void *beta,
+    const hipdnnTensorDescriptor_t yDesc, void *y, size_t workspaceSize,
+    void *workspace, bool do_backward) {
+    miopenLRNMode_t mimode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnLRNCrossChannelForward");
+
+    CHECK_HIPDNN(hipTomiopenLRNMode(lrnMode, &mimode));
+    // mimode is otherwise unused.
+
+    CHECK_MIO(miopenLRNForward((miopenHandle_t)handle,
+                               (miopenLRNDescriptor_t)normDesc, alpha,
+                               (miopenTensorDescriptor_t)xDesc, x, beta,
+                               (miopenTensorDescriptor_t)yDesc, y,
+                               do_backward,
+                               workspace));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnLRNCrossChannelBackward(
+    hipdnnHandle_t handle, hipdnnLRNDescriptor_t normDesc,
+    hipdnnLRNMode_t lrnMode, const void *alpha,
+    const hipdnnTensorDescriptor_t yDesc, const void *y,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnTensorDescriptor_t xDesc, const void *x, const void *beta,
+    const hipdnnTensorDescriptor_t dxDesc, void *dx) {
+
+    int8_t *devptr = 0;
+
+    size_t workSpaceSize = 0;
+    miopenStatus_t miStat;
+    miopenLRNMode_t mimode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnLRNCrossChannelBackward");
+
+    CHECK_HIPDNN(hipTomiopenLRNMode(lrnMode, &mimode));
+    if (sDescToWorkspaceLRN.find((miopenTensorDescriptor_t)yDesc) ==
+        sDescToWorkspaceLRN.end()) {
+        // yDesc is used for the workspace, not the
+        // hipdnnLRNDescriptor_t
+
+        CHECK_MIO(miopenLRNGetWorkSpaceSize((miopenTensorDescriptor_t)yDesc,
+                                            &workSpaceSize));
+        CHECK_HIP(hipMalloc((void **)&devptr, workSpaceSize));
+        sDescToWorkspaceLRN[(miopenTensorDescriptor_t)yDesc] = std::make_pair(devptr, workSpaceSize);
+
+    } else {
+        devptr = sDescToWorkspaceLRN[(miopenTensorDescriptor_t)yDesc].first;
+        workSpaceSize =
+            sDescToWorkspaceLRN[(miopenTensorDescriptor_t)yDesc].second;
+    }
+
+    CHECK_HIPDNN(hipdnnLRNCrossChannelBackwardEx(
+        handle, normDesc, lrnMode, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta,
+        dxDesc, dx, workSpaceSize, devptr));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnLRNCrossChannelBackwardEx(
+    hipdnnHandle_t handle, hipdnnLRNDescriptor_t normDesc,
+    hipdnnLRNMode_t lrnMode, const void *alpha,
+    const hipdnnTensorDescriptor_t yDesc, const void *y,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnTensorDescriptor_t xDesc, const void *x, const void *beta,
+    const hipdnnTensorDescriptor_t dxDesc, void *dx,
+    size_t workspacesize,  // HGSOS //NOTYET unused!!!
+    void *workspace) {
+    miopenLRNMode_t mimode;
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnLRNCrossChannelBackwardEx");
+
+    CHECK_HIPDNN(hipTomiopenLRNMode(lrnMode, &mimode));
+    // mimode is otherwise unused.
+
+    void *dwPrior = SaveAsPriorBuffer(dx);
+    const float alpha1 = 1;
+    const float beta1 = 0;
+
+    CHECK_MIO(miopenLRNBackward(
+        (miopenHandle_t)handle, (miopenLRNDescriptor_t)normDesc, &alpha1,
+        (miopenTensorDescriptor_t)yDesc, y, (miopenTensorDescriptor_t)dyDesc,
+        dy, (miopenTensorDescriptor_t)xDesc, x, &beta1,
+        (miopenTensorDescriptor_t)dxDesc, dx, workspace));
+
+    int alpha2 =0;
+    CHECK_MIO(miopenOpTensor((miopenHandle_t)handle, miopenTensorOpAdd, alpha,
+                             (miopenTensorDescriptor_t)dxDesc, dx, beta,
+                             (miopenTensorDescriptor_t)dxDesc, dwPrior, &alpha2,
+                             (miopenTensorDescriptor_t)dxDesc, dx));
+    deallocPrior(dwPrior);
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//==================================!
+
+hipdnnStatus_t hipdnnDeriveBNTensorDescriptor(
+    hipdnnTensorDescriptor_t derivedBnDesc,
+    const hipdnnTensorDescriptor_t xDesc, hipdnnBatchNormMode_t mode) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnDeriveBNTensorDescriptor");
+
+    miopenBatchNormMode_t miBNMode;
+    CHECK_HIPDNN(hipTomiopenBatchNormMode(mode, &miBNMode));
+    CHECK_MIO(miopenDeriveBNTensorDescriptor(
+        (miopenTensorDescriptor_t)derivedBnDesc,
+        (miopenTensorDescriptor_t)xDesc, miBNMode));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//=============================================================================
+
+hipdnnStatus_t hipdnnBatchNormalizationForwardTraining(
+    hipdnnHandle_t handle, hipdnnBatchNormMode_t mode, void *alpha, void *beta,
+    const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const hipdnnTensorDescriptor_t yDesc, void *y,
+    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc, void *bnScale,
+    void *bnBias, double exponentialAverageFactor, void *resultRunningMean,
+    void *resultRunningVariance, double epsilon, void *resultSaveMean,
+    void *resultSaveInvVariance) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnBatchNormalizationForwardTraining");
+    miopenBatchNormMode_t miBNMode;
+    CHECK_HIPDNN(hipTomiopenBatchNormMode(mode, &miBNMode));
+    CHECK_MIO(miopenBatchNormalizationForwardTraining(
+        (miopenHandle_t)handle, miBNMode, alpha, beta,
+        (miopenTensorDescriptor_t)xDesc, x, (miopenTensorDescriptor_t)yDesc, y,
+        (miopenTensorDescriptor_t)bnScaleBiasMeanVarDesc, bnScale, bnBias,
+        exponentialAverageFactor, resultRunningMean, resultRunningVariance,
+        epsilon, resultSaveMean, resultSaveInvVariance));
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=============================================================================
+
+hipdnnStatus_t hipdnnnBatchNormalizationForwardInference(
+    hipdnnHandle_t handle, hipdnnBatchNormMode_t mode, void *alpha, void *beta,
+    const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const hipdnnTensorDescriptor_t yDesc, void *y,
+    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc, const void *bnScale,
+    const void *bnBias, const void *estimatedMean,
+    const void *estimatedVariance, double epsilon) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnBatchNormalizationForwardInference");
+    miopenBatchNormMode_t miBNMode;
+    CHECK_HIPDNN(hipTomiopenBatchNormMode(mode, &miBNMode));
+    CHECK_MIO(miopenBatchNormalizationForwardInference(
+        (miopenHandle_t)handle, miBNMode, alpha, beta,
+        (miopenTensorDescriptor_t)xDesc, x, (miopenTensorDescriptor_t)yDesc, y,
+        (miopenTensorDescriptor_t)bnScaleBiasMeanVarDesc,
+        const_cast<void *>(bnScale), const_cast<void *>(bnBias),
+        const_cast<void *>(estimatedMean),
+        const_cast<void *>(estimatedVariance), epsilon));
+    return HIPDNN_STATUS_SUCCESS;
+}
+//=============================================================================
+
+hipdnnStatus_t hipdnnBatchNormalizationBackward(
+    hipdnnHandle_t handle, hipdnnBatchNormMode_t mode,
+    const void *alphaDataDiff, const void *betaDataDiff,
+    const void *alphaParamDiff, const void *betaParamDiff,
+    const hipdnnTensorDescriptor_t xDesc, const void *x,
+    const hipdnnTensorDescriptor_t dyDesc, const void *dy,
+    const hipdnnTensorDescriptor_t dxDesc, void *dx,
+    const hipdnnTensorDescriptor_t bnScaleBiasDiffDesc, const void *bnScale,
+    void *resultBnScaleDiff, void *resultBnBiasDiff, double epsilon,
+    const void *savedMean, const void *savedInvVariance) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnBatchNormalizationBackward");
+
+    miopenBatchNormMode_t miBNMode;
+	int nbDimsRequested=1;
+    int nbDims,dimA[1],strideA[1];
+    hipdnnDataType_t dataType;
+    hipdnnGetTensorNdDescriptor(xDesc, nbDimsRequested, &dataType, &nbDims, dimA,strideA);
+    CHECK_HIPDNN(hipTomiopenBatchNormMode(mode, &miBNMode));
+    if ((*static_cast<const float *>(betaDataDiff) == 0) &&
+        (*static_cast<const float *>(betaParamDiff) == 0)) {
+        HIPDNN_OPEN_LOG_I2("Accumulate Gradients is false");
+        CHECK_MIO(miopenBatchNormalizationBackward(
+            (miopenHandle_t)handle, miBNMode, alphaDataDiff, betaDataDiff,
+            alphaParamDiff, betaParamDiff, (miopenTensorDescriptor_t)xDesc, x,
+            (miopenTensorDescriptor_t)dyDesc, dy,
+            (miopenTensorDescriptor_t)dxDesc, dx,
+            (miopenTensorDescriptor_t)bnScaleBiasDiffDesc, bnScale,
+            resultBnScaleDiff, resultBnBiasDiff, epsilon, savedMean,
+            savedInvVariance));
+        return HIPDNN_STATUS_SUCCESS;
+    } else {
+        HIPDNN_OPEN_LOG_I2("Accumulate Gradients is true");
+        HIPDNN_OPEN_LOG_C(
+            "Case where either betaDataDiff or betaParamDiff is nonzero");
+        // Accumulate for resultBnScaleDiff
+        const float tempBetaDataDiff = 0;
+        const float tempBetaParamDiff = 0;
+        void *dxPrior = SaveAsPriorBuffer(dx);
+        void *resultBnScaleDiffPrior = SaveAsPriorBuffer(
+            resultBnScaleDiff);  // Pointer to keep track of priorDst value
+        void *resultBnBiasDiffPrior = SaveAsPriorBuffer(resultBnBiasDiff);
+        CHECK_MIO(miopenBatchNormalizationBackward(
+            (miopenHandle_t)handle, miBNMode, alphaDataDiff, &tempBetaDataDiff,
+            alphaParamDiff, &tempBetaParamDiff, (miopenTensorDescriptor_t)xDesc,
+            x, (miopenTensorDescriptor_t)dyDesc, dy,
+            (miopenTensorDescriptor_t)dxDesc, dx,
+            (miopenTensorDescriptor_t)bnScaleBiasDiffDesc, bnScale,
+            resultBnScaleDiff, resultBnBiasDiff, epsilon, savedMean,
+            savedInvVariance));
+        accumulateGradients(dx, dxPrior, dxDesc, betaDataDiff, &dataType);
+        accumulateGradients(resultBnScaleDiff, resultBnScaleDiffPrior,
+                            bnScaleBiasDiffDesc, betaParamDiff, &dataType);
+        accumulateGradients(resultBnBiasDiff, resultBnBiasDiffPrior,
+                            bnScaleBiasDiffDesc, betaParamDiff, &dataType);
+        deallocPrior(dxPrior);
+        deallocPrior(resultBnBiasDiffPrior);
+        deallocPrior(resultBnScaleDiffPrior);
+    }
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnSetTensorNdDescriptor(hipdnnTensorDescriptor_t tensorDesc,
+                                           hipdnnDataType_t dataType,
+                                           int nbDims, const int dimA[],
+                                           const int strideA[]) {
+    miopenDataType_t moDT;
+    HIPDNN_OPEN_LOG_C("ENTER: hipdnnSetTensorNdDescriptor "
+                      << tensorDesc << "... nbDims=" << nbDims << std::flush);
+    if (dataType != HIPDNN_DATA_FLOAT && dataType!= HIPDNN_DATA_HALF) {
+        HIPDNN_OPEN_LOG_E(
+            "ERROR: hipdnnSetTensorNdDescriptor only supports floats and half:"
+            << dataType << std::flush);
+        return HIPDNN_STATUS_NOT_SUPPORTED;
+
+    } else {
+        CHECK_HIPDNN(hipTomiopenDataType(dataType, &moDT));
+        CHECK_MIO(miopenSetTensorDescriptor(
+            (miopenTensorDescriptor_t)tensorDesc, moDT, nbDims,
+            const_cast<int *>(dimA), const_cast<int *>(strideA)));
+    }
+
+    HIPDNN_OPEN_LOG_C("EXIT: hipdnnSetTensorNdDescriptor." << std::flush);
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetTensorNdDescriptor(
+    const hipdnnTensorDescriptor_t tensorDesc, int nbDimsRequested,
+    hipdnnDataType_t *dataType, int *nbDims, int dimA[], int strideA[]) {
+    miopenDataType_t moDT;
+    HIPDNN_OPEN_LOG_C("ENTER hipdnnGetTensorNdDescriptor " << tensorDesc
+                                                           << std::flush);
+    CHECK_MIO(miopenGetTensorDescriptor((miopenTensorDescriptor_t)tensorDesc,
+                                        &moDT, dimA, strideA));
+
+    CHECK_HIPDNN(miopenTohipDataType(moDT, dataType));
+    CHECK_MIO(miopenGetTensorDescriptorSize(
+        (miopenTensorDescriptor_t)tensorDesc, nbDims));
+    HIPDNN_OPEN_LOG_C(
+        "EXIT hipdnnGetTensorNdDescriptor, datatype  (miopen, hipdnn)= "
+        << moDT << ", " << *dataType << ",size=" << *nbDims << std::flush);
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnSetFilterNdDescriptor(
+    hipdnnFilterDescriptor_t filterDesc,
+    hipdnnDataType_t dataType,  // image data type
+    hipdnnTensorFormat_t format, int nbDims, const int filterDimA[]) {
+    miopenDataType_t moDT;
+    HIPDNN_OPEN_LOG_C("ENTER hipdnnSetFilterNdDescriptor " << filterDesc
+                                                           << std::flush);
+
+    int strideA[nbDims - 1];
+
+    for (int k = nbDims - 1; k >= 0; k--) {
+        strideA[k] = (k != nbDims - 1) ? strideA[k + 1] * filterDimA[k + 1] : 1;
+    }
+    CHECK_HIPDNN(hipTomiopenDataType(dataType, &moDT));
+    int strideDimA[nbDims - 1];
+    for (int k = nbDims - 1; k >= 0; k--) {
+        strideDimA[k] =
+            (k != nbDims - 1) ? strideDimA[k + 1] * filterDimA[k + 1] : 1;
+    }
+    CHECK_MIO(miopenSetTensorDescriptor(
+    	(miopenTensorDescriptor_t)filterDesc, moDT, nbDims,
+	const_cast<int *>(filterDimA), const_cast<int *>(strideDimA)));
+    HIPDNN_OPEN_LOG_C("EXIT hipdnnSetFilterNdDescriptor." << std::flush);
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetFilterNdDescriptor(
+    const hipdnnFilterDescriptor_t filterDesc, int nbDimsRequested,
+    hipdnnDataType_t *dataType,  // image data type
+    hipdnnTensorFormat_t *format, int *nbDims, int filterDimA[]) {
+    miopenDataType_t moDT;
+    int strideDimA[nbDimsRequested];
+
+    HIPDNN_OPEN_LOG_C("ENTER hipdnnGetFilterNdDescriptor " << filterDesc
+                                                           << std::flush);
+    CHECK_MIO(miopenGetTensorDescriptor((miopenTensorDescriptor_t)filterDesc,
+                                        &moDT, filterDimA, strideDimA ));
+
+    CHECK_HIPDNN(miopenTohipDataType(moDT, dataType));
+
+    CHECK_MIO(miopenGetTensorDescriptorSize(
+        (miopenTensorDescriptor_t)filterDesc, nbDims));
+    *format = HIPDNN_TENSOR_NCHW;  // miopen defines only this format
+
+    HIPDNN_OPEN_LOG_C("EXIT hipdnnGetFilterNdDescriptor");
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnDestroyFilterDescriptor(
+    hipdnnFilterDescriptor_t filterDesc) {
+    HIPDNN_OPEN_LOG_C("ENTER hipdnnDestroyFilterDescriptor " << filterDesc
+                                                             << std::flush);
+    CHECK_MIO(
+        miopenDestroyTensorDescriptor((miopenTensorDescriptor_t)filterDesc));
+    HIPDNN_OPEN_LOG_C("EXIT hipdnnDestroyFilterDescriptor." << std::flush);
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+// RNN APIs
+
+hipdnnStatus_t hipdnnCreateRNNDescriptor(hipdnnRNNDescriptor_t *rnnDesc) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnCreateRNNDescriptor");
+    CHECK_MIO(miopenCreateRNNDescriptor((miopenRNNDescriptor_t *)rnnDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnDestroyRNNDescriptor(hipdnnRNNDescriptor_t rnnDesc) {
+    CHECK_MIO(miopenDestroyRNNDescriptor((miopenRNNDescriptor_t)rnnDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnCreatePersistentRNNPlan(hipdnnRNNDescriptor_t rnnDesc,
+                                             const int minibatch,
+                                             const hipdnnDataType_t dataType,
+                                             hipdnnPersistentRNNPlan_t *plan) {
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnSetPersistentRNNPlan(hipdnnRNNDescriptor_t rnnDesc,
+                                          hipdnnPersistentRNNPlan_t plan) {
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnDestroyPersistentRNNPlan(hipdnnPersistentRNNPlan_t plan) {
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnSetRNNDescriptor_v6(
+    hipdnnHandle_t handle, hipdnnRNNDescriptor_t rnnDesc, const int hiddenSize,
+    const int numLayers,
+    hipdnnDropoutDescriptor_t
+        dropoutDesc,  // Between layers, not between recurrent steps.
+    hipdnnRNNInputMode_t inputMode, hipdnnDirectionMode_t direction,
+    hipdnnRNNMode_t mode, hipdnnRNNAlgo_t algo, hipdnnDataType_t dataType) {
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnSetRNNDescriptor( hipdnnHandle_t handle,
+    hipdnnRNNDescriptor_t rnnDesc, int hiddenSize, int numLayers,
+    hipdnnDropoutDescriptor_t
+        dropoutDesc,  // Between layers, not between recurrent steps.
+    hipdnnRNNInputMode_t inputMode, hipdnnDirectionMode_t direction,
+    hipdnnRNNMode_t mode, hipdnnRNNAlgo_t algo, hipdnnDataType_t dataType,
+    hipdnnRNNBiasMode_t biasMode) {
+
+    HIPDNN_OPEN_LOG_C("Inside hipdnnSetRNNDescriptor");
+
+    miopenRNNInputMode_t inMode;
+    miopenRNNDirectionMode_t miopendirection;
+    miopenRNNMode_t rnnMode;
+    miopenRNNAlgo_t algorithm;
+    miopenDataType_t moDT;
+    miopenRNNBiasMode_t moBT;
+
+    CHECK_HIPDNN(hipTomiopenRNNInputMode(inputMode, &inMode));
+    CHECK_HIPDNN(hipTomiopenRNNDirectionMode(direction, &miopendirection));
+    CHECK_HIPDNN(hipTomiopenRNNMode(mode, &rnnMode));
+    CHECK_HIPDNN(hipTomiopenRNNAlgo(algo, &algorithm));
+    CHECK_HIPDNN(hipTomiopenDataType(dataType, &moDT));
+    CHECK_HIPDNN(hipTomiopenRNNBias(biasMode, &moBT))
+
+    CHECK_MIO(miopenSetRNNDescriptor((miopenRNNDescriptor_t) rnnDesc,
+        hiddenSize, numLayers, inMode, miopendirection, rnnMode,  moBT,
+        algorithm, moDT));
+}
+
+hipdnnStatus_t hipdnnSetRNNDescriptor_v5(
+    hipdnnRNNDescriptor_t rnnDesc, int hiddenSize, int numLayers,
+    hipdnnDropoutDescriptor_t
+        dropoutDesc, /* Between layers, not between remorrent steps. */
+    hipdnnRNNInputMode_t inputMode, hipdnnDirectionMode_t direction,
+    hipdnnRNNMode_t mode, hipdnnDataType_t dataType) {
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnGetRNNDescriptor(hipdnnHandle_t handle,
+    hipdnnRNNDescriptor_t rnnDesc, int* hiddenSize, int* numLayers,
+    hipdnnDropoutDescriptor_t *dropoutDesc, hipdnnRNNInputMode_t *inputMode,
+    hipdnnDirectionMode_t *direction, hipdnnRNNMode_t *mode, hipdnnRNNAlgo_t *algo,
+    hipdnnDataType_t *dataType, hipdnnRNNBiasMode_t *biasMode) {
+
+    miopenRNNInputMode_t moRIM;
+    miopenRNNDirectionMode_t moDM;
+    miopenRNNMode_t moRM;
+    miopenDataType_t moDT;
+    miopenRNNAlgo_t moRA;
+    miopenRNNBiasMode_t moBM;
+
+    CHECK_MIO(miopenGetRNNDescriptor((miopenRNNDescriptor_t) rnnDesc, &moRM, &moRA, &moRIM, &moDM,
+        &moBM, hiddenSize, numLayers));
+
+    CHECK_HIPDNN(miopenTohipRNNInputMode(moRIM, inputMode));
+    CHECK_HIPDNN(miopenTohipRNNDirectionMode(moDM, direction));
+    CHECK_HIPDNN(miopenTohipRNNAlgo(moRA, algo));
+    CHECK_HIPDNN(miopenTohipDataType(moDT, dataType));
+    CHECK_HIPDNN(miopenTohipRNNMode(moRM, mode));
+    CHECK_HIPDNN(miopenTohipRNNBias(moBM, biasMode));
+}
+
+hipdnnStatus_t hipdnnGetRNNLayerParamSize(hipdnnHandle_t handle,
+                                        hipdnnRNNDescriptor_t rnnDesc,
+                                        const int layer,
+                                        hipdnnTensorDescriptor_t xDesc,
+                                        const int paramID,
+                                        size_t *numBytes) {
+    CHECK_MIO(miopenGetRNNLayerParamSize(
+        (miopenHandle_t) handle, (miopenRNNDescriptor_t) rnnDesc,
+        layer, (miopenTensorDescriptor_t) xDesc, paramID, numBytes));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetRNNLayerBiasSize(hipdnnHandle_t handle,
+                                        hipdnnRNNDescriptor_t rnnDesc,
+                                        const int layer,
+                                        const int biasID,
+                                        size_t *numBytes) {
+
+    CHECK_MIO(miopenGetRNNLayerBiasSize((miopenHandle_t) handle, (miopenRNNDescriptor_t) rnnDesc, layer,
+                    biasID, numBytes));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+
+hipdnnStatus_t hipdnnGetRNNWorkspaceSize(hipdnnHandle_t handle,
+                                         const hipdnnRNNDescriptor_t rnnDesc,
+                                         const int seqLength,
+                                         const hipdnnTensorDescriptor_t *xDesc,
+                                         size_t *sizeInBytes) {
+    CHECK_MIO(miopenGetRNNWorkspaceSize(
+        (miopenHandle_t)handle, (miopenRNNDescriptor_t)rnnDesc, seqLength,
+        (miopenTensorDescriptor_t *)xDesc, sizeInBytes));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetRNNTrainingReserveSize(
+    hipdnnHandle_t handle, const hipdnnRNNDescriptor_t rnnDesc,
+    const int seqLength, const hipdnnTensorDescriptor_t *xDesc,
+    size_t *sizeInBytes) {
+    CHECK_MIO(miopenGetRNNTrainingReserveSize(
+        (miopenHandle_t)handle, (miopenRNNDescriptor_t)rnnDesc, seqLength,
+        (miopenTensorDescriptor_t *)xDesc, sizeInBytes));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetRNNParamsSize(hipdnnHandle_t handle,
+                                      const hipdnnRNNDescriptor_t rnnDesc,
+                                      const hipdnnTensorDescriptor_t xDesc,
+                                      size_t *sizeInBytes,
+                                      hipdnnDataType_t dataType) {
+
+    miopenDataType_t moDT;
+    CHECK_HIPDNN(hipTomiopenDataType(dataType, &moDT));
+
+    CHECK_MIO(miopenGetRNNParamsSize((miopenHandle_t)handle,
+        static_cast<miopenRNNDescriptor_t> (rnnDesc),
+        static_cast<miopenTensorDescriptor_t> (xDesc), sizeInBytes, moDT));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetRNNLinLayerMatrixParams(
+    hipdnnHandle_t handle, const hipdnnRNNDescriptor_t rnnDesc, const int layer,
+    const hipdnnTensorDescriptor_t xDesc, const hipdnnFilterDescriptor_t wDesc,
+    const void *w, const int linLayerID,
+    hipdnnFilterDescriptor_t linLayerMatDesc, void **linLayerMat) {
+
+    CHECK_MIO(miopenGetRNNLayerParam(
+        (miopenHandle_t)handle, (miopenRNNDescriptor_t)rnnDesc, layer,
+        (miopenTensorDescriptor_t) xDesc, (miopenTensorDescriptor_t) wDesc, w,
+        linLayerID, (miopenTensorDescriptor_t) linLayerMatDesc, linLayerMat));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetRNNLinLayerBiasParams(
+    hipdnnHandle_t handle, const hipdnnRNNDescriptor_t rnnDesc, const int layer,
+    const hipdnnTensorDescriptor_t xDesc, const hipdnnFilterDescriptor_t wDesc,
+    const void *w, const int linLayerID,
+    hipdnnFilterDescriptor_t linLayerBiasDesc, void **linLayerBias) {
+
+    CHECK_MIO(miopenGetRNNLayerBias((miopenHandle_t) handle,
+        (miopenRNNDescriptor_t) rnnDesc, layer,
+        static_cast<miopenTensorDescriptor_t> (xDesc),
+        static_cast<miopenTensorDescriptor_t> (wDesc), w, linLayerID,
+        (miopenTensorDescriptor_t) linLayerBiasDesc, *linLayerBias));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetRNNParamsDescriptor(
+    hipdnnHandle_t handle, hipdnnRNNDescriptor_t rnnDesc, hipdnnTensorDescriptor_t xDesc,
+    hipdnnTensorDescriptor_t wDesc, hipdnnDataType_t dtype) {
+
+    miopenDataType_t moDT;
+    CHECK_HIPDNN(hipTomiopenDataType(dtype, &moDT));
+    CHECK_MIO(miopenGetRNNParamsDescriptor((miopenHandle_t) handle,
+            (miopenRNNDescriptor_t) rnnDesc, (miopenTensorDescriptor_t) xDesc,
+            (miopenTensorDescriptor_t) wDesc, moDT));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnGetRNNInputTensorSize(
+    hipdnnHandle_t handle, hipdnnRNNDescriptor_t rnnDesc, const int seqLen,
+    hipdnnTensorDescriptor_t *xDesc, size_t *numBytes) {
+
+    CHECK_MIO(miopenGetRNNInputTensorSize((miopenHandle_t) handle,
+            (miopenRNNDescriptor_t) rnnDesc, seqLen, (miopenTensorDescriptor_t *) xDesc,
+            numBytes));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+hipdnnStatus_t hipdnnGetRNNHiddenTensorSize(
+    hipdnnHandle_t handle, hipdnnRNNDescriptor_t rnnDesc, const int seqLen,
+    hipdnnTensorDescriptor_t *xDesc, size_t *numBytes) {
+
+    CHECK_MIO(miopenGetRNNHiddenTensorSize((miopenHandle_t) handle,
+           (miopenRNNDescriptor_t) rnnDesc, seqLen, (miopenTensorDescriptor_t* )xDesc,
+            numBytes));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnSetRNNLayerParam(
+    hipdnnHandle_t handle, hipdnnRNNDescriptor_t rnnDesc, const int layer,
+    hipdnnTensorDescriptor_t xDesc, hipdnnTensorDescriptor_t wDesc, void *w,
+    const int paramID, hipdnnTensorDescriptor_t paramDesc, const void *layerParam) {
+
+    CHECK_MIO(miopenSetRNNLayerParam((miopenHandle_t) handle,
+            (miopenRNNDescriptor_t) rnnDesc, layer, (miopenTensorDescriptor_t) xDesc,
+            (miopenTensorDescriptor_t) wDesc, w, paramID, (miopenTensorDescriptor_t) paramDesc,
+            layerParam));
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnSetRNNLayerBias(hipdnnHandle_t handle, hipdnnRNNDescriptor_t rnnDesc,
+    const int layer, hipdnnTensorDescriptor_t xDesc, hipdnnTensorDescriptor_t wDesc, void *w,
+    const int biasID, hipdnnTensorDescriptor_t biasDesc, const void *layerBias) {
+
+    CHECK_MIO(miopenSetRNNLayerBias((miopenHandle_t) handle, (miopenRNNDescriptor_t) rnnDesc,
+            layer, (miopenTensorDescriptor_t) xDesc, (miopenTensorDescriptor_t) wDesc, w, biasID,
+            (miopenTensorDescriptor_t) biasDesc, layerBias));;
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnRNNForwardInference(
+    hipdnnHandle_t handle, const hipdnnRNNDescriptor_t rnnDesc,
+    const int seqLength, const hipdnnTensorDescriptor_t *xDesc, const void *x,
+    const hipdnnTensorDescriptor_t hxDesc, const void *hx,
+    const hipdnnTensorDescriptor_t cxDesc, const void *cx,
+    const hipdnnFilterDescriptor_t wDesc, const void *w,
+    const hipdnnTensorDescriptor_t *yDesc, void *y,
+    const hipdnnTensorDescriptor_t hyDesc, void *hy,
+    const hipdnnTensorDescriptor_t cyDesc, void *cy, void *workspace,
+    size_t workSpaceSizeInBytes) {
+
+    CHECK_MIO(miopenRNNForwardInference(
+        (miopenHandle_t) handle, static_cast<miopenRNNDescriptor_t> (rnnDesc),
+        seqLength, (miopenTensorDescriptor_t *)xDesc, x,
+        (miopenTensorDescriptor_t) hxDesc, hx, (miopenTensorDescriptor_t) cxDesc, cx,
+        (miopenTensorDescriptor_t) wDesc, w, (miopenTensorDescriptor_t *) yDesc, y,
+        (miopenTensorDescriptor_t) hyDesc, hy, (miopenTensorDescriptor_t) cyDesc, cy,
+        workspace, workSpaceSizeInBytes));
+
+    return HIPDNN_STATUS_SUCCESS;
+
+}
+
+hipdnnStatus_t hipdnnRNNForwardTraining(
+    hipdnnHandle_t handle, const hipdnnRNNDescriptor_t rnnDesc,
+    const int seqLength, const hipdnnTensorDescriptor_t *xDesc, const void *x,
+    const hipdnnTensorDescriptor_t hxDesc, const void *hx,
+    const hipdnnTensorDescriptor_t cxDesc, const void *cx,
+    const hipdnnFilterDescriptor_t wDesc, const void *w,
+    const hipdnnTensorDescriptor_t *yDesc, void *y,
+    const hipdnnTensorDescriptor_t hyDesc, void *hy,
+    const hipdnnTensorDescriptor_t cyDesc, void *cy, void *workspace,
+    size_t workSpaceSizeInBytes, void *reserveSpace,
+    size_t reserveSpaceSizeInBytes) {
+    CHECK_MIO(miopenRNNForwardTraining(
+        (miopenHandle_t)handle, (miopenRNNDescriptor_t)rnnDesc, seqLength,
+        (miopenTensorDescriptor_t *)xDesc, x, (miopenTensorDescriptor_t)hxDesc,
+        hx, (miopenTensorDescriptor_t)cxDesc, cx,
+        (miopenTensorDescriptor_t)wDesc, w, (miopenTensorDescriptor_t *)yDesc,
+        y, (miopenTensorDescriptor_t)hyDesc, hy,
+        (miopenTensorDescriptor_t)cyDesc, cy, workspace, workSpaceSizeInBytes,
+        reserveSpace, reserveSpaceSizeInBytes));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnRNNBackwardData(
+    hipdnnHandle_t handle, const hipdnnRNNDescriptor_t rnnDesc,
+    const int seqLength, const hipdnnTensorDescriptor_t *yDesc, const void *y,
+    const hipdnnTensorDescriptor_t *dyDesc, const void *dy,
+    const hipdnnTensorDescriptor_t dhyDesc, const void *dhy,
+    const hipdnnTensorDescriptor_t dcyDesc, const void *dcy,
+    const hipdnnFilterDescriptor_t wDesc, const void *w,
+    const hipdnnTensorDescriptor_t hxDesc, const void *hx,
+    const hipdnnTensorDescriptor_t cxDesc, const void *cx,
+    const hipdnnTensorDescriptor_t *dxDesc, void *dx,
+    const hipdnnTensorDescriptor_t dhxDesc, void *dhx,
+    const hipdnnTensorDescriptor_t dcxDesc, void *dcx, void *workspace,
+    size_t workSpaceSizeInBytes, void *reserveSpace,
+    size_t reserveSpaceSizeInBytes) {
+    CHECK_MIO(miopenRNNBackwardData(
+        (miopenHandle_t)handle, (miopenRNNDescriptor_t)rnnDesc, seqLength,
+        (miopenTensorDescriptor_t *)yDesc, y,
+        (miopenTensorDescriptor_t *)dyDesc, dy,
+        (miopenTensorDescriptor_t)dhyDesc, dhy,
+        (miopenTensorDescriptor_t)dcyDesc, dcy, (miopenTensorDescriptor_t)wDesc,
+        w, (miopenTensorDescriptor_t)hxDesc, hx,
+        (miopenTensorDescriptor_t)cxDesc, cx,
+        (miopenTensorDescriptor_t *)dxDesc, dx,
+        (miopenTensorDescriptor_t)dhxDesc, dhx,
+        (miopenTensorDescriptor_t)dcxDesc, dcx, workspace, workSpaceSizeInBytes,
+        reserveSpace, reserveSpaceSizeInBytes));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnRNNBackwardWeights(
+    hipdnnHandle_t handle, const hipdnnRNNDescriptor_t rnnDesc,
+    const int seqLength, const hipdnnTensorDescriptor_t *xDesc, const void *x,
+    const hipdnnTensorDescriptor_t hxDesc, const void *hx,
+    const hipdnnTensorDescriptor_t *yDesc, const void *y, const void *workspace,
+    size_t workSpaceSizeInBytes, const hipdnnFilterDescriptor_t dwDesc,
+    void *dw, const void *reserveSpace, size_t reserveSpaceSizeInBytes) {
+    CHECK_MIO(miopenRNNBackwardWeights(
+        (miopenHandle_t)handle, (miopenRNNDescriptor_t)rnnDesc, seqLength,
+        (miopenTensorDescriptor_t *)xDesc, x, (miopenTensorDescriptor_t)hxDesc,
+        hx, (miopenTensorDescriptor_t *)yDesc, y,
+        (miopenTensorDescriptor_t)dwDesc, dw, const_cast<void *>(workspace),
+        workSpaceSizeInBytes, reserveSpace, reserveSpaceSizeInBytes));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnSetPoolingNdDescriptor(
+    hipdnnPoolingDescriptor_t poolingDesc, const hipdnnPoolingMode_t mode,
+    const hipdnnNanPropagation_t maxpoolingNanOpt, int nbDims,
+    const int windowDimA[], const int paddingA[], const int strideA[]) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnSetPoolingNdDescriptor with nbDims :"
+                      << nbDims
+
+                      << std::flush);
+    if (nbDims == 2) {
+        // 2D Pooling
+        int windowHeight = windowDimA[0];
+        int windowWidth = windowDimA[1];
+        int pad_h = paddingA[0];
+        int pad_w = paddingA[1];
+        int u = strideA[0];
+        int v = strideA[1];
+        miopenPoolingMode_t pooling_mode;
+        CHECK_HIPDNN(hipTomiopenPoolingMode(mode, &pooling_mode));
+        CHECK_MIO(miopenSet2dPoolingDescriptor(
+            (miopenPoolingDescriptor_t)poolingDesc, pooling_mode, windowHeight,
+            windowWidth, pad_h, pad_w, u, v));
+    } else {
+        HIPDNN_OPEN_LOG_E("Higher dimensions > 2 Pooling is not supported"
+                          << std::flush);
+        return HIPDNN_STATUS_NOT_SUPPORTED;
+    }
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+// human-readable error messages
+// hipdnnGetErrorString
+const char *hipdnnGetErrorString(hipdnnStatus_t status) {
+    switch (status) {
+        case HIPDNN_STATUS_SUCCESS:
+            return "HIPDNN_STATUS_SUCCESS";
+
+        case HIPDNN_STATUS_NOT_INITIALIZED:
+            return "HIPDNN_STATUS_NOT_INITIALIZED";
+
+        case HIPDNN_STATUS_ALLOC_FAILED:
+            return "HIPDNN_STATUS_ALLOC_FAILED";
+
+        case HIPDNN_STATUS_BAD_PARAM:
+            return "HIPDNN_STATUS_BAD_PARAM";
+
+        case HIPDNN_STATUS_INTERNAL_ERROR:
+            return "HIPDNN_STATUS_INTERNAL_ERROR";
+
+        case HIPDNN_STATUS_INVALID_VALUE:
+            return "HIPDNN_STATUS_INVALID_VALUE";
+
+        case HIPDNN_STATUS_ARCH_MISMATCH:
+            return "HIPDNN_STATUS_ARCH_MISMATCH";
+
+        case HIPDNN_STATUS_MAPPING_ERROR:
+            return "HIPDNN_STATUS_MAPPING_ERROR";
+
+        case HIPDNN_STATUS_EXECUTION_FAILED:
+            return "HIPDNN_STATUS_EXECUTION_FAILED";
+
+        case HIPDNN_STATUS_NOT_SUPPORTED:
+            return "HIPDNN_STATUS_NOT_SUPPORTED";
+
+        case HIPDNN_STATUS_LICENSE_ERROR:
+            return "HIPDNN_STATUS_LICENSE_ERROR";
+
+        case HIPDNN_STATUS_RUNTIME_PREREQUISITE_MISSING:
+            return "HIPDNN_STATUS_RUNTIME_PREREQUISITE_MISSING";
+
+        default:
+            return "Unrecognized Status Code";
+    }
+}
+
+hipdnnStatus_t hipdnnBatchNormalizationForwardInference(
+    hipdnnHandle_t handle, hipdnnBatchNormMode_t mode,
+    const void *alpha,  // alpha[0] = result blend factor
+    const void *beta,   // beta[0] = dest layer blend factor
+    const hipdnnTensorDescriptor_t xDesc,
+    const void *x,  // NxCxHxW
+    const hipdnnTensorDescriptor_t yDesc,
+    void *y,  // NxCxHxW
+    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc, const void *bnScale,
+    const void *bnBias, const void *estimatedMean,
+    const void *estimatedVariance, double epsilon) {
+    HIPDNN_OPEN_LOG_C("Inside hipdnnBatchNormalizationForwardInference");
+    miopenBatchNormMode_t miBNMode;
+    CHECK_HIPDNN(hipTomiopenBatchNormMode(mode, &miBNMode));
+    CHECK_MIO(miopenBatchNormalizationForwardInference(
+        (miopenHandle_t)handle, miBNMode, const_cast<void *>(alpha),
+        const_cast<void *>(beta), (miopenTensorDescriptor_t)xDesc, x,
+        (miopenTensorDescriptor_t)yDesc, y,
+        (miopenTensorDescriptor_t)bnScaleBiasMeanVarDesc,
+        const_cast<void *>(bnScale), const_cast<void *>(bnBias),
+        const_cast<void *>(estimatedMean),
+        const_cast<void *>(estimatedVariance), epsilon));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnCreateDropoutDescriptor(
+    hipdnnDropoutDescriptor_t *dropoutDesc) {
+    HIPDNN_OPEN_LOG_E("hipdnnCreateDropoutDescriptor: NOT SUPPORTED."
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnSetDropoutDescriptor(hipdnnDropoutDescriptor_t dropoutDesc,
+                                          hipdnnHandle_t handle, float dropout,
+                                          void *states, size_t stateSizeInBytes,
+                                          unsigned long long seed) {
+    HIPDNN_OPEN_LOG_E("hipdnnSetDropoutDescriptor: NOT SUPPORTED."
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnDropoutGetStatesSize(hipdnnHandle_t handle,
+                                          size_t *sizeInBytes) {
+    HIPDNN_OPEN_LOG_E("hipdnnDropoutGetStatesSize: NOT SUPPORTED."
+                      << std::endl
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnDestroyDropoutDescriptor(
+    hipdnnDropoutDescriptor_t dropoutDesc) {
+    HIPDNN_OPEN_LOG_E("hipdnnDestroyDropoutDescriptor: NOT SUPPORTED."
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnCreateReduceTensorDescriptor(
+    hipdnnReduceTensorDescriptor_t *reduceTensorDesc) {
+    HIPDNN_OPEN_LOG_E("hipdnnCreateReduceTensorDescriptor: NOT SUPPORTED."
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnSetTensor4dDescriptorEx(
+    hipdnnTensorDescriptor_t tensorDesc,
+    hipdnnDataType_t dataType, /* image data type */
+    int n,                     /* number of inputs (batch size) */
+    int c,                     /* number of input feature maps */
+    int h,                     /* height of input section */
+    int w,                     /* width of input section */
+    int nStride, int cStride, int hStride, int wStride) {
+    HIPDNN_OPEN_LOG_E("hipdnnSetTensor4dDescriptorEx: NOT SUPPORTED."
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnSetReduceTensorDescriptor(
+    hipdnnReduceTensorDescriptor_t reduceTensorDesc,
+    hipdnnReduceTensorOp_t reduceTensorOp,
+    hipdnnDataType_t reduceTensorCompType,
+    hipdnnNanPropagation_t reduceTensorNanOpt,
+    hipdnnReduceTensorIndices_t reduceTensorIndices,
+    hipdnnIndicesType_t reduceTensorIndicesType) {
+    HIPDNN_OPEN_LOG_E("hipdnnSetReduceTensorDescriptor: NOT SUPPORTED."
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnGetReductionWorkspaceSize(
+    hipdnnHandle_t handle,
+    const hipdnnReduceTensorDescriptor_t reduceTensorDesc,
+    const hipdnnTensorDescriptor_t aDesc, const hipdnnTensorDescriptor_t cDesc,
+    size_t *sizeInBytes) {
+    HIPDNN_OPEN_LOG_E("hipdnnGetReductionWorkspaceSize: NOT SUPPORTED."
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnReduceTensor(
+    hipdnnHandle_t handle,
+    const hipdnnReduceTensorDescriptor_t reduceTensorDesc, void *indices,
+    size_t indicesSizeInBytes, void *workspace, size_t workspaceSizeInBytes,
+    const void *alpha, const hipdnnTensorDescriptor_t aDesc, const void *A,
+    const void *beta, const hipdnnTensorDescriptor_t cDesc, void *C) {
+    HIPDNN_OPEN_LOG_E("hipdnnReduceTensor: NOT SUPPORTED." << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+hipdnnStatus_t hipdnnDestroyReduceTensorDescriptor(
+    hipdnnReduceTensorDescriptor_t reduceTensorDesc) {
+    HIPDNN_OPEN_LOG_E("hipdnnDestroyReduceTensorDescriptor: NOT SUPPORTED."
+                      << std::flush);
+    return HIPDNN_STATUS_NOT_SUPPORTED;
+}
+
+
+ hipdnnStatus_t hipdnnSetConvolutionGroupCount(
+    hipdnnConvolutionDescriptor_t convDesc, int groupCount ) {
+
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO(miopenSetConvolutionGroupCount(
+        (miopenConvolutionDescriptor_t)convDesc_cast, groupCount) );
+    return HIPDNN_STATUS_SUCCESS;
+
+}
+
+//============================ MIO-Fusion ======================================
+
+hipdnnStatus_t
+hipdnnCreateFusionPlan(hipdnnFusionPlanDescriptor_t *fusePlanDesc,
+                       const hipdnnFusionDirection_t fuseDirection,
+                       const hipdnnTensorDescriptor_t inputDesc) {
+    CHECK_MIO(
+        miopenCreateFusionPlan((miopenFusionPlanDescriptor_t *)fusePlanDesc,
+                               (miopenFusionDirection_t)fuseDirection,
+                               (miopenTensorDescriptor_t)inputDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnFusionPlanGetOp(hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                                     const int op_idx,
+                                     hipdnnFusionOpDescriptor_t *op) {
+    CHECK_MIO(miopenFusionPlanGetOp((miopenFusionPlanDescriptor_t)fusePlanDesc,
+                                    op_idx, (miopenFusionOpDescriptor_t *)op));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnFusionPlanGetWorkSpaceSize(
+    hipdnnHandle_t handle, hipdnnFusionPlanDescriptor_t fusePlanDesc,
+    size_t *workSpaceSize, hipdnnConvolutionFwdAlgo_t algo) {
+    CHECK_MIO(miopenFusionPlanGetWorkSpaceSize(
+        (miopenHandle_t)handle, (miopenFusionPlanDescriptor_t)fusePlanDesc,
+        workSpaceSize, (miopenConvFwdAlgorithm_t)algo));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnFusionPlanConvolutionGetAlgo(
+    hipdnnFusionPlanDescriptor_t fusePlanDesc, const int requestAlgoCount,
+    int* returnedAlgoCount, hipdnnConvolutionFwdAlgo_t* returnedAlgos) {
+
+    miopenConvFwdAlgorithm_t mi_returnedAlgos;
+    CHECK_MIO(miopenFusionPlanConvolutionGetAlgo(
+        (miopenFusionPlanDescriptor_t)fusePlanDesc, requestAlgoCount,
+        returnedAlgoCount, &mi_returnedAlgos));
+    miopenTohipConvolutionFwdAlgo(mi_returnedAlgos,returnedAlgos);
+
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnCreateOpConvForward(
+    hipdnnFusionPlanDescriptor_t fusePlanDesc,
+    hipdnnFusionOpDescriptor_t *convOp, hipdnnConvolutionDescriptor_t convDesc,
+    const hipdnnTensorDescriptor_t wDesc) {
+
+    hipdnnConvolutionDescriptor_t convDesc_cast =
+                                    ((structConvDesc_t*)(convDesc))->descriptor;
+    CHECK_MIO(
+        miopenCreateOpConvForward((miopenFusionPlanDescriptor_t)fusePlanDesc,
+                                  (miopenFusionOpDescriptor_t *)convOp,
+                                  (miopenConvolutionDescriptor_t)convDesc_cast,
+                                  (miopenTensorDescriptor_t)wDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnCreateOpBiasForward(
+    hipdnnFusionPlanDescriptor_t fusePlanDesc,
+    hipdnnFusionOpDescriptor_t *biasOp, const hipdnnTensorDescriptor_t bDesc) {
+    CHECK_MIO(miopenCreateOpBiasForward(
+        (miopenFusionPlanDescriptor_t)fusePlanDesc,
+        (miopenFusionOpDescriptor_t *)biasOp, (miopenTensorDescriptor_t)bDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t
+hipdnnCreateOpActivationForward(hipdnnFusionPlanDescriptor_t fusePlanDesc,
+                                hipdnnFusionOpDescriptor_t *activOp,
+                                hipdnnActivationMode_t mode) {
+    miopenActivationMode_t mi_mode;
+    hipTomiopenActivationMode(mode, &mi_mode);
+
+    CHECK_MIO(miopenCreateOpActivationForward(
+        (miopenFusionPlanDescriptor_t)fusePlanDesc,
+        (miopenFusionOpDescriptor_t *)activOp, mi_mode));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnCreateOpBatchNormInference(
+    hipdnnFusionPlanDescriptor_t fusePlanDesc, hipdnnFusionOpDescriptor_t *bnOp,
+    const hipdnnBatchNormMode_t bn_mode,
+    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc) {
+
+    miopenBatchNormMode_t mi_bn_mode;
+    hipTomiopenBatchNormMode(bn_mode, &mi_bn_mode);
+    CHECK_MIO(miopenCreateOpBatchNormInference(
+        (miopenFusionPlanDescriptor_t)fusePlanDesc,
+        (miopenFusionOpDescriptor_t *)bnOp, mi_bn_mode,
+        (miopenTensorDescriptor_t)bnScaleBiasMeanVarDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnCompileFusionPlan(
+    hipdnnHandle_t handle, hipdnnFusionPlanDescriptor_t fusePlanDesc) {
+    CHECK_MIO(miopenCompileFusionPlan(
+        (miopenHandle_t)handle, (miopenFusionPlanDescriptor_t)fusePlanDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnCreateOperatorArgs(hipdnnOperatorArgs_t *args) {
+    CHECK_MIO(miopenCreateOperatorArgs((miopenOperatorArgs_t *)args));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetOpArgsConvForward(
+    hipdnnOperatorArgs_t args, const hipdnnFusionOpDescriptor_t convOp,
+    const void *alpha, const void *beta, const void *w) {
+    CHECK_MIO(miopenSetOpArgsConvForward((miopenOperatorArgs_t)args,
+                                         (miopenFusionOpDescriptor_t)convOp,
+                                         alpha, beta, w));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetOpArgsBiasForward(
+    hipdnnOperatorArgs_t args, const hipdnnFusionOpDescriptor_t biasOp,
+    const void *alpha, const void *beta, const void *bias) {
+    CHECK_MIO(miopenSetOpArgsBiasForward((miopenOperatorArgs_t)args,
+                                         (miopenFusionOpDescriptor_t)biasOp,
+                                         alpha, beta, bias));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetOpArgsActivForward(
+    hipdnnOperatorArgs_t args, const hipdnnFusionOpDescriptor_t activOp,
+    const void *alpha, const void *beta, double activAlpha, double activBeta,
+    double activGamma) {
+    CHECK_MIO(miopenSetOpArgsActivForward(
+        (miopenOperatorArgs_t)args, (miopenFusionOpDescriptor_t)activOp, alpha,
+        beta, activAlpha, activBeta, activGamma));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnSetOpArgsBatchNormInference(
+    hipdnnOperatorArgs_t args, const hipdnnFusionOpDescriptor_t bnOp,
+    const void *alpha, const void *beta, const void *bnScale,
+    const void *bnBias, const void *estimatedMean,
+    const void *estimatedVariance, double epsilon) {
+    CHECK_MIO(miopenSetOpArgsBatchNormInference(
+        (miopenOperatorArgs_t)args, (miopenFusionOpDescriptor_t)bnOp, alpha,
+        beta, bnScale, bnBias, estimatedMean, estimatedVariance, epsilon));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnExecuteFusionPlan(
+    const hipdnnHandle_t handle,
+    const hipdnnFusionPlanDescriptor_t fusePlanDesc,
+    const hipdnnTensorDescriptor_t inputDesc, const void *input,
+    const hipdnnTensorDescriptor_t outputDesc, void *output,
+    hipdnnOperatorArgs_t args) {
+    CHECK_MIO(miopenExecuteFusionPlan(
+        (miopenHandle_t)handle, (miopenFusionPlanDescriptor_t)fusePlanDesc,
+        (miopenTensorDescriptor_t)inputDesc, input,
+        (miopenTensorDescriptor_t)outputDesc, output,
+        (miopenOperatorArgs_t)args));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnDestroyOperatorArgs(hipdnnOperatorArgs_t args) {
+    CHECK_MIO(miopenDestroyOperatorArgs((miopenOperatorArgs_t) args) );
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+hipdnnStatus_t hipdnnDestroyFusionPlan(
+    hipdnnFusionPlanDescriptor_t fusePlanDesc) {
+    CHECK_MIO(
+        miopenDestroyFusionPlan((miopenFusionPlanDescriptor_t)fusePlanDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+//==============================================================================
+
+#endif //WITH_HIP

--- a/oneflow/core/hipdnn/hipdnn_miopen.h
+++ b/oneflow/core/hipdnn/hipdnn_miopen.h
@@ -1,0 +1,42 @@
+/*
+ Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+#pragma once
+
+#ifdef WITH_HIP
+
+#include <hip/hip_runtime_api.h>
+#include <hipdnn.h>
+#include <miopen/miopen.h>
+
+
+hipdnnStatus_t miopenTohipConvolutionFwdAlgo(miopenConvFwdAlgorithm_t in,
+                                             hipdnnConvolutionFwdAlgo_t *out);
+
+hipdnnStatus_t
+miopenTohipConvolutionBwdFilterAlgo(miopenConvBwdWeightsAlgorithm_t in,
+                                    hipdnnConvolutionBwdFilterAlgo_t *out);
+
+hipdnnStatus_t
+miopenTohipConvolutionBwdDataAlgo(miopenConvBwdDataAlgorithm_t in,
+                                  hipdnnConvolutionBwdDataAlgo_t *out);
+
+#endif //WITH_HIP

--- a/oneflow/core/hipdnn/logger.cpp
+++ b/oneflow/core/hipdnn/logger.cpp
@@ -1,0 +1,15 @@
+
+#ifdef WITH_HIP
+
+#include "logger.h"
+#include <sstream>
+
+namespace open {
+
+int IsLogging(const LoggingLevel level) {
+  const int enable_level = DEBUG_CURRENT_CALL_STACK_LEVEL;
+  return enable_level >= ((int)level - 1);
+}
+} // namespace open
+
+#endif //WITH_HIP

--- a/oneflow/core/hipdnn/logger.h
+++ b/oneflow/core/hipdnn/logger.h
@@ -1,0 +1,57 @@
+
+#ifdef WITH_HIP
+
+#include <iostream>
+#include <sstream>
+extern std::ostream cerr;
+
+#if ENABLE_LOG == 0
+#define DEBUG_CURRENT_CALL_STACK_LEVEL DEBUG_CALL_STACK_LEVEL_NONE
+#endif
+
+#define DEBUG_CALL_STACK_LEVEL_NONE 0
+#define DEBUG_CALL_STACK_LEVEL_ERRORS 1
+#define DEBUG_CALL_STACK_LEVEL_PROMOTED 2
+#define DEBUG_CALL_STACK_LEVEL_INTERNAL_ALLOC 2
+#define DEBUG_CALL_STACK_LEVEL_CALLS 3
+#define DEBUG_CALL_STACK_LEVEL_MARSHALLING 4
+#define DEBUG_CALL_STACK_LEVEL_INFO 5
+
+#ifndef DEBUG_CURRENT_CALL_STACK_LEVEL
+#define DEBUG_CURRENT_CALL_STACK_LEVEL DEBUG_CALL_STACK_LEVEL_INFO
+#endif
+
+namespace open {
+
+enum class LoggingLevel {
+  NONE = 0, // WARNING for Release builds, INFO for Debug builds.
+  ERRORS,
+  PROMOTED,
+  INTERNAL_ALLOC = 2,
+  CALLS,
+  MARSHALLING = 4,
+  INFO = 5
+};
+
+int IsLogging(LoggingLevel level);
+
+#define OPEN_LOG(level, ...)                                                   \
+  do {                                                                         \
+    if (open::IsLogging(level)) {                                              \
+      std::cerr << __VA_ARGS__ << std ::endl;                                  \
+    }                                                                          \
+  } while (false)
+
+#define HIPDNN_OPEN_LOG_E(...) OPEN_LOG(open::LoggingLevel::ERRORS, __VA_ARGS__)
+#define HIPDNN_OPEN_LOG_P(...)                                                 \
+  OPEN_LOG(open::LoggingLevel::PROMOTED, __VA_ARGS__)
+#define HIPDNN_OPEN_LOG_I(...)                                                 \
+  OPEN_LOG(open::LoggingLevel::INTERNAL_ALLOC, __VA_ARGS__)
+#define HIPDNN_OPEN_LOG_C(...) OPEN_LOG(open::LoggingLevel::CALLS, __VA_ARGS__)
+#define HIPDNN_OPEN_LOG_M(...)                                                 \
+  OPEN_LOG(open::LoggingLevel::MARSHALLING, __VA_ARGS__)
+#define HIPDNN_OPEN_LOG_I2(...) OPEN_LOG(open::LoggingLevel::INFO, __VA_ARGS__)
+
+} // namespace open
+
+#endif //WITH_HIP


### PR DESCRIPTION
移植运行时与数学库函数与库数据结构，目前移植了ep内源文件以及相关源文件，均以WITH_HIP或HIPCC区分。文件名，oneflow自定义的cuda函数名、类名、数据结构以及打印字符串部分均不再改动，尽可能减少改动地方。ep下添加hip文件夹，头文件包含需要改动。cudnn与miopen接口与数据结构无法一一对应，采用hipdnn缓解兼容性压力。仍将进行后续移植。