### PR TITLE
docs(docstring): Modify all reference links to version 1.10

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -2,7 +2,7 @@ oneflow.autograd
 ====================================================
 
 .. The documentation is referenced from:
-.. https://pytorch.org/docs/1.10/autograd.html
+   https://pytorch.org/docs/1.10/autograd.html
 
 ``oneflow.autograd`` provides classes and functions implementing automatic differentiation of arbitrary scalar 
 valued functions. It requires minimal changes to the existing code - you only need to declare ``Tensor`` s 

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -9,7 +9,7 @@ OneFlow provides two ways to accomplish `Distributed Training`:
 
 - The first way is that users are recommended to use OneFlow's global Tensor for distributed training. Global Tensor regards the computing cluster as a supercomputing device, allowing users to write distributed training code just like in a single-machine environment.
 
-- OneFlow also provides a DDP（DistributedDataParallel） module aligned with PyTorch. DDP has been well-known and widely used in data parallelism by the majority of PyTorch users. Also see `PyTorch DDP introduction <https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html#torch.nn.parallel.DistributedDataParallel>`_.
+- OneFlow also provides a DDP（DistributedDataParallel） module aligned with PyTorch. DDP has been well-known and widely used in data parallelism by the majority of PyTorch users. Also see `PyTorch DDP introduction <https://pytorch.org/docs/1.10/generated/torch.nn.parallel.DistributedDataParallel.html#torch.nn.parallel.DistributedDataParallel>`_.
 
 
 

--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -2,7 +2,7 @@ oneflow.linalg
 ===================================
 
 .. The documentation is referenced from: 
-.. https://pytorch.org/docs/1.10/linalg.html
+   https://pytorch.org/docs/1.10/linalg.html
 
 Common linear algebra operations.
 

--- a/docs/source/nn.init.rst
+++ b/docs/source/nn.init.rst
@@ -2,7 +2,7 @@ oneflow.nn.init
 ===============
 
 .. The documentation is referenced from: 
-.. https://pytorch.org/docs/1.10/nn.init.html
+   https://pytorch.org/docs/1.10/nn.init.html
 
 .. currentmodule:: oneflow.nn.init
 .. autofunction:: calculate_gain

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -2,7 +2,7 @@ oneflow.nn
 ===================================
 
 .. The documentation is referenced from: 
-.. https://pytorch.org/docs/1.10/nn.html
+   https://pytorch.org/docs/1.10/nn.html
 
 These are the basic building blocks for graphs:
 

--- a/docs/source/oneflow.rst
+++ b/docs/source/oneflow.rst
@@ -2,7 +2,7 @@ oneflow
 ===================================
 
 .. The documentation is referenced from: 
-.. https://pytorch.org/docs/1.10/torch.html
+   https://pytorch.org/docs/1.10/torch.html
 
 The oneflow package contains data structures for multi-dimensional tensors and defines mathematical operations over these tensors. Additionally, it provides many utilities for efficient serializing of Tensors and arbitrary types, and other useful utilities.
 

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -2,7 +2,7 @@ oneflow.optim
 ===================================
 
 .. The documentation is referenced from: 
-.. https://pytorch.org/docs/1.10/optim.html
+   https://pytorch.org/docs/1.10/optim.html
 
 oneflow.optim is a package implementing various optimization algorithms. Most commonly used methods are already supported, and the interface is general enough, so that more sophisticated ones can be also easily integrated in the future.
 

--- a/docs/source/tensor.rst
+++ b/docs/source/tensor.rst
@@ -2,7 +2,7 @@ oneflow.Tensor
 ===================================
 
 .. The documentation is referenced from: 
-.. https://pytorch.org/docs/1.10/tensors.html
+   https://pytorch.org/docs/1.10/tensors.html
 
 A :class:`oneflow.Tensor` is a multi-dimensional matrix containing elements of
 a single data type.

--- a/docs/source/utils.data.rst
+++ b/docs/source/utils.data.rst
@@ -2,7 +2,7 @@ oneflow.utils.data
 ===================================
 
 .. The documentation is referenced from: 
-.. https://pytorch.org/docs/1.10/data.html
+   https://pytorch.org/docs/1.10/data.html
 
 .. automodule:: oneflow.utils.data
 

--- a/python/oneflow/cuda/__init__.py
+++ b/python/oneflow/cuda/__init__.py
@@ -79,7 +79,7 @@ def set_device(device: Union[flow.device, str, int]) -> None:
     r"""Sets the current device.
     
     The documentation is referenced from:
-    https://pytorch.org/docs/stable/generated/torch.cuda.set_device.html.
+    https://pytorch.org/docs/1.10/generated/torch.cuda.set_device.html.
 
     Usage of this function is discouraged in favor of :attr:`device`. In most
     cases it's better to use ``CUDA_VISIBLE_DEVICES`` environmental variable.

--- a/python/oneflow/framework/docstr/amin.py
+++ b/python/oneflow/framework/docstr/amin.py
@@ -26,7 +26,7 @@ add_docstr(
     If `keepdim` is `True`, the output tensor is of the same size as `input` except in the dimension(s) `dim` where it is of size 1. Otherwise, `dim` is squeezed (see :func:`oneflow.squeeze`), resulting in the output tensor having 1 (or `len(dim)`) fewer dimension(s).
     
     This function is equivalent to PyTorch’s amin function. 
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.amin.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.amin.html.
 
     Parameters:
         input (oneflow.Tensor): the input Tensor.

--- a/python/oneflow/framework/docstr/deconv.py
+++ b/python/oneflow/framework/docstr/deconv.py
@@ -23,7 +23,7 @@ add_docstr(
 
     Applies a 1D transposed convolution operator over an input signal composed of several input planes, sometimes also called “deconvolution”.
     
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.functional.conv_transpose1d.html
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.functional.conv_transpose1d.html
 
     See :class:`~oneflow.nn.ConvTranspose1d` for details and output shape.
 
@@ -59,7 +59,7 @@ add_docstr(
 
     Applies a 2D transposed convolution operator over an input image composed of several input planes, sometimes also called “deconvolution”.
 
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.functional.conv_transpose3d.html
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.functional.conv_transpose3d.html
 
     See :class:`~oneflow.nn.ConvTranspose2d` for details and output shape.
 
@@ -95,7 +95,7 @@ add_docstr(
 
     Applies a 3D transposed convolution operator over an input image composed of several input planes, sometimes also called “deconvolution”.
 
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.functional.conv_transpose3d.html
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.functional.conv_transpose3d.html
 
     See :class:`~oneflow.nn.ConvTranspose3d` for details and output shape.
 

--- a/python/oneflow/framework/docstr/distance.py
+++ b/python/oneflow/framework/docstr/distance.py
@@ -21,7 +21,7 @@ add_docstr(
     r"""
     cosine_similarity(x1, x2, dim=1, eps=1e-8) -> Tensor
 
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.functional.cosine_similarity.html#torch.nn.functional.cosine_similarity
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.functional.cosine_similarity.html
 
     Returns cosine similarity between ``x1`` and ``x2``, computed along dim. ``x1`` and ``x2`` must be broadcastable
     to a common shape. ``dim`` refers to the dimension in this common shape. Dimension ``dim`` of the output is

--- a/python/oneflow/framework/docstr/math_ops.py
+++ b/python/oneflow/framework/docstr/math_ops.py
@@ -1562,7 +1562,7 @@ add_docstr(
     Performs the element-wise multiplication of tensor1 by tensor2, multiply the result
     by the scalar value and add it to input.
     The documentation is referenced from:
-    https://pytorch.org/docs/stable/generated/torch.addcmul.html
+    https://pytorch.org/docs/1.10/generated/torch.addcmul.html
     
     .. math::
         \text{out}_i = \text{input}_i + value \times\  \text{tensor1}_i \times\ \text{tensor2}_i

--- a/python/oneflow/framework/docstr/meshgrid.py
+++ b/python/oneflow/framework/docstr/meshgrid.py
@@ -25,7 +25,7 @@ add_docstr(
     
     The interface is consistent with PyTorch.
     The documentation is referenced from:
-    https://pytorch.org/docs/1.10/_modules/torch/functional.html#meshgrid.
+    https://pytorch.org/docs/1.10/generated/torch.meshgrid.html#torch.meshgrid
 
     Args:
         tensors (list of Tensor): list of scalars or 1 dimensional tensors. Scalars will be

--- a/python/oneflow/framework/docstr/repeat_interleave.py
+++ b/python/oneflow/framework/docstr/repeat_interleave.py
@@ -27,7 +27,7 @@ add_docstr(
 
         This is different from :meth:`oneflow.Tensor.repeat` but similar to ``numpy.repeat``.
 
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.repeat_interleave.html
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.repeat_interleave.html
 
     Args:
         input (oneflow.Tensor): the input Tensor.

--- a/python/oneflow/framework/docstr/searchsorted.py
+++ b/python/oneflow/framework/docstr/searchsorted.py
@@ -38,7 +38,7 @@ add_docstr(
                                                     sorted_sequence[m][n]...[l][i]
     =================  =========  ==========================================================================
 
-    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.searchsorted.html?highlight=searchsorted
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.searchsorted.html
 
     Args:
         sorted_sequence (Tensor): N-D or 1-D tensor, containing monotonically increasing sequence on the

--- a/python/oneflow/nn/init.py
+++ b/python/oneflow/nn/init.py
@@ -98,7 +98,7 @@ def orthogonal_(tensor, gain=1.0):
     trailing dimensions are flattened.
 
     The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/nn.init.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/nn.init.html.
 
     Args:
         tensor: an n-dimensional `torch.Tensor`, where :math:`n \geq 2`

--- a/python/oneflow/nn/module.py
+++ b/python/oneflow/nn/module.py
@@ -56,7 +56,7 @@ class Module(object):
     
     This class is consistent with PyTorch.
     The documentation is referenced from:
-    https://pytorch.org/docs/stable/generated/torch.nn.Module.html.
+    https://pytorch.org/docs/1.10/generated/torch.nn.Module.html.
 
     Your models should also subclass this class.
 

--- a/python/oneflow/nn/modules/distance.py
+++ b/python/oneflow/nn/modules/distance.py
@@ -28,7 +28,7 @@ class CosineSimilarity(Module):
         \text{similarity} = \dfrac{x_1 \cdot x_2}{\max(\Vert x_1 \Vert _2 \cdot \Vert x_2 \Vert _2, \epsilon)}.
 
     The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.CosineSimilarity.html#torch.nn.CosineSimilarity
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.CosineSimilarity.html#torch.nn.CosineSimilarity
 
     Args:
         dim (int, optional): Dimension where cosine similarity is computed. Default: 1

--- a/python/oneflow/nn/modules/rnn.py
+++ b/python/oneflow/nn/modules/rnn.py
@@ -1058,7 +1058,7 @@ class RNNCell(RNNCellBase):
     If :attr:`nonlinearity` is `'relu'`, then ReLU is used in place of tanh.
 
     The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.RNNCell.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.RNNCell.html.
 
     Args:
         input_size: The number of expected features in the input `x`
@@ -1188,7 +1188,7 @@ class LSTMCell(RNNCellBase):
     where :math:`\sigma` is the sigmoid function, and :math:`*` is the Hadamard product.
 
     The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.LSTMCell.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.LSTMCell.html.
 
     Args:
         input_size: The number of expected features in the input `x`
@@ -1304,7 +1304,7 @@ class GRUCell(RNNCellBase):
     where :math:`\sigma` is the sigmoid function, and :math:`*` is the Hadamard product.
 
     The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.GRUCell.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.GRUCell.html.
 
     Args:
         input_size: The number of expected features in the input `x`

--- a/python/oneflow/nn/utils/rnn.py
+++ b/python/oneflow/nn/utils/rnn.py
@@ -45,7 +45,7 @@ def invert_permutation(permutation: Optional[Tensor]) -> Optional[Tensor]:
 
 class PackedSequence(object):
     """The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.utils.rnn.PackedSequence.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.utils.rnn.PackedSequence.html.
     
     Holds the data and list of :attr:`batch_sizes` of a packed sequence.
 
@@ -209,7 +209,7 @@ def pack_padded_sequence(
     enforce_sorted: bool = True,
 ) -> PackedSequence:
     """The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.utils.rnn.pack_padded_sequence.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.utils.rnn.pack_padded_sequence.html.
     
     Packs a Tensor containing padded sequences of variable length.
 
@@ -264,7 +264,7 @@ def pad_packed_sequence(
     total_length: Optional[int] = None,
 ) -> Tuple[Tensor, Tensor]:
     """The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.utils.rnn.pad_packed_sequence.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.utils.rnn.pad_packed_sequence.html.
     
     Pads a packed batch of variable length sequences.
 
@@ -416,7 +416,7 @@ def pad_sequence(
     padding_value: float = 0.0,
 ) -> Tensor:
     """The interface is consistent with PyTorch.
-    The documentation is referenced from: https://pytorch.org/docs/stable/generated/torch.nn.utils.rnn.pad_sequence.html.
+    The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.nn.utils.rnn.pad_sequence.html.
     
     Pad a list of variable length Tensors with ``padding_value``
 


### PR DESCRIPTION
- 修改 rst 中引用的格式
- 规范 docstring 中的 pytorch 引用链接，并统一为 1.10 版本