### PR TITLE
重构 oneflow.autograd 文档

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -30,15 +30,7 @@ Locally disabling gradient computation
 Default gradient layouts
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-If ``create_graph=True``, ``backward()`` replaces ``.grad`` with a
-new tensor ``.grad + new grad``, which attempts (but does not guarantee)
-matching the preexisting ``.grad``'s strides.
-
-The default behavior (letting ``.grad``\ s be ``None`` before the first
-``backward()``, such that their layout is created according to 1 or 2,
-and retained over time according to 3 or 4) is recommended for best performance.
-Calls to ``model.zero_grad()`` or ``optimizer.zero_grad()`` will not affect ``.grad``
-layouts.
+``backward()`` replaces ``.grad`` with a new tensor ``.grad + new grad``.
 
 In-place operations on Tensors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -27,12 +27,13 @@ Locally disabling gradient computation
     set_grad_enabled
     inference_mode
 
-Default gradient layouts
-^^^^^^^^^^^^^^^^^^^^^^^^
+.. TODO(wyg): uncomment this after aligning accumulate grad
+.. Default gradient layouts
+.. ^^^^^^^^^^^^^^^^^^^^^^^^
 
-A ``param.grad`` is accumulated by replacing ``.grad`` with a 
-new tensor ``.grad + new grad`` during :func:`oneflow.autograd.backward()` or 
-:func:`oneflow.Tensor.backward()`.
+.. A ``param.grad`` is accumulated by replacing ``.grad`` with a 
+.. new tensor ``.grad + new grad`` during :func:`oneflow.autograd.backward()` or 
+.. :func:`oneflow.Tensor.backward()`.
 
 In-place operations on Tensors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -30,7 +30,9 @@ Locally disabling gradient computation
 Default gradient layouts
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-``backward()`` replaces ``.grad`` with a new tensor ``.grad + new grad``.
+A ``param.grad`` is accumulated by replacing ``.grad`` with a 
+new tensor ``.grad + new grad`` during :func:`oneflow.autograd.backward()` or 
+:func:`oneflow.Tensor.backward()`.
 
 In-place operations on Tensors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -1,21 +1,56 @@
 oneflow.autograd
-================================================
-oneflow.autograd provides classes and functions implementing automatic differentiation of arbitrary scalar valued functions. It requires minimal changes to the existing code - you only need to declare Tensor s for which gradients should be computed with the requires_grad=True keyword. 
+====================================================
+
+``oneflow.autograd`` provides classes and functions implementing automatic differentiation of arbitrary scalar 
+valued functions. It requires minimal changes to the existing code - you only need to declare ``Tensor`` s 
+for which gradients should be computed with the ``requires_grad=True`` keyword. As of now, we only support 
+autograd for floating point ``Tensor`` types ( half, float, double and bfloat16).
+
 
 .. currentmodule:: oneflow.autograd
-
-Functions and classes for autograd.
----------------------------------------------------
 
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
-    grad
     backward
+    grad
+
+Locally disabling gradient computation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    no_grad
+    enable_grad
+    set_grad_enabled
+    inference_mode
+
+Default gradient layouts
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If ``create_graph=True``, ``backward()`` replaces ``.grad`` with a
+new tensor ``.grad + new grad``, which attempts (but does not guarantee)
+matching the preexisting ``.grad``'s strides.
+
+The default behavior (letting ``.grad``\ s be ``None`` before the first
+``backward()``, such that their layout is created according to 1 or 2,
+and retained over time according to 3 or 4) is recommended for best performance.
+Calls to ``model.zero_grad()`` or ``optimizer.zero_grad()`` will not affect ``.grad``
+layouts.
+
+In-place operations on Tensors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Supporting in-place operations in autograd is a hard matter, and we discourage
+their use in most cases. Autograd's aggressive buffer freeing and reuse makes
+it very efficient and there are very few occasions when in-place operations
+actually lower memory usage by any significant amount. Unless you're operating
+under heavy memory pressure, you might never need to use them.
 
 Tensor autograd functions
----------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autosummary::
     :nosignatures:
 
@@ -27,6 +62,28 @@ Tensor autograd functions
    oneflow.Tensor.register_hook
    oneflow.Tensor.retain_grad
 
-.. autoclass:: oneflow.autograd.Function
-    :members: apply,
-    :special-members: __call__,
+Function
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: Function
+.. currentmodule:: oneflow.autograd
+.. autosummary::
+    :toctree generated
+    :nosignatures:
+
+    Function.forward
+    Function.backward
+    Function.apply
+
+Context method mixins
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+When creating a new :class:`Function`, the following methods are available to `ctx`.
+
+.. currentmodule:: oneflow.autograd.autograd_function
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    
+    FunctionAutoGradCaptureState.mark_non_differentiable
+    FunctionAutoGradCaptureState.save_for_backward
+    FunctionAutoGradCaptureState.saved_tensors

--- a/python/oneflow/autograd/autograd_function.py
+++ b/python/oneflow/autograd/autograd_function.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from oneflow._oneflow_internal import TensorTuple
-from oneflow._oneflow_internal.autograd import AutogradFunctionBase
+from oneflow._oneflow_internal.autograd import AutogradFunctionBase, FunctionAutoGradCaptureState
 
 
 class Function(AutogradFunctionBase):


### PR DESCRIPTION
1. 参照 pytorch 文档和王迎港老师的指导重构 autograd 文档
2. 在 autograd_function.py 导入已经完成的接口 FunctionAutoGradCaptureState

### 重构思路
1. oneflow 的 autograd 模块在接口上与 pytorch 基本一致，因此参考 pytorch 文档进行重构
2. Default gradient layouts 模块只描述 oneflow 内部的求导机制
3. Function 和 Context method mixins 部分展示 oneflow 目前实现的接口，调用方式与 pytorch 不同

### 存在的问题：
1. oneflow.Tensor.detach 没有 docstring
2. 最后 Context method mixins 部分的三个接口没有 docstring

网页展示：
![img](https://img1.imgtp.com/2022/07/12/HXTKiG5r.png)