### PR TITLE
Fix invalid inputs in some unit tests

### DIFF
--- a/python/oneflow/test/modules/test_arange.py
+++ b/python/oneflow/test/modules/test_arange.py
@@ -70,8 +70,8 @@ class TestArange(flow.unittest.TestCase):
     @autotest(n=10, auto_backward=False, rtol=1e-5, atol=1e-5, check_graph=True)
     def test_arange_with_random_data(test_case):
         start = random().to(int)
-        end = start + random().to(int)
-        step = random(0, end - start).to(int)
+        end = start + random(low=2).to(int)
+        step = random(1, end - start).to(int)
         x = torch.arange(start=start, end=end, step=step)
         device = random_device()
         x.to(device)
@@ -80,8 +80,8 @@ class TestArange(flow.unittest.TestCase):
     @autotest(n=5, auto_backward=False, rtol=1e-5, atol=1e-5, check_graph=True)
     def test_arange_with_float_delta(test_case):
         start = random().to(int)
-        end = start + random().to(int)
-        step = random(0, end - start).to(float)
+        end = start + random(low=2).to(int)
+        step = random(1, end - start).to(float)
         x = torch.arange(start=start, end=end, step=step)
         device = random_device()
         x.to(device)

--- a/python/oneflow/test/modules/test_autograd.py
+++ b/python/oneflow/test/modules/test_autograd.py
@@ -89,9 +89,10 @@ class TestAutograd(flow.unittest.TestCase):
     @autotest(n=10, auto_backward=True, rtol=1e-3, atol=1e-3, check_graph=True)
     def test_accumulate_grad(test_case):
         device = random_device()
-        ndim = random(1, 4).to(int)
-        x = random_tensor(ndim=ndim, requires_grad=True).to(device)
-        y = random_tensor(ndim=ndim, requires_grad=True).to(device)
+        ndim = random(1, 4).to(int).value()
+        shape = [random(low=1, high=4) for i in range(ndim)]
+        x = random_tensor(ndim, *shape, requires_grad=True).to(device)
+        y = random_tensor(ndim, *shape, requires_grad=True).to(device)
         return x / (x + y)
 
     @autotest(n=10, auto_backward=True, rtol=1e-3, atol=1e-3, check_graph=True)

--- a/python/oneflow/test/modules/test_avgpool.py
+++ b/python/oneflow/test/modules/test_avgpool.py
@@ -85,7 +85,7 @@ class TestAvgPoolingFunctional(flow.unittest.TestCase):
         x = random_tensor(ndim=3, dim2=random(20, 22)).to(device)
         y = torch.nn.functional.avg_pool1d(
             x,
-            kernel_size=random(1, 6).to(int),
+            kernel_size=random(4, 6).to(int),
             stride=random(1, 3).to(int) | nothing(),
             padding=random(1, 3).to(int),
             ceil_mode=random_bool(),
@@ -99,7 +99,7 @@ class TestAvgPoolingFunctional(flow.unittest.TestCase):
         x = random_tensor(ndim=4, dim2=random(20, 22), dim3=random(20, 22)).to(device)
         y = torch.nn.functional.avg_pool2d(
             x,
-            kernel_size=random(1, 6).to(int),
+            kernel_size=random(4, 6).to(int),
             stride=random(1, 3).to(int) | nothing(),
             padding=random(1, 3).to(int),
             ceil_mode=random_bool(),
@@ -115,7 +115,7 @@ class TestAvgPoolingFunctional(flow.unittest.TestCase):
         ).to(device)
         y = torch.nn.functional.avg_pool3d(
             x,
-            kernel_size=random(1, 6).to(int),
+            kernel_size=random(4, 6).to(int),
             stride=random(1, 3).to(int) | nothing(),
             padding=random(1, 3).to(int),
             ceil_mode=random_bool(),

--- a/python/oneflow/test/modules/test_consistent_avgpool.py
+++ b/python/oneflow/test/modules/test_consistent_avgpool.py
@@ -84,7 +84,7 @@ def _test_functional_avgpool1d_with_random_data(test_case, placement, sbp):
     x = random_tensor(ndim, *dims).to_global(placement=placement, sbp=sbp)
     y = torch.nn.functional.avg_pool1d(
         x,
-        kernel_size=random(1, 6).to(int),
+        kernel_size=random(4, 6).to(int),
         stride=random(1, 3).to(int),
         padding=random(1, 3).to(int),
         ceil_mode=random_bool(),
@@ -100,7 +100,7 @@ def _test_functional_avgpool2d_with_random_data(test_case, placement, sbp):
     x = random_tensor(ndim, *dims).to_global(placement=placement, sbp=sbp)
     y = torch.nn.functional.avg_pool2d(
         x,
-        kernel_size=random(1, 6).to(int),
+        kernel_size=random(4, 6).to(int),
         stride=random(1, 3).to(int),
         padding=random(1, 3).to(int),
         ceil_mode=random_bool(),
@@ -116,7 +116,7 @@ def _test_functional_avgpool3d_with_random_data(test_case, placement, sbp):
     x = random_tensor(ndim, *dims).to_global(placement=placement, sbp=sbp)
     y = torch.nn.functional.avg_pool3d(
         x,
-        kernel_size=random(1, 6).to(int),
+        kernel_size=random(4, 6).to(int),
         stride=random(1, 3).to(int),
         padding=random(1, 3).to(int),
         ceil_mode=random_bool(),

--- a/python/oneflow/test/modules/test_consistent_diagonal.py
+++ b/python/oneflow/test/modules/test_consistent_diagonal.py
@@ -23,11 +23,19 @@ from oneflow.test_utils.automated_test_util import *
 @autotest(n=1, auto_backward=True, check_graph=False)
 def _test_diagonal_impl(test_case, placement, sbp):
     offset = random(-5, 5).to(int).value()
-    dim1 = random(-4, 4).to(int).value()
-    dim2 = random(-4, 4).to(int).value()
+    ndims = 4
+    dim1 = 0
+    dim2 = 0
+    p_dim1 = 0
+    p_dim2 = 0
+    while p_dim1 == p_dim2:
+        dim1 = random(-4, 4).to(int).value()
+        dim2 = random(-4, 4).to(int).value()
+        p_dim1 = dim1 if dim1 >= 0 else dim1 + ndims;
+        p_dim2 = dim2 if dim2 >= 0 else dim2 + ndims;
 
     x = random_tensor(
-        ndim=4,
+        ndim=ndims,
         dim0=random(1, 4) * 8,
         dim1=random(1, 4) * 8,
         dim2=random(1, 4) * 8,

--- a/python/oneflow/test/modules/test_consistent_maxpool.py
+++ b/python/oneflow/test/modules/test_consistent_maxpool.py
@@ -80,9 +80,9 @@ def _test_maxpool3d_functional(test_case, placement, sbp):
         ndim=5,
         dim0=dim0,
         dim1=dim1,
-        dim2=random(10, 12),
-        dim3=random(10, 12),
-        dim4=random(10, 12),
+        dim2=random(20, 22),
+        dim3=random(20, 22),
+        dim4=random(20, 22),
     ).to_global(placement, sbp)
     y = torch.nn.functional.max_pool3d(
         x,
@@ -166,9 +166,9 @@ def _test_maxpool3d(test_case, placement, sbp):
         ndim=5,
         dim0=dim0,
         dim1=dim1,
-        dim2=random(10, 12),
-        dim3=random(10, 12),
-        dim4=random(10, 12),
+        dim2=random(20, 22),
+        dim3=random(20, 22),
+        dim4=random(20, 22),
     ).to_global(placement, sbp)
     y = m(x)
 

--- a/python/oneflow/test/modules/test_diagonal.py
+++ b/python/oneflow/test/modules/test_diagonal.py
@@ -27,11 +27,19 @@ class TestDiagonal(flow.unittest.TestCase):
     def test_flow_diagonal_with_random_data(test_case):
         device = random_device()
         offset = random(-5, 5).to(int)
-        dim1 = random(-4, 4).to(int)
-        dim2 = random(-4, 4).to(int)
+        ndims = 4
+        dim1 = 0
+        dim2 = 0
+        p_dim1 = 0
+        p_dim2 = 0
+        while p_dim1 == p_dim2:
+            dim1 = random(-4, 4).to(int).value()
+            dim2 = random(-4, 4).to(int).value()
+            p_dim1 = dim1 if dim1 >= 0 else dim1 + ndims;
+            p_dim2 = dim2 if dim2 >= 0 else dim2 + ndims;
 
         x = random_tensor(
-            ndim=4,
+            ndim=ndims,
             dim1=random(4, 6),
             dim2=random(4, 6),
             dim3=random(4, 6),
@@ -44,11 +52,19 @@ class TestDiagonal(flow.unittest.TestCase):
     def test_flow_diagonal_with_random_data(test_case):
         device = random_device()
         offset = random(-5, 5).to(int)
-        dim1 = random(-4, 4).to(int)
-        dim2 = random(-4, 4).to(int)
+        ndims = 4
+        dim1 = 0
+        dim2 = 0
+        p_dim1 = 0
+        p_dim2 = 0
+        while p_dim1 == p_dim2:
+            dim1 = random(-4, 4).to(int).value()
+            dim2 = random(-4, 4).to(int).value()
+            p_dim1 = dim1 if dim1 >= 0 else dim1 + ndims;
+            p_dim2 = dim2 if dim2 >= 0 else dim2 + ndims;
 
         x = random_tensor(
-            ndim=4,
+            ndim=ndims,
             dim1=random(4, 6),
             dim2=random(4, 6),
             dim3=random(4, 6),


### PR DESCRIPTION
## Motivation
很多unit test case在某些随机情况下的输入是错误的，但是由于CI环境没有打开ONEFLOW_TEST_ALIGN_EXCEPTION=1，所以报错也就忽略过去了，但是本地运行会导致aborted。

## 复现样例

test_avgpool.py && test_consistent_avgpool.py

```
x = torch.randn(10, 10, 20)
y = torch.nn.functional.avg_pool1d(
    x,
    kernel_size=2,
    stride=3,
    padding=3,
    ceil_mode=True,
    count_include_pad=True,
)

Traceback (most recent call last):
  File "test_torch.py", line 4, in <module>
    y = torch.nn.functional.avg_pool1d(
RuntimeError: pad should be smaller than or equal to half of kernel size, but got padW = 3, padH = 0, kW = 2, kH = 1
```
oneflow结果：
```
Traceback (most recent call last):
  File "test_torch.py", line 5, in <module>
    y = torch.nn.functional.avg_pool1d(
RuntimeError: 
  File "../oneflow/core/framework/op_interpreter/op_interpreter_util.cpp", line 137, in Dispatch
    Dispatch<TensorTuple>(op_expr, inputs, ctx)
  File "../oneflow/core/framework/op_interpreter/op_interpreter_util.cpp", line 129, in Dispatch
    Dispatch(op_expr, inputs, outputs.get(), ctx)
  File "../oneflow/core/framework/op_interpreter/op_interpreter.cpp", line 107, in Apply
    internal_->Apply(op_expr, *inputs_ptr, outputs, ctx)
  File "../oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp", line 143, in NaiveInterpret
    user_op_expr.InferPhysicalTensorDesc( attrs, device_tag ... TensorMeta* { return output_tensor_metas->at(i); })
  File "../oneflow/core/framework/op_expr.cpp", line 486, in InferPhysicalTensorDesc
    tensor_desc_infer_fn_(&infer_ctx)
  File "../oneflow/user/ops/avg_pool_op.cpp", line 52, in operator()
    Check failed: (kernel_size[i]) >= (2 * padding[i]) (2 vs 6) pad should be smaller than half of kernel size
```

test_arange.py

```
start = 1
end = 5
step = 0
x = torch.arange(start=start, end=end, step=step)

Traceback (most recent call last):
  File "test_torch.py", line 21, in <module>
    x = torch.arange(start=start, end=end, step=step)
RuntimeError: step must be nonzero
```
oneflow结果：
```
Traceback (most recent call last):
  File "test_torch.py", line 22, in <module>
    x = torch.arange(start=start, end=end, step=step)
  File "/home/yaozihang/oneflow/python/oneflow/nn/modules/arange.py", line 39, in arange_op
    res = flow._C.arange(start, end, step, dtype=dtype, device=device)
RuntimeError: 
  File "../oneflow/core/framework/op_interpreter/op_interpreter_util.cpp", line 137, in Dispatch
    Dispatch<TensorTuple>(op_expr, inputs, ctx)
  File "../oneflow/core/framework/op_interpreter/op_interpreter_util.cpp", line 129, in Dispatch
    Dispatch(op_expr, inputs, outputs.get(), ctx)
  File "../oneflow/core/framework/op_interpreter/op_interpreter.cpp", line 107, in Apply
    internal_->Apply(op_expr, *inputs_ptr, outputs, ctx)
  File "../oneflow/core/framework/op_interpreter/eager_mirrored_op_interpreter.cpp", line 143, in NaiveInterpret
    user_op_expr.InferPhysicalTensorDesc( attrs, device_tag ... TensorMeta* { return output_tensor_metas->at(i); })
  File "../oneflow/core/framework/op_expr.cpp", line 486, in InferPhysicalTensorDesc
    tensor_desc_infer_fn_(&infer_ctx)
  File "../oneflow/user/ops/arange_op.cpp", line 29, in InferLogicalTensorDesc
    Check failed: (integer_delta) != (static_cast<int64_t>(0)) (0 vs 0) RuntimeError: step must be nonzero.
```

test_autograd.py

```
x = torch.randn(1, 2, 3, 4, requires_grad=True)
y = torch.randn(4, 3, 2, 1, requires_grad=True)
z = x / (x + y)

Traceback (most recent call last):
  File "test_torch.py", line 30, in <module>
    z = x / (x + y)
RuntimeError: The size of tensor a (3) must match the size of tensor b (2) at non-singleton dimension 2
```

oneflow结果：
```
Traceback (most recent call last):
  File "test_torch.py", line 31, in <module>
    z = x / (x + y)
RuntimeError: The size of tensor a (2) must match the size of tensor b (3) at non-singleton dimension 1
```

test_diagonal.py && test_consistent_diagonal.py

```
offset = 0
dim1 = 2
dim2 = 2

x = torch.randn(8,8,8,8)
y = torch.diagonal(x, 0, dim1, dim1)

Traceback (most recent call last):
  File "test_torch.py", line 42, in <module>
    y = torch.diagonal(x, 0, dim1, dim1)
RuntimeError: diagonal dimensions cannot be identical 2, 2
```

oneflow结果：
```
Traceback (most recent call last):
  File "test_torch.py", line 43, in <module>
    y = torch.diagonal(x, 0, dim1, dim1)
RuntimeError: diagonal dimensions cannot be identical 2, 2
```

test_consistent_maxpool.py
```
x = torch.randn(
    8,
    16,
    10,
    10,
    10,
)
y = torch.nn.functional.max_pool3d(
    x,
    kernel_size=5,
    stride=1,
    padding=1,
    dilation=3,
    ceil_mode=False,
    return_indices=True,
)

Traceback (most recent call last):
  File "test_torch.py", line 56, in <module>
    y = torch.nn.functional.max_pool3d(
  File "/home/yaozihang/anaconda3/envs/oneflow-dev-clang10-v2/lib/python3.8/site-packages/torch/_jit_internal.py", line 420, in fn
    return if_true(*args, **kwargs)
  File "/home/yaozihang/anaconda3/envs/oneflow-dev-clang10-v2/lib/python3.8/site-packages/torch/nn/functional.py", line 864, in max_pool3d_with_indices
    return torch._C._nn.max_pool3d_with_indices(input, kernel_size, stride, padding, dilation, ceil_mode)
RuntimeError: Given input size: (16x10x10x10). Calculated output size: (16x0x0x0). Output size is too small
```

oneflow结果：
```
无报错输出
```