### PR TITLE
Refactor add straighten algo interface

### DIFF
--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -420,7 +420,7 @@ void ForEachOpGraphNecessaryCtrlEdge(
 
 }  // namespace
 
-TaskGraph::TaskGraph() {
+TaskGraph::TaskGraph(bool random_straighten_nodes) {
   OpGraph* op_graph = Global<OpGraph>::Get();
   sub_tsk_gph_builder_ctx_.reset(new SubTskGphBuilderCtx(this));
   boxing_logger_ = CreateBoxingLogger();
@@ -451,7 +451,7 @@ TaskGraph::TaskGraph() {
     }
   });
 
-  if (ParseBooleanFromEnv("ONEFLOW_RANDOM_STRAIGHTEN_NODES", false)) {
+  if (random_straighten_nodes) {
     SetOrderInGraphForEachNode();
   } else {
     StraightenNodes(this, &ordered_task_nodes_);

--- a/oneflow/core/graph/task_graph.h
+++ b/oneflow/core/graph/task_graph.h
@@ -43,7 +43,7 @@ class TaskGraph final : public Graph<TaskNode, TaskEdge> {
   OF_DISALLOW_COPY_AND_MOVE(TaskGraph);
   ~TaskGraph() override;
 
-  explicit TaskGraph();
+  explicit TaskGraph(bool random_straighten_nodes);
 
   const char* TypeName() const override { return "TaskGraph"; }
   void RemoveEmptyRegsts();

--- a/oneflow/core/job/compiler.cpp
+++ b/oneflow/core/job/compiler.cpp
@@ -61,7 +61,8 @@ void Compiler::Compile(Job* job, Plan* plan, bool need_job_complete) const {
 
   // Step3: build task_gph.
   // TODO(levi): we can rewrite this part of code in visitor pattern.
-  auto task_gph = std::make_unique<TaskGraph>();
+  auto task_gph =
+      std::make_unique<TaskGraph>(job->job_conf().random_straighten_nodes_in_task_graph());
   using std::placeholders::_1;
   task_gph->ForEachNode(std::bind(&TaskNode::ProduceAllRegstsAndBindEdges, _1));
   task_gph->ForEachNode(std::bind(&TaskNode::ConsumeAllRegsts, _1));

--- a/oneflow/core/job/job_conf.proto
+++ b/oneflow/core/job/job_conf.proto
@@ -239,6 +239,8 @@ message JobConfigProto {
   optional bool cudnn_conv_enable_pseudo_half = 600 [default = true];
   optional bool enable_auto_mixed_precision = 602 [default = false];
   optional bool enable_quantization_aware_training = 603 [default = false];
+
+  optional bool random_straighten_nodes_in_task_graph = 700 [default = false];
   
   optional int64 concurrency_width = 1000 [default = 128];
 

--- a/python/oneflow/nn/graph/graph_config.py
+++ b/python/oneflow/nn/graph/graph_config.py
@@ -269,6 +269,16 @@ class GraphConfig(object):
         """
         self.proto.cudnn_conv_heuristic_search_algo = mode
 
+    def set_random_straighten_nodes(self, mode: bool = False):
+        r""" Whether turn off the straighten algorithm.
+
+        If using nccl compute stream, turning it on will not speed up the training.
+        If not using nccl compute stream, turning it on will slow down data parallelism by 0.6% and slow down model parallelism by 6%.
+
+        The switch is off by default (i.e. use the straighten algorithm by default).
+        """
+        self.proto.random_straighten_nodes_in_task_graph = mode
+
     def _generate_optimizer_and_variable_configs(
         self, opt_dict: OptDict = None, variables_conf: OrderedDict = None,
     ):


### PR DESCRIPTION
为拉直算法提供 api 接口，代替之前环境变量的方式。

```python
# nn.Graph 中调用
self.config.set_random_straighten_nodes(True)
```

文档：

![image](https://user-images.githubusercontent.com/39889784/174021207-eda0ebde-37cf-432b-8ea9-e62d9b3e6aca.png)
