### PR TITLE
Add tril fill value

### DIFF
--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -2120,7 +2120,7 @@
   bind_python: False
 
 - name: "fused_scale_tril_softmax_mask_scale"
-  signature: "TensorTuple (Tensor a, *, Float p=0.5, Int64 diagonal, Float tril_scale_value, Generator generator=None) => FusedScaleTrilSoftmaxMaskScale"
+  signature: "TensorTuple (Tensor a, *, Float p=0.5, Int64 diagonal, Float tril_scale_value, Float tril_fill_value=0.0, Generator generator=None) => FusedScaleTrilSoftmaxMaskScale"
   bind_python: True
 
 - name: "fused_scale_tril_softmax_mask_scale_grad"

--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -2593,6 +2593,7 @@ class FusedScaleTrilSoftmaxMaskScaleFunctor {
   }
   Maybe<TensorTuple> operator()(const std::shared_ptr<one::Tensor>& x, const float p,
                                 const int64_t diagonal, const float tril_scale_value,
+                                const float tril_fill_value,
                                 const Optional<one::Generator>& generator) const {
     const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
     MutableAttrMap random_mask_like_attrs;
@@ -2610,6 +2611,7 @@ class FusedScaleTrilSoftmaxMaskScaleFunctor {
     JUST(fused_attrs.SetAttr<int64_t>("diagonal", diagonal));
     JUST(fused_attrs.SetAttr<float>("tril_scale_value", tril_scale_value));
     JUST(fused_attrs.SetAttr<float>("mask_scale_value", mask_scale_value));
+    JUST(fused_attrs.SetAttr<float>("tril_fill_value", tril_fill_value));
 
     return OpInterpUtil::Dispatch<TensorTuple>(*fused_op_, {x, mask}, fused_attrs);
   }


### PR DESCRIPTION
```python
import oneflow as flow 

attention_scores = flow.randn(1, 12, 8, 8, dtype=flow.float32).cuda()

attention_weights1 = flow._C.fused_scale_tril_softmax_mask_scale(
                    attention_scores,
                    p=0.0,
                    diagonal=0,
                    tril_scale_value=1.0,
                    tril_fill_value=-10000.0
                )[0]

attention_mask = flow.tril(
    flow.ones(
        (8, 8),
        dtype=flow.int8,
    )
).unsqueeze(0).unsqueeze(1)
attention_mask = attention_mask.to(flow.bool).to("cuda")

attention_scores = flow.mul(attention_scores, attention_mask)
attention_scores = attention_scores - 10000.0 * (1 - attention_mask)
attention_weights2 = flow.softmax(attention_scores, dim=-1)

print(attention_weights1 == attention_weights2)
print(attention_weights1.sum(), attention_weights2.sum())
```