### PR TITLE
print np version and mismatch error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,9 @@ jobs:
             3.8
             3.9
             3.10
+      - name: Sleep
+        run: sleep 99999999999
+        if: ${{ matrix.entry =='cpu' }}
       - name: Upload wheel
         uses: ./.github/actions/upload_oss
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,11 @@ jobs:
           clean-ccache: true
           nightly: ${{ github.event_name == 'schedule' }}
           python-versions: |
+            3.10
+            3.9
+            3.8
             3.6
             3.7
-            3.8
-            3.9
-            3.10
       - uses: Oneflow-Inc/get-oneflow@single-matrix-for-efficiency
         name: Build ${{ matrix.entry }}
         if: ${{ matrix.entry =='cpu' }}

--- a/cmake/oneflow.cmake
+++ b/cmake/oneflow.cmake
@@ -338,6 +338,8 @@ if(BUILD_PYTHON)
                              ${oneflow_third_party_libs} of_pyext_obj glog::glog)
   target_include_directories(oneflow_internal PRIVATE ${Python_INCLUDE_DIRS}
                                                       ${Python_NumPy_INCLUDE_DIRS})
+  target_compile_definitions(oneflow_internal PRIVATE
+                             ONEFLOW_NP_INCLUDE_DIR=${Python_NumPy_INCLUDE_DIRS})
 
   target_compile_definitions(oneflow_internal PRIVATE ONEFLOW_CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   if(WITH_MLIR)

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -71,6 +71,26 @@ if(NOT Python_NumPy_INCLUDE_DIRS)
 endif()
 message(STATUS "Found numpy include directory ${Python_NumPy_INCLUDE_DIRS}")
 
+message(STATUS "Getting numpy version..")
+execute_process(COMMAND ${Python_EXECUTABLE} -c "import numpy; print(numpy.__version__)"
+                OUTPUT_VARIABLE NumPy_VERSION RESULT_VARIABLE ret_code)
+if (NOT ret_code EQUAL 0)
+  message(FATAL_ERROR "Cannot get numpy version")
+endif()
+message(STATUS "numpy version: ${NumPy_VERSION}")
+
+message(STATUS "Getting numpy c api feature version..")
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E echo "#include <numpy/arrayobject.h>\nNPY_FEATURE_VERSION"
+  OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/temp.cpp)
+execute_process(COMMAND ${CMAKE_CXX_COMPILER} -E ${CMAKE_CURRENT_BINARY_DIR}/temp.cpp -I ${Python_NumPy_INCLUDE_DIRS} -I ${Python_INCLUDE_DIRS} 
+                COMMAND tail -1
+                OUTPUT_VARIABLE NumPy_C_API_FEATURE_VERSION RESULT_VARIABLE ret_code ERROR_QUIET)
+if (NOT ret_code EQUAL 0)
+  message(FATAL_ERROR "Cannot get numpy c api feature version")
+endif()
+message(STATUS "numpy c api feature version: ${NumPy_C_API_FEATURE_VERSION}")
+
 # PYTHON_EXECUTABLE will be used by pybind11
 set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
 include(pybind11)

--- a/oneflow/api/python/flags.cpp
+++ b/oneflow/api/python/flags.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "oneflow/api/python/of_api_registry.h"
+#include "oneflow/extension/python/numpy.h"
 #ifdef WITH_CUDA
 #include <cuda.h>
 #endif
@@ -85,17 +86,29 @@ ONEFLOW_API_PYBIND11_MODULE("flags", m) {
 #endif  // RPC_BACKEND_LOCAL
   });
 
-#define STRINGIFY(x) STRINGIFY_(x)
-#define STRINGIFY_(x) #x
   m.def("cmake_build_type", []() {
 #ifdef ONEFLOW_CMAKE_BUILD_TYPE
-    return std::string(STRINGIFY(ONEFLOW_CMAKE_BUILD_TYPE));
+    return std::string(OF_PP_STRINGIZE(ONEFLOW_CMAKE_BUILD_TYPE));
 #else
     return std::string("Undefined");
 #endif  // ONEFLOW_CMAKE_BUILD_TYPE
   });
-#undef STRINGIFY
-#undef STRINGIFY_
+
+  m.def("compile_time_numpy_include_dir", []() {
+#ifdef ONEFLOW_NP_INCLUDE_DIR
+    return std::string(OF_PP_STRINGIZE(ONEFLOW_NP_INCLUDE_DIR));
+#else
+#error "ONEFLOW_NP_INCLUDE_DIR is not defined"
+#endif
+  });
+
+  m.def("compile_time_numpy_c_api_feature_version", []() {
+#ifdef NPY_FEATURE_VERSION
+    return std::string(OF_PP_STRINGIZE(NPY_FEATURE_VERSION));
+#else
+#error "NPY_FEATURE_VERSION is not defined"
+#endif
+  });
 }
 
 }  // namespace oneflow

--- a/oneflow/extension/python/numpy.cpp
+++ b/oneflow/extension/python/numpy.cpp
@@ -109,8 +109,11 @@ bool PyArrayCheckBoolScalar(PyObject* obj) {
 // https://numpy.org/doc/stable/reference/c-api/array.html#importing-the-api
 Maybe<void> InitNumpyCAPI() {
   CHECK_ISNULL_OR_RETURN(PyArray_API);
-  CHECK_EQ_OR_RETURN(_import_array(), 0)
-      << ". Unable to import Numpy array, try to upgrade Numpy version!";
+  if (_import_array() < 0) {
+    PyErr_Print();
+    return Error::RuntimeError() << "numpy.core.multiarray failed to import. Please check the "
+                                    "above error message for more information.";
+  }
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
在 cmake 里打印 numpy 版本和 NPY_FEATURE_VERSION 的值，运行时发现 numpy 版本不匹配时打印原生错误信息