### PR TITLE
optimize eager test speed by relax autotest in some key eager tests

### DIFF
--- a/python/oneflow/test/modules/test_activation.py
+++ b/python/oneflow/test/modules/test_activation.py
@@ -29,7 +29,7 @@ import oneflow.unittest
 
 @flow.unittest.skip_unless_1n1d()
 class TestReLUModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_relu_module_with_random_data(test_case):
         m = torch.nn.ReLU()
         m.train(random())
@@ -39,7 +39,7 @@ class TestReLUModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_relu_module_with_0dim_data(test_case):
         m = torch.nn.ReLU()
         m.train(random())
@@ -49,7 +49,7 @@ class TestReLUModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_relu_module_with_0_size_data(test_case):
         m = torch.nn.ReLU()
         m.train(random())
@@ -67,7 +67,7 @@ class TestReLUModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestReLU6Module(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_relu6_module_with_random_data(test_case):
         m = torch.nn.ReLU6()
         m.train(random())
@@ -77,7 +77,7 @@ class TestReLU6Module(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_relu6_module_with_0dim_data(test_case):
         m = torch.nn.ReLU6()
         m.train(random())
@@ -87,7 +87,7 @@ class TestReLU6Module(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_relu6_module_with_0_size_data(test_case):
         m = torch.nn.ReLU6()
         m.train(random())
@@ -105,7 +105,7 @@ class TestReLU6Module(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestTanh(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_tanh_module_with_random_data(test_case):
         m = torch.nn.Tanh()
         m.train(random())
@@ -115,7 +115,7 @@ class TestTanh(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_tanh_module_with_0dim_data(test_case):
         m = torch.nn.Tanh()
         m.train(random())
@@ -125,7 +125,7 @@ class TestTanh(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_tanh_module_with_0_size_data(test_case):
         m = torch.nn.Tanh()
         m.train(random())
@@ -135,21 +135,21 @@ class TestTanh(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tanh_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.tanh(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tanh_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
         y = torch.tanh(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_flow_tanh_with_0_size_data(test_case):
         device = random_device()
         x = random_tensor(4, 2, 3, 0, 3).to(device)
@@ -164,7 +164,7 @@ class TestTanh(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestELUModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_elu_module_with_random_data(test_case):
         m = torch.nn.ELU(alpha=random() | nothing())
         m.train(random())
@@ -174,7 +174,7 @@ class TestELUModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_elu_module_with_0dim_data(test_case):
         m = torch.nn.ELU(alpha=random() | nothing())
         m.train(random())
@@ -184,7 +184,7 @@ class TestELUModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_elu_module_with_0_size_data(test_case):
         m = torch.nn.ELU(alpha=random() | nothing())
         m.train(random())
@@ -197,7 +197,7 @@ class TestELUModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestCELUModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_celu_module_with_random_data(test_case):
         m = torch.nn.CELU(alpha=random() | nothing())
         m.train(random())
@@ -207,7 +207,7 @@ class TestCELUModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_celu_module_with_0dim_data(test_case):
         m = torch.nn.CELU(alpha=random() | nothing())
         m.train(random())
@@ -217,7 +217,7 @@ class TestCELUModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_celu_module_with_0_size_data(test_case):
         m = torch.nn.CELU(alpha=random() | nothing())
         m.train(random())
@@ -240,7 +240,7 @@ class TestCELUModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestGelu(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_gelu_module_with_random_data(test_case):
         m = torch.nn.GELU()
         m.train(random())
@@ -250,7 +250,7 @@ class TestGelu(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_gelu_module_with_0dim_data(test_case):
         m = torch.nn.GELU()
         m.train(random())
@@ -263,7 +263,7 @@ class TestGelu(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestSigmoidModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_sigmoid_module_with_random_data(test_case):
         m = torch.nn.Sigmoid()
         m.train(random())
@@ -273,7 +273,7 @@ class TestSigmoidModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_sigmoid_module_with_0dim_data(test_case):
         m = torch.nn.Sigmoid()
         m.train(random())
@@ -283,28 +283,28 @@ class TestSigmoidModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_sigmoid_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.sigmoid(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_sigmoid_flow_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
         y = torch.sigmoid(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_sigmoid_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = x.sigmoid()
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_sigmoid_tensor_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
@@ -357,7 +357,7 @@ class TestHardsigmoidModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             test_hardsigmoid_inplace_impl(test_case, *arg)
 
-    @autotest()
+    @autotest(n=5)
     def test_hardsigmoid_module_with_random_data(test_case):
         m = torch.nn.Hardsigmoid()
         m.train(random())
@@ -367,7 +367,7 @@ class TestHardsigmoidModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_hardsigmoid_module_with_0dim_data(test_case):
         m = torch.nn.Hardsigmoid()
         m.train(random())
@@ -377,14 +377,14 @@ class TestHardsigmoidModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_functional_hardsigmoid_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.nn.functional.hardsigmoid(x, random_bool())
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_functional_hardsigmoid_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
@@ -411,11 +411,11 @@ def do_test_softmax(batch_size: int, log_softmax: bool = False):
 
 @flow.unittest.skip_unless_1n1d()
 class TestSoftmax(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_softmax_module_with_random_data(test_case):
         return do_test_softmax(batch_size=-1, log_softmax=False)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_softmax_module_with_batch_size_equal_1024(test_case):
         return do_test_softmax(batch_size=1024, log_softmax=False)
 
@@ -435,11 +435,11 @@ class TestSoftmax(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestLogSoftmaxModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_logsoftmax_module_with_random_data(test_case):
         return do_test_softmax(batch_size=-1, log_softmax=True)
 
-    @autotest()
+    @autotest(n=5)
     def test_softmax_module_with_batch_size_equal_1024(test_case):
         return do_test_softmax(batch_size=1024, log_softmax=True)
 
@@ -454,7 +454,7 @@ class TestLogSoftmaxModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestLogSigmoidModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_logsigmoid_module_with_random_data(test_case):
         m = torch.nn.LogSigmoid()
         m.train(random())
@@ -464,7 +464,7 @@ class TestLogSigmoidModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_logsigmoid_module_with_0dim_data(test_case):
         m = torch.nn.LogSigmoid()
         m.train(random())
@@ -537,7 +537,7 @@ class TestSoftplusModule(flow.unittest.TestCase):
             arg[0](test_case, *arg[1:])
 
     @unittest.skip("pytorch softplus backward has bug")
-    @autotest()
+    @autotest(n=5)
     def test_softplus_module_with_random_data(test_case):
         m = torch.nn.Softplus(beta=random() | nothing(), threshold=random() | nothing())
         m.train(random())
@@ -550,7 +550,7 @@ class TestSoftplusModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestHardswishModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_hardswish_module_with_random_data(test_case):
         m = torch.nn.Hardswish()
         m.train(random())
@@ -560,7 +560,7 @@ class TestHardswishModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_hardswish_module_with_0dim_data(test_case):
         m = torch.nn.Hardswish()
         m.train(random())
@@ -573,7 +573,7 @@ class TestHardswishModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestHardtanhModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_hardtanh_module_with_random_data(test_case):
         m = torch.nn.Hardtanh(
             min_val=random().to(float) | nothing(),
@@ -586,7 +586,7 @@ class TestHardtanhModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_hardtanh_module_with_0dim_data(test_case):
         m = torch.nn.Hardtanh(
             min_val=random().to(float) | nothing(),
@@ -602,7 +602,7 @@ class TestHardtanhModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestLeakyReLUModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_leakyrelu_module_with_random_data(test_case):
         m = torch.nn.LeakyReLU(negative_slope=random() | nothing())
         m.train(random())
@@ -624,7 +624,7 @@ class TestLeakyReLUModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_leakyrelu_module_with_0dim_data(test_case):
         m = torch.nn.LeakyReLU(negative_slope=random() | nothing())
         m.train(random())
@@ -719,14 +719,14 @@ class TestSoftsignModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestReluFunction(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_relu_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=3).to(device)
         y = torch.relu(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_relu_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
@@ -736,14 +736,14 @@ class TestReluFunction(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestRelu6Function(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_nn_functional_relu6_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=3).to(device)
         y = torch.nn.functional.relu6(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_nn_functional_relu6_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
@@ -753,14 +753,14 @@ class TestRelu6Function(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestLogSigmoidFunction(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_nn_functional_logsigmoid_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=3).to(device)
         y = torch.nn.functional.logsigmoid(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_nn_functional_logsigmoid_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
@@ -790,7 +790,7 @@ class TestHardshrinkModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_hardshrink_module_with_0_size_data(test_case):
         m = torch.nn.Hardshrink(lambd=random() | nothing())
         m.train(random())
@@ -823,7 +823,7 @@ class TestSoftshrinkModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_softshrink_module_with_0_size_data(test_case):
         m = torch.nn.Softshrink(alpha=random() | nothing())
         m.train(random())
@@ -860,7 +860,7 @@ class TestThresholdModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False)
     def test_threshold_module_with_0_size_data(test_case):
         m = torch.nn.Threshold(
             threshold=random() | nothing(), value=random() | nothing()

--- a/python/oneflow/test/modules/test_loss.py
+++ b/python/oneflow/test/modules/test_loss.py
@@ -116,23 +116,23 @@ def _test_nn_functional_cross_entropy_loss(dim=int):
 
 @flow.unittest.skip_unless_1n1d()
 class TestCrossEntropyLossModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_cross_entropy_loss_with_random_data_dim_2(test_case):
         return _test_cross_entropy_loss(2)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_cross_entropy_loss_with_random_data_dim_3(test_case):
         return _test_cross_entropy_loss(3)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_cross_entropy_loss_with_random_data_dim_4(test_case):
         return _test_cross_entropy_loss(4)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_cross_entropy_loss_with_random_data_dim_5(test_case):
         return _test_cross_entropy_loss(5)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_nn_functional_cross_entropy_with_random_data_dim(test_case):
         dim = random(2, 6).to(int).value()
         return _test_nn_functional_cross_entropy_loss(dim)
@@ -160,19 +160,19 @@ def _test_nll_loss(dim=int):
 
 @flow.unittest.skip_unless_1n1d()
 class TestNLLLossModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_nll_loss_with_random_data_dim_2(test_case):
         return _test_nll_loss(2)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_nll_loss_with_random_data_dim_3(test_case):
         return _test_nll_loss(3)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_nll_loss_with_random_data_dim_4(test_case):
         return _test_nll_loss(4)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_nll_loss_with_random_data_dim_5(test_case):
         return _test_nll_loss(5)
 
@@ -199,45 +199,45 @@ def _test_bce_loss(dim=int, with_logits: bool = False):
 
 @flow.unittest.skip_unless_1n1d()
 class TestBCELossModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_bce_loss_with_random_data_dim_2(test_case):
         return _test_bce_loss(2)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_bce_loss_with_random_data_dim_3(test_case):
         return _test_bce_loss(3)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_bce_loss_with_random_data_dim_4(test_case):
         return _test_bce_loss(4)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_bce_loss_with_random_data_dim_5(test_case):
         return _test_bce_loss(5)
 
 
 @flow.unittest.skip_unless_1n1d()
 class TestBCEWithLogitsLossModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_bce_with_logits_loss_with_random_data_dim_2(test_case):
         return _test_bce_loss(2, True)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_bce_with_logits_loss_with_random_data_dim_3(test_case):
         return _test_bce_loss(3, True)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_bce_with_logits_loss_with_random_data_dim_4(test_case):
         return _test_bce_loss(4, True)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_bce_with_logits_loss_with_random_data_dim_5(test_case):
         return _test_bce_loss(5, True)
 
 
 @flow.unittest.skip_unless_1n1d()
 class TestL1LossModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_l1_loss_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -255,7 +255,7 @@ class TestL1LossModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestSmoothL1LossModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_smooth_l1_loss_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -275,7 +275,7 @@ class TestSmoothL1LossModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestMSELossModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_mse_loss_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -293,7 +293,7 @@ class TestMSELossModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestKLDivLossModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_kldiv_loss_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -314,7 +314,7 @@ class TestKLDivLossModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestMarginRankingLossModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_margin_ranking_loss_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape

--- a/python/oneflow/test/modules/test_math_ops.py
+++ b/python/oneflow/test/modules/test_math_ops.py
@@ -31,7 +31,7 @@ from oneflow.test_utils.test_util import (
 
 @flow.unittest.skip_unless_1n1d()
 class TestSinh(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_sinh_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -41,7 +41,7 @@ class TestSinh(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestSin(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_sin_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -51,7 +51,7 @@ class TestSin(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestInplaceSin(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_inplace_sin_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -96,7 +96,7 @@ class TestCos(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestLogModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_log_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -105,14 +105,14 @@ class TestLogModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestSqrt(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_sqrt_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         z = torch.sqrt(x)
         return z
 
-    @autotest()
+    @autotest(n=5)
     def test_sqrt_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -122,7 +122,7 @@ class TestSqrt(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestExp(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_exp_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -132,7 +132,7 @@ class TestExp(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestRsqrt(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_rsqrt_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -142,14 +142,14 @@ class TestRsqrt(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestSquare(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_square_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         z = torch.square(x)
         return z
 
-    @autotest()
+    @autotest(n=5)
     def test_square_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -159,7 +159,7 @@ class TestSquare(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestPow(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_pow_float_scalar_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -186,21 +186,21 @@ class TestPow(flow.unittest.TestCase):
         y = random().to(int)
         return y ** x
 
-    @autotest()
+    @autotest(n=5)
     def test_pow_elementwise_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=2).to(device)
         y = random_tensor(ndim=2, dim1=2).to(device)
         return torch.pow(x, y)
 
-    @autotest()
+    @autotest(n=5)
     def test_pow_broadcast_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=2).to(device)
         y = random_tensor(ndim=2, dim1=1).to(device)
         return torch.pow(x, y)
 
-    @autotest()
+    @autotest(n=5)
     def test_pow_broadcast_with_random_data_reverse(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=1).to(device)
@@ -210,14 +210,14 @@ class TestPow(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAsin(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_asin_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.5).to(device)
         y = torch.asin(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_arcsin_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.5).to(device)
@@ -227,14 +227,14 @@ class TestAsin(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAsinh(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_asinh_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.asinh(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_arcsinh_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -244,7 +244,7 @@ class TestAsinh(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestTan(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_tan_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -254,21 +254,21 @@ class TestTan(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAtan(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_atan_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.atan(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_arctan_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.arctan(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_atan2_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=3).to(device)
@@ -276,14 +276,14 @@ class TestAtan(flow.unittest.TestCase):
         z = torch.atan2(x, y)
         return z
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_atanh_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.5).to(device)
         y = torch.atanh(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_arctanh_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.5).to(device)
@@ -309,14 +309,14 @@ class TestTopk(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestPow(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_pow_scalar_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = random().to(float)
         return torch.pow(x, y)
 
-    @autotest()
+    @autotest(n=5)
     def test_pow_elementwise_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=2).to(device)
@@ -324,7 +324,7 @@ class TestPow(flow.unittest.TestCase):
         return torch.pow(x, y)
 
     @unittest.skip("not support for broadcast currently")
-    @autotest()
+    @autotest(n=5)
     def test_pow_broadcast_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=2).to(device)
@@ -334,7 +334,7 @@ class TestPow(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestArccos(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_arccos_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-1, high=1).to(device)
@@ -344,7 +344,7 @@ class TestArccos(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAcos(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_acos_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-1, high=1).to(device)
@@ -354,7 +354,7 @@ class TestAcos(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestArccosh(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_arccosh_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=2, high=3).to(device)
@@ -364,7 +364,7 @@ class TestArccosh(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAcosh(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_acosh_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=2, high=3).to(device)
@@ -374,7 +374,7 @@ class TestAcosh(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAtan2(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_atan2_with_random_data(test_case):
         device = random_device()
         x1 = random_tensor(ndim=1, dim0=1).to(device)
@@ -385,7 +385,7 @@ class TestAtan2(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestMinimum(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_elementwise_minimum_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -393,7 +393,7 @@ class TestMinimum(flow.unittest.TestCase):
         y = random_tensor(ndim=2, dim0=k1, dim1=k2)
         return torch.minimum(x, y)
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_broadcast_minimum_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -405,7 +405,7 @@ class TestMinimum(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestMaximum(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_flow_elementwise_mximum_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -413,7 +413,7 @@ class TestMaximum(flow.unittest.TestCase):
         y = random_tensor(ndim=2, dim0=k1, dim1=k2)
         return torch.maximum(x, y)
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_broadcast_maximum_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)

--- a/python/oneflow/test/tensor/test_tensor_part_1.py
+++ b/python/oneflow/test/tensor/test_tensor_part_1.py
@@ -128,7 +128,7 @@ class TestTensor(flow.unittest.TestCase):
         test_case.assertEqual(str(np_arr), str(tensor.numpy()))
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_sign_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -136,7 +136,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tensor_gather_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=4, dim1=3, dim2=4, dim3=5).to(device)
@@ -453,7 +453,7 @@ class TestTensor(flow.unittest.TestCase):
         )
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_matmul_with_random_data(test_case):
         device = random_device()
         dim0 = random(low=2, high=10).to(int)
@@ -464,7 +464,7 @@ class TestTensor(flow.unittest.TestCase):
         return a @ b
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest()
+    @autotest(n=5)
     def test_mm_with_random_data(test_case):
         device = random_device()
         dim0 = random(low=2, high=10).to(int)
@@ -542,7 +542,7 @@ class TestTensor(flow.unittest.TestCase):
         compare_setitem_with_numpy(x, se[1, :, 2], v)
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_setitem_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=0, high=0, ndim=1, dim0=16).to(device)
@@ -591,7 +591,7 @@ class TestTensor(flow.unittest.TestCase):
         test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 0.0001, 0.0001))
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_mul_inplace_tensor(test_case):
         device = random_device()
         rand_tensor = random_tensor(
@@ -605,7 +605,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_broadcast_mul_inplace_tensor(test_case):
         device = random_device()
         rand_tensor = random_tensor(ndim=3, dim0=4, dim1=8, dim2=13).to(device)
@@ -615,7 +615,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_div_inplace_tensor(test_case):
         device = random_device()
         rand_tensor = random_tensor(
@@ -629,7 +629,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_broadcast_div_inplace_tensor(test_case):
         device = random_device()
         rand_tensor = random_tensor(ndim=3, dim0=4, dim1=8, dim2=13).to(device)
@@ -639,7 +639,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_add_inplace_tensor(test_case):
         device = random_device()
         rand_tensor = random_tensor(
@@ -653,7 +653,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_broadcast_add_inplace_tensor(test_case):
         device = random_device()
         rand_tensor = random_tensor(ndim=3, dim0=5, dim1=9, dim2=23).to(device)
@@ -663,7 +663,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_sub_inplace_tensor(test_case):
         device = random_device()
         rand_tensor = random_tensor(
@@ -677,7 +677,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_broadcast_sub_inplace_tensor(test_case):
         device = random_device()
         rand_tensor = random_tensor(ndim=3, dim0=5, dim1=9, dim2=23).to(device)
@@ -746,7 +746,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_tanh_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -754,7 +754,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tensor_asin_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.5).to(device)
@@ -762,7 +762,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tensor_arcsin_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.5).to(device)
@@ -770,7 +770,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tensor_asinh_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -778,7 +778,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tensor_arcsinh_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -786,7 +786,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tensor_sinh_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -794,7 +794,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_tensor_atan2_with_random_data(test_case):
         device = random_device()
         x1 = random_tensor(ndim=1, dim0=1).to(device)
@@ -803,7 +803,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_arccos_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=2, high=3).to(device)
@@ -811,7 +811,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_arccosh_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=2, high=3).to(device)
@@ -819,7 +819,7 @@ class TestTensor(flow.unittest.TestCase):
         return y
 
     @flow.unittest.skip_unless_1n1d()
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_acosh_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=2, high=3).to(device)
@@ -842,44 +842,44 @@ class TestTensor(flow.unittest.TestCase):
         y = x.argsort(dim=random(low=-4, high=4).to(int), descending=random_bool())
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_mean_with_random_data(test_case):
         device = random_device()
         dim = random(1, 4).to(int)
         x = random_tensor(ndim=4, dtype=float).to(device)
         return x.mean(dim)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_log_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         return x.log()
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_log1p_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         return x.log1p()
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_log2_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         return x.log2()
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_neg_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         return -x
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_negative_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         return x.negative()
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_neg_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -945,7 +945,7 @@ class TestTensor(flow.unittest.TestCase):
         y = x.fmod(2)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_flip_list_with_random_data(test_case):
         device = random_device()
         x = random_tensor(
@@ -954,7 +954,7 @@ class TestTensor(flow.unittest.TestCase):
         y = x.flip(constant([0, 1, 2]))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_flip_tuple_with_random_data(test_case):
         device = random_device()
         x = random_tensor(
@@ -963,7 +963,7 @@ class TestTensor(flow.unittest.TestCase):
         y = x.flip(constant((0, 1, 2)))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_chunk_list_with_random_data(test_case):
         device = random_device()
         dim = random(1, 4).to(int)
@@ -977,7 +977,7 @@ class TestTensor(flow.unittest.TestCase):
         z = torch.cat(y, dim=dim)
         return z
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_reciprocal_list_with_random_data(test_case):
         device = random_device()
         x = random_tensor(
@@ -1031,14 +1031,14 @@ class TestTensor(flow.unittest.TestCase):
             np.allclose(tensor.numpy(), np.array(scalar), 0.0001, 0.0001)
         )
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_floor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = x.floor()
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_round_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -1054,7 +1054,7 @@ class TestTensor(flow.unittest.TestCase):
         np_shape = (2, 2, 2, 2)
         test_case.assertTrue(np.allclose(of_shape, np_shape))
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flatten_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -1079,14 +1079,14 @@ class TestTensor(flow.unittest.TestCase):
         z = y.reshape_as(other=x)
         return z
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tensor_squeeze_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = x.squeeze(random().to(int))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_unsqueeze_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)

--- a/python/oneflow/test/tensor/test_tensor_part_2.py
+++ b/python/oneflow/test/tensor/test_tensor_part_2.py
@@ -54,7 +54,7 @@ class TestTensor(flow.unittest.TestCase):
         y = x.t()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_T_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=random(1, 4)).to(device)
@@ -146,7 +146,7 @@ class TestTensor(flow.unittest.TestCase):
             np.allclose(of_out.numpy(), np_out, 1e-05, 1e-05, equal_nan=True)
         )
 
-    @autotest()
+    @autotest(n=5)
     def test_addmm_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=2, dim0=2, dim1=3).to(device)
@@ -160,7 +160,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_addmm_broadcast_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=2, dim0=1, dim1=1).to(device)
@@ -174,7 +174,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clamp_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor(low=-2, high=2).to(device)
@@ -184,7 +184,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clamp_inplace_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-2, high=2).to(device)
@@ -206,7 +206,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clamp_minnone_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor(low=-2, high=2).to(device)
@@ -227,7 +227,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clamp_inplace_minnone_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-2, high=2).to(device)
@@ -249,7 +249,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clamp_maxnone_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor(low=-2, high=2).to(device)
@@ -259,7 +259,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clamp_inplace_maxnone_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-2, high=2).to(device)
@@ -270,7 +270,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clip_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor(low=-2, high=2).to(device)
@@ -280,7 +280,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clip_inplace_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-2, high=2).to(device)
@@ -291,7 +291,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clip_minnone_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor(low=-2, high=2).to(device)
@@ -301,7 +301,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clip_inplace_maxnone_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-2, high=2).to(device)
@@ -312,7 +312,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clip_maxnone_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
@@ -322,7 +322,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_clip_inplace_maxnone_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-2, high=2).to(device)
@@ -333,35 +333,35 @@ class TestTensor(flow.unittest.TestCase):
         )
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_ceil_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = len(input)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_ceil_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = input.ceil()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_expm1_tensor_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = input.expm1()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_floor_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = x.floor()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_tensor_var_all_dim_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -398,7 +398,7 @@ class TestTensor(flow.unittest.TestCase):
         test_case.assertTrue(np.allclose(of_out_2.numpy(), np_out_2, 1e-05, 1e-05))
         test_case.assertTrue(np.allclose(of_out_3.numpy(), np_out_3, 1e-05, 1e-05))
 
-    @autotest()
+    @autotest(n=5)
     def test_pow_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -406,49 +406,49 @@ class TestTensor(flow.unittest.TestCase):
         z = x.pow(y)
         return z
 
-    @autotest()
+    @autotest(n=5)
     def test_atanh_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.49).to(device)
         y = x.atanh()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_acos_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.49).to(device)
         y = x.acos()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_acosh_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=2.0, high=3.0).to(device)
         y = x.acosh()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_atan_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = x.atan()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_arctan_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = x.arctan()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_tan_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = x.tan()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_tan2_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim1=3).to(device)
@@ -456,7 +456,7 @@ class TestTensor(flow.unittest.TestCase):
         z = x.atan2(y)
         return z
 
-    @autotest()
+    @autotest(n=5)
     def test_arctanh_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor(low=-0.5, high=0.5).to(device)
@@ -682,13 +682,13 @@ class TestTensor(flow.unittest.TestCase):
         x = random_tensor(len(shape), *shape, requires_grad=False).to(device)
         return x.eq(x)
 
-    @autotest()
+    @autotest(n=5)
     def test_erf_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         return x.erf()
 
-    @autotest()
+    @autotest(n=5)
     def test_erfc_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -712,25 +712,25 @@ class TestTensor(flow.unittest.TestCase):
         y.erfinv_()
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_exp_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         return x.exp()
 
-    @autotest()
+    @autotest(n=5)
     def test_round_tensor_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         return x.round()
 
-    @autotest()
+    @autotest(n=5)
     def test_tensor_diag_one_dim(test_case):
         device = random_device()
         x = random_tensor(ndim=1, dim0=random()).to(device)
         return x.diag()
 
-    @autotest()
+    @autotest(n=5)
     def test_flow_tensor_expand_with_random_data(test_case):
         random_expand_size = random(1, 6).to(int).value()
         x = random_tensor(ndim=5, dim0=1, dim1=1, dim2=1, dim3=1, dim4=1)
@@ -768,7 +768,7 @@ class TestTensor(flow.unittest.TestCase):
         )
         return x.view_as(other)
 
-    @autotest()
+    @autotest(n=5)
     def test_tensor_diag_other_dim(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim0=random(), dim1=random()).to(device)


### PR DESCRIPTION
- [x] 减少 test_math_ops.py 运行时间。127s->47s。
- [x] 减少 test_loss.py 运行时间。168s->29s。
- [x] 减少 test_activation.py 运行时间。204s->68s。
- [x] 减少 test_tensor_part1.py 运行时间。119s->53s。
- [x] 减少 test_tensor_part2.py 运行时间。63s->38s。

以上几个耗时最高的Eager Test执行时间总和可以优化到原来执行时间的 (127+168+204+119+63) /(47+29+68+53+38)  = 681/235 约等于3倍。
