### PR TITLE
Fix a bug in the old version group boxing with 2D SBP

### DIFF
--- a/oneflow/core/boxing/nd_sbp_dim_reduce_boxing.cpp
+++ b/oneflow/core/boxing/nd_sbp_dim_reduce_boxing.cpp
@@ -18,9 +18,9 @@ limitations under the License.
 #include "oneflow/core/framework/nd_sbp.h"
 #include "oneflow/core/framework/device.h"
 #include "oneflow/core/functional/functional.h"
-#include "oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.h"
 #include "oneflow/core/common/decorator.h"
 #include "oneflow/core/operator/operator.h"
+#include "oneflow/core/framework/sbp_infer_util.h"
 
 namespace oneflow {
 

--- a/oneflow/core/framework/sbp_infer_util.cpp
+++ b/oneflow/core/framework/sbp_infer_util.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 
 #include "oneflow/core/framework/sbp_infer_util.h"
 #include "oneflow/core/auto_parallel/boxing_collector.h"
-#include "oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.h"
 #include "oneflow/core/boxing/eager_boxing_interpreter_mgr.h"
 #include "oneflow/core/common/util.h"
 #include "oneflow/core/job/lazy_mode.h"
@@ -361,7 +360,101 @@ Maybe<CopyCostFunc*> GetComputeCopyCostFunc() {
   }
 }
 
+void CollaborativeParallelDimReduce(const ParallelDesc& in_parallel_desc,
+                                    const ParallelDesc& out_parallel_desc, const NdSbp& in_nd_sbp,
+                                    const NdSbp& out_nd_sbp, ParallelDesc* reduced_in_parallel_desc,
+                                    ParallelDesc* reduced_out_parallel_desc,
+                                    NdSbp* reduced_in_nd_sbp, NdSbp* reduced_out_nd_sbp) {
+  const auto& in_hierarchy = in_parallel_desc.hierarchy();
+  const auto& out_hierarchy = out_parallel_desc.hierarchy();
+  CHECK_EQ(in_hierarchy->NumAxes(), out_hierarchy->NumAxes());
+
+  DimVector reduced_in_hierarchy;
+  DimVector reduced_out_hierarchy;
+  FOR_RANGE(int64_t, i, 0, in_hierarchy->NumAxes()) {
+    if (in_hierarchy->At(i) != 1 || out_hierarchy->At(i) != 1) {
+      if (reduced_in_nd_sbp->sbp_parallel().empty()
+          || (in_nd_sbp.sbp_parallel(i)
+                  != reduced_in_nd_sbp->sbp_parallel(reduced_in_nd_sbp->sbp_parallel_size() - 1)
+              || out_nd_sbp.sbp_parallel(i)
+                     != reduced_out_nd_sbp->sbp_parallel(reduced_out_nd_sbp->sbp_parallel_size()
+                                                         - 1))) {
+        reduced_in_hierarchy.emplace_back(in_hierarchy->At(i));
+        *reduced_in_nd_sbp->add_sbp_parallel() = in_nd_sbp.sbp_parallel(i);
+
+        reduced_out_hierarchy.emplace_back(out_hierarchy->At(i));
+        *reduced_out_nd_sbp->add_sbp_parallel() = out_nd_sbp.sbp_parallel(i);
+      } else {
+        reduced_in_hierarchy.back() *= in_hierarchy->At(i);
+        reduced_out_hierarchy.back() *= out_hierarchy->At(i);
+      }
+    }
+  }
+  if (reduced_in_hierarchy.empty()) {
+    reduced_in_hierarchy.emplace_back(in_hierarchy->At(0));
+    *reduced_in_nd_sbp->add_sbp_parallel() = in_nd_sbp.sbp_parallel(0);
+
+    reduced_out_hierarchy.emplace_back(out_hierarchy->At(0));
+    *reduced_out_nd_sbp->add_sbp_parallel() = out_nd_sbp.sbp_parallel(0);
+  }
+
+  ParallelConf reduced_in_parallel_conf = in_parallel_desc.parallel_conf();
+  Shape(reduced_in_hierarchy).ToProto(reduced_in_parallel_conf.mutable_hierarchy());
+  *reduced_in_parallel_desc = ParallelDesc(reduced_in_parallel_conf);
+
+  ParallelConf reduced_out_parallel_conf = out_parallel_desc.parallel_conf();
+  Shape(reduced_out_hierarchy).ToProto(reduced_out_parallel_conf.mutable_hierarchy());
+  *reduced_out_parallel_desc = ParallelDesc(reduced_out_parallel_conf);
+}
+
 }  // namespace
+
+void NdSbpDimReduce(const ParallelDesc& parallel_desc, const NdSbp& nd_sbp,
+                    ParallelDesc* reduced_parallel_desc, NdSbp* reduced_nd_sbp) {
+  const auto& hierarchy = parallel_desc.hierarchy();
+  DimVector reduced_hierarchy;
+  FOR_RANGE(int64_t, i, 0, hierarchy->NumAxes()) {
+    if (hierarchy->At(i) != 1) {
+      if (reduced_nd_sbp->sbp_parallel().empty()
+          || (nd_sbp.sbp_parallel(i)
+              != reduced_nd_sbp->sbp_parallel(reduced_nd_sbp->sbp_parallel_size() - 1))) {
+        reduced_hierarchy.emplace_back(hierarchy->At(i));
+        *reduced_nd_sbp->add_sbp_parallel() = nd_sbp.sbp_parallel(i);
+      } else {
+        reduced_hierarchy.back() *= hierarchy->At(i);
+      }
+    }
+  }
+  if (reduced_hierarchy.empty()) {
+    reduced_hierarchy.emplace_back(hierarchy->At(0));
+    *reduced_nd_sbp->add_sbp_parallel() = nd_sbp.sbp_parallel(0);
+  }
+  ParallelConf reduced_parallel_conf = parallel_desc.parallel_conf();
+  Shape(reduced_hierarchy).ToProto(reduced_parallel_conf.mutable_hierarchy());
+  *reduced_parallel_desc = ParallelDesc(reduced_parallel_conf);
+}
+
+void InOutParallelDimReduce(const ParallelDesc& in_parallel_desc,
+                            const ParallelDesc& out_parallel_desc, const NdSbp& in_nd_sbp,
+                            const NdSbp& out_nd_sbp, ParallelDesc* reduced_in_parallel_desc,
+                            ParallelDesc* reduced_out_parallel_desc, NdSbp* reduced_in_nd_sbp,
+                            NdSbp* reduced_out_nd_sbp) {
+  const int64_t in_hierarchy_axes = in_parallel_desc.hierarchy()->NumAxes();
+  const int64_t out_hierarchy_axes = out_parallel_desc.hierarchy()->NumAxes();
+  if (in_hierarchy_axes == 1 && out_hierarchy_axes == 1) {
+    *reduced_in_parallel_desc = in_parallel_desc;
+    *reduced_out_parallel_desc = out_parallel_desc;
+    *reduced_in_nd_sbp = in_nd_sbp;
+    *reduced_out_nd_sbp = out_nd_sbp;
+  } else if (in_hierarchy_axes != out_hierarchy_axes) {
+    NdSbpDimReduce(in_parallel_desc, in_nd_sbp, reduced_in_parallel_desc, reduced_in_nd_sbp);
+    NdSbpDimReduce(out_parallel_desc, out_nd_sbp, reduced_out_parallel_desc, reduced_out_nd_sbp);
+  } else {
+    CollaborativeParallelDimReduce(in_parallel_desc, out_parallel_desc, in_nd_sbp, out_nd_sbp,
+                                   reduced_in_parallel_desc, reduced_out_parallel_desc,
+                                   reduced_in_nd_sbp, reduced_out_nd_sbp);
+  }
+}
 
 Maybe<double> ComputeLazyCopyCostBetweenNdSbp(const NdSbp& producer_sbp_parallel,
                                               const NdSbp& consumer_sbp_parallel,

--- a/oneflow/core/framework/sbp_infer_util.cpp
+++ b/oneflow/core/framework/sbp_infer_util.cpp
@@ -580,7 +580,6 @@ Maybe<double> ComputeCopyCostWithMiddleNodes(const NdSbp& producer_sbp_parallel,
 // Decide the priority to infer sbp
 double ComputeSbpInferPriority(const NdSbp& producer_sbp_parallel,
                                const NdSbp& consumer_sbp_parallel,
-                               const BlobDesc& logical_blob_desc,
                                const ParallelDesc& producer_parallel_desc,
                                const ParallelDesc& consumer_parallel_desc, bool requires_same_sbp) {
   ParallelDesc reduced_in_parallel_desc = producer_parallel_desc;
@@ -613,6 +612,15 @@ double ComputeSbpInferPriority(const NdSbp& producer_sbp_parallel,
       return 1.0;
     }
   }
+}
+
+// Check if two sbp is actually the same
+double IsPhysicalSameNdSbp(const NdSbp& producer_sbp_parallel, const NdSbp& consumer_sbp_parallel,
+                           const ParallelDesc& producer_parallel_desc,
+                           const ParallelDesc& consumer_parallel_desc) {
+  return ComputeSbpInferPriority(producer_sbp_parallel, consumer_sbp_parallel,
+                                 producer_parallel_desc, consumer_parallel_desc, true)
+         == 0.0;
 }
 
 }  // namespace oneflow

--- a/oneflow/core/framework/sbp_infer_util.cpp
+++ b/oneflow/core/framework/sbp_infer_util.cpp
@@ -614,13 +614,4 @@ double ComputeSbpInferPriority(const NdSbp& producer_sbp_parallel,
   }
 }
 
-// Check if two sbp is actually the same
-double IsPhysicalSameNdSbp(const NdSbp& producer_sbp_parallel, const NdSbp& consumer_sbp_parallel,
-                           const ParallelDesc& producer_parallel_desc,
-                           const ParallelDesc& consumer_parallel_desc) {
-  return ComputeSbpInferPriority(producer_sbp_parallel, consumer_sbp_parallel,
-                                 producer_parallel_desc, consumer_parallel_desc, true)
-         == 0.0;
-}
-
 }  // namespace oneflow

--- a/oneflow/core/framework/sbp_infer_util.h
+++ b/oneflow/core/framework/sbp_infer_util.h
@@ -33,6 +33,15 @@ enum Penalty4PartialInConsumerTag : int {
   kStrict = 3   // Not allow a transfer to P
 };
 
+void NdSbpDimReduce(const ParallelDesc& parallel_desc, const NdSbp& nd_sbp,
+                    ParallelDesc* reduced_parallel_desc, NdSbp* reduced_nd_sbp);
+
+void InOutParallelDimReduce(const ParallelDesc& in_parallel_desc,
+                            const ParallelDesc& out_parallel_desc, const NdSbp& in_nd_sbp,
+                            const NdSbp& out_nd_sbp, ParallelDesc* reduced_in_parallel_desc,
+                            ParallelDesc* reduced_out_parallel_desc, NdSbp* reduced_in_nd_sbp,
+                            NdSbp* reduced_out_nd_sbp);
+
 double GetValidMaxCopyCost();
 
 double GetTransferCost();

--- a/oneflow/core/framework/sbp_infer_util.h
+++ b/oneflow/core/framework/sbp_infer_util.h
@@ -87,11 +87,6 @@ double ComputeSbpInferPriority(const NdSbp& producer_sbp_parallel,
                                const ParallelDesc& producer_parallel_desc,
                                const ParallelDesc& consumer_parallel_desc, bool requires_same_sbp);
 
-// Check if two sbp is actually the same
-double IsPhysicalSameNdSbp(const NdSbp& producer_sbp_parallel, const NdSbp& consumer_sbp_parallel,
-                           const ParallelDesc& producer_parallel_desc,
-                           const ParallelDesc& consumer_parallel_desc);
-
 }  // namespace oneflow
 
 #endif  // ONEFLOW_CORE_FRAMEWORK_SBP_INFER_UTIL_H_

--- a/oneflow/core/framework/sbp_infer_util.h
+++ b/oneflow/core/framework/sbp_infer_util.h
@@ -84,9 +84,13 @@ Maybe<double> ComputeCopyCostWithMiddleNodes(const NdSbp& producer_sbp_parallel,
 // 2.0: Penality, the same as infinity
 double ComputeSbpInferPriority(const NdSbp& producer_sbp_parallel,
                                const NdSbp& consumer_sbp_parallel,
-                               const BlobDesc& logical_blob_desc,
                                const ParallelDesc& producer_parallel_desc,
                                const ParallelDesc& consumer_parallel_desc, bool requires_same_sbp);
+
+// Check if two sbp is actually the same
+double IsPhysicalSameNdSbp(const NdSbp& producer_sbp_parallel, const NdSbp& consumer_sbp_parallel,
+                           const ParallelDesc& producer_parallel_desc,
+                           const ParallelDesc& consumer_parallel_desc);
 
 }  // namespace oneflow
 

--- a/oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.cpp
+++ b/oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.cpp
@@ -25,58 +25,12 @@ limitations under the License.
 #include "oneflow/core/graph/boxing/b21_sub_task_graph_builder.h"
 #include "oneflow/core/graph/boxing/one_to_one_sub_task_graph_builder.h"
 #include "oneflow/core/graph/boxing/sub_task_graph_builder_util.h"
+#include "oneflow/core/framework/sbp_infer_util.h"
 #include "oneflow/core/job/sbp_parallel.h"
 
 namespace oneflow {
 
 namespace {
-
-void CollaborativeParallelDimReduce(const ParallelDesc& in_parallel_desc,
-                                    const ParallelDesc& out_parallel_desc, const NdSbp& in_nd_sbp,
-                                    const NdSbp& out_nd_sbp, ParallelDesc* reduced_in_parallel_desc,
-                                    ParallelDesc* reduced_out_parallel_desc,
-                                    NdSbp* reduced_in_nd_sbp, NdSbp* reduced_out_nd_sbp) {
-  const auto& in_hierarchy = in_parallel_desc.hierarchy();
-  const auto& out_hierarchy = out_parallel_desc.hierarchy();
-  CHECK_EQ(in_hierarchy->NumAxes(), out_hierarchy->NumAxes());
-
-  DimVector reduced_in_hierarchy;
-  DimVector reduced_out_hierarchy;
-  FOR_RANGE(int64_t, i, 0, in_hierarchy->NumAxes()) {
-    if (in_hierarchy->At(i) != 1 || out_hierarchy->At(i) != 1) {
-      if (reduced_in_nd_sbp->sbp_parallel().empty()
-          || (in_nd_sbp.sbp_parallel(i)
-                  != reduced_in_nd_sbp->sbp_parallel(reduced_in_nd_sbp->sbp_parallel_size() - 1)
-              || out_nd_sbp.sbp_parallel(i)
-                     != reduced_out_nd_sbp->sbp_parallel(reduced_out_nd_sbp->sbp_parallel_size()
-                                                         - 1))) {
-        reduced_in_hierarchy.emplace_back(in_hierarchy->At(i));
-        *reduced_in_nd_sbp->add_sbp_parallel() = in_nd_sbp.sbp_parallel(i);
-
-        reduced_out_hierarchy.emplace_back(out_hierarchy->At(i));
-        *reduced_out_nd_sbp->add_sbp_parallel() = out_nd_sbp.sbp_parallel(i);
-      } else {
-        reduced_in_hierarchy.back() *= in_hierarchy->At(i);
-        reduced_out_hierarchy.back() *= out_hierarchy->At(i);
-      }
-    }
-  }
-  if (reduced_in_hierarchy.empty()) {
-    reduced_in_hierarchy.emplace_back(in_hierarchy->At(0));
-    *reduced_in_nd_sbp->add_sbp_parallel() = in_nd_sbp.sbp_parallel(0);
-
-    reduced_out_hierarchy.emplace_back(out_hierarchy->At(0));
-    *reduced_out_nd_sbp->add_sbp_parallel() = out_nd_sbp.sbp_parallel(0);
-  }
-
-  ParallelConf reduced_in_parallel_conf = in_parallel_desc.parallel_conf();
-  Shape(reduced_in_hierarchy).ToProto(reduced_in_parallel_conf.mutable_hierarchy());
-  *reduced_in_parallel_desc = ParallelDesc(reduced_in_parallel_conf);
-
-  ParallelConf reduced_out_parallel_conf = out_parallel_desc.parallel_conf();
-  Shape(reduced_out_hierarchy).ToProto(reduced_out_parallel_conf.mutable_hierarchy());
-  *reduced_out_parallel_desc = ParallelDesc(reduced_out_parallel_conf);
-}
 
 std::shared_ptr<ChainSubTskGphBuilder> Make1DSubTskGphBuilder() {
   std::vector<std::shared_ptr<SubTskGphBuilder>> builders;
@@ -93,53 +47,6 @@ std::shared_ptr<ChainSubTskGphBuilder> Make1DSubTskGphBuilder() {
 }
 
 }  // namespace
-
-void NdSbpDimReduce(const ParallelDesc& parallel_desc, const NdSbp& nd_sbp,
-                    ParallelDesc* reduced_parallel_desc, NdSbp* reduced_nd_sbp) {
-  const auto& hierarchy = parallel_desc.hierarchy();
-  DimVector reduced_hierarchy;
-  FOR_RANGE(int64_t, i, 0, hierarchy->NumAxes()) {
-    if (hierarchy->At(i) != 1) {
-      if (reduced_nd_sbp->sbp_parallel().empty()
-          || (nd_sbp.sbp_parallel(i)
-              != reduced_nd_sbp->sbp_parallel(reduced_nd_sbp->sbp_parallel_size() - 1))) {
-        reduced_hierarchy.emplace_back(hierarchy->At(i));
-        *reduced_nd_sbp->add_sbp_parallel() = nd_sbp.sbp_parallel(i);
-      } else {
-        reduced_hierarchy.back() *= hierarchy->At(i);
-      }
-    }
-  }
-  if (reduced_hierarchy.empty()) {
-    reduced_hierarchy.emplace_back(hierarchy->At(0));
-    *reduced_nd_sbp->add_sbp_parallel() = nd_sbp.sbp_parallel(0);
-  }
-  ParallelConf reduced_parallel_conf = parallel_desc.parallel_conf();
-  Shape(reduced_hierarchy).ToProto(reduced_parallel_conf.mutable_hierarchy());
-  *reduced_parallel_desc = ParallelDesc(reduced_parallel_conf);
-}
-
-void InOutParallelDimReduce(const ParallelDesc& in_parallel_desc,
-                            const ParallelDesc& out_parallel_desc, const NdSbp& in_nd_sbp,
-                            const NdSbp& out_nd_sbp, ParallelDesc* reduced_in_parallel_desc,
-                            ParallelDesc* reduced_out_parallel_desc, NdSbp* reduced_in_nd_sbp,
-                            NdSbp* reduced_out_nd_sbp) {
-  const int64_t in_hierarchy_axes = in_parallel_desc.hierarchy()->NumAxes();
-  const int64_t out_hierarchy_axes = out_parallel_desc.hierarchy()->NumAxes();
-  if (in_hierarchy_axes == 1 && out_hierarchy_axes == 1) {
-    *reduced_in_parallel_desc = in_parallel_desc;
-    *reduced_out_parallel_desc = out_parallel_desc;
-    *reduced_in_nd_sbp = in_nd_sbp;
-    *reduced_out_nd_sbp = out_nd_sbp;
-  } else if (in_hierarchy_axes != out_hierarchy_axes) {
-    NdSbpDimReduce(in_parallel_desc, in_nd_sbp, reduced_in_parallel_desc, reduced_in_nd_sbp);
-    NdSbpDimReduce(out_parallel_desc, out_nd_sbp, reduced_out_parallel_desc, reduced_out_nd_sbp);
-  } else {
-    CollaborativeParallelDimReduce(in_parallel_desc, out_parallel_desc, in_nd_sbp, out_nd_sbp,
-                                   reduced_in_parallel_desc, reduced_out_parallel_desc,
-                                   reduced_in_nd_sbp, reduced_out_nd_sbp);
-  }
-}
 
 class FlatSubTskGphBuilder final : public HierarchicalSubTskGphBuilder {
  public:

--- a/oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.h
+++ b/oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.h
@@ -41,6 +41,9 @@ class DispatchHierarchicalSubTskGphBuilder final : public HierarchicalSubTskGphB
   std::unique_ptr<Impl> impl_;
 };
 
+void NdSbpDimReduce(const ParallelDesc& parallel_desc, const NdSbp& nd_sbp,
+                    ParallelDesc* reduced_parallel_desc, NdSbp* reduced_nd_sbp);
+
 void InOutParallelDimReduce(const ParallelDesc& in_parallel_desc,
                             const ParallelDesc& out_parallel_desc, const NdSbp& in_nd_sbp,
                             const NdSbp& out_nd_sbp, ParallelDesc* reduced_in_parallel_desc,

--- a/oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.h
+++ b/oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.h
@@ -41,15 +41,6 @@ class DispatchHierarchicalSubTskGphBuilder final : public HierarchicalSubTskGphB
   std::unique_ptr<Impl> impl_;
 };
 
-void NdSbpDimReduce(const ParallelDesc& parallel_desc, const NdSbp& nd_sbp,
-                    ParallelDesc* reduced_parallel_desc, NdSbp* reduced_nd_sbp);
-
-void InOutParallelDimReduce(const ParallelDesc& in_parallel_desc,
-                            const ParallelDesc& out_parallel_desc, const NdSbp& in_nd_sbp,
-                            const NdSbp& out_nd_sbp, ParallelDesc* reduced_in_parallel_desc,
-                            ParallelDesc* reduced_out_parallel_desc, NdSbp* reduced_in_nd_sbp,
-                            NdSbp* reduced_out_nd_sbp);
-
 }  // namespace oneflow
 
 #endif  // ONEFLOW_CORE_GRAPH_BOXING_HIERARCHICAL_SUB_TASK_GRAPH_BUILDER_IMPL_H_

--- a/oneflow/core/job_rewriter/group_boxing_by_dst_parallel.cpp
+++ b/oneflow/core/job_rewriter/group_boxing_by_dst_parallel.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 */
 #include "oneflow/core/job_rewriter/group_boxing_by_dst_parallel.h"
 #include "oneflow/core/framework/sbp_infer_util.h"
-#include "oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.h"
 #include "oneflow/core/job/job_desc.h"
 #include "oneflow/core/common/protobuf.h"
 

--- a/oneflow/core/job_rewriter/group_boxing_by_dst_parallel.cpp
+++ b/oneflow/core/job_rewriter/group_boxing_by_dst_parallel.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "oneflow/core/job_rewriter/group_boxing_by_dst_parallel.h"
+#include "oneflow/core/framework/sbp_infer_util.h"
 #include "oneflow/core/job/job_desc.h"
 #include "oneflow/core/common/protobuf.h"
 
@@ -28,18 +29,21 @@ Maybe<void> GroupBoxingByDstParallel(const OpGraph& op_graph, JobBuilder* job_bu
     OperatorConf::OpTypeCase op_type_case = node->op().op_conf().op_type_case();
     if (IsClassRegistered<int32_t, DisableInputBoxingGroup>(op_type_case)) { return; }
     for (const std::string& ibn : node->op().input_bns()) {
+      const auto& blob_modifier_ = node->op().InputBlobModifier4Ibn(ibn);
+      if (blob_modifier_.has_is_mutable() && blob_modifier_.is_mutable()) { return; }
       const LogicalBlobId& lbi = node->op().BnInOp2Lbi(ibn);
       const OpNode& producer = node->ProducerOpNode4Lbi(lbi);
       const NdSbp& producer_nd_sbp = producer.NdSbp4Lbi(lbi);
       const NdSbp& consumer_nd_sbp = node->NdSbp4BnInOp(ibn);
 
-      if (producer.parallel_desc() != node->parallel_desc()
-          || (node->parallel_desc().parallel_num() != 1 && producer_nd_sbp != consumer_nd_sbp)) {
-        lbi2consumer_grouped_by_parallel[lbi][{node->parallel_desc(), consumer_nd_sbp}].push_back(
-            {node, ibn});
-        if (op_node2op_conf.find(node) == op_node2op_conf.end()) {
-          op_node2op_conf[node] = node->op().op_conf();
-        }
+      if (IsPhysicalSameNdSbp(producer_nd_sbp, consumer_nd_sbp, producer.parallel_desc(),
+                              node->parallel_desc())) {
+        continue;
+      }
+      lbi2consumer_grouped_by_parallel[lbi][{node->parallel_desc(), consumer_nd_sbp}].push_back(
+          {node, ibn});
+      if (op_node2op_conf.find(node) == op_node2op_conf.end()) {
+        op_node2op_conf[node] = node->op().op_conf();
       }
     }
   });

--- a/oneflow/core/job_rewriter/insert_nccl_logical_op_pass.cpp
+++ b/oneflow/core/job_rewriter/insert_nccl_logical_op_pass.cpp
@@ -26,7 +26,7 @@ limitations under the License.
 #include "oneflow/core/vm/vm_util.h"
 #include "oneflow/core/vm/symbol_storage.h"
 #include "oneflow/core/operator/operator.h"
-#include "oneflow/core/graph/boxing/hierarchical_sub_task_graph_builder_impl.h"
+#include "oneflow/core/framework/sbp_infer_util.h"
 
 namespace oneflow {
 

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -727,7 +727,6 @@ Maybe<void> Operator::GreedilyFindMinCopyCostNdSbp(
           double priority_ratio = ComputeSbpInferPriority(
               producer_infer_hint4ibn->nd_sbp(),
               JUST(VectorAt(nd_sbp_sig_list, i)).bn_in_op2nd_sbp().at(ibn),
-              producer_infer_hint4ibn->logical_blob_desc(),
               producer_infer_hint4ibn->parallel_desc(), *JUST(GetParallelDesc4BnInOp(ibn)),
               requires_same_sbp[ibn_id]);
           sum_priority_ratio += priority_ratio;


### PR DESCRIPTION
Update group boxing to deal with hierarchy [1, 2]

Consider such graph:
A: [1, 2], (B, B) ----> B: [1, 2], (S0, B)
A: [1, 2], (B, B) ----> C: [1, 2], (S0, B)

Group boxing would create a boxing node with placement [1, 2] and sbp (S0, B), namely node D. It changes the graph to
A ---> D 
D ---> B
D ---> C

However, if A ---> C does not accept any kind of boxing, bugs will occur.
In our test cases, 
A is module.input_grad
B is module_add_n-0
C is module.input_grad_optimizer

A ---> C is "is_mutable", which does not accept any kind of nodes in the middle.

This PR fixes the problem above.