### PR TITLE
fix autotest bug and optimize eager test speed in ci

### DIFF
--- a/python/oneflow/test/modules/test_abs.py
+++ b/python/oneflow/test/modules/test_abs.py
@@ -30,7 +30,7 @@ class TestAbsModule(flow.unittest.TestCase):
         y = torch.abs(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_abs_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_adaptive_pool.py
+++ b/python/oneflow/test/modules/test_adaptive_pool.py
@@ -45,7 +45,7 @@ class TestAdaptiveAvgPool(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_adaptive_avgpool2d(test_case):
         m = torch.nn.AdaptiveAvgPool2d(output_size=random().to(_size_2_opt_t_not_none))
         m.train(random())
@@ -59,7 +59,7 @@ class TestAdaptiveAvgPool(flow.unittest.TestCase):
         version.parse(torch_original.__version__) < version.parse("1.10.0"),
         "GPU version 'nn.AdaptiveAvgPool3d' has a bug in PyTorch before '1.10.0'",
     )
-    @autotest()
+    @autotest(n=5)
     def test_adaptive_avgpool3d(test_case):
         m = torch.nn.AdaptiveAvgPool3d(output_size=random().to(_size_3_opt_t_not_none))
         m.train(random())
@@ -72,13 +72,13 @@ class TestAdaptiveAvgPool(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAdaptiveAvgPoolFunctional(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_adaptive_avgpool1d_functional(test_case):
         device = random_device()
         x = random_tensor(ndim=3).to(device)
         return torch.nn.functional.adaptive_avg_pool1d(x, output_size=random().to(int))
 
-    @autotest()
+    @autotest(n=5)
     def test_adaptive_avgpool2d_functional(test_case):
         device = random_device()
         x = random_tensor(ndim=4).to(device)
@@ -88,7 +88,7 @@ class TestAdaptiveAvgPoolFunctional(flow.unittest.TestCase):
         version.parse(torch_original.__version__) <= version.parse("1.10.0"),
         "GPU version 'nn.AdaptiveAvgPool3d' has a bug in PyTorch before '1.10.0'",
     )
-    @autotest()
+    @autotest(n=5)
     def test_adaptive_avgpool3d_functional(test_case):
         device = random_device()
         x = random_tensor(ndim=5).to(device)

--- a/python/oneflow/test/modules/test_add.py
+++ b/python/oneflow/test/modules/test_add.py
@@ -170,7 +170,7 @@ class TestAddModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_0_size_add(test_case):
         device = random_device()
         x = random_tensor(2, 0, 3).to(device)
@@ -178,7 +178,7 @@ class TestAddModule(flow.unittest.TestCase):
         out = x + y
         return out
 
-    @autotest(n=3, auto_backward=False, check_graph=True)
+    @autotest(n=3, auto_backward=False)
     def test_0dim_inplace_add(test_case):
         device = random_device()
         x = random_tensor(2, 2, 3, requires_grad=False).to(device)
@@ -186,7 +186,7 @@ class TestAddModule(flow.unittest.TestCase):
         x += y.mean()
         return x
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_0dim_two_inplace_add(test_case):
         device = random_device()
         x = random_tensor(2, 2, 3).to(device).mean()
@@ -194,7 +194,7 @@ class TestAddModule(flow.unittest.TestCase):
         x += y.mean()
         return x
 
-    @autotest(n=3, check_graph=True)
+    @autotest(n=3)
     def test_add_with_alpha(test_case):
         device = random_device()
         x1 = random_tensor(2, 2, 3).to(device).mean()
@@ -208,7 +208,7 @@ class TestAddModule(flow.unittest.TestCase):
         z3 = torch.add(s, x3, alpha=alpha)
         return z1, z2, z3
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(auto_backward=False)
     def test_bool_add(test_case):
         device = random_device()
         x = random_tensor(2, 1, 3).to(device, torch.bool)
@@ -216,7 +216,7 @@ class TestAddModule(flow.unittest.TestCase):
         out = x + y
         return out
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(auto_backward=False)
     def test_0shape_bool_add(test_case):
         device = random_device()
         x = random_tensor(2, 0, 3).to(device, torch.bool)
@@ -224,7 +224,7 @@ class TestAddModule(flow.unittest.TestCase):
         out = x + y
         return out
 
-    @autotest(n=3, auto_backward=False, check_graph=True)
+    @autotest(n=3, auto_backward=False)
     def test_0dim_bool_inplace_add(test_case):
         device = random_device()
         x = random_tensor(2, 2, 3, requires_grad=False).to(device, torch.bool)
@@ -232,7 +232,7 @@ class TestAddModule(flow.unittest.TestCase):
         x += y.mean().to(torch.bool)
         return x
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(auto_backward=False)
     def test_0dim_two_inplace_add(test_case):
         device = random_device()
         x = random_tensor(2, 2, 3).to(device).mean().to(torch.bool)
@@ -240,7 +240,7 @@ class TestAddModule(flow.unittest.TestCase):
         return x
         x += y.mean().to(torch.bool)
 
-    @autotest(n=3, check_graph=True)
+    @autotest(n=3)
     def test_add_with_alpha_0dim(test_case):
         device = random_device()
         x1 = random_tensor(ndim=0).to(device).mean()

--- a/python/oneflow/test/modules/test_addmm.py
+++ b/python/oneflow/test/modules/test_addmm.py
@@ -67,7 +67,7 @@ class TestAddmm(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_addmm_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=2, dim0=2, dim1=3).to(device)
@@ -82,7 +82,7 @@ class TestAddmm(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_addmm_broadcast_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=2, dim0=1, dim1=1).to(device)

--- a/python/oneflow/test/modules/test_amax.py
+++ b/python/oneflow/test/modules/test_amax.py
@@ -104,7 +104,7 @@ class TestAmax(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest()
+    @autotest(n=5)
     def test_amax_with_random_data_single_dim(test_case):
         device = random_device()
         ndim = random(1, 6).to(int)
@@ -112,7 +112,7 @@ class TestAmax(flow.unittest.TestCase):
         y = torch.amax(x, dim=random(0, ndim), keepdim=random().to(bool))
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_amax_with_random_data_empty_dim(test_case):
         device = random_device()
         ndim = random(1, 6).to(int)
@@ -120,7 +120,7 @@ class TestAmax(flow.unittest.TestCase):
         y = torch.amax(x, dim=None, keepdim=random().to(bool))
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_amax_with_random_data_multi_dims(test_case):
         device = random_device()
         ndim = random(2, 6).to(int)

--- a/python/oneflow/test/modules/test_amin.py
+++ b/python/oneflow/test/modules/test_amin.py
@@ -103,7 +103,7 @@ class TestAmax(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest()
+    @autotest(n=5)
     def test_amin_with_random_data_single_dim(test_case):
         device = random_device()
         ndim = random(1, 6).to(int)
@@ -111,7 +111,7 @@ class TestAmax(flow.unittest.TestCase):
         y = torch.amin(x, dim=random(0, ndim), keepdim=random().to(bool))
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_amin_with_random_data_empty_dim(test_case):
         device = random_device()
         ndim = random(1, 6).to(int)
@@ -119,7 +119,7 @@ class TestAmax(flow.unittest.TestCase):
         y = torch.amin(x, dim=None, keepdim=random().to(bool))
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_amin_with_random_data_multi_dims(test_case):
         device = random_device()
         ndim = random(2, 6).to(int)

--- a/python/oneflow/test/modules/test_avgpool.py
+++ b/python/oneflow/test/modules/test_avgpool.py
@@ -24,7 +24,7 @@ from oneflow.test_utils.automated_test_util import *
 
 @flow.unittest.skip_unless_1n1d()
 class TestAvgPoolingModule(flow.unittest.TestCase):
-    @autotest()
+    @autotest(n=5)
     def test_avgpool1d_with_random_data(test_case):
         m = torch.nn.AvgPool1d(
             kernel_size=random(4, 6),
@@ -40,7 +40,7 @@ class TestAvgPoolingModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_avgpool2d_with_random_data(test_case):
         m = torch.nn.AvgPool2d(
             kernel_size=random(4, 6),
@@ -57,7 +57,7 @@ class TestAvgPoolingModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_avgpool3d_with_random_data(test_case):
         m = torch.nn.AvgPool3d(
             kernel_size=random(4, 6),
@@ -79,7 +79,7 @@ class TestAvgPoolingModule(flow.unittest.TestCase):
 
 @flow.unittest.skip_unless_1n1d()
 class TestAvgPoolingFunctional(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_avgpool1d_functional(test_case):
         device = random_device()
         x = random_tensor(ndim=3, dim2=random(20, 22)).to(device)
@@ -93,7 +93,7 @@ class TestAvgPoolingFunctional(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_avgpool2d_functional(test_case):
         device = random_device()
         x = random_tensor(ndim=4, dim2=random(20, 22), dim3=random(20, 22)).to(device)
@@ -107,7 +107,7 @@ class TestAvgPoolingFunctional(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_avgpool3d_functional(test_case):
         device = random_device()
         x = random_tensor(

--- a/python/oneflow/test/modules/test_ceil.py
+++ b/python/oneflow/test/modules/test_ceil.py
@@ -25,28 +25,28 @@ from oneflow.test_utils.automated_test_util import *
 
 @flow.unittest.skip_unless_1n1d()
 class TestCeilModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_ceil_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = torch.ceil(input)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_ceil_flow_with_random_0d_data(test_case):
         device = random_device()
         input = random_tensor(ndim=0).to(device)
         y = torch.ceil(input)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_ceil_with_0_size_data(test_case):
         device = random_device()
         x = random_tensor(4, 2, 1, 0, 3).to(device)
         y = torch.ceil(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_ceil_with_0shape_0d_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_clamp.py
+++ b/python/oneflow/test/modules/test_clamp.py
@@ -108,21 +108,21 @@ class TestClampModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_clamp_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = torch.clamp(input, min=random().to(float), max=random().to(float))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_clamp_min_none_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = torch.clamp(input, min=random().to(float), max=random().to(float))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_clamp_max_none_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
@@ -131,21 +131,21 @@ class TestClampModule(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_clip_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = torch.clip(input, min=random().to(float), max=random().to(float))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_clip_min_none_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = torch.clip(input, min=random().to(float), max=random().to(float))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_clip_max_none_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
@@ -154,7 +154,7 @@ class TestClampModule(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_clamp_with_0_size_data(test_case):
         device = random_device()
         x = random_tensor(4, 2, 1, 0, 3).to(device)

--- a/python/oneflow/test/modules/test_concat.py
+++ b/python/oneflow/test/modules/test_concat.py
@@ -134,7 +134,7 @@ class TestModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_cat_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim0=random(), dim1=random()).to(device)
@@ -160,7 +160,7 @@ class TestModule(flow.unittest.TestCase):
             input_list.append(y)
         return torch.cat(tuple(input_list), random(0, 2).to(int))
 
-    @autotest(n=10, auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_concat_with_input_0_size_data(test_case):
         device = random_device()
         x = random_tensor(4, 2, 3, 2, 4).to(device)
@@ -168,7 +168,7 @@ class TestModule(flow.unittest.TestCase):
         z = torch.cat((x, y), dim=2)
         return z
 
-    @autotest(n=10, auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_concat_with_output_0_size_data(test_case):
         device = random_device()
         x = random_tensor(4, 2, 0, 2, 4).to(device)
@@ -177,13 +177,13 @@ class TestModule(flow.unittest.TestCase):
         z = torch.cat((x, y), dim=dim)
         return z
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_cat_bool_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=2, dim0=random(), dim1=random()).to(device, torch.bool)
         return torch.cat((x, x, x), random(0, 2).to(int))
 
-    @autotest(n=10, check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_cat_only_one_tensor(test_case):
         device = random_device()
         x = random_tensor(4, 2, 3, random(0, 3)).to(device)

--- a/python/oneflow/test/modules/test_conv1d.py
+++ b/python/oneflow/test/modules/test_conv1d.py
@@ -443,7 +443,7 @@ class TestConv1d(flow.unittest.TestCase):
         y = torch.nn.functional.conv1d(img, kernel, groups=3)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_conv1d_with_random_data(test_case):
         channels = random(1, 6)
         m = torch.nn.Conv1d(
@@ -464,7 +464,7 @@ class TestConv1d(flow.unittest.TestCase):
         return y
 
     @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
-    @autotest(n=30, check_allclose=False)
+    @autotest(n=5, check_allclose=False)
     def test_conv1d_group_with_random_data(test_case):
         channels = 720  # lcm(1, 2, 3, 4, 5, 6)
         m = torch.nn.Conv1d(

--- a/python/oneflow/test/modules/test_conv2d.py
+++ b/python/oneflow/test/modules/test_conv2d.py
@@ -1831,7 +1831,7 @@ class TestConv2d(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest()
+    @autotest(n=5)
     def test_conv2d_with_random_data(test_case):
         channels = random(1, 6)
         m = torch.nn.Conv2d(
@@ -1851,7 +1851,7 @@ class TestConv2d(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(check_graph=False)
+    @autotest(n=5, check_graph=False)
     def test_conv2d_0size_with_random_data(test_case):
         channels = random(1, 6)
         m = torch.nn.Conv2d(
@@ -1872,7 +1872,7 @@ class TestConv2d(flow.unittest.TestCase):
         return y
 
     @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
-    @autotest(n=30, check_allclose=False)
+    @autotest(n=5, check_allclose=False)
     def test_conv2d_group_with_random_data(test_case):
         channels = 720  # lcm(1, 2, 3, 4, 5, 6)
         m = torch.nn.Conv2d(

--- a/python/oneflow/test/modules/test_div.py
+++ b/python/oneflow/test/modules/test_div.py
@@ -98,7 +98,7 @@ class TestDiv(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             _test_div_impl(test_case, *arg)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_random_dim_div(test_case):
         device = random_device()
         dim0 = random(low=1, high=4).to(int)
@@ -108,7 +108,7 @@ class TestDiv(flow.unittest.TestCase):
         z = x / y
         return z
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_random_dim_scalar_div(test_case):
         device = random_device()
         dim0 = random(low=1, high=4).to(int)
@@ -118,7 +118,7 @@ class TestDiv(flow.unittest.TestCase):
         z = x / y
         return z
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_0_size_div(test_case):
         device = random_device()
         x = random_tensor(4, 2, 1, 0, 3).to(device)
@@ -126,7 +126,7 @@ class TestDiv(flow.unittest.TestCase):
         z = x / y
         return z
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_0dim_div(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_eq.py
+++ b/python/oneflow/test/modules/test_eq.py
@@ -28,7 +28,7 @@ from oneflow.test_utils.automated_test_util import *
 
 @flow.unittest.skip_unless_1n1d()
 class TestEq(flow.unittest.TestCase):
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_eq_with_0_size_data(test_case):
         device = random_device()
         x = random_tensor(3, 2, 0, 3).to(device)
@@ -36,7 +36,7 @@ class TestEq(flow.unittest.TestCase):
         z = torch.eq(x, y)
         return z
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_eq_with_0shape_0d_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
@@ -44,16 +44,15 @@ class TestEq(flow.unittest.TestCase):
         z = torch.eq(x, y)
         return z
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_eq_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
-        print(*shape)
         x = random_tensor(len(shape), *shape, requires_grad=False).to(device)
         y = random_tensor(len(shape), *shape, requires_grad=False).to(device)
         return torch.eq(x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_eq_with_random_0d_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -61,14 +60,14 @@ class TestEq(flow.unittest.TestCase):
         y = random_tensor(ndim=0, requires_grad=False).to(device)
         return torch.eq(x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_eq_with_same_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
         x = random_tensor(len(shape), *shape, requires_grad=False).to(device)
         return torch.eq(x, x)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_eq_bool_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -80,7 +79,7 @@ class TestEq(flow.unittest.TestCase):
         )
         return torch.eq(x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_eq_with_same_random_0d_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape

--- a/python/oneflow/test/modules/test_erf.py
+++ b/python/oneflow/test/modules/test_erf.py
@@ -29,14 +29,14 @@ from oneflow.test_utils.automated_test_util import *
 
 @flow.unittest.skip_unless_1n1d()
 class TestErfModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_erf_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.erf(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_erf_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_erfc.py
+++ b/python/oneflow/test/modules/test_erfc.py
@@ -29,14 +29,14 @@ from oneflow.test_utils.automated_test_util import *
 
 @flow.unittest.skip_unless_1n1d()
 class TestErfcModule(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_erfc_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.erfc(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_erfc_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_expm1.py
+++ b/python/oneflow/test/modules/test_expm1.py
@@ -51,21 +51,21 @@ class TestExpm1Module(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_expm1_flow_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
         y = torch.expm1(input)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_expm1_with_0_size_data(test_case):
         device = random_device()
         x = random_tensor(4, 2, 1, 0, 3).to(device)
         y = torch.expm1(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_expm1_flow_with_0dim_data(test_case):
         device = random_device()
         input = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_flatten.py
+++ b/python/oneflow/test/modules/test_flatten.py
@@ -67,7 +67,7 @@ class TestFlattenModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flatten_module_with_random_data(test_case):
         m = torch.nn.Flatten(
             start_dim=random(1, 6) | nothing(), end_dim=random(1, 6) | nothing()
@@ -79,7 +79,7 @@ class TestFlattenModule(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flatten_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
@@ -90,7 +90,7 @@ class TestFlattenModule(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flatten_bool_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device=device, dtype=torch.bool)
@@ -101,7 +101,7 @@ class TestFlattenModule(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flatten_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_flip.py
+++ b/python/oneflow/test/modules/test_flip.py
@@ -37,7 +37,7 @@ class TestFlip(flow.unittest.TestCase):
         y = torch.flip(x, constant([0, 1, 2]))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_flip_tuple_with_random_data(test_case):
         device = random_device()
         x = random_tensor(
@@ -46,7 +46,7 @@ class TestFlip(flow.unittest.TestCase):
         y = torch.flip(x, constant((0, 1, 2)))
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_flip_bool_tuple_with_random_data(test_case):
         device = random_device()
         x = random_tensor(

--- a/python/oneflow/test/modules/test_greater.py
+++ b/python/oneflow/test/modules/test_greater.py
@@ -100,7 +100,7 @@ class TestGreater(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(n=10, auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_greater_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -109,7 +109,7 @@ class TestGreater(flow.unittest.TestCase):
         y = torch.gt(x1, oneof(x2, random().to(int), random().to(float)))
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_tensor_greater_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -119,7 +119,7 @@ class TestGreater(flow.unittest.TestCase):
         y2 = x1 > x2
         return (y1, y2)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_greater_with_0_size_data(test_case):
         device = random_device()
         x1 = random_tensor(4, 2, 3, 0, 5).to(device)
@@ -128,7 +128,7 @@ class TestGreater(flow.unittest.TestCase):
         y2 = x1 > x2
         return (y1, y2)
 
-    @autotest(n=10, auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_greater_bool_with_random_data(test_case):
         device = random_device()
         shape = random_tensor().oneflow.shape
@@ -141,7 +141,7 @@ class TestGreater(flow.unittest.TestCase):
         y = torch.gt(x1, oneof(x2, random().to(int), random().to(float)))
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_greater_with_0dim_data(test_case):
         device = random_device()
         x1 = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_linear.py
+++ b/python/oneflow/test/modules/test_linear.py
@@ -180,7 +180,7 @@ class TestLinear(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest()
+    @autotest(n=5)
     def test_linear_with_random_data(test_case):
         input_size = random()
         m = torch.nn.Linear(
@@ -193,7 +193,7 @@ class TestLinear(flow.unittest.TestCase):
         y = m(x)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_nn_functional_linear_with_random_data(test_case):
         input_size = random()
         device = random_device()
@@ -202,7 +202,7 @@ class TestLinear(flow.unittest.TestCase):
         y = torch.nn.functional.linear(x, weight)
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_nn_functional_bias_linear_with_random_data(test_case):
         input_size = random()
         bias_size = random()
@@ -213,7 +213,7 @@ class TestLinear(flow.unittest.TestCase):
         y = torch.nn.functional.linear(x, weight, bias)
         return y
 
-    @autotest()
+    @autotest(n=5)
     def test_identity_with_random_data(test_case):
         m = torch.nn.Identity(
             x=random().to(int),

--- a/python/oneflow/test/modules/test_linspace.py
+++ b/python/oneflow/test/modules/test_linspace.py
@@ -28,7 +28,7 @@ from oneflow.test_utils.automated_test_util import *
 
 @flow.unittest.skip_unless_1n1d()
 class TestLinspace(flow.unittest.TestCase):
-    @autotest(n=30, auto_backward=False, rtol=1e-5, atol=1e-5, check_graph=True)
+    @autotest(n=5, auto_backward=False, rtol=1e-5, atol=1e-5, check_graph=True)
     def test_linspace_int_with_random_data(test_case):
         start = random().to(int)
         end = start + random().to(int)
@@ -38,7 +38,7 @@ class TestLinspace(flow.unittest.TestCase):
         x.to(device)
         return x
 
-    @autotest(n=30, auto_backward=False, rtol=1e-5, atol=1e-5, check_graph=True)
+    @autotest(n=5, auto_backward=False, rtol=1e-5, atol=1e-5, check_graph=True)
     def test_linspace_float_with_random_data(test_case):
         start = random()
         end = start + random()

--- a/python/oneflow/test/modules/test_norm.py
+++ b/python/oneflow/test/modules/test_norm.py
@@ -263,7 +263,7 @@ class TestNormModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_no_dim_no_ord_norm_with_random_data(test_case):
         device = random_device()
         input = random_tensor().to(device)
@@ -271,7 +271,7 @@ class TestNormModule(flow.unittest.TestCase):
         m = torch.linalg.norm(input, keepdim=keepdim)
         return m
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_one_dim_norm_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=4).to(device)
@@ -282,7 +282,7 @@ class TestNormModule(flow.unittest.TestCase):
         m = torch.linalg.norm(input, ord, dim, keepdim)
         return m
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_no_dim_one_shape_norm_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=1).to(device)
@@ -292,7 +292,7 @@ class TestNormModule(flow.unittest.TestCase):
         m = torch.linalg.norm(input, ord=ord, keepdim=keepdim)
         return m
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_no_dim_two_shape_norm_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=2).to(device)
@@ -301,7 +301,7 @@ class TestNormModule(flow.unittest.TestCase):
         m = torch.linalg.norm(input, ord=ord, keepdim=keepdim)
         return m
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_tuple_dim_norm_with_random_data(test_case):
         device = random_device()
         input = random_tensor(ndim=2).to(device)

--- a/python/oneflow/test/modules/test_prod.py
+++ b/python/oneflow/test/modules/test_prod.py
@@ -22,7 +22,7 @@ import oneflow.unittest
 
 @flow.unittest.skip_unless_1n1d()
 class TestReduceProd(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_reduce_prod_without_dim(test_case):
         device = random_device()
         ndim = random(1, 5).to(int)
@@ -31,7 +31,7 @@ class TestReduceProd(flow.unittest.TestCase):
 
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_reduce_prod_with_dim(test_case):
         device = random_device()
         ndim = random(1, 5).to(int)
@@ -42,7 +42,7 @@ class TestReduceProd(flow.unittest.TestCase):
 
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_reduce_prod_bool_without_dim(test_case):
         device = random_device()
         ndim = random(1, 5).to(int)
@@ -51,7 +51,7 @@ class TestReduceProd(flow.unittest.TestCase):
 
         return y
 
-    @autotest(auto_backward=False, check_graph=False)
+    @autotest(n=5, auto_backward=False, check_graph=False)
     def test_reduce_prod_with_dtype(test_case):
         device = random_device()
         ndim = random(1, 5).to(int)

--- a/python/oneflow/test/modules/test_reshape.py
+++ b/python/oneflow/test/modules/test_reshape.py
@@ -95,21 +95,21 @@ class TestModule(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_reshape_flow_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=4).to(device)
         y = torch.reshape(x, shape=(-1,))
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_reshape_flow_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)
         y = torch.reshape(x, shape=(-1,))
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_reshape_with_0_size_data(test_case):
         device = random_device()
         x = random_tensor(4, 2, 0, 3).to(device)
@@ -118,7 +118,7 @@ class TestModule(flow.unittest.TestCase):
         )
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_reshape_flow_bool_with_random_data(test_case):
         device = random_device()
         x = random_tensor(ndim=4).to(device=device, dtype=torch.bool)

--- a/python/oneflow/test/modules/test_sign.py
+++ b/python/oneflow/test/modules/test_sign.py
@@ -49,28 +49,28 @@ class TestSign(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             _test_sign_impl(test_case, *arg)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_sign_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device)
         y = torch.sign(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_sign_with_0_size_data(test_case):
         device = random_device()
         x = random_tensor(4, 2, 3, 0, 4).to(device)
         y = torch.sign(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_sign_with_random_data(test_case):
         device = random_device()
         x = random_tensor().to(device=device, dtype=torch.bool)
         y = torch.sign(x)
         return y
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_sign_with_0dim_data(test_case):
         device = random_device()
         x = random_tensor(ndim=0).to(device)

--- a/python/oneflow/test/modules/test_split.py
+++ b/python/oneflow/test/modules/test_split.py
@@ -24,7 +24,7 @@ import oneflow.unittest
 
 @flow.unittest.skip_unless_1n1d()
 class TestSplit(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_split_with_random_data(test_case):
         k0 = random(2, 6)
         k1 = random(2, 6)
@@ -35,7 +35,7 @@ class TestSplit(flow.unittest.TestCase):
         res = torch.split(x, 2, dim=rand_dim)
         return torch.cat(res, rand_dim)
 
-    @autotest(n=10, check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_flow_split_with_stride(test_case):
         k0 = random(2, 6)
         k1 = random(2, 6)
@@ -49,7 +49,7 @@ class TestSplit(flow.unittest.TestCase):
         z = torch.split(y, 2, dim=rand_dim)
         return torch.cat(z, rand_dim)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_split_sizes_with_random_data(test_case):
         k0 = random(2, 6)
         k1 = 7
@@ -59,7 +59,7 @@ class TestSplit(flow.unittest.TestCase):
         res = torch.split(x, [1, 2, 3, 1], dim=1)
         return torch.cat(res, dim=1)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_split_sizes_neg_dim_with_random_data(test_case):
         k0 = random(2, 6)
         k1 = 7
@@ -69,7 +69,7 @@ class TestSplit(flow.unittest.TestCase):
         res = torch.split(x, [1, 2, 3, 1], dim=-2)
         return torch.cat(res, dim=1)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_split_bool_with_random_data(test_case):
         k0 = random(2, 6)
         k1 = random(2, 6)

--- a/python/oneflow/test/modules/test_tril.py
+++ b/python/oneflow/test/modules/test_tril.py
@@ -22,7 +22,7 @@ import oneflow.unittest
 
 @flow.unittest.skip_unless_1n1d()
 class TestTril(flow.unittest.TestCase):
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_tril_without_diag(test_case):
         device = random_device()
         x = random_tensor(
@@ -37,7 +37,7 @@ class TestTril(flow.unittest.TestCase):
 
         return y
 
-    @autotest(check_graph=True)
+    @autotest(n=5, check_graph=True)
     def test_tril_with_diag(test_case):
         device = random_device()
         diagonal = random(-3, 3).to(int)

--- a/python/oneflow/test/modules/test_where.py
+++ b/python/oneflow/test/modules/test_where.py
@@ -209,7 +209,7 @@ class TestWhere(flow.unittest.TestCase):
         for arg in GenArgList(arg_dict):
             arg[0](test_case, *arg[1:])
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_where_tensor_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -219,7 +219,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random_tensor(ndim=2, dim0=k1, dim1=k2).to(device)
         return torch.where(cond > 0, x, y)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_where_tensor_with_0dim_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -229,7 +229,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random_tensor(ndim=0).to(device)
         return torch.where(cond > 0, x, y)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_where_tensor_broadcast_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -239,7 +239,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random_tensor(ndim=2, dim0=k1, dim1=1).to(device)
         return torch.where(cond > 0, x, y)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_where_scalar_x_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -251,7 +251,7 @@ class TestWhere(flow.unittest.TestCase):
         )
         return torch.where(cond > 0, x, y)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_where_scalar_x_broadcast_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -263,7 +263,7 @@ class TestWhere(flow.unittest.TestCase):
         )
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_x_int_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -273,7 +273,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random_tensor(ndim=2, dim0=k1, dim1=k2, dtype=int).to(device)
         return torch.where(cond > 0, x, y)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_where_scalar_y_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -285,7 +285,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random().to(float)
         return torch.where(cond > 0, x, y)
 
-    @autotest(check_graph=True)
+    @autotest(n=5)
     def test_flow_where_scalar_y_broadcast_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -297,7 +297,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random().to(float)
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_y_int_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -307,7 +307,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random().to(int)
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_xy_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -317,7 +317,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random().to(float)
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_xy_int_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -327,7 +327,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random().to(int)
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_tensor_bool_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -337,7 +337,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random_tensor(ndim=2, dim0=k1, dim1=k2).to(device=device, dtype=torch.bool)
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_tensor_broadcast_bool_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -347,7 +347,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random_tensor(ndim=2, dim0=k1, dim1=1).to(device=device, dtype=torch.bool)
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_x_bool_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -359,7 +359,7 @@ class TestWhere(flow.unittest.TestCase):
         )
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_x_broadcast_bool_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -371,7 +371,7 @@ class TestWhere(flow.unittest.TestCase):
         )
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_y_bool_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -383,7 +383,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random().to(bool)
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_y_broadcast_bool_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)
@@ -395,7 +395,7 @@ class TestWhere(flow.unittest.TestCase):
         y = random().to(bool)
         return torch.where(cond > 0, x, y)
 
-    @autotest(auto_backward=False, check_graph=True)
+    @autotest(n=5, auto_backward=False, check_graph=True)
     def test_flow_where_scalar_xy_bool_with_random_data(test_case):
         k1 = random(2, 6)
         k2 = random(2, 6)

--- a/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
+++ b/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
@@ -251,6 +251,8 @@ def check_eager_graph_tensor(eager_res, graph_res):
             equal_nan=True,
         )
         return equality_res
+    else:
+        return True
 
 
 # NOTE(lixiang): Deepcopy the input parameters in order to correctly test the inplace version of the op.
@@ -428,8 +430,8 @@ def get_tensor_graph_res(
                 oneflow,
                 "nn.Graph",
                 "get_tensor_graph_res",
-                oneflow_args,
-                oneflow_kwargs,
+                tensor_graph_args,
+                tensor_graph_kwargs,
             )
         raise OneFlowGraphBuildOrRunError(e)
     return test_g_res
@@ -509,17 +511,6 @@ def oneflow_eager_run_with_graph_check(
             if isinstance(test_g_res, tuple):
                 for _, g_res in enumerate(test_g_res):
                     if not check_eager_graph_tensor(oneflow_res, g_res):
-                        if verbose:
-                            get_fake_program_more_detail(
-                                oneflow,
-                                "Eager + nn.Graph",
-                                "oneflow_eager_run_with_graph_check",
-                                oneflow_args,
-                                oneflow_kwargs,
-                            )
-            else:
-                if not check_eager_graph_tensor(oneflow_res, test_g_res):
-                    if verbose:
                         get_fake_program_more_detail(
                             oneflow,
                             "Eager + nn.Graph",
@@ -527,6 +518,15 @@ def oneflow_eager_run_with_graph_check(
                             oneflow_args,
                             oneflow_kwargs,
                         )
+            else:
+                if not check_eager_graph_tensor(oneflow_res, test_g_res):
+                    get_fake_program_more_detail(
+                        oneflow,
+                        "Eager + nn.Graph",
+                        "oneflow_eager_run_with_graph_check",
+                        oneflow_args,
+                        oneflow_kwargs,
+                    )
     return oneflow_res
 
 


### PR DESCRIPTION
- [x] 修复AutoTest打印fake_program时一个判断条件写错的bug。
- [x] 减少 test_adaptive.py 运行时间。25s->11s。
- [x] 减少test_addmm.py 运行时间。12s->8s。
- [x] 减少test_amax.py 运行时间。17s->8s.
- [x] 减少test_amin.py 运行时间。16s->8s。
- [x] 减少 test_avgpool.py 运行时间。28s->11s。
- [x] 减少 test_ceil.py 运行时间。20s->9s。
- [x] 减少 test_clamp.py 运行时间。30s->11s。
- [x] 减少test_concat.py 运行时间。20s->12s。
- [x] 减少test_conv1d.py 运行时间。26s->10s。
- [x] 减少test_conv2d.py 运行时间。23s->11s。
- [x] 减少test_div.py 运行时间。20s->9s。
- [x]  减少 test_eq.py 运行时间。32s->12s。
- [x] 减少 test_erf.py / test_erfc.py 运行时间。13s->7s。
- [x] 减少test_expm1.py 运行时间。16s->8s。
- [x] 减少 test_flatten.py 运行时间。20s->9s。
- [x] 减少test_flip.py 运行时间。16s->11s。
- [x] 减少 test_greater.py 运行时间。26s->12s。
- [x] 减少 test_linear.py 运行时间。21s->9s。
- [x] 减少 test_linspace.py 运行时间。16s->7s。
- [x] 减少 test_norm.py 运行时间。25s->11s。
- [x] 减少 test_prod.py 运行时间。20s->9s。
- [x] 减少 test_reshape.py 运行时间。20s->9s。
- [x] 减少test_sign.py 运行时间。15s->9s。
- [x] 减少test_split.py 运行时间。40s->14s。
- [x] 减少test_tril.py 运行时间。20s->9s。
- [x] 减少test_where.py 运行时间。137s->37s。

以上CI里耗时大于10s的Eager Test可以优化到原来总执行时间的 (25+12+17+16+28+20+30+20+26+23+20+32+13+16+20+16+26+21+16+25+20+20+15+40+20+137) /(11+8+8+8+11+9+11+12+10+11+9+12+7+8+9+11+12+9+7+11+9+9+9+14+9+37)  = 674/291 等于2.3倍。

