### PR TITLE
fix add_param_group step key not match error

### DIFF
--- a/python/oneflow/nn/optimizer/optimizer.py
+++ b/python/oneflow/nn/optimizer/optimizer.py
@@ -211,6 +211,10 @@ class Optimizer(object):
 
         self.param_groups.append(ParamGroup(param_group, self._default_options))
 
+        for param in param_group["params"]:
+            assert param.is_leaf, "parameters must be leaf tensor"
+            self._state[param] = dict()
+
     def load_state_dict(self, state_dict) -> None:
         r"""
         Load the state of the optimizer which is created by `state_dict` function.

--- a/python/oneflow/test/modules/test_optim_add_param_group.py
+++ b/python/oneflow/test/modules/test_optim_add_param_group.py
@@ -30,12 +30,15 @@ def _test_sgd_add_param_group(test_case):
     test_case.assertTrue(o.param_groups[0]["weight_decay"] == 0.0)
     test_case.assertTrue(o.param_groups[0]["nesterov"] == False)
     test_case.assertTrue(o.param_groups[0]["maximize"] == False)
+    o.step()
     o.add_param_group({"params": w2})
     test_case.assertTrue(o.param_groups[1]["lr"] == 0.001)
     test_case.assertTrue(o.param_groups[1]["momentum"] == 0.0)
     test_case.assertTrue(o.param_groups[1]["weight_decay"] == 0.0)
     test_case.assertTrue(o.param_groups[1]["nesterov"] == False)
     test_case.assertTrue(o.param_groups[1]["maximize"] == False)
+    o.step()
+
 
 
 class TestAddParamGroup(flow.unittest.TestCase):

--- a/python/oneflow/test/modules/test_optim_add_param_group.py
+++ b/python/oneflow/test/modules/test_optim_add_param_group.py
@@ -40,7 +40,6 @@ def _test_sgd_add_param_group(test_case):
     o.step()
 
 
-
 class TestAddParamGroup(flow.unittest.TestCase):
     def test_sgd_add_param_group(test_case):
         _test_sgd_add_param_group(test_case)


### PR DESCRIPTION
修复 add_param_groups 对 optimizer 的 param_groups 更新后但忘记初始化 state 导致下一次 step 会报 keyError 的错误。

并添加了对应测试。