### PR TITLE
add 1d send recv in nccl logical

### DIFF
--- a/oneflow/core/job_rewriter/insert_nccl_logical_op_pass.cpp
+++ b/oneflow/core/job_rewriter/insert_nccl_logical_op_pass.cpp
@@ -218,6 +218,18 @@ bool TryBuildNcclBy1DHierarchy(OperatorConf* ret, const SbpParallel& src_sbp,
                .Build()
                .op_conf();
     return true;
+  } else if (!dst_sbp.has_partial_sum_parallel()) {
+    *ret = user_op::UserOpConfWrapperBuilder(kNcclLogicalOpNamePrefix + "-(Send)2(Recv)-"
+                                             + NewUniqueId())
+               .Op("_nccl_logical_send_recv")
+               .Input("in", lbn)
+               .Output("out")
+               .Attr<std::vector<std::string>>("src_nd_sbp", {SbpToString(src_sbp)})
+               .Attr<std::vector<std::string>>("dst_nd_sbp", {SbpToString(dst_sbp)})
+               .ScopeSymbolId(scope_symbol_id)
+               .Build()
+               .op_conf();
+    return true;
   }
   return false;
 }
@@ -503,7 +515,7 @@ void InsertNcclLogicalOpsAsCloseAsPossibleToSrcNode(
         }
 
         if (Global<ResourceDesc, ForSession>::Get()->enable_debug_mode()) {
-          VLOG(3) << " insert nccl op: " << nccl_op.name() << " from [" << src_op_name
+          VLOG(2) << " insert nccl op: " << nccl_op.name() << " from [" << src_op_name
                   << ", order=" << src_order << ", sbp=" << NdSbpToString(src_node->NdSbp4Lbi(lbi))
                   << "] to [" << dst_op_name << ", order=" << node2subgraph_order.at(dst_node)
                   << ", sbp=" << NdSbpToString(dst_node->NdSbp4Lbi(lbi)) << "] and before ["
@@ -569,7 +581,7 @@ void InsertNcclLogicalOpsAsCloseAsPossibleToDstNode(
         }
 
         if (Global<ResourceDesc, ForSession>::Get()->enable_debug_mode()) {
-          VLOG(3) << " insert nccl op: " << nccl_op.name() << " from [" << src_op_name
+          VLOG(2) << " insert nccl op: " << nccl_op.name() << " from [" << src_op_name
                   << ", order=" << node2subgraph_order.at(src_node) << "] to [" << dst_op_name
                   << ", order=" << dst_order << "] and after [" << pre_op_name
                   << ", order=" << dst_order - 1 << "]\n";

--- a/python/oneflow/test/graph/test_nccl_logical_send_recv.py
+++ b/python/oneflow/test/graph/test_nccl_logical_send_recv.py
@@ -29,7 +29,7 @@ import os
 os.environ["ONEFLOW_BOXING_DISABLE_MIDDLE_NODE_AND_CHECK"] = "1"
 
 
-def _test_nccl_logical_send_recv(test_case, src_nd_sbp, dst_nd_sbp):
+def _test_nccl_logical_send_recv_2d(test_case, src_nd_sbp, dst_nd_sbp):
     # can not process p in dst
     if flow.sbp.partial_sum() in dst_nd_sbp:
         return
@@ -66,7 +66,7 @@ def _test_nccl_logical_send_recv(test_case, src_nd_sbp, dst_nd_sbp):
     # check graph boxing
     flow.boxing.nccl.enable_use_compute_stream(True)
 
-    class TestNcclLogicalSendRecvGraph(flow.nn.Graph):
+    class TestNcclLogicalSendRecv2DGraph(flow.nn.Graph):
         def __init__(self):
             super().__init__()
 
@@ -74,7 +74,7 @@ def _test_nccl_logical_send_recv(test_case, src_nd_sbp, dst_nd_sbp):
             y = x.to_global(sbp=dst_nd_sbp, placement=placement)
             return y
 
-    graph = TestNcclLogicalSendRecvGraph()
+    graph = TestNcclLogicalSendRecv2DGraph()
     # graph.debug()
     y = graph(x)
     out_np = y.numpy()
@@ -88,7 +88,7 @@ def _test_nccl_logical_send_recv(test_case, src_nd_sbp, dst_nd_sbp):
     test_case.assertTrue(np.array_equal(out_np, in_np))
 
 
-def gen_nd_sbp():
+def gen_2d_sbp():
     sbp_list = [
         flow.sbp.partial_sum(),
         flow.sbp.broadcast(),
@@ -105,14 +105,82 @@ def gen_nd_sbp():
 
 @flow.unittest.skip_unless_1n4d()
 @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
-class TestNcclLogicalSendRecv(flow.unittest.TestCase):
-    def test_nccl_logical_send_recv(test_case):
+class TestNcclLogicalSendRecv2D(flow.unittest.TestCase):
+    def test_nccl_logical_send_recv_2d(test_case):
         arg_dict = OrderedDict()
-        arg_dict["src_nd_sbp"] = gen_nd_sbp()
-        arg_dict["dst_nd_sbp"] = gen_nd_sbp()
+        arg_dict["src_nd_sbp"] = gen_2d_sbp()
+        arg_dict["dst_nd_sbp"] = gen_2d_sbp()
         for arg in GenArgList(arg_dict):
-            _test_nccl_logical_send_recv(test_case, *arg)
+            _test_nccl_logical_send_recv_2d(test_case, *arg)
 
+def _test_nccl_logical_send_recv_1d(test_case, src_nd_sbp, dst_nd_sbp):
+    # can not process p in dst
+    if flow.sbp.partial_sum() in dst_nd_sbp:
+        return
+
+    # skip src == dst
+    if src_nd_sbp == dst_nd_sbp:
+        return
+
+    # input
+    placement = flow.placement("cuda", ranks=[0, 1])
+    local_np = np.arange(2 * 2 * 2).reshape(2, 2, 2)
+    x = flow.tensor(local_np, sbp=src_nd_sbp, placement=placement)
+
+    # check eager boxing
+    eager_out = x.to_global(sbp=dst_nd_sbp, placement=placement)
+    test_case.assertTrue(np.array_equal(eager_out.numpy(), x.numpy()))
+
+    # check graph boxing
+    flow.boxing.nccl.enable_use_compute_stream(True)
+
+    class TestNcclLogicalSendRecv1DGraph(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+
+        def build(self, x):
+            y = x.to_global(sbp=dst_nd_sbp, placement=placement)
+            return y
+
+    graph = TestNcclLogicalSendRecv1DGraph()
+    #graph.debug(0)
+    y = graph(x)
+    out_np = y.numpy()
+    in_np = x.numpy()
+    #if flow.env.get_rank() == 0:
+    #    print("src sbp ", src_nd_sbp, ", dst sbp ", dst_nd_sbp)
+    #    print(graph)
+    #    equal = np.array_equal(out_np, in_np)
+    #    if not equal:
+    #        print("in ", in_np)
+    #        print("out ", out_np)
+    #    print("====================")
+    test_case.assertTrue(np.array_equal(out_np, in_np))
+
+
+def gen_1d_sbp():
+    sbp_list = [
+        flow.sbp.partial_sum(),
+        flow.sbp.broadcast(),
+        flow.sbp.split(0),
+        flow.sbp.split(1),
+        flow.sbp.split(2),
+    ]
+    nd_sbp_list = []
+    for sbp0 in sbp_list:
+        nd_sbp_list.append([sbp0,])
+    return nd_sbp_list
+
+
+@flow.unittest.skip_unless_1n2d()
+@unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+class TestNcclLogicalSendRecv1D(flow.unittest.TestCase):
+    def test_nccl_logical_send_recv_1d(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["src_nd_sbp"] = gen_1d_sbp()
+        arg_dict["dst_nd_sbp"] = gen_1d_sbp()
+        for arg in GenArgList(arg_dict):
+            _test_nccl_logical_send_recv_1d(test_case, *arg)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
P -> S(i), i > 0, with nccl logical send recv.

All 1D nccl logical test log:
```
E20220602 16:44:43.706897 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-P2B-39 from [_TestNcclLogicalSendRecv1DGraph_0_input.0.0_2, order=0, sbp=(P)] to [_TestNcclLogicalSendRecv1DGraph_0_output.0.0_2, order=1, sbp=(B)] and before [_TestNcclLogicalSendRecv1DGraph_0_output.0.0_2, order=1]
src sbp  [oneflow.sbp.partial_sum] , dst sbp  [oneflow.sbp.broadcast]
(GRAPH:TestNcclLogicalSendRecv1DGraph_0:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_0_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.partial_sum,), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_0_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.broadcast,), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:44.050542 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-P2S-77 from [_TestNcclLogicalSendRecv1DGraph_1_input.0.0_2, order=0, sbp=(P)] to [_TestNcclLogicalSendRecv1DGraph_1_output.0.0_2, order=1, sbp=(S(0))] and before [_TestNcclLogicalSendRecv1DGraph_1_output.0.0_2, order=1]
src sbp  [oneflow.sbp.partial_sum] , dst sbp  [oneflow.sbp.split(axis=0)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_1:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_1_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.partial_sum,), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_1_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=0),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:44.374456 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-(Send)2(Recv)-115 from [_TestNcclLogicalSendRecv1DGraph_2_input.0.0_2, order=0, sbp=(P)] to [_TestNcclLogicalSendRecv1DGraph_2_output.0.0_2, order=1, sbp=(S(1))] and before [_TestNcclLogicalSendRecv1DGraph_2_output.0.0_2, order=1]
src sbp  [oneflow.sbp.partial_sum] , dst sbp  [oneflow.sbp.split(axis=1)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_2:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_2_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.partial_sum,), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_2_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=1),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:44.697863 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-(Send)2(Recv)-153 from [_TestNcclLogicalSendRecv1DGraph_3_input.0.0_2, order=0, sbp=(P)] to [_TestNcclLogicalSendRecv1DGraph_3_output.0.0_2, order=1, sbp=(S(2))] and before [_TestNcclLogicalSendRecv1DGraph_3_output.0.0_2, order=1]
src sbp  [oneflow.sbp.partial_sum] , dst sbp  [oneflow.sbp.split(axis=2)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_3:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_3_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.partial_sum,), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_3_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=2),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:44.975345 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-(Send)2(Recv)-190 from [_TestNcclLogicalSendRecv1DGraph_4_input.0.0_2, order=0, sbp=(B)] to [_TestNcclLogicalSendRecv1DGraph_4_output.0.0_2, order=1, sbp=(S(0))] and before [_TestNcclLogicalSendRecv1DGraph_4_output.0.0_2, order=1]
src sbp  [oneflow.sbp.broadcast] , dst sbp  [oneflow.sbp.split(axis=0)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_4:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_4_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.broadcast,), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_4_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=0),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:45.247880 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-(Send)2(Recv)-226 from [_TestNcclLogicalSendRecv1DGraph_5_input.0.0_2, order=0, sbp=(B)] to [_TestNcclLogicalSendRecv1DGraph_5_output.0.0_2, order=1, sbp=(S(1))] and before [_TestNcclLogicalSendRecv1DGraph_5_output.0.0_2, order=1]
src sbp  [oneflow.sbp.broadcast] , dst sbp  [oneflow.sbp.split(axis=1)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_5:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_5_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.broadcast,), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_5_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=1),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:45.511830 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-(Send)2(Recv)-262 from [_TestNcclLogicalSendRecv1DGraph_6_input.0.0_2, order=0, sbp=(B)] to [_TestNcclLogicalSendRecv1DGraph_6_output.0.0_2, order=1, sbp=(S(2))] and before [_TestNcclLogicalSendRecv1DGraph_6_output.0.0_2, order=1]
src sbp  [oneflow.sbp.broadcast] , dst sbp  [oneflow.sbp.split(axis=2)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_6:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_6_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.broadcast,), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_6_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=2),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:45.779754 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2B-298 from [_TestNcclLogicalSendRecv1DGraph_7_input.0.0_2, order=0, sbp=(S(0))] to [_TestNcclLogicalSendRecv1DGraph_7_output.0.0_2, order=1, sbp=(B)] and before [_TestNcclLogicalSendRecv1DGraph_7_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=0)] , dst sbp  [oneflow.sbp.broadcast]
(GRAPH:TestNcclLogicalSendRecv1DGraph_7:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_7_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=0),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_7_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.broadcast,), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:46.055204 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2S-334 from [_TestNcclLogicalSendRecv1DGraph_8_input.0.0_2, order=0, sbp=(S(0))] to [_TestNcclLogicalSendRecv1DGraph_8_output.0.0_2, order=1, sbp=(S(1))] and before [_TestNcclLogicalSendRecv1DGraph_8_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=0)] , dst sbp  [oneflow.sbp.split(axis=1)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_8:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_8_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=0),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_8_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=1),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:46.334779 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2S-370 from [_TestNcclLogicalSendRecv1DGraph_9_input.0.0_2, order=0, sbp=(S(0))] to [_TestNcclLogicalSendRecv1DGraph_9_output.0.0_2, order=1, sbp=(S(2))] and before [_TestNcclLogicalSendRecv1DGraph_9_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=0)] , dst sbp  [oneflow.sbp.split(axis=2)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_9:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_9_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=0),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_9_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=2),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:46.619133 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2B-406 from [_TestNcclLogicalSendRecv1DGraph_10_input.0.0_2, order=0, sbp=(S(1))] to [_TestNcclLogicalSendRecv1DGraph_10_output.0.0_2, order=1, sbp=(B)] and before [_TestNcclLogicalSendRecv1DGraph_10_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=1)] , dst sbp  [oneflow.sbp.broadcast]
(GRAPH:TestNcclLogicalSendRecv1DGraph_10:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_10_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=1),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_10_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.broadcast,), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:46.899516 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2S-442 from [_TestNcclLogicalSendRecv1DGraph_11_input.0.0_2, order=0, sbp=(S(1))] to [_TestNcclLogicalSendRecv1DGraph_11_output.0.0_2, order=1, sbp=(S(0))] and before [_TestNcclLogicalSendRecv1DGraph_11_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=1)] , dst sbp  [oneflow.sbp.split(axis=0)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_11:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_11_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=1),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_11_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=0),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:47.178555 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2S-479 from [_TestNcclLogicalSendRecv1DGraph_12_input.0.0_2, order=0, sbp=(S(1))] to [_TestNcclLogicalSendRecv1DGraph_12_output.0.0_2, order=1, sbp=(S(2))] and before [_TestNcclLogicalSendRecv1DGraph_12_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=1)] , dst sbp  [oneflow.sbp.split(axis=2)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_12:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_12_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=1),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_12_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=2),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:47.474185 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2B-515 from [_TestNcclLogicalSendRecv1DGraph_13_input.0.0_2, order=0, sbp=(S(2))] to [_TestNcclLogicalSendRecv1DGraph_13_output.0.0_2, order=1, sbp=(B)] and before [_TestNcclLogicalSendRecv1DGraph_13_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=2)] , dst sbp  [oneflow.sbp.broadcast]
(GRAPH:TestNcclLogicalSendRecv1DGraph_13:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_13_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=2),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_13_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.broadcast,), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:47.753445 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2S-551 from [_TestNcclLogicalSendRecv1DGraph_14_input.0.0_2, order=0, sbp=(S(2))] to [_TestNcclLogicalSendRecv1DGraph_14_output.0.0_2, order=1, sbp=(S(0))] and before [_TestNcclLogicalSendRecv1DGraph_14_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=2)] , dst sbp  [oneflow.sbp.split(axis=0)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_14:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_14_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=2),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_14_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=0),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
E20220602 16:44:48.028358 1165989 insert_nccl_logical_op_pass.cpp:518]  insert nccl op: System-NCCL-Logical-S2S-588 from [_TestNcclLogicalSendRecv1DGraph_15_input.0.0_2, order=0, sbp=(S(2))] to [_TestNcclLogicalSendRecv1DGraph_15_output.0.0_2, order=1, sbp=(S(1))] and before [_TestNcclLogicalSendRecv1DGraph_15_output.0.0_2, order=1]
src sbp  [oneflow.sbp.split(axis=2)] , dst sbp  [oneflow.sbp.split(axis=1)]
(GRAPH:TestNcclLogicalSendRecv1DGraph_15:TestNcclLogicalSendRecv1DGraph): (
  (CONFIG:config:GraphConfig(training=False, ))
  (INPUT:_TestNcclLogicalSendRecv1DGraph_15_input.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=2),), size=(2, 2, 2), dtype=oneflow.int64))
  (OUTPUT:_TestNcclLogicalSendRecv1DGraph_15_output.0.0_2:tensor(..., placement=oneflow.placement(type="cuda", ranks=[0, 1]),
         sbp=(oneflow.sbp.split(axis=1),), is_lazy='True', size=(2, 2, 2),
         dtype=oneflow.int64))
)
====================
```