### PR TITLE
重构 oneflow.nn.init 文档

### DIFF
--- a/docs/source/nn.init.rst
+++ b/docs/source/nn.init.rst
@@ -1,15 +1,19 @@
 oneflow.nn.init
-===================================
-Operators for initialization
-----------------------------------
+===============
+
 .. currentmodule:: oneflow.nn.init
-
-.. autosummary::
-    :toctree: generated
-    :nosignatures:
-
-    xavier_uniform_
-    xavier_normal_
-    kaiming_uniform_
-    kaiming_normal_
-    orthogonal_
+.. autofunction:: calculate_gain
+.. autofunction:: uniform_
+.. autofunction:: normal_
+.. autofunction:: constant_
+.. autofunction:: ones_
+.. autofunction:: zeros_
+.. .. autofunction:: eye_
+.. .. autofunction:: dirac_
+.. autofunction:: xavier_uniform_
+.. autofunction:: xavier_normal_
+.. autofunction:: kaiming_uniform_
+.. autofunction:: kaiming_normal_
+.. autofunction:: trunc_normal_
+.. autofunction:: orthogonal_
+.. .. autofunction:: sparse_


### PR DESCRIPTION
### 重构思路

按照 torch.nn.init 文档排布方式，罗列 init 模块下现有接口

### 网页展示

![init](https://img1.imgtp.com/2022/07/11/I2ohz6As.png)