### PR TITLE
Modify sbp.split()'s karg: axis to dim

### DIFF
--- a/oneflow/api/common/sbp.h
+++ b/oneflow/api/common/sbp.h
@@ -33,7 +33,7 @@ inline Maybe<std::string> SbpToString(Symbol<SbpParallel> sbp_sym) {
   } else if (sbp_sym->has_partial_sum_parallel()) {
     sbp_str += "partial_sum";
   } else if (sbp_sym->has_split_parallel()) {
-    sbp_str += "split(axis=" + std::to_string(sbp_sym->split_parallel().axis()) + ")";
+    sbp_str += "split(dim=" + std::to_string(sbp_sym->split_parallel().axis()) + ")";
   } else {
     UNIMPLEMENTED_THEN_RETURN();
   }

--- a/python/oneflow/framework/distribute.py
+++ b/python/oneflow/framework/distribute.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 import oneflow._oneflow_internal
 
 
-def split_sbp(*arg, **karg) -> oneflow._oneflow_internal.sbp.sbp:
+def split_sbp(*dim, **karg) -> oneflow._oneflow_internal.sbp.sbp:
     """Generate a split scheme in which op will be splitted at `dim`.
 
     Args:
@@ -44,7 +44,7 @@ def split_sbp(*arg, **karg) -> oneflow._oneflow_internal.sbp.sbp:
                 "This 'axis' parameter of oneflow.sbp.split() will be updated to 'dim' in version 0.8."
             )
     else:
-        dim = arg[0]
+        dim = dim[0]
 
     assert type(dim) is int
     return oneflow._oneflow_internal.sbp.split(dim)

--- a/python/oneflow/framework/distribute.py
+++ b/python/oneflow/framework/distribute.py
@@ -14,16 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import traceback
+import warnings
 from contextlib import contextmanager
 
 import oneflow._oneflow_internal
 
 
-def split_sbp(axis: int) -> oneflow._oneflow_internal.sbp.sbp:
-    """Generate a split scheme in which op will be splitted at `axis`.
+def split_sbp(*arg, **karg) -> oneflow._oneflow_internal.sbp.sbp:
+    """Generate a split scheme in which op will be splitted at `dim`.
 
     Args:
-        axis (int): At `axis` the op will be splitted.
+        dim (int): At `dim` the op will be splitted.
 
     Returns:
         SbpParallel: Split scheme object, often required by `to_global` method of `Tensor`
@@ -34,5 +35,16 @@ def split_sbp(axis: int) -> oneflow._oneflow_internal.sbp.sbp:
         ct2 = t1.to_global(sbp=flow.sbp.split(0), placement=("cuda", ranks=[0, 1, 2, 3]))
 
     """
-    assert type(axis) is int
-    return oneflow._oneflow_internal.sbp.split(axis)
+    if len(karg) != 0:
+        try:
+            dim = karg["dim"]
+        except:
+            dim = karg["axis"]
+            warnings.warn(
+                "This 'axis' parameter of oneflow.sbp.split() will be updated to 'dim' in version 0.8."
+            )
+    else:
+        dim = arg[0]
+
+    assert type(dim) is int
+    return oneflow._oneflow_internal.sbp.split(dim)


### PR DESCRIPTION
## This PR is done:

flow.sbp.split() 的关键字参数由 axis 修改为 dim，并向前兼容 axis，需要做下面的改动：

### python 层接口改动：

- [ ] 修改 split_sbp() 方法的参数。
- [ ] TODO

### C++ 层改动：

- [ ] TODO

该 PR 来源的 issue：https://github.com/Oneflow-Inc/OneTeam/issues/897#issuecomment-1138109022
