### PR TITLE
fix test graph optimization conf CI bug

### DIFF
--- a/oneflow/core/framework/multi_client_session_context.h
+++ b/oneflow/core/framework/multi_client_session_context.h
@@ -16,7 +16,6 @@ limitations under the License.
 #ifndef ONEFLOW_CORE_FRAMEWORK_MULTI_CLIENT_SESSION_CONTEXT_H_
 #define ONEFLOW_CORE_FRAMEWORK_MULTI_CLIENT_SESSION_CONTEXT_H_
 
-#include <string>
 #include "oneflow/core/common/util.h"
 #include "oneflow/core/job/job_set.pb.h"
 #include "oneflow/core/common/maybe.h"

--- a/python/oneflow/test/graph/test_optimization_conf.py
+++ b/python/oneflow/test/graph/test_optimization_conf.py
@@ -15,11 +15,10 @@ limitations under the License.
 """
 import os
 import unittest
-
+import oneflow.framework.session_context as session_ctx
 import oneflow as flow
 import oneflow.framework.config_util as config_util
 import oneflow.framework.attr_util as attr_util
-import oneflow.framework.session_context as session_ctx
 import random
 
 

--- a/python/oneflow/test/graph/test_optimization_conf.py
+++ b/python/oneflow/test/graph/test_optimization_conf.py
@@ -93,7 +93,7 @@ class TestGraphWithSysConf(flow.unittest.TestCase):
                     attr_value = random.choice([True, False])
                     attrs_and_values_to_check.append((attrs, attr_value))
                 else:
-                    raise Exception("Unsupported type!")
+                    raise TypeError("Unsupported type!")
 
                 api(attr_value)
                 num_api_tested += 1

--- a/python/oneflow/test/graph/test_optimization_conf.py
+++ b/python/oneflow/test/graph/test_optimization_conf.py
@@ -16,13 +16,10 @@ limitations under the License.
 import os
 import unittest
 
-import numpy as np
-
 import oneflow as flow
-import oneflow.framework.graph_build_util as graph_build_util
-import oneflow.unittest
 import oneflow.framework.config_util as config_util
 import oneflow.framework.attr_util as attr_util
+import oneflow.framework.session_context as session_ctx
 import random
 
 
@@ -96,7 +93,7 @@ class TestGraphWithSysConf(flow.unittest.TestCase):
                     attr_value = random.choice([True, False])
                     attrs_and_values_to_check.append((attrs, attr_value))
                 else:
-                    assert False, "unsupported type!"
+                    raise Exception("Unsupported type!")
 
                 api(attr_value)
                 num_api_tested += 1
@@ -117,10 +114,17 @@ class TestGraphWithSysConf(flow.unittest.TestCase):
 
             print("number of APIs tested: " + str(num_api_tested))
 
+        # save the resource config before running random resource api tests
+        session = session_ctx.GetDefaultSession()
+        prev_resource_config = session.resource
+
         for i in range(5):
             test_resource_config_update_apis_eagerly_automatically()
 
         print("optimization conf after session init: \n", g._optimization_conf_proto)
+
+        # restore the resource config
+        session.update_resource_eagerly(prev_resource_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Related bug: https://github.com/Oneflow-Inc/OneTeam/issues/1548
Restore resource conf after resource conf API random tests. 