### PR TITLE
WIP: support nn_graph inplace operation and reuse memory (does not need to be reviewed!)

### DIFF
--- a/oneflow/core/framework/op_expr.h
+++ b/oneflow/core/framework/op_expr.h
@@ -174,6 +174,7 @@ class UserOpExpr final : public BuiltinOpExprImpl<UserOpConf> {
   user_op::DeviceAndStreamInferFn device_and_stream_infer_fn_;
   mutable HashMap<Symbol<Stream>, std::shared_ptr<StatefulOpKernel>> stream2kernel_;
   std::shared_ptr<ConsistentTensorInferCache> consistent_tensor_infer_cache_;
+  bool is_inplace_operation;
 };
 
 class ConsistentToConsistentOpExpr : public OpExpr {


### PR DESCRIPTION
### 支持Graph 模式下的inplace算子



**现状**：目前的算子`Functor`调用`OpBuilder`生成`UserOpExpr`的时候，在build output的时候都会给output的tensor生成一个新的logical blob name：

```c++
Maybe<OpBuilder&> OpBuilder::MaybeOutput(const std::string& output_name, const int count) {
  CHECK_GT_OR_RETURN(count, 0);
  CHECK_EQ_OR_RETURN(proto_.output().count(output_name), 0)
      << "The output " << output_name << " has been specified more than once.";
  proto_.add_output_order(output_name);
  auto* output_list = &((*(proto_.mutable_output()))[output_name]);
  for (int i = 0; i < count; ++i) {
    const std::string& tensor_name = op_name_ + "/" + output_name + "_" + std::to_string(i);
    output_list->mutable_s()->Add()->assign(tensor_name);
    indexed_obns_.emplace_back(output_name + "_" + std::to_string(i));
  }
  CHECK_EQ_OR_RETURN(proto_.output().size(), proto_.output_order().size());
  return *this;
}
```

对于不是inplace的算子，这个没有问题，但对于inplace的算子，这样会生成一个全新的logical blob name，这样C++端和python端inplace的逻辑就不太一致，所以为了解决这个问题，让算子在C++层也能inplace，提出以下解决方案。



1. 给`UserOpExpr` class增加一个flag - `is_inplace`来显示这个算子是否是inplace算子，这个flag可以在OpBuilder build output (`OpBuilder**&** Output(**const** std::string**&** output_name);`)的时候输入这个flag。如果是inplace， 就不生产一个新的logical blob name，还是复用input的logical blob name。
2. 这个`is_inplace`的flag需要传递到Kernel执行之前，在Kernel执行之前检查这个flag
   1. 如果`is_inplace`是false，照常执行
   2. 如果`is_inplace`是true，分配一个新的临时内存，用这个内存去kernel Compute，执行完之后，把这个临时内存的内容memcpy到input的内存，并释放这个零时内存