### PR TITLE
optimize index_select/repeat_interleave performance

### DIFF
--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -2649,28 +2649,7 @@ class IndexSelectFunctor {
         << Error::IndexError() << "Dimension out of range (expected to be in range of ["
         << -input_num_axes << ", " << input_num_axes - 1 << "], but got " << new_dim << ")";
 
-    DimVector index_broad_cast(input_num_axes);
-    for (int i = 0; i < input_num_axes; i++) { index_broad_cast[i] = input->shape()->At(i); }
-    index_broad_cast[new_dim] = 1;
-    Shape expand_shape(index_broad_cast);
-    std::shared_ptr<one::Tensor> index_new;
-    if (index_num_axes == 1) {
-      index_new = index;
-    } else {
-      index_new = JUST(Unsqueeze(index, 0));
-    }
-    auto index_gather = JUST(functional::Expand(
-        JUST(functional::Slice(index_new, {0}, {1}, {1}, /*enable_view_slice=*/false)),
-        expand_shape));
-    for (int i = 1; i < index->dim(0); i++) {
-      index_gather = JUST(functional::Concat(
-          {index_gather,
-           JUST(functional::Expand(
-               JUST(functional::Slice(index_new, {i}, {i + 1}, {1}, /*enable_view_slice=*/false)),
-               expand_shape))},
-          new_dim));
-    }
-    return JUST(functional::DimGather(input, new_dim, index_gather, false));
+    return JUST(functional::Gather(input, index, new_dim));
   }
 };
 

--- a/oneflow/user/kernels/gather_kernel_util.h
+++ b/oneflow/user/kernels/gather_kernel_util.h
@@ -34,7 +34,7 @@ struct GatherKernelUtilImpl final {
                       const Shape& flat_in_shape, T* out, int64_t offset);
 };
 
-#define GATHER_DATA_TYPE_SEQ ARITHMETIC_DATA_TYPE_SEQ
+#define GATHER_DATA_TYPE_SEQ ARITHMETIC_DATA_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(bool, DataType::kBool)
 #define GATHER_INDEX_TYPE_SEQ INDEX_DATA_TYPE_SEQ OF_PP_MAKE_TUPLE_SEQ(uint32_t, DataType::kUInt32)
 
 }  // namespace oneflow


### PR DESCRIPTION
以前误解了Gather和DimGather的语义，然后使用DimGather来实现index_select op的时候有大量的overhead。经俊丞提醒以及我多次确认实际上index_select可以使用flow._C.gather直接表示。去掉大量的overhead可以提升index_select/repeat_interleave等相关op的性能，性能测试结果下个pr补上。

另外，此外本PR还给gather注册了bool type支持。相关测试(test_index_select.py, test_repeat_interleave.py)已经通过。