### PR TITLE
修复pooling.py文档里未实现的内容

### DIFF
--- a/python/oneflow/nn/modules/pooling.py
+++ b/python/oneflow/nn/modules/pooling.py
@@ -55,7 +55,6 @@ class MaxPool1d(Module):
         padding: Implicit negative infinity padding to be added on both sides, must be >= 0 and <= kernel_size / 2.
         dilation: The stride between elements within a sliding window, must be > 0.
         return_indices: If ``True``, will return the argmax along with the max values.
-                        Useful for :class:`torch.nn.MaxUnpool1d` later
         ceil_mode: If ``True``, will use `ceil` instead of `floor` to compute the output shape. This
                    ensures that every element in the input tensor is covered by a sliding window.
 


### PR DESCRIPTION
python/oneflow/nn/modules/pooling.py 文档里有这样的字样：“Useful for :class:`torch.nn.MaxUnpool1d` later”，应该是从 pytorch 抄过来时没改，而且我们还没有实现 MaxUnpool op 
此pr是为了修正这个问题