### PR TITLE
Fix autoprof when no kernel, and fix input shapes

### DIFF
--- a/python/oneflow/autoprof/__main__.py
+++ b/python/oneflow/autoprof/__main__.py
@@ -38,7 +38,7 @@ def get_pytorch_cpu_kernel_time(prof) -> Union[str, float]:
     assert prof.num > 1
     cpu_kernel_items = list(filter(lambda x: x.count >= prof.num, prof.key_averages()))
     if len(cpu_kernel_items) == 0:
-        return '-'
+        return "-"
     kernel_cpu_time = (
         sum(map(lambda x: x.self_cpu_time_total, cpu_kernel_items)) / prof.num
     )
@@ -49,7 +49,7 @@ def get_oneflow_cpu_kernel_time(prof) -> Union[str, float]:
     assert prof.num > 1
     cpu_kernel_items = list(filter(lambda x: x.count >= prof.num, prof.key_averages()))
     if len(cpu_kernel_items) == 0:
-        return '-'
+        return "-"
     kernel_cpu_time = sum(map(lambda x: x.time_total, cpu_kernel_items)) / prof.num
     return round(kernel_cpu_time, 1)
 
@@ -57,7 +57,7 @@ def get_oneflow_cpu_kernel_time(prof) -> Union[str, float]:
 def get_pytorch_gpu_kernel_time(prof) -> Union[str, float]:
     gpu_kernel_items = list(filter(lambda x: x.count >= prof.num, prof.key_averages()))
     if len(gpu_kernel_items) == 0:
-        return '-'
+        return "-"
     kernel_gpu_time = (
         sum(map(lambda x: x.self_cuda_time_total, gpu_kernel_items)) / prof.num
     )
@@ -69,7 +69,7 @@ def get_oneflow_gpu_kernel_time(prof) -> Union[str, float]:
         filter(lambda x: x.event_type == 1 and x.on_gpu, prof.key_averages())
     )
     if len(gpu_kernel_items) == 0:
-        return '-'
+        return "-"
     kernel_gpu_time = sum(map(lambda x: x.time_total, gpu_kernel_items)) / prof.num
     return round(kernel_gpu_time, 1)
 

--- a/python/oneflow/autoprof/__main__.py
+++ b/python/oneflow/autoprof/__main__.py
@@ -17,6 +17,7 @@ import atexit
 import csv
 import unittest
 import os
+from typing import Iterable, Union, TypeVar
 
 import prettytable
 from prettytable import PrettyTable
@@ -24,49 +25,56 @@ from prettytable import PrettyTable
 import oneflow.test_utils.automated_test_util.profiler as auto_profiler
 
 
-def get_sole_value(x):
+T = TypeVar("T")
+
+
+def get_sole_value(x: Iterable[T]) -> T:
     s = set(x)
     assert len(s) == 1
     return list(s)[0]
 
 
-def get_pytorch_cpu_kernel_time(prof):
+def get_pytorch_cpu_kernel_time(prof) -> Union[str, float]:
     assert prof.num > 1
     cpu_kernel_items = list(filter(lambda x: x.count >= prof.num, prof.key_averages()))
-    assert len(cpu_kernel_items) > 0
+    if len(cpu_kernel_items) == 0:
+        return '-'
     kernel_cpu_time = (
         sum(map(lambda x: x.self_cpu_time_total, cpu_kernel_items)) / prof.num
     )
     return round(kernel_cpu_time, 1)
 
 
-def get_oneflow_cpu_kernel_time(prof):
+def get_oneflow_cpu_kernel_time(prof) -> Union[str, float]:
     assert prof.num > 1
     cpu_kernel_items = list(filter(lambda x: x.count >= prof.num, prof.key_averages()))
-    assert len(cpu_kernel_items) > 0
+    if len(cpu_kernel_items) == 0:
+        return '-'
     kernel_cpu_time = sum(map(lambda x: x.time_total, cpu_kernel_items)) / prof.num
     return round(kernel_cpu_time, 1)
 
 
-def get_pytorch_gpu_kernel_time(prof):
+def get_pytorch_gpu_kernel_time(prof) -> Union[str, float]:
     gpu_kernel_items = list(filter(lambda x: x.count >= prof.num, prof.key_averages()))
-    assert len(gpu_kernel_items) > 0
+    if len(gpu_kernel_items) == 0:
+        return '-'
     kernel_gpu_time = (
         sum(map(lambda x: x.self_cuda_time_total, gpu_kernel_items)) / prof.num
     )
     return round(kernel_gpu_time, 1)
 
 
-def get_oneflow_gpu_kernel_time(prof):
+def get_oneflow_gpu_kernel_time(prof) -> Union[str, float]:
     gpu_kernel_items = list(
         filter(lambda x: x.event_type == 1 and x.on_gpu, prof.key_averages())
     )
-    assert len(gpu_kernel_items) > 0
+    if len(gpu_kernel_items) == 0:
+        return '-'
     kernel_gpu_time = sum(map(lambda x: x.time_total, gpu_kernel_items)) / prof.num
     return round(kernel_gpu_time, 1)
 
 
-def get_pytorch_cpu_end_to_end_time(prof):
+def get_pytorch_cpu_end_to_end_time(prof) -> float:
     total = get_sole_value(
         filter(lambda x: x.key == auto_profiler.END_TO_END, prof.key_averages())
     )
@@ -74,7 +82,7 @@ def get_pytorch_cpu_end_to_end_time(prof):
     return round(total.cpu_time / prof.num, 1)
 
 
-def get_oneflow_cpu_end_to_end_time(prof):
+def get_oneflow_cpu_end_to_end_time(prof) -> float:
     total = list(
         filter(lambda x: x.name == auto_profiler.END_TO_END, prof.key_averages())
     )[0]
@@ -82,7 +90,7 @@ def get_oneflow_cpu_end_to_end_time(prof):
     return round(total.time / prof.num, 1)
 
 
-def print_summary_from_csv():
+def print_summary_from_csv() -> None:
     print("----------------------------------------------------------------------")
     print('Summary ("KT" means "Kernel Time", "ET" means "End-to-end Time"):')
     with open(csv_filename, "r") as f:

--- a/python/oneflow/test/modules/test_activation.py
+++ b/python/oneflow/test/modules/test_activation.py
@@ -61,8 +61,8 @@ class TestReLUModule(flow.unittest.TestCase):
 
     @profile(torch.nn.functional.relu)
     def profile_relu(test_case):
-        torch.nn.functional.relu(torch.ones(1, 32, 64, 64))
-        torch.nn.functional.relu(torch.ones(16, 32, 64, 64))
+        torch.nn.functional.relu(torch.ones(1, 128, 28, 28))
+        torch.nn.functional.relu(torch.ones(16, 128, 28, 28))
 
 
 @flow.unittest.skip_unless_1n1d()
@@ -99,8 +99,8 @@ class TestReLU6Module(flow.unittest.TestCase):
 
     @profile(torch.nn.functional.relu6)
     def profile_relu6(test_case):
-        torch.nn.functional.relu6(torch.ones(1, 32, 64, 64))
-        torch.nn.functional.relu6(torch.ones(16, 32, 64, 64))
+        torch.nn.functional.relu6(torch.ones(1, 128, 28, 28))
+        torch.nn.functional.relu6(torch.ones(16, 128, 28, 28))
 
 
 @flow.unittest.skip_unless_1n1d()
@@ -158,8 +158,8 @@ class TestTanh(flow.unittest.TestCase):
 
     @profile(torch.tanh)
     def profile_tanh(test_case):
-        torch.tanh(torch.ones(1, 32, 64, 64))
-        torch.tanh(torch.ones(16, 32, 64, 64))
+        torch.tanh(torch.ones(1, 128, 28, 28))
+        torch.tanh(torch.ones(16, 128, 28, 28))
 
 
 @flow.unittest.skip_unless_1n1d()
@@ -313,8 +313,8 @@ class TestSigmoidModule(flow.unittest.TestCase):
 
     @profile(torch.sigmoid)
     def profile_sigmoid(test_case):
-        torch.sigmoid(torch.ones(1, 32, 64, 64))
-        torch.sigmoid(torch.ones(16, 32, 64, 64))
+        torch.sigmoid(torch.ones(1, 128, 28, 28))
+        torch.sigmoid(torch.ones(16, 128, 28, 28))
 
 
 @flow.unittest.skip_unless_1n1d()
@@ -429,8 +429,8 @@ class TestSoftmax(flow.unittest.TestCase):
 
     @profile(torch.nn.functional.softmax)
     def profile_softmax(test_case):
-        torch.nn.functional.softmax(torch.ones(1, 32, 64, 64))
-        torch.nn.functional.softmax(torch.ones(16, 32, 64, 64))
+        torch.nn.functional.softmax(torch.ones(1, 128, 28, 28))
+        torch.nn.functional.softmax(torch.ones(16, 128, 28, 28))
 
 
 @flow.unittest.skip_unless_1n1d()

--- a/python/oneflow/test/modules/test_avgpool.py
+++ b/python/oneflow/test/modules/test_avgpool.py
@@ -126,19 +126,19 @@ class TestAvgPoolingFunctional(flow.unittest.TestCase):
     @profile(torch.nn.functional.avg_pool2d)
     def profile_avgpool2d(test_case):
         torch.nn.functional.avg_pool2d(
-            torch.ones(1, 32, 64, 64), kernel_size=3, padding=1
+            torch.ones(1, 128, 28, 28), kernel_size=3, padding=1
         )
         torch.nn.functional.avg_pool2d(
-            torch.ones(1, 32, 64, 64), kernel_size=3, stride=2, padding=1
+            torch.ones(1, 128, 28, 28), kernel_size=3, stride=2, padding=1
         )
         torch.nn.functional.avg_pool2d(
-            torch.ones(16, 32, 64, 64), kernel_size=3, padding=1
+            torch.ones(16, 128, 28, 28), kernel_size=3, padding=1
         )
         torch.nn.functional.avg_pool2d(
-            torch.ones(16, 32, 64, 64), kernel_size=3, stride=2, padding=1
+            torch.ones(16, 128, 28, 28), kernel_size=3, stride=2, padding=1
         )
         torch.nn.functional.avg_pool2d(
-            torch.ones(16, 32, 64, 64),
+            torch.ones(16, 128, 28, 28),
             kernel_size=3,
             stride=2,
             padding=1,

--- a/python/oneflow/test/modules/test_conv2d.py
+++ b/python/oneflow/test/modules/test_conv2d.py
@@ -1896,9 +1896,9 @@ class TestConv2d(flow.unittest.TestCase):
 
     @profile(torch.nn.functional.conv2d)
     def profile_conv2d(test_case):
-        input = torch.ones(8, 16, 3, 3)
-        weight = torch.ones(16, 16, 3, 3)
-        bias = torch.ones(16)
+        input = torch.ones(8, 128, 28, 28)
+        weight = torch.ones(128, 128, 3, 3)
+        bias = torch.ones(128)
         torch.nn.functional.conv2d(input, weight, padding=1)
         torch.nn.functional.conv2d(input, weight, padding=1, stride=2)
         torch.nn.functional.conv2d(input, weight, bias=bias, padding=1)

--- a/python/oneflow/test/modules/test_maxpool.py
+++ b/python/oneflow/test/modules/test_maxpool.py
@@ -222,25 +222,25 @@ class TestMaxPoolingFunctional(flow.unittest.TestCase):
     @profile(torch.nn.functional.max_pool2d)
     def profile_maxpool2d(test_case):
         torch.nn.functional.max_pool2d(
-            torch.ones(1, 32, 64, 64), kernel_size=3, padding=1
+            torch.ones(1, 128, 28, 28), kernel_size=3, padding=1
         )
         torch.nn.functional.max_pool2d(
-            torch.ones(1, 32, 64, 64), kernel_size=3, stride=2, padding=1
+            torch.ones(1, 128, 28, 28), kernel_size=3, stride=2, padding=1
         )
         torch.nn.functional.max_pool2d(
-            torch.ones(16, 32, 64, 64), kernel_size=3, padding=1
+            torch.ones(16, 128, 28, 28), kernel_size=3, padding=1
         )
         torch.nn.functional.max_pool2d(
-            torch.ones(16, 32, 64, 64), kernel_size=3, stride=2, padding=1
+            torch.ones(16, 128, 28, 28), kernel_size=3, stride=2, padding=1
         )
         torch.nn.functional.max_pool2d(
-            torch.ones(16, 32, 64, 64),
+            torch.ones(16, 128, 28, 28),
             kernel_size=3,
             stride=2,
             padding=1,
             ceil_mode=True,
         )
-        # torch.nn.functional.max_pool2d(torch.ones(16, 32, 64, 64), kernel_size=3, dilation=2, padding=2)
+        # torch.nn.functional.max_pool2d(torch.ones(16, 128, 28, 28), kernel_size=3, dilation=2, padding=2)
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_reshape.py
+++ b/python/oneflow/test/modules/test_reshape.py
@@ -125,6 +125,10 @@ class TestModule(flow.unittest.TestCase):
         y = torch.reshape(x, shape=(-1,))
         return y
 
+    @profile(torch.reshape)
+    def profile_reshape(test_case):
+        torch.reshape(torch.ones(50, 20), (20, 50))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
1. autoprof 支持没有 kernel 的 api，这个时候只显示 cpu end-to-end 的时间：
    <img width="1031" alt="image" src="https://user-images.githubusercontent.com/11607199/170616880-a2c8d8de-27f3-4144-8df3-e671bcc1960a.png">

2. 修改已有测试的 input shape，和 resnet 中的 shape 保持一致