### PR TITLE
Fix arange dtype

### DIFF
--- a/oneflow/core/functional/impl/math_functor.cpp
+++ b/oneflow/core/functional/impl/math_functor.cpp
@@ -1018,7 +1018,7 @@ class ArangeFunctor {
         JUST(attrs.SetAttr<DataType>("dtype", range_dtype));
       }
     } else {
-      if (delta.IsIntegral()) {
+      if (start.IsIntegral() && limit.IsIntegral() && delta.IsIntegral()) {
         JUST(attrs.SetAttr<int64_t>("integer_start", JUST(start.As<int64_t>())));
         JUST(attrs.SetAttr<int64_t>("integer_limit", JUST(limit.As<int64_t>())));
         JUST(attrs.SetAttr<int64_t>("integer_delta", JUST(delta.As<int64_t>())));
@@ -1070,7 +1070,7 @@ class ConsistentArangeFunctor {
         JUST(attrs.SetAttr<DataType>("dtype", range_dtype));
       }
     } else {
-      if (delta.IsIntegral()) {
+      if (start.IsIntegral() && limit.IsIntegral() && delta.IsIntegral()) {
         JUST(attrs.SetAttr<int64_t>("integer_start", JUST(start.As<int64_t>())));
         JUST(attrs.SetAttr<int64_t>("integer_limit", JUST(limit.As<int64_t>())));
         JUST(attrs.SetAttr<int64_t>("integer_delta", JUST(delta.As<int64_t>())));

--- a/python/oneflow/framework/docstr/arange.py
+++ b/python/oneflow/framework/docstr/arange.py
@@ -34,7 +34,7 @@ add_docstr(
         step (int): the gap between each pair of adjacent points. Default: ``1``.
 
     Keyword args:
-        dtype(flow.dtype, optional): If `dtype` is not given, the `dtype` is inferred to be `flow.int64`.
+        dtype(flow.dtype, optional): If `dtype` is not given, infer the `dtype` from the other input arguments. If any of start, end, or step are floating-point, the `dtype` is inferred to be the floating-point data type. Otherwise, the `dtype` is inferred to be `flow.int64`.
         device(flow.device, optional): the desired device of returned tensor. Default: if None, uses the current device for the default tensor.
         requires_grad(bool, optional): If autograd should record operations on the returned tensor. Default: `False`.
 

--- a/python/oneflow/framework/docstr/tensor.py
+++ b/python/oneflow/framework/docstr/tensor.py
@@ -579,7 +579,7 @@ add_docstr(
         >>> import numpy as np
         >>> import oneflow as flow
 
-        >>> x = flow.arange(1., 8)
+        >>> x = flow.arange(1, 8)
         >>> x
         tensor([1, 2, 3, 4, 5, 6, 7], dtype=oneflow.int64)
         >>> x.unfold(0, 2, 1)


### PR DESCRIPTION
If any of start, end, or step are floating-point, the dtype is inferred to be the floating-point dtype.

before:
\> oneflow.arange(3.2)
tensor([0, 1, 2], dtype=oneflow.int64)
\> oneflow.arange(1.5, 4.2, 1)
tensor([1, 2, 3], dtype=oneflow.int64)

fixed:
\> oneflow.arange(3.2)
tensor([0., 1., 2., 3.], dtype=oneflow.float32)
\> oneflow.arange(1.5, 4.2, 1)
tensor([1.5000, 2.5000, 3.5000], dtype=oneflow.float32)