### PR TITLE
添加oneflow, nn 等模块文档中遗漏的接口

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -239,8 +239,8 @@ DataParallel Layers (multi-GPU, distributed)
     nn.parallel.DistributedDataParallel
 
 
-Other Layers
--------------------------
+Data loading and preprocessing Layers
+----------------------------------------
 
 .. autosummary::
     :toctree: generated
@@ -249,16 +249,12 @@ Other Layers
     nn.COCOReader
     nn.CoinFlip
     nn.CropMirrorNormalize
-    nn.FakeQuantization
-    nn.MinMaxObserver
-    nn.MovingAverageMinMaxObserver
     nn.OFRecordBytesDecoder
     nn.OFRecordImageDecoder
     nn.OFRecordImageDecoderRandomCrop
     nn.OFRecordRawDecoder
     nn.OFRecordReader
-    nn.Quantization
-
+    
 
 Utilities
 ---------
@@ -294,3 +290,19 @@ Utility functions in other modules
     :template:
 
     nn.Flatten
+
+Quantized Functions
+--------------------
+
+Quantization refers to techniques for performing computations and 
+storing tensors at lower bitwidths than floating point precision.
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template:
+
+    nn.FakeQuantization
+    nn.MinMaxObserver
+    nn.MovingAverageMinMaxObserver
+    nn.Quantization

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -12,6 +12,13 @@ These are the basic building blocks for graphs:
     :class: this-will-duplicate-information-and-it-is-still-useful-here
     :backlinks: top
 
+.. currentmodule:: oneflow.nn
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: 
+
+    Parameter
 
 Containers
 ----------------------------------
@@ -230,6 +237,28 @@ DataParallel Layers (multi-GPU, distributed)
     :nosignatures:
     
     nn.parallel.DistributedDataParallel
+
+
+Other Layers
+-------------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    nn.COCOReader
+    nn.CoinFlip
+    nn.CropMirrorNormalize
+    nn.FakeQuantization
+    nn.MinMaxObserver
+    nn.MovingAverageMinMaxObserver
+    nn.OFRecordBytesDecoder
+    nn.OFRecordImageDecoder
+    nn.OFRecordImageDecoderRandomCrop
+    nn.OFRecordRawDecoder
+    nn.OFRecordReader
+    nn.Quantization
+
 
 Utilities
 ---------

--- a/docs/source/oneflow.rst
+++ b/docs/source/oneflow.rst
@@ -18,6 +18,20 @@ Tensor
     :toctree: generated
     :nosignatures:
 
+    BoolTensor
+    ByteTensor
+    CharTensor
+    DoubleTensor
+    FloatTensor
+    HalfTensor
+    IntTensor
+    LongTensor
+
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
     is_tensor
     is_floating_point
     is_nonzero
@@ -49,12 +63,16 @@ Creation Ops
     zeros_like
     ones
     ones_like
+    randint_like
+    masked_fill
+    new_ones
     arange
     linspace
     eye
     empty
     full
     full_like
+    tensor_scatter_nd_update
 
 .. _indexing-slicing-joining:
 
@@ -69,7 +87,10 @@ Indexing, Slicing, Joining, Mutating Ops
     cat
     concat
     chunk
+    expand
     gather
+    gather_nd
+    batch_gather
     hsplit
     vsplit
     index_select
@@ -78,11 +99,14 @@ Indexing, Slicing, Joining, Mutating Ops
     narrow
     nonzero
     permute
+    repeat
     reshape
     select
     scatter
     scatter_add
     scatter_nd
+    slice
+    slice_update
     split
     squeeze
     stack
@@ -222,14 +246,15 @@ Pointwise Ops
     floor 
     floor_ 
     fmod 
+    gelu
     log 
     log1p 
     log2 
     logical_and 
     logical_not 
     logical_or 
-     
     logical_xor 
+    mish
     mul 
     neg 
     negative 
@@ -237,6 +262,11 @@ Pointwise Ops
     reciprocal 
     round 
     rsqrt 
+    selu
+    softmax
+    softplus
+    softsign
+    silu
     sigmoid 
     sign 
     sin 
@@ -305,16 +335,23 @@ Other Ops
     :toctree: generated
     :nosignatures:
 
-    
+    adaptive_avg_pool1d
+    adaptive_avg_pool2d
+    adaptive_avg_pool3d
     broadcast_like 
+    cast
     cumprod 
     cumsum 
+    decode_onerec
     diag 
     diagonal 
     einsum 
     flatten 
     flip 
+    in_top_k
     meshgrid 
+    nms
+    roc_auc_score
     roll 
     searchsorted
     tensordot

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -172,6 +172,7 @@ Algorithms
     :toctree: generated
     :nosignatures:
 
+    Optimizer
     Adagrad
     Adam
     AdamW

--- a/docs/source/tensor.rst
+++ b/docs/source/tensor.rst
@@ -260,6 +260,7 @@ Tensor class reference
     Tensor.item
     Tensor.le
     Tensor.log
+    Tensor.log1p
     Tensor.log2
     Tensor.logical_and
     Tensor.logical_or

--- a/python/oneflow/framework/docstr/random.py
+++ b/python/oneflow/framework/docstr/random.py
@@ -232,10 +232,10 @@ add_docstr(
     """
     randint_like(input, low=0, high, size, *, dtype=None, generator=None, device=None, placement=None, sbp=None, requires_grad=False) -> Tensor
 
+    Returns a tensor filled with random integers generated uniformly between low (inclusive) and high (exclusive).
+
     The interface is consistent with PyTorch.    
     The documentation is referenced from: https://pytorch.org/docs/1.10/generated/torch.randint_like.html.
-
-    Returns a tensor filled with random integers generated uniformly between low (inclusive) and high (exclusive).
 
     Args:
         input (oneflow.Tensor): the size of ``input`` will determine size of the output tensor.

--- a/python/oneflow/nn/modules/dataset.py
+++ b/python/oneflow/nn/modules/dataset.py
@@ -169,9 +169,6 @@ class CoinFlip(Module):
     r"""
     CoinFlip(batch_size=1, random_seed=None, probability=0.5, device=None, placement=None, sbp=None)
 
-    The documentation is referenced from:
-    https://docs.nvidia.com/deeplearning/dali/user-guide/docs/supported_ops_legacy.html#nvidia.dali.ops.CoinFlip.
-
     Generates random boolean values following a bernoulli distribution.
 
     The probability of generating a value 1 (true) is determined by the ``probability`` argument.
@@ -179,6 +176,9 @@ class CoinFlip(Module):
     The shape of the generated data can be either specified explicitly with a ``shape`` argument,
     or chosen to match the shape of the input, if provided. If none are present, a single value per
     sample is generated.
+
+    The documentation is referenced from:
+    https://docs.nvidia.com/deeplearning/dali/user-guide/docs/supported_ops_legacy.html#nvidia.dali.ops.CoinFlip.
 
     Args:
         batch_size (int, optional): Maximum batch size of the pipeline. Negative values for this parameter 
@@ -264,9 +264,6 @@ class CoinFlip(Module):
 class CropMirrorNormalize(Module):
     r"""
     CropMirrorNormalize(color_space="BGR", output_layout="NCHW", crop_h=0, crop_w=0, crop_pos_y=0.5, crop_pos_x=0.5, mean= [0.0], std= [1.0], output_dtype=oneflow.float)
-    
-    The documentation is referenced from:
-    https://docs.nvidia.com/deeplearning/dali/user-guide/docs/supported_ops_legacy.html#nvidia.dali.ops.CropMirrorNormalize.
 
     Performs fused cropping, normalization, format conversion
     (NHWC to NCHW) if desired, and type casting.
@@ -280,6 +277,9 @@ class CropMirrorNormalize(Module):
         If no cropping arguments are specified, only mirroring and normalization will occur.
 
     This operator allows sequence inputs and supports volumetric data.
+
+    The documentation is referenced from:
+    https://docs.nvidia.com/deeplearning/dali/user-guide/docs/supported_ops_legacy.html#nvidia.dali.ops.CropMirrorNormalize.
 
     Args:
         color_space (str, optional): The color space of the input image. Default: "BGR"


### PR DESCRIPTION
模块包括: oneflow, oneflow.nn, oneflow.optim, oneflow.Tensor

遗漏接口统计：https://github.com/Oneflow-Inc/oneflow/issues/8695#issuecomment-1189009588

现已全部添加完成，缺少 docstring 的接口已经记录至：https://github.com/Oneflow-Inc/OneTeam/issues/1570