### PR TITLE
Fix different dtype backward bug

### DIFF
--- a/python/oneflow/test/modules/test_autograd.py
+++ b/python/oneflow/test/modules/test_autograd.py
@@ -111,9 +111,7 @@ class TestAutograd(flow.unittest.TestCase):
 
     @autotest(n=1, auto_backward=False, check_graph=False)
     def test_out_grad_with_different_dtype(test_case):
-        device = random_device()
         x = random_tensor(ndim=2, requires_grad=True)
-        x = x.to(device)
         y = x.sum()
         y.backward(torch.tensor(False))
         return x.grad


### PR DESCRIPTION
 这个单测只是测试不同类型的 dtype 后向是否正常工作，不需要 to device。fix #8233 中的 bug