### PR TITLE
align exception msg to torch

### DIFF
--- a/oneflow/core/common/maybe.h
+++ b/oneflow/core/common/maybe.h
@@ -308,6 +308,9 @@ std::string GetFormatedSerializedError(const std::shared_ptr<ErrorProto>& error_
   return Error::CheckFailedError().AddStackFrame(__FILE__, __LINE__, __FUNCTION__) \
          << "Check failed: " << OF_PP_STRINGIZE(expr) << " "
 
+#define CHECK_OR_RETURN_ERROR(expr) \
+  if (!(expr)) return Error::CheckFailedError().AddStackFrame(__FILE__, __LINE__, __FUNCTION__)
+
 #define CHECK_EQ_OR_RETURN(lhs, rhs) \
   CHECK_OR_RETURN((lhs) == (rhs)) << "(" << (lhs) << " vs " << (rhs) << ") "
 

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -1173,7 +1173,7 @@ class ViewFunctor {
     if (view::IsViewApplicable(x)) {
       Optional<Stride> infered_stride =
           ComputeStride(*(x->shape()), *JUST(x->stride()), infered_shape);
-      CHECK_OR_RETURN(infered_stride.has_value())
+      CHECK_OR_RETURN_ERROR(infered_stride.has_value())
           << Error::RuntimeError()
           << "view size is not compatible with input tensor's size and stride (at least one "
              "dimension spans across two contiguous subspaces). Use .reshape(...) instead.";

--- a/python/oneflow/test/exceptions/test_view.py
+++ b/python/oneflow/test/exceptions/test_view.py
@@ -31,7 +31,10 @@ class TestModule(flow.unittest.TestCase):
         b = a.permute(1, 0)
         with test_case.assertRaises(RuntimeError) as ctx:
             print(b.view(9))
-        test_case.assertTrue("view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead." in str(ctx.exception))
+        test_case.assertTrue(
+            "view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead."
+            in str(ctx.exception)
+        )
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/exceptions/test_view.py
+++ b/python/oneflow/test/exceptions/test_view.py
@@ -1,0 +1,38 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+import oneflow as flow
+import oneflow.unittest
+
+
+@flow.unittest.skip_unless_1n1d()
+class TestModule(flow.unittest.TestCase):
+    def test_view_exception(test_case):
+        # torch exception and messge:
+        #
+        #   RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
+        #
+        a = flow.arange(9).reshape(3, 3)
+        b = a.permute(1, 0)
+        with test_case.assertRaises(RuntimeError) as ctx:
+            print(b.view(9))
+        test_case.assertTrue("view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead." in str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [x] view op异常信息对齐torch
- [x] 新增宏：`CHECK_OR_RETURN_ERROR`，用于异常发生时，去除了check信息，仅返回相应Error
- [x] exception test case