### PR TITLE
define_mut_output_shape_and_mut_output_stride_in_infer_ctx

### DIFF
--- a/oneflow/core/framework/infer_util.cpp
+++ b/oneflow/core/framework/infer_util.cpp
@@ -40,7 +40,7 @@ Maybe<void> TensorDescInferFnUtil::Unchanged(InferContext* ctx) {
   for (size_t i = 0; i < ctx->outputs().size(); ++i) {
     const std::pair<std::string, int32_t>& output_arg = ctx->outputs().at(i);
     *ctx->OutputIsDynamic(output_arg.first, output_arg.second) = first_tensor_desc->is_dynamic();
-    *ctx->OutputShape(output_arg.first, output_arg.second) = first_tensor_desc->shape();
+    *ctx->MutOutputShape(output_arg.first, output_arg.second) = first_tensor_desc->shape();
   }
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/framework/infer_util.h
+++ b/oneflow/core/framework/infer_util.h
@@ -43,11 +43,15 @@ class InferContext {
   virtual const TensorDesc* LogicalTensorDesc4ArgNameAndIndex(const std::string&,
                                                               int32_t) const = 0;
   virtual const Shape& InputShape(const std::string&, int32_t) const = 0;
-  virtual Shape* OutputShape(const std::string&, int32_t) = 0;
-  virtual Shape* Shape4ArgNameAndIndex(const std::string&, int32_t) = 0;
+  virtual const Shape& OutputShape(const std::string&, int32_t) const = 0;
+  virtual Shape* MutOutputShape(const std::string&, int32_t) = 0;
+  virtual const Shape& Shape4ArgNameAndIndex(const std::string&, int32_t) const = 0;
+  virtual Shape* MutShape4ArgNameAndIndex(const std::string&, int32_t) = 0;
   virtual const Stride& InputStride(const std::string&, int32_t) const = 0;
-  virtual Stride* OutputStride(const std::string&, int32_t) = 0;
-  virtual Stride* Stride4ArgNameAndIndex(const std::string&, int32_t) = 0;
+  virtual const Stride& OutputStride(const std::string&, int32_t) const = 0;
+  virtual Stride* MutOutputStride(const std::string&, int32_t) = 0;
+  virtual const Stride& Stride4ArgNameAndIndex(const std::string&, int32_t) const = 0;
+  virtual Stride* MutStride4ArgNameAndIndex(const std::string&, int32_t) = 0;
   virtual const DataType& InputDType(const std::string&, int32_t) const = 0;
   virtual DataType* OutputDType(const std::string&, int32_t) = 0;
   virtual DataType* Dtype4ArgNameAndIndex(const std::string&, int32_t) = 0;

--- a/oneflow/core/framework/op_expr.cpp
+++ b/oneflow/core/framework/op_expr.cpp
@@ -221,14 +221,27 @@ class UserOpExprInferContext : public user_op::InferContext {
     return tensor_meta4input_index_(tuple_index)->shape();
   }
 
-  Shape* OutputShape(const std::string& name, int32_t index) override {
+  const Shape& OutputShape(const std::string& name, int32_t index) const override {
+    const auto& arg_tuple = *user_op_expr_->output_arg_tuple();
+    int32_t tuple_index = arg_tuple.TensorTupleIndex4ArgNameAndIndex(name, index);
+    CHECK_GE(tuple_index, 0);
+    return tensor_meta4input_index_(tuple_index)->shape();
+  }
+
+  Shape* MutOutputShape(const std::string& name, int32_t index) override {
     const auto& arg_tuple = *user_op_expr_->output_arg_tuple();
     int32_t tuple_index = arg_tuple.TensorTupleIndex4ArgNameAndIndex(name, index);
     CHECK_GE(tuple_index, 0);
     return tensor_meta4output_index_(tuple_index)->mut_shape();
   }
 
-  Shape* Shape4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
+  const Shape& Shape4ArgNameAndIndex(const std::string& arg_name, int32_t index) const override {
+    return const_cast<UserOpExprInferContext*>(this)
+        ->TensorDesc4ArgNameAndIndex(arg_name, index)
+        ->shape();
+  }
+
+  Shape* MutShape4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
     return TensorDesc4ArgNameAndIndex(arg_name, index)->mut_shape();
   }
 
@@ -239,14 +252,27 @@ class UserOpExprInferContext : public user_op::InferContext {
     return tensor_meta4input_index_(tuple_index)->stride();
   }
 
-  Stride* OutputStride(const std::string& name, int32_t index) override {
+  const Stride& OutputStride(const std::string& name, int32_t index) const override {
+    const auto& arg_tuple = *user_op_expr_->input_arg_tuple();
+    int32_t tuple_index = arg_tuple.TensorTupleIndex4ArgNameAndIndex(name, index);
+    CHECK_GE(tuple_index, 0);
+    return tensor_meta4input_index_(tuple_index)->stride();
+  }
+
+  Stride* MutOutputStride(const std::string& name, int32_t index) override {
     const auto& arg_tuple = *user_op_expr_->output_arg_tuple();
     int32_t tuple_index = arg_tuple.TensorTupleIndex4ArgNameAndIndex(name, index);
     CHECK_GE(tuple_index, 0);
     return tensor_meta4output_index_(tuple_index)->mut_stride();
   }
 
-  Stride* Stride4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
+  const Stride& Stride4ArgNameAndIndex(const std::string& arg_name, int32_t index) const override {
+    return const_cast<UserOpExprInferContext*>(this)
+        ->TensorDesc4ArgNameAndIndex(arg_name, index)
+        ->stride();
+  }
+
+  Stride* MutStride4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
     return TensorDesc4ArgNameAndIndex(arg_name, index)->mut_stride();
   }
 

--- a/oneflow/core/framework/op_kernel.cpp
+++ b/oneflow/core/framework/op_kernel.cpp
@@ -25,7 +25,7 @@ void OpKernel::InferShape(KernelInferContext* ctx) const {
   CHECK_NOTNULL(op_infer_ctx);
   ctx->GetOpInferFn()(op_infer_ctx);
   for (const auto& arg_pair : ctx->outputs()) {
-    const Shape& shape = *op_infer_ctx->OutputShape(arg_pair.first, arg_pair.second);
+    const Shape& shape = op_infer_ctx->OutputShape(arg_pair.first, arg_pair.second);
     auto mut_shape_view = ctx->MutShapeView4ArgNameAndIndex(arg_pair.first, arg_pair.second);
     mut_shape_view.set_shape(shape);
   }

--- a/oneflow/core/kernel/user_kernel.cpp
+++ b/oneflow/core/kernel/user_kernel.cpp
@@ -261,21 +261,37 @@ class UserKernelOpInferContext : public user_op::InferContext {
     return it->second.get();
   }
   const Shape& InputShape(const std::string& arg_name, int32_t index) const override {
-    return *const_cast<UserKernelOpInferContext*>(this)->Shape4ArgNameAndIndex(arg_name, index);
-  }
-  Shape* OutputShape(const std::string& arg_name, int32_t index) override {
     return Shape4ArgNameAndIndex(arg_name, index);
   }
-  Shape* Shape4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
+  const Shape& OutputShape(const std::string& arg_name, int32_t index) const override {
+    return Shape4ArgNameAndIndex(arg_name, index);
+  }
+  Shape* MutOutputShape(const std::string& arg_name, int32_t index) override {
+    return MutShape4ArgNameAndIndex(arg_name, index);
+  }
+  const Shape& Shape4ArgNameAndIndex(const std::string& arg_name, int32_t index) const override {
+    return const_cast<UserKernelOpInferContext*>(this)
+        ->TensorDesc4ArgNameAndIndex(arg_name, index)
+        ->shape();
+  }
+  Shape* MutShape4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
     return TensorDesc4ArgNameAndIndex(arg_name, index)->mut_shape();
   }
   const Stride& InputStride(const std::string& arg_name, int32_t index) const override {
-    return *const_cast<UserKernelOpInferContext*>(this)->Stride4ArgNameAndIndex(arg_name, index);
-  }
-  Stride* OutputStride(const std::string& arg_name, int32_t index) override {
     return Stride4ArgNameAndIndex(arg_name, index);
   }
-  Stride* Stride4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
+  const Stride& OutputStride(const std::string& arg_name, int32_t index) const override {
+    return Stride4ArgNameAndIndex(arg_name, index);
+  }
+  Stride* MutOutputStride(const std::string& arg_name, int32_t index) override {
+    return MutStride4ArgNameAndIndex(arg_name, index);
+  }
+  const Stride& Stride4ArgNameAndIndex(const std::string& arg_name, int32_t index) const override {
+    return const_cast<UserKernelOpInferContext*>(this)
+        ->TensorDesc4ArgNameAndIndex(arg_name, index)
+        ->stride();
+  }
+  Stride* MutStride4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
     return TensorDesc4ArgNameAndIndex(arg_name, index)->mut_stride();
   }
   const DataType& InputDType(const std::string& arg_name, int32_t index) const override {

--- a/oneflow/ir/oneflow-extension/extension.cpp
+++ b/oneflow/ir/oneflow-extension/extension.cpp
@@ -49,7 +49,7 @@ REGISTER_USER_OP("mlir_jit")
       CHECK_EQ(ctx->inputs().size(), 2);
       CHECK_EQ(ctx->outputs().size(), 1);
       const Shape& in_shape = ctx->InputShape("in", 0);
-      Shape* out_shape = ctx->OutputShape("out", 0);
+      Shape* out_shape = ctx->MutOutputShape("out", 0);
       *out_shape = in_shape;
       *ctx->OutputDType("out", 0) = ctx->InputDType("in", 1);
       return Maybe<void>::Ok();

--- a/oneflow/user/kernels/fused_self_attention_query_mul_key_and_value_kernel.cu
+++ b/oneflow/user/kernels/fused_self_attention_query_mul_key_and_value_kernel.cu
@@ -266,9 +266,9 @@ class FusedSelfAttentionQueryMulKeyAndValueGradGpuKernel final : public user_op:
 };
 
 size_t InferTmpBufferSize(user_op::InferContext* ctx) {
-  const Shape* value_shape = ctx->OutputShape("value", 0);
+  const Shape& value_shape = ctx->OutputShape("value", 0);
   DataType value_dtype = *ctx->OutputDType("value", 0);
-  return value_shape->elem_cnt() * GetSizeOfDataType(value_dtype);
+  return value_shape.elem_cnt() * GetSizeOfDataType(value_dtype);
 }
 
 size_t InferGradTmpBufferSize(user_op::InferContext* ctx) {

--- a/oneflow/user/kernels/generate_random_batch_permutation_indices_kernel.cu
+++ b/oneflow/user/kernels/generate_random_batch_permutation_indices_kernel.cu
@@ -119,8 +119,8 @@ REGISTER_USER_KERNEL("generate_random_batch_permutation_indices")
     .SetCreateFn<GenerateRandomBatchPermutationIndicesGPUKernel>()
     .SetIsMatchedHob(user_op::HobDeviceType() == DeviceType::kCUDA)
     .SetInferTmpSizeFn([](oneflow::user_op::InferContext* ctx) {
-      const Shape* y_shape = ctx->OutputShape("y", 0);
-      const int32_t batch_size = y_shape->At(0);
+      const Shape& y_shape = ctx->OutputShape("y", 0);
+      const int32_t batch_size = y_shape.At(0);
 
       const int32_t random_value_aligned_bytes = GetCudaAlignedSize(batch_size * sizeof(float));
       const int32_t sorted_value_aligned_bytes = GetCudaAlignedSize(batch_size * sizeof(float));

--- a/oneflow/user/kernels/nccl_logical_send_recv_kernel.cpp
+++ b/oneflow/user/kernels/nccl_logical_send_recv_kernel.cpp
@@ -252,7 +252,7 @@ void NcclLogicalSendRecv::Compute(user_op::KernelComputeContext* ctx, user_op::O
 }
 
 size_t InferTmpBufferSize(user_op::InferContext* ctx) {
-  const Shape* out_shape = ctx->OutputShape("out", 0);
+  const Shape& out_shape = ctx->OutputShape("out", 0);
   const user_op::TensorDesc* logical_in_tensor = ctx->LogicalTensorDesc4ArgNameAndIndex("in", 0);
   const Shape& logical_shape = logical_in_tensor->shape();
   const DataType data_type = logical_in_tensor->data_type();
@@ -278,7 +278,7 @@ size_t InferTmpBufferSize(user_op::InferContext* ctx) {
   }
   if (NdSbpHasPartialParallel(src_nd_sbp)) {
     // Note: when src_nd_sbp has partial_sum, need a out_size buffer to copy and add to out.
-    buf_count += out_shape->elem_cnt();
+    buf_count += out_shape.elem_cnt();
   }
   return buf_count * GetSizeOfDataType(data_type);
 }

--- a/oneflow/user/kernels/nms_kernel.cu
+++ b/oneflow/user/kernels/nms_kernel.cu
@@ -132,8 +132,8 @@ class NmsGpuKernel final : public user_op::OpKernel {
                        && (user_op::HobDataType("out", 0) == DataType::kInt8)           \
                        && (user_op::HobDataType("in", 0) == GetDataType<dtype>::value)) \
       .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                               \
-        Shape* in_shape = ctx->Shape4ArgNameAndIndex("in", 0);                          \
-        int64_t num_boxes = in_shape->At(0);                                            \
+        const Shape& in_shape = ctx->Shape4ArgNameAndIndex("in", 0);                    \
+        int64_t num_boxes = in_shape.At(0);                                             \
         int64_t blocks = CeilDiv<int64_t>(num_boxes, kBlockSize);                       \
         return num_boxes * blocks * sizeof(int64_t);                                    \
       });

--- a/oneflow/user/kernels/stateful_opkernel.cpp
+++ b/oneflow/user/kernels/stateful_opkernel.cpp
@@ -174,26 +174,42 @@ class UserOpInferContextHelper final {
 
   const Shape& InputShape(eager::CallContext* call_ctx, const std::string& arg_name,
                           int32_t index) const {
-    return *Shape4ArgNameAndIndex(call_ctx, arg_name, index);
-  }
-  Shape* OutputShape(eager::CallContext* call_ctx, const std::string& arg_name,
-                     int32_t index) const {
     return Shape4ArgNameAndIndex(call_ctx, arg_name, index);
   }
-  Shape* Shape4ArgNameAndIndex(eager::CallContext* call_ctx, const std::string& arg_name,
-                               int32_t index) const {
+  const Shape& OutputShape(eager::CallContext* call_ctx, const std::string& arg_name,
+                           int32_t index) const {
+    return Shape4ArgNameAndIndex(call_ctx, arg_name, index);
+  }
+  Shape* MutOutputShape(eager::CallContext* call_ctx, const std::string& arg_name,
+                        int32_t index) const {
+    return MutShape4ArgNameAndIndex(call_ctx, arg_name, index);
+  }
+  const Shape& Shape4ArgNameAndIndex(eager::CallContext* call_ctx, const std::string& arg_name,
+                                     int32_t index) const {
+    return NonNullTensorDesc4ArgNameAndIndex(call_ctx, arg_name, index)->shape();
+  }
+  Shape* MutShape4ArgNameAndIndex(eager::CallContext* call_ctx, const std::string& arg_name,
+                                  int32_t index) const {
     return NonNullTensorDesc4ArgNameAndIndex(call_ctx, arg_name, index)->mut_shape();
   }
   const Stride& InputStride(eager::CallContext* call_ctx, const std::string& arg_name,
                             int32_t index) const {
-    return *Stride4ArgNameAndIndex(call_ctx, arg_name, index);
-  }
-  Stride* OutputStride(eager::CallContext* call_ctx, const std::string& arg_name,
-                       int32_t index) const {
     return Stride4ArgNameAndIndex(call_ctx, arg_name, index);
   }
-  Stride* Stride4ArgNameAndIndex(eager::CallContext* call_ctx, const std::string& arg_name,
-                                 int32_t index) const {
+  const Stride& OutputStride(eager::CallContext* call_ctx, const std::string& arg_name,
+                             int32_t index) const {
+    return Stride4ArgNameAndIndex(call_ctx, arg_name, index);
+  }
+  Stride* MutOutputStride(eager::CallContext* call_ctx, const std::string& arg_name,
+                          int32_t index) const {
+    return MutStride4ArgNameAndIndex(call_ctx, arg_name, index);
+  }
+  const Stride& Stride4ArgNameAndIndex(eager::CallContext* call_ctx, const std::string& arg_name,
+                                       int32_t index) const {
+    return NonNullTensorDesc4ArgNameAndIndex(call_ctx, arg_name, index)->stride();
+  }
+  Stride* MutStride4ArgNameAndIndex(eager::CallContext* call_ctx, const std::string& arg_name,
+                                    int32_t index) const {
     return NonNullTensorDesc4ArgNameAndIndex(call_ctx, arg_name, index)->mut_stride();
   }
   const DataType& InputDType(eager::CallContext* call_ctx, const std::string& arg_name,
@@ -317,20 +333,32 @@ class UserOpInferContext : public user_op::InferContext {
   const Shape& InputShape(const std::string& arg_name, int32_t index) const override {
     return helper_->InputShape(call_ctx_, arg_name, index);
   }
-  Shape* OutputShape(const std::string& arg_name, int32_t index) override {
+  const Shape& OutputShape(const std::string& arg_name, int32_t index) const override {
     return helper_->OutputShape(call_ctx_, arg_name, index);
   }
-  Shape* Shape4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
+  Shape* MutOutputShape(const std::string& arg_name, int32_t index) override {
+    return helper_->MutOutputShape(call_ctx_, arg_name, index);
+  }
+  const Shape& Shape4ArgNameAndIndex(const std::string& arg_name, int32_t index) const override {
     return helper_->Shape4ArgNameAndIndex(call_ctx_, arg_name, index);
+  }
+  Shape* MutShape4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
+    return helper_->MutShape4ArgNameAndIndex(call_ctx_, arg_name, index);
   }
   const Stride& InputStride(const std::string& arg_name, int32_t index) const override {
     return helper_->InputStride(call_ctx_, arg_name, index);
   }
-  Stride* OutputStride(const std::string& arg_name, int32_t index) override {
-    return helper_->OutputStride(call_ctx_, arg_name, index);
+  const Stride& OutputStride(const std::string& arg_name, int32_t index) const override {
+    return helper_->InputStride(call_ctx_, arg_name, index);
   }
-  Stride* Stride4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
+  Stride* MutOutputStride(const std::string& arg_name, int32_t index) override {
+    return helper_->MutOutputStride(call_ctx_, arg_name, index);
+  }
+  const Stride& Stride4ArgNameAndIndex(const std::string& arg_name, int32_t index) const override {
     return helper_->Stride4ArgNameAndIndex(call_ctx_, arg_name, index);
+  }
+  Stride* MutStride4ArgNameAndIndex(const std::string& arg_name, int32_t index) override {
+    return helper_->MutStride4ArgNameAndIndex(call_ctx_, arg_name, index);
   }
   const DataType& InputDType(const std::string& arg_name, int32_t index) const override {
     return helper_->InputDType(call_ctx_, arg_name, index);

--- a/oneflow/user/kernels/two_stage_reduce_kernel.cpp
+++ b/oneflow/user/kernels/two_stage_reduce_kernel.cpp
@@ -127,9 +127,9 @@ template<typename T>
 user_op::InferTmpSizeFn GenDeviceStageGradInferTmpSizeFn() {
   return [](user_op::InferContext* ctx) {
     const Shape& out_diff_shape = ctx->InputShape("out_diff", 0);
-    const Shape* in_diff_shape = ctx->OutputShape("in_diff", 0);
+    const Shape& in_diff_shape = ctx->OutputShape("in_diff", 0);
     const size_t tmp_bytes = GetCudaAlignedSize(out_diff_shape.elem_cnt() * sizeof(T));
-    const size_t broadcasted_tmp_bytes = GetCudaAlignedSize(in_diff_shape->elem_cnt() * sizeof(T));
+    const size_t broadcasted_tmp_bytes = GetCudaAlignedSize(in_diff_shape.elem_cnt() * sizeof(T));
     return tmp_bytes + broadcasted_tmp_bytes;
   };
 }
@@ -259,7 +259,7 @@ user_op::InferTmpSizeFn GenGlobalStageGradInferTmpSizeFn() {
   return [](user_op::InferContext* ctx) {
     const Shape& device_count_shape = ctx->InputShape("device_count", 0);
     const Shape& out_diff_shape = ctx->InputShape("out_diff", 0);
-    const Shape* in_diff_shape = ctx->OutputShape("in_diff", 0);
+    const Shape& in_diff_shape = ctx->OutputShape("in_diff", 0);
     const size_t device_count_with_mask_bytes =
         GetCudaAlignedSize(device_count_shape.elem_cnt() * sizeof(int32_t));
     const size_t global_count_bytes =
@@ -268,7 +268,7 @@ user_op::InferTmpSizeFn GenGlobalStageGradInferTmpSizeFn() {
         GetCudaAlignedSize(device_count_shape.elem_cnt() * sizeof(int32_t));
     const size_t divided_buf_bytes = GetCudaAlignedSize(out_diff_shape.elem_cnt() * sizeof(T));
     const size_t broadcasted_divided_buf_bytes =
-        GetCudaAlignedSize(in_diff_shape->elem_cnt() * sizeof(T));
+        GetCudaAlignedSize(in_diff_shape.elem_cnt() * sizeof(T));
     const size_t total_bytes = device_count_with_mask_bytes + global_count_bytes
                                + reduce_sum_tmp_bytes + divided_buf_bytes
                                + broadcasted_divided_buf_bytes;

--- a/oneflow/user/kernels/unsorted_segment_sum_kernel.cpp
+++ b/oneflow/user/kernels/unsorted_segment_sum_kernel.cpp
@@ -193,8 +193,8 @@ class UnsortedSegmentSumHalfKernel final : public user_op::OpKernel {
           && (user_op::HobDataType("segment_ids", 0) == OF_PP_PAIR_SECOND(segment_ids_type))    \
           && (user_op::HobDataType("out", 0) == OF_PP_PAIR_SECOND(out_type)))                   \
       .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                                       \
-        const Shape* out_shape = ctx->OutputShape("out", 0);                                    \
-        return GetCudaAlignedSize(out_shape->elem_cnt() * sizeof(float));                       \
+        const Shape& out_shape = ctx->OutputShape("out", 0);                                    \
+        return GetCudaAlignedSize(out_shape.elem_cnt() * sizeof(float));                        \
       });
 
 #define REGISTER_UNSORTED_SEGMENT_SUM_HALF_KERNEL_CASE(out_type, segment_ids_type) \

--- a/oneflow/user/kernels/where_kernel.cpp
+++ b/oneflow/user/kernels/where_kernel.cpp
@@ -191,13 +191,13 @@ class WhereScalarXYKernel final : public user_op::OpKernel {
                        && (user_op::HobDataType("condition", 0) == OF_PP_PAIR_SECOND(ctype_pair)) \
                        && (user_op::HobDataType("out", 0) == OF_PP_PAIR_SECOND(dtype_pair)))      \
       .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                                         \
-        Shape* out_shape = ctx->OutputShape("out", 0);                                            \
+        const Shape& out_shape = ctx->OutputShape("out", 0);                                      \
         const size_t x_bytes =                                                                    \
-            GetCudaAlignedSize(out_shape->elem_cnt() * sizeof(OF_PP_PAIR_FIRST(dtype_pair)));     \
+            GetCudaAlignedSize(out_shape.elem_cnt() * sizeof(OF_PP_PAIR_FIRST(dtype_pair)));      \
         const size_t y_bytes =                                                                    \
-            GetCudaAlignedSize(out_shape->elem_cnt() * sizeof(OF_PP_PAIR_FIRST(dtype_pair)));     \
+            GetCudaAlignedSize(out_shape.elem_cnt() * sizeof(OF_PP_PAIR_FIRST(dtype_pair)));      \
         const size_t cond_bytes =                                                                 \
-            GetCudaAlignedSize(out_shape->elem_cnt() * sizeof(OF_PP_PAIR_FIRST(ctype_pair)));     \
+            GetCudaAlignedSize(out_shape.elem_cnt() * sizeof(OF_PP_PAIR_FIRST(ctype_pair)));      \
         return x_bytes + y_bytes + cond_bytes;                                                    \
       });
 
@@ -209,11 +209,11 @@ class WhereScalarXYKernel final : public user_op::OpKernel {
                        && (user_op::HobDataType("condition", 0) == OF_PP_PAIR_SECOND(ctype_pair)) \
                        && (user_op::HobDataType("out", 0) == OF_PP_PAIR_SECOND(dtype_pair)))      \
       .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                                         \
-        Shape* out_shape = ctx->OutputShape("out", 0);                                            \
+        const Shape& out_shape = ctx->OutputShape("out", 0);                                      \
         const size_t y_bytes =                                                                    \
-            GetCudaAlignedSize(out_shape->elem_cnt() * sizeof(OF_PP_PAIR_FIRST(dtype_pair)));     \
+            GetCudaAlignedSize(out_shape.elem_cnt() * sizeof(OF_PP_PAIR_FIRST(dtype_pair)));      \
         const size_t cond_bytes =                                                                 \
-            GetCudaAlignedSize(out_shape->elem_cnt() * sizeof(OF_PP_PAIR_FIRST(ctype_pair)));     \
+            GetCudaAlignedSize(out_shape.elem_cnt() * sizeof(OF_PP_PAIR_FIRST(ctype_pair)));      \
         return y_bytes + cond_bytes;                                                              \
       });
 
@@ -225,11 +225,11 @@ class WhereScalarXYKernel final : public user_op::OpKernel {
                        && (user_op::HobDataType("condition", 0) == OF_PP_PAIR_SECOND(ctype_pair)) \
                        && (user_op::HobDataType("out", 0) == OF_PP_PAIR_SECOND(dtype_pair)))      \
       .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                                         \
-        Shape* out_shape = ctx->OutputShape("out", 0);                                            \
+        const Shape& out_shape = ctx->OutputShape("out", 0);                                      \
         const size_t x_bytes =                                                                    \
-            GetCudaAlignedSize(out_shape->elem_cnt() * sizeof(OF_PP_PAIR_FIRST(dtype_pair)));     \
+            GetCudaAlignedSize(out_shape.elem_cnt() * sizeof(OF_PP_PAIR_FIRST(dtype_pair)));      \
         const size_t cond_bytes =                                                                 \
-            GetCudaAlignedSize(out_shape->elem_cnt() * sizeof(OF_PP_PAIR_FIRST(ctype_pair)));     \
+            GetCudaAlignedSize(out_shape.elem_cnt() * sizeof(OF_PP_PAIR_FIRST(ctype_pair)));      \
         return x_bytes + cond_bytes;                                                              \
       });
 

--- a/oneflow/user/ops/acc_op.cpp
+++ b/oneflow/user/ops/acc_op.cpp
@@ -30,7 +30,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> AccOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/adaptive_pool_op.cpp
+++ b/oneflow/user/ops/adaptive_pool_op.cpp
@@ -31,12 +31,12 @@ Maybe<void> InferFWTensorDesc(user_op::InferContext* ctx) {
     out_shape[i] = output_size.size() > i - 2 ? output_size[i - 2] : output_size[0];
   }
 
-  *ctx->OutputShape("y", 0) = Shape(out_shape);
+  *ctx->MutOutputShape("y", 0) = Shape(out_shape);
   return Maybe<void>::Ok();
 }
 
 Maybe<void> InferBWTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("x", 0);
   *ctx->OutputIsDynamic("dx", 0) = ctx->InputIsDynamic("x", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/arange_op.cpp
+++ b/oneflow/user/ops/arange_op.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> ArangeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   DataType dtype = ctx->Attr<DataType>("dtype");
   int64_t range_elem_cnt = 0;
   if (IsIntegralDataType(dtype)) {
@@ -88,7 +88,7 @@ namespace oneflow {
       GetTensorSliceView4ParallelId(parallel_hierarchy, nd_sbp, logical_shape, parallel_id);
   const Shape& physical_shape = tensor_slice_view.shape();
 
-  *ctx->OutputShape("out", 0) = physical_shape;
+  *ctx->MutOutputShape("out", 0) = physical_shape;
 
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/arg_sort_op.cpp
+++ b/oneflow/user/ops/arg_sort_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> ArgSortOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/argmax_op.cpp
+++ b/oneflow/user/ops/argmax_op.cpp
@@ -21,7 +21,7 @@ namespace oneflow {
 /* static */ Maybe<void> ArgmaxOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   auto dim_vec = ctx->InputShape("in", 0).dim_vec();
   dim_vec.pop_back();
-  *ctx->OutputShape("out", 0) = Shape(std::move(dim_vec));
+  *ctx->MutOutputShape("out", 0) = Shape(std::move(dim_vec));
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/avg_pool_op.cpp
+++ b/oneflow/user/ops/avg_pool_op.cpp
@@ -27,7 +27,7 @@ typedef std::function<Maybe<void>(const user_op::UserOpWrapper& op, user_op::Add
 
 TensorDescInferFn AvgPoolMakeForwardTensorDescInferFn(const int32_t dim) {
   return [dim](user_op::InferContext* ctx) -> Maybe<void> {
-    const Shape* x_shape = ctx->Shape4ArgNameAndIndex("x", 0);
+    const Shape& x_shape = ctx->Shape4ArgNameAndIndex("x", 0);
     const std::string& data_format = ctx->Attr<std::string>("data_format");
     const std::vector<int32_t>& padding = ctx->Attr<std::vector<int32_t>>("padding");
     const std::vector<int32_t>& kernel_size = ctx->Attr<std::vector<int32_t>>("kernel_size");
@@ -53,7 +53,7 @@ TensorDescInferFn AvgPoolMakeForwardTensorDescInferFn(const int32_t dim) {
           << "pad should be smaller than half of kernel size";
     }
 
-    const AvgPoolParams3D params_3d(dim, *x_shape, data_format, padding, kernel_size, stride,
+    const AvgPoolParams3D params_3d(dim, x_shape, data_format, padding, kernel_size, stride,
                                     ceil_mode, count_include_pad, divisor_override);
     user_op::TensorDesc* y_desc = ctx->OutputTensorDesc("y", 0);
     *y_desc = ctx->InputTensorDesc("x", 0);

--- a/oneflow/user/ops/bias_add_op.cpp
+++ b/oneflow/user/ops/bias_add_op.cpp
@@ -35,7 +35,7 @@ namespace oneflow {
       << Error::RuntimeError() << "The size of tensor " << a_tensor_desc.shape().ToString()
       << " must match the size of tensor " << b_tensor_desc.shape().ToString() << " at dimension "
       << bias_add_axis;
-  *ctx->OutputShape("out", 0) = ctx->InputShape("a", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("a", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("a", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/broadcast_div_grad_op.cpp
+++ b/oneflow/user/ops/broadcast_div_grad_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> BroadcastDivGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dy", 0) = ctx->InputShape("y", 0);
+  *ctx->MutOutputShape("dy", 0) = ctx->InputShape("y", 0);
   *ctx->OutputIsDynamic("dy", 0) = ctx->InputIsDynamic("y", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/broadcast_like_op.cpp
+++ b/oneflow/user/ops/broadcast_like_op.cpp
@@ -78,8 +78,8 @@ Maybe<void> InferTensorDesc(user_op::InferContext* ctx) {
   CHECK_OR_RETURN(!broadcast_axes.empty());
   const Shape& in_shape = ctx->InputShape("x", 0);
   const Shape& like_shape = ctx->InputShape("like", 0);
-  Shape* out_shape = ctx->OutputShape("y", 0);
-  Stride* out_stride = ctx->OutputStride("y", 0);
+  Shape* out_shape = ctx->MutOutputShape("y", 0);
+  Stride* out_stride = ctx->MutOutputStride("y", 0);
   const AxisVector axis_vec = {broadcast_axes.begin(), broadcast_axes.end()};
   CHECK_OR_RETURN(IsAxesLegal(axis_vec, like_shape, in_shape));
   *out_shape = like_shape;

--- a/oneflow/user/ops/broadcast_pow_grad_op.cpp
+++ b/oneflow/user/ops/broadcast_pow_grad_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> BroadcastPowXGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("x", 0);
   *ctx->OutputIsDynamic("dx", 0) = ctx->InputIsDynamic("x", 0);
   return Maybe<void>::Ok();
 }
@@ -76,7 +76,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> BroadcastPowYGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dy", 0) = ctx->InputShape("y", 0);
+  *ctx->MutOutputShape("dy", 0) = ctx->InputShape("y", 0);
   *ctx->OutputIsDynamic("dy", 0) = ctx->InputIsDynamic("y", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/buffer_op.cpp
+++ b/oneflow/user/ops/buffer_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> IdentityBufferOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/cast_like_op.cpp
+++ b/oneflow/user/ops/cast_like_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> CastLikeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/cast_to_tick_op.cpp
+++ b/oneflow/user/ops/cast_to_tick_op.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> CastToTickOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   *out_shape = Shape({1});
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/categorical_ordinal_encode_op.cpp
+++ b/oneflow/user/ops/categorical_ordinal_encode_op.cpp
@@ -26,7 +26,7 @@ namespace oneflow {
   const Shape& size_shape = ctx->InputShape("size", 0);
   CHECK_EQ_OR_RETURN(size_shape.NumAxes(), 1);
   CHECK_EQ_OR_RETURN(size_shape.elem_cnt(), 1);
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -39,7 +39,7 @@ namespace oneflow {
   const Shape& size_shape = ctx->InputShape("size", 0);
   CHECK_EQ_OR_RETURN(size_shape.NumAxes(), 1);
   CHECK_EQ_OR_RETURN(size_shape.elem_cnt(), 1);
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/celu_op.cpp
+++ b/oneflow/user/ops/celu_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> CeluOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 /* static */ Maybe<void> CeluGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/clip_by_value_op.cpp
+++ b/oneflow/user/ops/clip_by_value_op.cpp
@@ -21,7 +21,7 @@ namespace oneflow {
 namespace {
 
 Maybe<void> InferClipTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("y", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("y", 0) = ctx->InputShape("x", 0);
   return Maybe<void>::Ok();
 }
 
@@ -34,7 +34,7 @@ Maybe<void> GetClipSbpSignature(user_op::SbpContext* ctx) {
 }
 
 Maybe<void> InferClipGradTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("x", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/combined_margin_loss_op.cpp
+++ b/oneflow/user/ops/combined_margin_loss_op.cpp
@@ -24,7 +24,7 @@ namespace oneflow {
   user_op::TensorDesc* theta = ctx->OutputTensorDesc("theta", 0);
   CHECK_EQ_OR_RETURN(label.shape().At(0), x.shape().At(0));
   CHECK_GE_OR_RETURN(x.shape().NumAxes(), 2);
-  *ctx->OutputShape("y", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("y", 0) = ctx->InputShape("x", 0);
   *ctx->IsDynamic4ArgNameAndIndex("y", 0) = ctx->InputIsDynamic("x", 0);
   *theta->mut_is_dynamic() = x.is_dynamic();
   *theta->mut_shape() = label.shape();
@@ -72,7 +72,7 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(label.shape().At(0), dy.shape().At(0));
   CHECK_EQ_OR_RETURN(label.shape().At(0), theta.shape().At(0));
   CHECK_GE_OR_RETURN(dy.shape().NumAxes(), 2);
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("dy", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("dy", 0);
   *ctx->IsDynamic4ArgNameAndIndex("dx", 0) = ctx->InputIsDynamic("dy", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/constant_op.cpp
+++ b/oneflow/user/ops/constant_op.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> ConstantOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
+  *ctx->MutOutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
   return Maybe<void>::Ok();
 }
 
@@ -33,7 +33,7 @@ namespace oneflow {
       GetTensorSliceView4ParallelId(parallel_hierarchy, nd_sbp, logical_shape, parallel_id);
   const Shape& physical_shape = tensor_slice_view.shape();
 
-  *ctx->OutputShape("out", 0) = physical_shape;
+  *ctx->MutOutputShape("out", 0) = physical_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/conv_op.cpp
+++ b/oneflow/user/ops/conv_op.cpp
@@ -308,7 +308,7 @@ Maybe<void> GenerateBackwardOpConf4Conv(const user_op::UserOpWrapper& op, user_o
     const user_op::TensorDesc& add_to_output = ctx->InputTensorDesc("_add_to_output", 0);
     CHECK_EQ_OR_RETURN(add_to_output.shape(), x_like.shape());
   }
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("x_like", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("x_like", 0);
   *ctx->OutputIsDynamic("dx", 0) = ctx->InputIsDynamic("x_like", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/copy_op.cpp
+++ b/oneflow/user/ops/copy_op.cpp
@@ -42,8 +42,8 @@ Maybe<Symbol<Stream>> MakeCopyStream(const Symbol<Device>& in_device,
 }  // namespace
 
 /* static */ Maybe<void> CopyOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
-  *ctx->OutputStride("out", 0) = ctx->InputStride("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputStride("out", 0) = ctx->InputStride("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/ctc_loss_op.cpp
+++ b/oneflow/user/ops/ctc_loss_op.cpp
@@ -34,8 +34,8 @@ namespace oneflow {
   CHECK_GE_OR_RETURN(ctx->Attr<int32_t>("blank"), 0);
   CHECK_LT_OR_RETURN(ctx->Attr<int32_t>("blank"), log_probs.shape().At(2));
 
-  *ctx->OutputShape("loss", 0) = Shape({batch_size});
-  *ctx->OutputShape("alpha", 0) =
+  *ctx->MutOutputShape("loss", 0) = Shape({batch_size});
+  *ctx->MutOutputShape("alpha", 0) =
       Shape({batch_size, log_probs.shape().At(0), 2 * max_target_length + 1});
   return Maybe<void>::Ok();
 }
@@ -78,7 +78,7 @@ namespace oneflow {
   CHECK_GE_OR_RETURN(ctx->Attr<int32_t>("blank"), 0);
   CHECK_LT_OR_RETURN(ctx->Attr<int32_t>("blank"), log_probs.shape().At(2));
 
-  *ctx->OutputShape("grad", 0) = log_probs.shape();
+  *ctx->MutOutputShape("grad", 0) = log_probs.shape();
   return Maybe<void>::Ok();
 }
 
@@ -110,8 +110,8 @@ namespace oneflow {
   const user_op::TensorDesc& input_lengths = ctx->InputTensorDesc("input_lengths", 0);
   const int64_t batch_size = log_probs.shape().At(1);
   CHECK_EQ_OR_RETURN(batch_size, input_lengths.shape().At(0));
-  *ctx->OutputShape("decoded", 0) = Shape({batch_size, log_probs.shape().At(0)});
-  *ctx->OutputShape("neg_sum_logits", 0) = Shape({batch_size, 1});
+  *ctx->MutOutputShape("decoded", 0) = Shape({batch_size, log_probs.shape().At(0)});
+  *ctx->MutOutputShape("neg_sum_logits", 0) = Shape({batch_size, 1});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/cublas_bias_add_relu_matmul_grad_op.cpp
+++ b/oneflow/user/ops/cublas_bias_add_relu_matmul_grad_op.cpp
@@ -28,8 +28,8 @@ Maybe<void> InferTensorDesc4FusedMatmulBackward(user_op::InferContext* ctx) {
   const user_op::TensorDesc& dy_desc = ctx->InputTensorDesc("dy", 0);
   const int64_t bias_size = weight_desc.shape().At(1);
   Shape d_grad_shape({dy_desc.shape().At(0), weight_desc.shape().At(1)});
-  *ctx->OutputShape("d_grad", 0) = d_grad_shape;
-  *ctx->OutputShape("d_bias", 0) = Shape({bias_size});
+  *ctx->MutOutputShape("d_grad", 0) = d_grad_shape;
+  *ctx->MutOutputShape("d_bias", 0) = Shape({bias_size});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/cublas_fused_matmul_bias_add_grad_op.cpp
+++ b/oneflow/user/ops/cublas_fused_matmul_bias_add_grad_op.cpp
@@ -36,8 +36,8 @@ Maybe<void> InferTensorDesc4MatmulBiasAddBackward(user_op::InferContext* ctx) {
 
   const int64_t bias_size = dy_desc.shape().At(1);
   Shape w_grad_shape({dy_desc.shape().At(1), x_desc.shape().At(1)});
-  *ctx->OutputShape("w_grad", 0) = w_grad_shape;
-  *ctx->OutputShape("b_grad", 0) = Shape({bias_size});
+  *ctx->MutOutputShape("w_grad", 0) = w_grad_shape;
+  *ctx->MutOutputShape("b_grad", 0) = Shape({bias_size});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/cublas_fused_mlp_grad_op.cpp
+++ b/oneflow/user/ops/cublas_fused_mlp_grad_op.cpp
@@ -25,10 +25,10 @@ Maybe<void> InferTensorDesc4FusedMatmulBackward(user_op::InferContext* ctx) {
   const user_op::TensorDesc& x_desc = ctx->InputTensorDesc("x", 0);
   for (int idx = weight_num - 1; idx >= 0; idx--) {
     const user_op::TensorDesc& weight_desc = ctx->InputTensorDesc("weights", idx);
-    *ctx->OutputShape("d_weights", idx) = weight_desc.shape();
-    *ctx->OutputShape("d_biases", idx) = Shape({weight_desc.shape().At(0)});
+    *ctx->MutOutputShape("d_weights", idx) = weight_desc.shape();
+    *ctx->MutOutputShape("d_biases", idx) = Shape({weight_desc.shape().At(0)});
   }
-  *ctx->OutputShape("d_x", 0) = x_desc.shape();
+  *ctx->MutOutputShape("d_x", 0) = x_desc.shape();
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/cublas_fused_mlp_op.cpp
+++ b/oneflow/user/ops/cublas_fused_mlp_op.cpp
@@ -65,12 +65,12 @@ Maybe<void> InferTensorDesc4FusedMatmul(user_op::InferContext* ctx) {
     // Set Middle result shape.
     long cublas_aligned_aux_ld = AlignReluAuxLd(cublas_aux_ld);
     int64_t aux_size = cublas_aligned_aux_ld / 32;  // Cause we use int32_t as dtype
-    *ctx->OutputShape("cublas_aux", idx) = Shape({m, aux_size});
-    *ctx->OutputShape("hidden", idx) = Shape({m, n});
+    *ctx->MutOutputShape("cublas_aux", idx) = Shape({m, aux_size});
+    *ctx->MutOutputShape("hidden", idx) = Shape({m, n});
     // Set for next layer.
     k = n;
   }
-  *ctx->OutputShape("out", 0) = {m, n};
+  *ctx->MutOutputShape("out", 0) = {m, n};
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/cum_ops.cpp
+++ b/oneflow/user/ops/cum_ops.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 Maybe<void> CumsumOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("y", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("y", 0) = ctx->InputShape("x", 0);
   return Maybe<void>::Ok();
 }
 
@@ -73,7 +73,7 @@ REGISTER_USER_OP_GRAD("cumsum").SetGenBackwardOpConfFn(
     });
 
 Maybe<void> CumProdOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("y", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("y", 0) = ctx->InputShape("x", 0);
   return Maybe<void>::Ok();
 }
 
@@ -96,7 +96,7 @@ Maybe<void> CumProdOp::InferDataType(user_op::InferContext* ctx) {
 }
 
 Maybe<void> CumProdGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("dy", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("dy", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/data_shuffle_op.cpp
+++ b/oneflow/user/ops/data_shuffle_op.cpp
@@ -32,10 +32,10 @@ namespace oneflow {
       CHECK_EQ_OR_RETURN(keys_shape.At(1), num_tables) << "keys cols must equal to num_tables";
     }
   }
-  *ctx->OutputShape("num_unique", 0) = Shape({1});
-  *ctx->OutputShape("unique_keys", 0) = Shape({keys_shape.elem_cnt()});
-  *ctx->OutputShape("unique_values", 0) = Shape({keys_shape.elem_cnt()});
-  *ctx->OutputShape("inverse_indices", 0) = keys_shape;
+  *ctx->MutOutputShape("num_unique", 0) = Shape({1});
+  *ctx->MutOutputShape("unique_keys", 0) = Shape({keys_shape.elem_cnt()});
+  *ctx->MutOutputShape("unique_values", 0) = Shape({keys_shape.elem_cnt()});
+  *ctx->MutOutputShape("inverse_indices", 0) = keys_shape;
   return Maybe<void>::Ok();
 }
 
@@ -74,12 +74,12 @@ namespace oneflow {
   }
   const int64_t num_ids = ids_shape.elem_cnt();
   const int64_t parallel_num = ctx->parallel_num();
-  *ctx->OutputShape("num_unique_matrix", 0) = Shape({parallel_num * parallel_num});
-  *ctx->OutputShape("inverse_unique_partition_indices", 0) = ids_shape;
-  *ctx->OutputShape("cur_rank_num_unique", 0) = Shape({1});
-  *ctx->OutputShape("cur_rank_unique_ids", 0) = Shape({num_ids * parallel_num});
-  *ctx->OutputShape("cur_rank_inverse_indices", 0) = Shape({num_ids * parallel_num});
-  *ctx->OutputShape("cur_rank_unique_table_ids", 0) = Shape({num_ids * parallel_num});
+  *ctx->MutOutputShape("num_unique_matrix", 0) = Shape({parallel_num * parallel_num});
+  *ctx->MutOutputShape("inverse_unique_partition_indices", 0) = ids_shape;
+  *ctx->MutOutputShape("cur_rank_num_unique", 0) = Shape({1});
+  *ctx->MutOutputShape("cur_rank_unique_ids", 0) = Shape({num_ids * parallel_num});
+  *ctx->MutOutputShape("cur_rank_inverse_indices", 0) = Shape({num_ids * parallel_num});
+  *ctx->MutOutputShape("cur_rank_unique_table_ids", 0) = Shape({num_ids * parallel_num});
   return Maybe<void>::Ok();
 }
 
@@ -135,7 +135,7 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(cur_rank_inverse_indices_shape.elem_cnt(), parallel_num * num_ids);
   DimVector out_dim_vec = inverse_unique_partition_indices_shape.dim_vec();
   out_dim_vec.push_back(embedding_size);
-  *ctx->OutputShape("embeddings", 0) = Shape(out_dim_vec);
+  *ctx->MutOutputShape("embeddings", 0) = Shape(out_dim_vec);
   return Maybe<void>::Ok();
 }
 
@@ -179,7 +179,7 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(cur_rank_inverse_indices_shape.elem_cnt(), parallel_num * num_ids);
   DimVector out_dim_vec = cur_rank_inverse_indices_shape.dim_vec();
   out_dim_vec.push_back(embedding_size);
-  *ctx->OutputShape("cur_rank_unique_embedding_grad", 0) = Shape(out_dim_vec);
+  *ctx->MutOutputShape("cur_rank_unique_embedding_grad", 0) = Shape(out_dim_vec);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/distributions/normal_op.cpp
+++ b/oneflow/user/ops/distributions/normal_op.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> NormalOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   const Shape& shape = ctx->Attr<Shape>("shape");
   *out_shape = shape;
   return Maybe<void>::Ok();
@@ -36,7 +36,7 @@ namespace oneflow {
       GetTensorSliceView4ParallelId(parallel_hierarchy, nd_sbp, logical_shape, parallel_id);
   const Shape& physical_shape = tensor_slice_view.shape();
 
-  *ctx->OutputShape("out", 0) = physical_shape;
+  *ctx->MutOutputShape("out", 0) = physical_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/distributions/uniform_int_op.cpp
+++ b/oneflow/user/ops/distributions/uniform_int_op.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> UniformIntOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   const Shape& shape = ctx->Attr<Shape>("shape");
   DimVector dim_vec;
   if (shape.NumAxes() > 0) {
@@ -39,7 +39,7 @@ namespace oneflow {
       GetTensorSliceView4ParallelId(parallel_hierarchy, nd_sbp, logical_shape, parallel_id);
   const Shape& physical_shape = tensor_slice_view.shape();
 
-  *ctx->OutputShape("out", 0) = physical_shape;
+  *ctx->MutOutputShape("out", 0) = physical_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/distributions/uniform_op.cpp
+++ b/oneflow/user/ops/distributions/uniform_op.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> UniformOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   const Shape& shape = ctx->Attr<Shape>("shape");
   DimVector dim_vec;
   if (shape.NumAxes() > 0) {
@@ -39,7 +39,7 @@ namespace oneflow {
       GetTensorSliceView4ParallelId(parallel_hierarchy, nd_sbp, logical_shape, parallel_id);
   const Shape& physical_shape = tensor_slice_view.shape();
 
-  *ctx->OutputShape("out", 0) = physical_shape;
+  *ctx->MutOutputShape("out", 0) = physical_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/dot_op.cpp
+++ b/oneflow/user/ops/dot_op.cpp
@@ -28,7 +28,7 @@ namespace oneflow {
   CHECK_OR_RETURN(x.shape().NumAxes() == 1)
       << Error::RuntimeError() << "1D tensors expected, but got " << x.shape().NumAxes()
       << "D tensors";
-  *ctx->OutputShape("out", 0) = Shape({});
+  *ctx->MutOutputShape("out", 0) = Shape({});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/dropout_op.cpp
+++ b/oneflow/user/ops/dropout_op.cpp
@@ -20,8 +20,8 @@ namespace oneflow {
 
 /* static */ Maybe<void> DropoutOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  *ctx->OutputShape("out", 0) = in_shape;
-  *ctx->OutputShape("mask", 0) = in_shape;
+  *ctx->MutOutputShape("out", 0) = in_shape;
+  *ctx->MutOutputShape("mask", 0) = in_shape;
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -53,7 +53,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> DropoutGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  *ctx->OutputShape("dx", 0) = dy_shape;
+  *ctx->MutOutputShape("dx", 0) = dy_shape;
   *ctx->OutputIsDynamic("dx", 0) = ctx->InputIsDynamic("dy", 0);
   CHECK_EQ_OR_RETURN(ctx->InputShape("mask", 0), dy_shape);
   return Maybe<void>::Ok();
@@ -89,7 +89,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> RandomMaskLikeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("like", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("like", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/eager_b_to_s_op.cpp
+++ b/oneflow/user/ops/eager_b_to_s_op.cpp
@@ -39,7 +39,7 @@ namespace oneflow {
     int64_t parallel_id = opt_parallel_id->value_or(0);
     dim_vec[out_split_axis] = bs.At(parallel_id).size();
   }
-  *ctx->OutputShape("out", 0) = Shape(dim_vec);
+  *ctx->MutOutputShape("out", 0) = Shape(dim_vec);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/eager_nccl_ops.cpp
+++ b/oneflow/user/ops/eager_nccl_ops.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> EagerNcclAllReduceOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -48,7 +48,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> EagerNcclBroadcastOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -96,7 +96,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> EagerNcclReduceOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -120,14 +120,14 @@ namespace oneflow {
 
 /* static */ Maybe<void> EagerNcclReduceScatterOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
 /* static */ Maybe<void> EagerNcclReduceScatterOp::InferPhysicalTensorDesc(
     user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   const int64_t& parallel_num = ctx->parallel_ctx().parallel_num();
   if (parallel_num > 1) {
     const Shape& parallel_hierarchy = *ctx->parallel_desc().hierarchy();
@@ -179,7 +179,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> EagerNcclAllGatherOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -226,7 +226,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> EagerNcclS2sOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/eager_p_to_b_op.cpp
+++ b/oneflow/user/ops/eager_p_to_b_op.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 namespace oneflow {
 // Can only be called in local
 /* static */ Maybe<void> EagerPToBOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
+  *ctx->MutOutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/eager_p_to_s_op.cpp
+++ b/oneflow/user/ops/eager_p_to_s_op.cpp
@@ -38,7 +38,7 @@ namespace oneflow {
     int64_t parallel_id = opt_parallel_id->value_or(0);
     dim_vec[out_split_axis] = bs.At(parallel_id).size();
   }
-  *ctx->OutputShape("out", 0) = Shape(dim_vec);
+  *ctx->MutOutputShape("out", 0) = Shape(dim_vec);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/eager_s_to_b_op.cpp
+++ b/oneflow/user/ops/eager_s_to_b_op.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> EagerSToBOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
+  *ctx->MutOutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/eager_s_to_p_op.cpp
+++ b/oneflow/user/ops/eager_s_to_p_op.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> EagerSToPOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
+  *ctx->MutOutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/eager_s_to_s_op.cpp
+++ b/oneflow/user/ops/eager_s_to_s_op.cpp
@@ -38,7 +38,7 @@ namespace oneflow {
     int64_t parallel_id = opt_parallel_id->value_or(0);
     dim_vec[out_split_axis] = bs.At(parallel_id).size();
   }
-  *ctx->OutputShape("out", 0) = Shape(dim_vec);
+  *ctx->MutOutputShape("out", 0) = Shape(dim_vec);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/eager_symmetric_s_to_p_op.cpp
+++ b/oneflow/user/ops/eager_symmetric_s_to_p_op.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> EagerSymmetricSToPOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/elu_op.cpp
+++ b/oneflow/user/ops/elu_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> EluOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 /* static */ Maybe<void> EluGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/embedding_op.cpp
+++ b/oneflow/user/ops/embedding_op.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> EmbeddingRenormOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/empty_op.cpp
+++ b/oneflow/user/ops/empty_op.cpp
@@ -38,8 +38,8 @@ Maybe<Symbol<Stream>> MakeEmptyStream(const Symbol<Device>& out_device, const bo
 }  // namespace
 
 /* static */ Maybe<void> EmptyOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
-  *ctx->OutputStride("out", 0) = Stride(Shape(ctx->Attr<Shape>("shape").dim_vec()));
+  *ctx->MutOutputShape("out", 0) = Shape(ctx->Attr<Shape>("shape").dim_vec());
+  *ctx->MutOutputStride("out", 0) = Stride(Shape(ctx->Attr<Shape>("shape").dim_vec()));
   return Maybe<void>::Ok();
 }
 
@@ -52,8 +52,8 @@ Maybe<Symbol<Stream>> MakeEmptyStream(const Symbol<Device>& out_device, const bo
       GetTensorSliceView4ParallelId(parallel_hierarchy, nd_sbp, logical_shape, parallel_id);
   const Shape& physical_shape = tensor_slice_view.shape();
 
-  *ctx->OutputShape("out", 0) = physical_shape;
-  *ctx->OutputStride("out", 0) = Stride(physical_shape);
+  *ctx->MutOutputShape("out", 0) = physical_shape;
+  *ctx->MutOutputStride("out", 0) = Stride(physical_shape);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/erfinv_op.cpp
+++ b/oneflow/user/ops/erfinv_op.cpp
@@ -20,7 +20,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> ErfInvOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
-  Shape* y_shape = ctx->OutputShape("y", 0);
+  Shape* y_shape = ctx->MutOutputShape("y", 0);
   *y_shape = x_shape;
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/expand_dims_op.cpp
+++ b/oneflow/user/ops/expand_dims_op.cpp
@@ -31,7 +31,7 @@ int32_t TransformNegativeAxisToPositive(int32_t axis, const int32_t num_axes) {
 
 /* static */ Maybe<void> ExpandDimsOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   const int32_t axis =
       TransformNegativeAxisToPositive(ctx->Attr<int32_t>("axis"), in_shape.NumAxes());
 

--- a/oneflow/user/ops/expand_op.cpp
+++ b/oneflow/user/ops/expand_op.cpp
@@ -32,7 +32,7 @@ namespace oneflow {
   std::vector<int32_t> stride;
   CHECK_JUST(getOutShapeAndStrideForFp(in_shape, logical_expand_shape, out_shape, stride));
 
-  Shape* output_shape = ctx->OutputShape("out", 0);
+  Shape* output_shape = ctx->MutOutputShape("out", 0);
   DimVector dim_vec(out_shape.begin(), out_shape.end());
   *output_shape = Shape(dim_vec);
 
@@ -90,7 +90,7 @@ namespace oneflow {
   CHECK_JUST(getOutShapeAndStrideForBp(logical_out_shape, logical_expand_shape, in_shape, out_shape,
                                        stride));
 
-  Shape* output_shape = ctx->OutputShape("out", 0);
+  Shape* output_shape = ctx->MutOutputShape("out", 0);
   DimVector dim_vec(out_shape.begin(), out_shape.end());
   *output_shape = Shape(dim_vec);
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/eye_op.cpp
+++ b/oneflow/user/ops/eye_op.cpp
@@ -21,7 +21,7 @@ namespace oneflow {
 /* static */ Maybe<void> EyeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   int64_t rows = ctx->Attr<int64_t>("rows");
   int64_t cols = ctx->Attr<int64_t>("cols");
-  *ctx->OutputShape("out", 0) = Shape({rows, cols});
+  *ctx->MutOutputShape("out", 0) = Shape({rows, cols});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/fake_quantization_op.cpp
+++ b/oneflow/user/ops/fake_quantization_op.cpp
@@ -30,7 +30,7 @@ namespace oneflow {
     CHECK_EQ_OR_RETURN(zero_point_shape.elem_cnt(), in_shape.At(0));
   }
 
-  *ctx->OutputShape("out", 0) = in_shape;
+  *ctx->MutOutputShape("out", 0) = in_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/fill_op.cpp
+++ b/oneflow/user/ops/fill_op.cpp
@@ -20,9 +20,9 @@ namespace oneflow {
 
 /* static */ Maybe<void> FillOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   *out_shape = in_shape;
-  Stride* out_stride = ctx->OutputStride("out", 0);
+  Stride* out_stride = ctx->MutOutputStride("out", 0);
   *out_stride = ctx->InputStride("in", 0);
   return Maybe<void>::Ok();
 }
@@ -46,9 +46,9 @@ namespace oneflow {
 
 /* static */ Maybe<void> FillTensorOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   *out_shape = in_shape;
-  Stride* out_stride = ctx->OutputStride("out", 0);
+  Stride* out_stride = ctx->MutOutputStride("out", 0);
   *out_stride = ctx->InputStride("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/fused_bias_add_op.cpp
+++ b/oneflow/user/ops/fused_bias_add_op.cpp
@@ -27,7 +27,7 @@ namespace oneflow {
   CHECK_GE_OR_RETURN(bias_add_axis, 0);
   CHECK_LT_OR_RETURN(bias_add_axis, a_tensor_desc.shape().NumAxes());
   CHECK_EQ_OR_RETURN(a_tensor_desc.shape().At(bias_add_axis), b_tensor_desc.shape().At(0));
-  *ctx->OutputShape("out", 0) = a_tensor_desc.shape();
+  *ctx->MutOutputShape("out", 0) = a_tensor_desc.shape();
   *ctx->OutputIsDynamic("out", 0) = a_tensor_desc.is_dynamic();
   return Maybe<void>::Ok();
 }
@@ -67,7 +67,7 @@ namespace oneflow {
   CHECK_GE_OR_RETURN(bias_add_axis, 0);
   CHECK_LT_OR_RETURN(bias_add_axis, a_tensor_desc.shape().NumAxes());
   CHECK_EQ_OR_RETURN(a_tensor_desc.shape().At(bias_add_axis), b_tensor_desc.shape().At(0));
-  *ctx->OutputShape("dx", 0) = a_tensor_desc.shape();
+  *ctx->MutOutputShape("dx", 0) = a_tensor_desc.shape();
   *ctx->OutputIsDynamic("dx", 0) = a_tensor_desc.is_dynamic();
   return Maybe<void>::Ok();
 }
@@ -152,7 +152,7 @@ REGISTER_USER_OP_GRAD("fused_bias_add_gelu")
   CHECK_LT_OR_RETURN(bias_add_axis, a_tensor_desc.shape().NumAxes());
   CHECK_EQ_OR_RETURN(a_tensor_desc.shape().At(bias_add_axis), b_tensor_desc.shape().At(0));
   CHECK_EQ_OR_RETURN(a_tensor_desc.shape(), mask_tensor_desc.shape());
-  *ctx->OutputShape("out", 0) = a_tensor_desc.shape();
+  *ctx->MutOutputShape("out", 0) = a_tensor_desc.shape();
   *ctx->OutputIsDynamic("out", 0) = a_tensor_desc.is_dynamic();
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/fused_cross_feature_interaction_op.cpp
+++ b/oneflow/user/ops/fused_cross_feature_interaction_op.cpp
@@ -24,11 +24,11 @@ namespace oneflow {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& weight_shape = ctx->InputShape("weight", 0);
   CHECK_EQ_OR_RETURN(x_shape.At(1), weight_shape.At(1)) << "Matmul K dims should be equal. ";
-  *ctx->OutputShape("matmul_result", 0) = Shape({x_shape.At(0), weight_shape.At(0)});
+  *ctx->MutOutputShape("matmul_result", 0) = Shape({x_shape.At(0), weight_shape.At(0)});
   const Shape& x0_shape = ctx->InputShape("x0", 0);
   const Shape& bias_shape = ctx->InputShape("bias", 0);
   CHECK_EQ_OR_RETURN(bias_shape.At(0), x0_shape.At(1)) << "Bias dim should be equal to X0 dim1. ";
-  *ctx->OutputShape("out", 0) = x0_shape;
+  *ctx->MutOutputShape("out", 0) = x0_shape;
   return Maybe<void>::Ok();
 }
 
@@ -59,10 +59,10 @@ namespace oneflow {
     user_op::InferContext* ctx) {
   const Shape& x0_shape = ctx->InputShape("x0", 0);
   const Shape& weight_shape = ctx->InputShape("weight", 0);
-  *ctx->OutputShape("dx0", 0) = x0_shape;
-  *ctx->OutputShape("dw", 0) = weight_shape;
-  *ctx->OutputShape("dx", 0) = x0_shape;
-  *ctx->OutputShape("dbias", 0) = Shape({x0_shape.At(1)});
+  *ctx->MutOutputShape("dx0", 0) = x0_shape;
+  *ctx->MutOutputShape("dw", 0) = weight_shape;
+  *ctx->MutOutputShape("dx", 0) = x0_shape;
+  *ctx->MutOutputShape("dbias", 0) = Shape({x0_shape.At(1)});
   return Maybe<void>::Ok();
 }
 
@@ -100,10 +100,10 @@ namespace oneflow {
     user_op::InferContext* ctx) {
   const Shape& x0_shape = ctx->InputShape("x0", 0);
   const Shape& weight_shape = ctx->InputShape("weight", 0);
-  *ctx->OutputShape("dx0", 0) = x0_shape;
-  *ctx->OutputShape("dw", 0) = weight_shape;
-  *ctx->OutputShape("dx", 0) = x0_shape;
-  *ctx->OutputShape("dbias", 0) = Shape({x0_shape.At(1)});
+  *ctx->MutOutputShape("dx0", 0) = x0_shape;
+  *ctx->MutOutputShape("dw", 0) = weight_shape;
+  *ctx->MutOutputShape("dx", 0) = x0_shape;
+  *ctx->MutOutputShape("dbias", 0) = Shape({x0_shape.At(1)});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/fused_dot_feature_interaction_op.cpp
+++ b/oneflow/user/ops/fused_dot_feature_interaction_op.cpp
@@ -36,7 +36,7 @@ namespace oneflow {
   }
   const std::string& pooling = ctx->Attr<std::string>("pooling");
   if (pooling == "sum") {
-    *ctx->OutputShape("out", 0) = Shape({batch_size, vector_size});
+    *ctx->MutOutputShape("out", 0) = Shape({batch_size, vector_size});
     return Maybe<void>::Ok();
   }
   if (ctx->has_input("sparse_feature", 0)) {
@@ -66,7 +66,7 @@ namespace oneflow {
     CHECK_EQ_OR_RETURN(output_concat_shape.At(0), batch_size);
     out_dim += output_concat_shape.At(1);
   }
-  *ctx->OutputShape("out", 0) = Shape({batch_size, out_dim});
+  *ctx->MutOutputShape("out", 0) = Shape({batch_size, out_dim});
   return Maybe<void>::Ok();
 }
 
@@ -109,14 +109,14 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(ctx->output_size("features_grad"), ctx->input_size("features"))
       << "features_grad and features must have same size";
   for (int64_t i = 0; i < ctx->output_size("features_grad"); ++i) {
-    *ctx->OutputShape("features_grad", i) = ctx->InputShape("features", i);
+    *ctx->MutOutputShape("features_grad", i) = ctx->InputShape("features", i);
   }
   if (ctx->has_output("output_concat_grad", 0)) {
     const int32_t output_concat_grad_dim = ctx->Attr<int32_t>("output_concat_grad_dim");
-    *ctx->OutputShape("output_concat_grad", 0) = Shape({batch_size, output_concat_grad_dim});
+    *ctx->MutOutputShape("output_concat_grad", 0) = Shape({batch_size, output_concat_grad_dim});
   }
   if (ctx->has_output("sparse_feature_grad", 0)) {
-    *ctx->OutputShape("sparse_feature_grad", 0) = ctx->InputShape("sparse_feature", 0);
+    *ctx->MutOutputShape("sparse_feature_grad", 0) = ctx->InputShape("sparse_feature", 0);
   }
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/fused_gru_cell_op.cpp
+++ b/oneflow/user/ops/fused_gru_cell_op.cpp
@@ -21,8 +21,8 @@ namespace oneflow {
 
 /* static */ Maybe<void> FusedGruCellOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& hx_shape = ctx->InputShape("hx", 0);
-  *ctx->OutputShape("hy", 0) = hx_shape;
-  *ctx->OutputShape("workspace", 0) = Shape({hx_shape.At(0), hx_shape.At(1) * 5});
+  *ctx->MutOutputShape("hy", 0) = hx_shape;
+  *ctx->MutOutputShape("workspace", 0) = Shape({hx_shape.At(0), hx_shape.At(1) * 5});
   return Maybe<void>::Ok();
 }
 
@@ -69,14 +69,14 @@ namespace oneflow {
 /* static */ Maybe<void> FusedGruCellGradOp ::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& grad_hy_shape = ctx->InputShape("grad_hy", 0);
   DimVector dim_vec({grad_hy_shape.At(0), grad_hy_shape.At(1) * 3});
-  *ctx->OutputShape("grad_input_gates", 0) = Shape(dim_vec);
-  *ctx->OutputShape("grad_hidden_gates", 0) = Shape(dim_vec);
+  *ctx->MutOutputShape("grad_input_gates", 0) = Shape(dim_vec);
+  *ctx->MutOutputShape("grad_hidden_gates", 0) = Shape(dim_vec);
 
-  if (ctx->has_output("grad_hx", 0)) { *ctx->OutputShape("grad_hx", 0) = grad_hy_shape; }
+  if (ctx->has_output("grad_hx", 0)) { *ctx->MutOutputShape("grad_hx", 0) = grad_hy_shape; }
 
   if (ctx->has_output("grad_input_bias", 0) && ctx->has_output("grad_hidden_bias", 0)) {
-    *ctx->OutputShape("grad_input_bias", 0) = Shape({grad_hy_shape.At(1) * 3});
-    *ctx->OutputShape("grad_hidden_bias", 0) = Shape({grad_hy_shape.At(1) * 3});
+    *ctx->MutOutputShape("grad_input_bias", 0) = Shape({grad_hy_shape.At(1) * 3});
+    *ctx->MutOutputShape("grad_hidden_bias", 0) = Shape({grad_hy_shape.At(1) * 3});
   }
 
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/fused_lstm_cell_op.cpp
+++ b/oneflow/user/ops/fused_lstm_cell_op.cpp
@@ -21,9 +21,9 @@ namespace oneflow {
 
 /* static */ Maybe<void> FusedLstmCellOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& cx_shape = ctx->InputShape("cx", 0);
-  *ctx->OutputShape("hy", 0) = cx_shape;
-  *ctx->OutputShape("cy", 0) = cx_shape;
-  *ctx->OutputShape("workspace", 0) = ctx->InputShape("input_gates", 0);
+  *ctx->MutOutputShape("hy", 0) = cx_shape;
+  *ctx->MutOutputShape("cy", 0) = cx_shape;
+  *ctx->MutOutputShape("workspace", 0) = ctx->InputShape("input_gates", 0);
   return Maybe<void>::Ok();
 }
 
@@ -71,12 +71,14 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> FusedLstmCellGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("grad_gates", 0) = ctx->InputShape("workspace", 0);
+  *ctx->MutOutputShape("grad_gates", 0) = ctx->InputShape("workspace", 0);
 
-  if (ctx->has_output("grad_cx", 0)) { *ctx->OutputShape("grad_cx", 0) = ctx->InputShape("cx", 0); }
+  if (ctx->has_output("grad_cx", 0)) {
+    *ctx->MutOutputShape("grad_cx", 0) = ctx->InputShape("cx", 0);
+  }
 
   if (ctx->has_output("grad_bias", 0)) {
-    *ctx->OutputShape("grad_bias", 0) = Shape({ctx->InputShape("workspace", 0).At(1)});
+    *ctx->MutOutputShape("grad_bias", 0) = Shape({ctx->InputShape("workspace", 0).At(1)});
   }
 
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/fused_matmul_bias_add_relu_dropout_op.cpp
+++ b/oneflow/user/ops/fused_matmul_bias_add_relu_dropout_op.cpp
@@ -65,12 +65,12 @@ Maybe<void> InferTensorDesc4FusedMatmul(user_op::InferContext* ctx) {
     // Set Middle result shape.
     long cublas_aligned_aux_ld = AlignReluAuxLd(cublas_aux_ld);
     int64_t aux_size = cublas_aligned_aux_ld / 32;  // Cause we use int32_t as dtype
-    *ctx->OutputShape("cublas_aux", idx) = Shape({m, aux_size});
-    *ctx->OutputShape("hidden", idx) = Shape({m, n});
+    *ctx->MutOutputShape("cublas_aux", idx) = Shape({m, aux_size});
+    *ctx->MutOutputShape("hidden", idx) = Shape({m, n});
     // Set for next layer.
     k = n;
   }
-  *ctx->OutputShape("out", 0) = {m, n};
+  *ctx->MutOutputShape("out", 0) = {m, n};
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/fused_relu_dropout_grad_op.cpp
+++ b/oneflow/user/ops/fused_relu_dropout_grad_op.cpp
@@ -25,7 +25,7 @@ namespace oneflow {
 namespace {
 
 Maybe<void> InferTensorDesc4FusedReluDropoutGrad(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("dy", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("dy", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/fused_scale_mask_softmax_dropout_op.cpp
+++ b/oneflow/user/ops/fused_scale_mask_softmax_dropout_op.cpp
@@ -27,9 +27,9 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(x_desc.shape().At(x_shape.NumAxes() - 1),
                      mask_desc.shape().At(mask_shape.NumAxes() - 1))
       << " last dim of x and mask is not equal.";
-  *ctx->OutputShape("y", 0) = x_desc.shape();
+  *ctx->MutOutputShape("y", 0) = x_desc.shape();
   *ctx->OutputIsDynamic("y", 0) = x_desc.is_dynamic();
-  *ctx->OutputShape("softmax_y", 0) = x_desc.shape();
+  *ctx->MutOutputShape("softmax_y", 0) = x_desc.shape();
   *ctx->OutputIsDynamic("softmax_y", 0) = x_desc.is_dynamic();
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/fused_scale_mask_softmax_op.cpp
+++ b/oneflow/user/ops/fused_scale_mask_softmax_op.cpp
@@ -27,7 +27,7 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(x_desc.shape().At(x_shape.NumAxes() - 1),
                      mask_desc.shape().At(mask_shape.NumAxes() - 1))
       << " last dim of x and mask is not equal.";
-  *ctx->OutputShape("y", 0) = x_desc.shape();
+  *ctx->MutOutputShape("y", 0) = x_desc.shape();
   *ctx->OutputIsDynamic("y", 0) = x_desc.is_dynamic();
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/fused_scale_tril_softmax_mask_scale_op.cpp
+++ b/oneflow/user/ops/fused_scale_tril_softmax_mask_scale_op.cpp
@@ -20,9 +20,9 @@ namespace oneflow {
 /*static*/ auto FusedTrilScaleSoftmaxMaskScaleOp::InferLogicalTensorDesc(user_op::InferContext* ctx)
     -> Maybe<void> {
   const user_op::TensorDesc& x_desc = ctx->InputTensorDesc("x", 0);
-  *ctx->OutputShape("y", 0) = x_desc.shape();
+  *ctx->MutOutputShape("y", 0) = x_desc.shape();
   *ctx->OutputIsDynamic("y", 0) = x_desc.is_dynamic();
-  *ctx->OutputShape("softmax_y", 0) = x_desc.shape();
+  *ctx->MutOutputShape("softmax_y", 0) = x_desc.shape();
   *ctx->OutputIsDynamic("softmax_y", 0) = x_desc.is_dynamic();
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/fused_self_attention_query_mul_key_and_value_ops.cpp
+++ b/oneflow/user/ops/fused_self_attention_query_mul_key_and_value_ops.cpp
@@ -41,8 +41,8 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(hidden_size % (head_size * 3), 0);
   int64_t num_heads = hidden_size / (head_size * 3);
 
-  *ctx->OutputShape("query_mul_key", 0) = Shape({batch_size, num_heads, seq_len, seq_len});
-  *ctx->OutputShape("value", 0) = Shape({batch_size, num_heads, seq_len, head_size});
+  *ctx->MutOutputShape("query_mul_key", 0) = Shape({batch_size, num_heads, seq_len, seq_len});
+  *ctx->MutOutputShape("value", 0) = Shape({batch_size, num_heads, seq_len, head_size});
 
   return Maybe<void>::Ok();
 }
@@ -98,7 +98,7 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(qmk_grad_shape.At(2), seq_len);
   CHECK_EQ_OR_RETURN(qmk_grad_shape.At(3), seq_len);
 
-  *ctx->OutputShape("hidden_states_grad", 0) = h_shape;
+  *ctx->MutOutputShape("hidden_states_grad", 0) = h_shape;
   return Maybe<void>::Ok();
 }
 /*static*/ auto FusedSelfAttentionQueryMulKeyAndValueGradOp::InferPhysicalTensorDesc(

--- a/oneflow/user/ops/gelu_op.cpp
+++ b/oneflow/user/ops/gelu_op.cpp
@@ -20,7 +20,7 @@ namespace oneflow {
 
 /*static*/ auto GeluOp::InferLogicalTensorDesc(user_op::InferContext* ctx) -> Maybe<void> {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   *out_shape = in_shape;
   return Maybe<void>::Ok();
 }
@@ -42,7 +42,7 @@ namespace oneflow {
 /*static*/ auto GeluGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) -> Maybe<void> {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/generate_random_batch_permutation_indices_op.cpp
+++ b/oneflow/user/ops/generate_random_batch_permutation_indices_op.cpp
@@ -21,7 +21,7 @@ namespace oneflow {
 
 /*static*/ auto GenerateRandomBatchPermutationIndicesOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) -> Maybe<void> {
-  *ctx->OutputShape("y", 0) = Shape({ctx->InputShape("x", 0).At(0)});
+  *ctx->MutOutputShape("y", 0) = Shape({ctx->InputShape("x", 0).At(0)});
   return Maybe<void>::Ok();
 }
 /*static*/ auto GenerateRandomBatchPermutationIndicesOp::InferPhysicalTensorDesc(

--- a/oneflow/user/ops/hardshrink_op.cpp
+++ b/oneflow/user/ops/hardshrink_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> HardShrinkOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 /* static */ Maybe<void> HardShrinkGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& y_shape = ctx->InputShape("y", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == y_shape) << "The shape of y_grad and y must be same.";
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/hardsigmoid_op.cpp
+++ b/oneflow/user/ops/hardsigmoid_op.cpp
@@ -20,7 +20,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> HardsigmoidOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   *out_shape = in_shape;
   return Maybe<void>::Ok();
 }
@@ -45,7 +45,7 @@ namespace oneflow {
 /* static */ Maybe<void> HardsigmoidGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/hardswish_op.cpp
+++ b/oneflow/user/ops/hardswish_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> HardswishOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 /* static */ Maybe<void> HardswishGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/hardtanh_op.cpp
+++ b/oneflow/user/ops/hardtanh_op.cpp
@@ -20,7 +20,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> HardtanhOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   *out_shape = in_shape;
   double min_val = ctx->Attr<double>("min_val");
   double max_val = ctx->Attr<double>("max_val");
@@ -48,7 +48,7 @@ namespace oneflow {
 /* static */ Maybe<void> HardtanhGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& y_shape = ctx->InputShape("y", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == y_shape);
   *dx_shape = dy_shape;
   double min_val = ctx->Attr<double>("min_val");

--- a/oneflow/user/ops/hierarchical_parallel_cast_op.cpp
+++ b/oneflow/user/ops/hierarchical_parallel_cast_op.cpp
@@ -21,7 +21,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> HierarchicalParallelCastOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -57,7 +57,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> HierarchicalParallelCastLikeOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/identity_op.cpp
+++ b/oneflow/user/ops/identity_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> IdentityOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/image_object_preprocess_ops.cpp
+++ b/oneflow/user/ops/image_object_preprocess_ops.cpp
@@ -35,7 +35,7 @@ Maybe<void> ImageObjectGetSbp(user_op::SbpContext* ctx) {
   const user_op::TensorDesc& flip_code_desc = ctx->InputTensorDesc("flip_code", 0);
   CHECK_EQ_OR_RETURN(flip_code_desc.shape().elem_cnt(), N);
 
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -66,7 +66,7 @@ Maybe<void> ImageObjectGetSbp(user_op::SbpContext* ctx) {
   const user_op::TensorDesc& flip_code_desc = ctx->InputTensorDesc("flip_code", 0);
   CHECK_EQ_OR_RETURN(flip_code_desc.shape().elem_cnt(), N);
 
-  *ctx->OutputShape("out", 0) = ctx->InputShape("bbox", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("bbox", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("bbox", 0);
   return Maybe<void>::Ok();
 }
@@ -98,7 +98,7 @@ Maybe<void> ImageObjectGetSbp(user_op::SbpContext* ctx) {
   const user_op::TensorDesc& scale_desc = ctx->InputTensorDesc("scale", 0);
   CHECK_EQ_OR_RETURN(scale_desc.shape().elem_cnt(), N * 2);
 
-  *ctx->OutputShape("out", 0) = ctx->InputShape("bbox", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("bbox", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("bbox", 0);
   return Maybe<void>::Ok();
 }
@@ -132,7 +132,7 @@ Maybe<void> ImageObjectGetSbp(user_op::SbpContext* ctx) {
   const user_op::TensorDesc& flip_code_desc = ctx->InputTensorDesc("flip_code", 0);
   CHECK_EQ_OR_RETURN(flip_code_desc.shape().elem_cnt(), N);
 
-  *ctx->OutputShape("out", 0) = ctx->InputShape("poly", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("poly", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("poly", 0);
   return Maybe<void>::Ok();
 }
@@ -167,7 +167,7 @@ Maybe<void> ImageObjectGetSbp(user_op::SbpContext* ctx) {
   const user_op::TensorDesc& scale_desc = ctx->InputTensorDesc("scale", 0);
   CHECK_EQ_OR_RETURN(scale_desc.shape().elem_cnt(), N * 2);
 
-  *ctx->OutputShape("out", 0) = ctx->InputShape("poly", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("poly", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("poly", 0);
   return Maybe<void>::Ok();
 }
@@ -194,7 +194,7 @@ Maybe<void> ImageObjectGetSbp(user_op::SbpContext* ctx) {
 /* static */ Maybe<void> ImageNormalizeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const user_op::TensorDesc& in_desc = ctx->InputTensorDesc("in", 0);
   CHECK_EQ_OR_RETURN(in_desc.shape().NumAxes(), 1);
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -227,7 +227,7 @@ Maybe<void> ImageObjectGetSbp(user_op::SbpContext* ctx) {
   const user_op::TensorDesc& image_size_desc = ctx->InputTensorDesc("image_size", 0);
   CHECK_EQ_OR_RETURN(image_size_desc.shape().elem_cnt(), N * 2);
 
-  *ctx->OutputShape("out", 0) = ctx->InputShape("poly", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("poly", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("poly", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/image_preprocess_ops.cpp
+++ b/oneflow/user/ops/image_preprocess_ops.cpp
@@ -159,7 +159,7 @@ namespace oneflow {
   const auto tensor_slice_view =
       GetTensorSliceView4ParallelId(parallel_hierarchy, nd_sbp, logical_shape, parallel_id);
   const Shape& physical_shape = tensor_slice_view.shape();
-  *ctx->OutputShape("out", 0) = physical_shape;
+  *ctx->MutOutputShape("out", 0) = physical_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/l1_l2_regularize_gradient_op.cpp
+++ b/oneflow/user/ops/l1_l2_regularize_gradient_op.cpp
@@ -24,7 +24,7 @@ Maybe<void> InferTensorDesc(user_op::InferContext* ctx) {
   const user_op::TensorDesc& model = ctx->InputTensorDesc("model", 0);
   const user_op::TensorDesc& model_diff = ctx->InputTensorDesc("model_diff", 0);
   CHECK_EQ_OR_RETURN(model_diff.shape(), model.shape());
-  *ctx->OutputShape("out", 0) = ctx->InputShape("model", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("model", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("model", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/l2_normalize_op.cpp
+++ b/oneflow/user/ops/l2_normalize_op.cpp
@@ -20,8 +20,8 @@ namespace oneflow {
 
 /* static */ Maybe<void> L2NormalizeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
-  Shape* y_shape = ctx->OutputShape("y", 0);
-  Shape* square_x_sum_shape = ctx->OutputShape("square_x_sum", 0);
+  Shape* y_shape = ctx->MutOutputShape("y", 0);
+  Shape* square_x_sum_shape = ctx->MutOutputShape("square_x_sum", 0);
   const int32_t axis = ctx->Attr<int32_t>("axis");
   const float epsilon = ctx->Attr<float>("epsilon");
   CHECK_GE_OR_RETURN(axis, 0);
@@ -62,7 +62,7 @@ namespace oneflow {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
   const Shape& y_shape = ctx->InputShape("y", 0);
   const Shape& square_x_sum_shape = ctx->InputShape("square_x_sum", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   const int32_t axis = ctx->Attr<int32_t>("axis");
   const float epsilon = ctx->Attr<float>("epsilon");
   CHECK_EQ_OR_RETURN(dy_shape, y_shape);

--- a/oneflow/user/ops/leaky_relu_op.cpp
+++ b/oneflow/user/ops/leaky_relu_op.cpp
@@ -20,7 +20,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> LeakyReluOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
-  Shape* y_shape = ctx->OutputShape("y", 0);
+  Shape* y_shape = ctx->MutOutputShape("y", 0);
   *y_shape = x_shape;
   return Maybe<void>::Ok();
 }
@@ -45,7 +45,7 @@ namespace oneflow {
 /* static */ Maybe<void> LeakyReluGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/log_softmax_op.cpp
+++ b/oneflow/user/ops/log_softmax_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> LogSoftmaxOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("prob", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("prob", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -46,7 +46,7 @@ namespace oneflow {
 /* static */ Maybe<void> LogSoftmaxGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& y_shape = ctx->InputShape("prob", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == y_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/masked_fill_op.cpp
+++ b/oneflow/user/ops/masked_fill_op.cpp
@@ -22,7 +22,7 @@ namespace {
 
 Maybe<void> InferMaskedFillTensorDesc(user_op::InferContext* ctx) {
   const Shape& mask_shape = ctx->InputShape("mask", 0);
-  *ctx->OutputShape("out", 0) = mask_shape;
+  *ctx->MutOutputShape("out", 0) = mask_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/math_binary_broadcast_ops.cpp
+++ b/oneflow/user/ops/math_binary_broadcast_ops.cpp
@@ -35,21 +35,21 @@ Maybe<void> InferTensorDescBinaryBroadcastNormal(user_op::InferContext* ctx) {
 
   size_t output_num_axes = std::max(tensor_x.shape().NumAxes(), tensor_y.shape().NumAxes());
   if (IsZeroDimTensor(&tensor_x)) {
-    *ctx->OutputShape("z", 0) = ctx->InputShape("y", 0);
+    *ctx->MutOutputShape("z", 0) = ctx->InputShape("y", 0);
     *ctx->OutputIsDynamic("z", 0) = ctx->InputIsDynamic("y", 0);
   } else if (IsZeroDimTensor(&tensor_y)) {
-    *ctx->OutputShape("z", 0) = ctx->InputShape("x", 0);
+    *ctx->MutOutputShape("z", 0) = ctx->InputShape("x", 0);
     *ctx->OutputIsDynamic("z", 0) = ctx->InputIsDynamic("x", 0);
   } else if (IsScalarTensor(&tensor_x)) {
-    *ctx->OutputShape("z", 0) = ctx->InputShape("y", 0);
+    *ctx->MutOutputShape("z", 0) = ctx->InputShape("y", 0);
     *ctx->OutputIsDynamic("z", 0) = ctx->InputIsDynamic("y", 0);
   } else if (IsScalarTensor(&tensor_y)) {
-    *ctx->OutputShape("z", 0) = ctx->InputShape("x", 0);
+    *ctx->MutOutputShape("z", 0) = ctx->InputShape("x", 0);
     *ctx->OutputIsDynamic("z", 0) = ctx->InputIsDynamic("x", 0);
   } else {
     const auto& x_shape = CreateLeftExtendedShape(ShapeView(tensor_x.shape()), output_num_axes);
     const auto& y_shape = CreateLeftExtendedShape(ShapeView(tensor_y.shape()), output_num_axes);
-    *ctx->OutputShape("z", 0) = ctx->InputShape("x", 0);
+    *ctx->MutOutputShape("z", 0) = ctx->InputShape("x", 0);
     *ctx->OutputIsDynamic("z", 0) = ctx->InputIsDynamic("x", 0);
     Shape out_shape(x_shape);
     FOR_RANGE(int64_t, i, 0, x_shape.NumAxes()) {

--- a/oneflow/user/ops/matmul_op.cpp
+++ b/oneflow/user/ops/matmul_op.cpp
@@ -36,7 +36,7 @@ Maybe<void> InferTensorDesc4Matmul(user_op::InferContext* ctx) {
 
   user_op::TensorDesc* out = ctx->OutputTensorDesc("out", 0);
 
-  *ctx->OutputShape("out", 0) = ctx->InputShape("a", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("a", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("a", 0);
 
   int64_t m, n, k;  // tensor a (no trans): m*k, tensor b (no trans): k*n

--- a/oneflow/user/ops/matrix_vector_product_op.cpp
+++ b/oneflow/user/ops/matrix_vector_product_op.cpp
@@ -26,7 +26,7 @@ Maybe<void> InferTensorDesc4MatrixVectorProduct(user_op::InferContext* ctx) {
   int64_t m = a.shape().At(0);
   int64_t k = a.shape().At(1);
   CHECK_EQ_OR_RETURN(k, b.shape().At(0)) << "Dim K should be equal to vector b's dim0. ";
-  *ctx->OutputShape("out", 0) = Shape({m});
+  *ctx->MutOutputShape("out", 0) = Shape({m});
   return Maybe<void>::Ok();
 }
 
@@ -47,7 +47,7 @@ Maybe<void> InferTensorDesc4MatrixVectorProductGradA(user_op::InferContext* ctx)
   const user_op::TensorDesc& b = ctx->InputTensorDesc("b", 0);
   int64_t m = dy.shape().At(0);
   int64_t n = b.shape().At(0);
-  *ctx->OutputShape("dx", 0) = Shape({m, n});
+  *ctx->MutOutputShape("dx", 0) = Shape({m, n});
   return Maybe<void>::Ok();
 }
 
@@ -58,7 +58,7 @@ Maybe<void> InferTensorDesc4MatrixVectorProductGradB(user_op::InferContext* ctx)
   */
   const user_op::TensorDesc& a = ctx->InputTensorDesc("a", 0);
   int64_t n = a.shape().At(1);
-  *ctx->OutputShape("dx", 0) = Shape({n});
+  *ctx->MutOutputShape("dx", 0) = Shape({n});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/median_op.cpp
+++ b/oneflow/user/ops/median_op.cpp
@@ -28,7 +28,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> MedianOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& ones_shape = {1};
-  *ctx->OutputShape("output", 0) = ones_shape.RemoveOnes({0});
+  *ctx->MutOutputShape("output", 0) = ones_shape.RemoveOnes({0});
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> MedianOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/median_with_indices_op.cpp
+++ b/oneflow/user/ops/median_with_indices_op.cpp
@@ -31,8 +31,8 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> MedianWithIndicesOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& input_shape = ctx->InputShape("input", 0);
-  Shape* values_shape = ctx->OutputShape("values", 0);
-  Shape* indices_shape = ctx->OutputShape("indices", 0);
+  Shape* values_shape = ctx->MutOutputShape("values", 0);
+  Shape* indices_shape = ctx->MutOutputShape("indices", 0);
   const Shape& reduce_shape = CreateReducedShape(input_shape, {-1});
   *values_shape = reduce_shape.RemoveOnes({-1});
   *indices_shape = reduce_shape.RemoveOnes({-1});

--- a/oneflow/user/ops/min_max_observer_op.cpp
+++ b/oneflow/user/ops/min_max_observer_op.cpp
@@ -23,16 +23,16 @@ namespace oneflow {
 
   if (ctx->Attr<std::string>("quantization_formula") == "google") {
     if (ctx->Attr<bool>("per_layer_quantization") == true) {
-      *ctx->OutputShape("scale", 0) = Shape({1});
-      *ctx->OutputShape("zero_point", 0) = Shape({1});
+      *ctx->MutOutputShape("scale", 0) = Shape({1});
+      *ctx->MutOutputShape("zero_point", 0) = Shape({1});
     } else {
       // NOTE(Liang Depeng): For now per-channel quantization only support axis 0
-      *ctx->OutputShape("scale", 0) = Shape({in_shape.At(0)});
-      *ctx->OutputShape("zero_point", 0) = Shape({in_shape.At(0)});
+      *ctx->MutOutputShape("scale", 0) = Shape({in_shape.At(0)});
+      *ctx->MutOutputShape("zero_point", 0) = Shape({in_shape.At(0)});
     }
   } else {  // quantization_formula == "cambricon"
-    *ctx->OutputShape("scale", 0) = Shape({1});
-    *ctx->OutputShape("zero_point", 0) = Shape({1});
+    *ctx->MutOutputShape("scale", 0) = Shape({1});
+    *ctx->MutOutputShape("zero_point", 0) = Shape({1});
   }
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/mish_op.cpp
+++ b/oneflow/user/ops/mish_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> MishOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 /* static */ Maybe<void> MishGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/model_update_ops.cpp
+++ b/oneflow/user/ops/model_update_ops.cpp
@@ -752,7 +752,7 @@ Maybe<void> InferLarsUpdateDataType(user_op::InferContext* ctx) {
 
 /* static */ Maybe<void> AdamBiasCorrectionFactorOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("train_step", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("train_step", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/moving_average_min_max_observer_op.cpp
+++ b/oneflow/user/ops/moving_average_min_max_observer_op.cpp
@@ -31,8 +31,8 @@ namespace oneflow {
 
   CHECK_OR_RETURN(current_train_step.NumAxes() == 1 && current_train_step.At(0) == 1);
 
-  *ctx->OutputShape("scale", 0) = Shape({1});
-  *ctx->OutputShape("zero_point", 0) = Shape({1});
+  *ctx->MutOutputShape("scale", 0) = Shape({1});
+  *ctx->MutOutputShape("zero_point", 0) = Shape({1});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/multi_reduce_ops.cpp
+++ b/oneflow/user/ops/multi_reduce_ops.cpp
@@ -23,7 +23,7 @@ namespace {
 
 Maybe<void> InferMultiReduceOpShape(user_op::InferContext* ctx) {
   CHECK_GT_OR_RETURN(ctx->input_size("x"), 0) << ctx->op_name() << "must have at least 1 input";
-  *ctx->OutputShape("y", 0) = Shape({});
+  *ctx->MutOutputShape("y", 0) = Shape({});
   return Maybe<void>::Ok();
 }
 
@@ -67,13 +67,13 @@ Maybe<void> InferLocalMultiReduceOpLogicalShape(user_op::InferContext* ctx) {
   for (int64_t i = 0; i < rank_mesh->NumAxes(); ++i) {
     if (any_nd_sbp.sbp_parallel(i).has_split_parallel()) { split_num *= rank_mesh->At(i); }
   }
-  *ctx->OutputShape("y", 0) = Shape({split_num});
+  *ctx->MutOutputShape("y", 0) = Shape({split_num});
   return Maybe<void>::Ok();
 }
 
 Maybe<void> InferLocalMultiReduceOpPhysicalShape(user_op::InferContext* ctx) {
   CHECK_GT_OR_RETURN(ctx->input_size("x"), 0) << ctx->op_name() << "must have at least 1 input";
-  *ctx->OutputShape("y", 0) = Shape({1});
+  *ctx->MutOutputShape("y", 0) = Shape({1});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/narrow_op.cpp
+++ b/oneflow/user/ops/narrow_op.cpp
@@ -83,7 +83,7 @@ namespace oneflow {
   const int64_t ndim = dy_shape.NumAxes();
   CHECK_EQ_OR_RETURN(like_shape.NumAxes(), ndim);
 
-  *ctx->OutputShape("dx", 0) = like_shape;
+  *ctx->MutOutputShape("dx", 0) = like_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/nccl_logical_2d_sbp_ops.cpp
+++ b/oneflow/user/ops/nccl_logical_2d_sbp_ops.cpp
@@ -23,7 +23,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogical_2DSameDim0AllReduceOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -65,7 +65,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogical_2DSameDim1AllReduceOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -107,7 +107,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogical_2DSameDim0AllGatherOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -150,7 +150,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogical_2DSameDim0AllGatherNoncontinuousOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -195,7 +195,7 @@ _ncclLogical_2DSameDim0AllGatherNoncontinuousOp::InferDeviceAndStream(
 
 /* static */ Maybe<void> _ncclLogical_2DSameDim0All2allOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/nccl_logical_ops.cpp
+++ b/oneflow/user/ops/nccl_logical_ops.cpp
@@ -23,7 +23,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogicalAllReduceOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -62,7 +62,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogicalReduceScatterOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -103,7 +103,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogicalAllGatherOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -143,7 +143,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogicalAllGatherNoncontinuousOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -185,7 +185,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogicalReduceScatterNoncontinuousOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -230,7 +230,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> _ncclLogicalS2sOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -269,7 +269,7 @@ namespace oneflow {
 
 /* static */ Maybe<void> _ncclLogicalSendRecvOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/nd_index_slice_ops.cpp
+++ b/oneflow/user/ops/nd_index_slice_ops.cpp
@@ -42,7 +42,7 @@ Maybe<void> InferScatterNdTensorDesc(user_op::InferContext* ctx) {
   const Shape& updates_shape = ctx->InputShape("updates", 0);
   const Shape& params_shape = ctx->Attr<Shape>("shape");
   JUST(CheckScatterNdShape(params_shape, indices_shape, updates_shape));
-  *ctx->OutputShape("out", 0) = params_shape;
+  *ctx->MutOutputShape("out", 0) = params_shape;
   return Maybe<void>::Ok();
 }
 
@@ -56,7 +56,7 @@ Maybe<void> InferScatterNdLikeTensorDesc(user_op::InferContext* ctx) {
   const Shape& updates_shape = ctx->InputShape("updates", 0);
   const Shape& like_shape = ctx->InputShape("like", 0);
   JUST(CheckScatterNdShape(like_shape, indices_shape, updates_shape));
-  *ctx->OutputShape("out", 0) = like_shape;
+  *ctx->MutOutputShape("out", 0) = like_shape;
   return Maybe<void>::Ok();
 }
 
@@ -70,7 +70,7 @@ Maybe<void> InferTensorScatterNdOptTensorDesc(user_op::InferContext* ctx) {
   const Shape& updates_shape = ctx->InputShape("updates", 0);
   const Shape& indices_shape = ctx->InputShape("indices", 0);
   JUST(CheckScatterNdShape(params_shape, indices_shape, updates_shape));
-  *ctx->OutputShape("out", 0) = params_shape;
+  *ctx->MutOutputShape("out", 0) = params_shape;
   return Maybe<void>::Ok();
 }
 
@@ -122,7 +122,7 @@ Maybe<void> GetTensorScatterNdOptSbpSignatures(user_op::SbpContext* ctx) {
   FOR_RANGE(int64_t, i, index_ndims, params_shape.NumAxes()) {
     out_shape_vec.emplace_back(params_shape.At(i));
   }
-  *ctx->OutputShape("out", 0) = Shape(out_shape_vec);
+  *ctx->MutOutputShape("out", 0) = Shape(out_shape_vec);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/nms_op.cpp
+++ b/oneflow/user/ops/nms_op.cpp
@@ -21,7 +21,7 @@ namespace oneflow {
 namespace {
 
 Maybe<void> InferNmsTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = Shape({ctx->InputShape("in", 0).At(0)});
+  *ctx->MutOutputShape("out", 0) = Shape({ctx->InputShape("in", 0).At(0)});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/nvtx_range_op.cpp
+++ b/oneflow/user/ops/nvtx_range_op.cpp
@@ -22,7 +22,7 @@ namespace oneflow {
 #ifdef WITH_CUDA
 
 /* static */ Maybe<void> NvtxStartOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }
@@ -49,7 +49,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> NvtxEndOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/one_embedding_ops.cpp
+++ b/oneflow/user/ops/one_embedding_ops.cpp
@@ -30,7 +30,7 @@ namespace oneflow {
   DimVector out_dim_vec = ids_shape.dim_vec();
   const int64_t embedding_size = ctx->Attr<int64_t>("embedding_size");
   out_dim_vec.push_back(embedding_size);
-  *ctx->MutMutOutputShape("embeddings", 0) = Shape(out_dim_vec);
+  *ctx->MutOutputShape("embeddings", 0) = Shape(out_dim_vec);
   return Maybe<void>::Ok();
 }
 
@@ -116,7 +116,7 @@ REGISTER_USER_OP_GRAD("embedding_lookup_placeholder")
   CHECK_EQ_OR_RETURN(unique_ids_shape, table_ids_shape)
       << "table_ids shape must equal to ids shape";
   CHECK_EQ_OR_RETURN(num_unique_ids_shape.elem_cnt(), 1);
-  *ctx->MutMutOutputShape("context", 0) = num_unique_ids_shape;
+  *ctx->MutOutputShape("context", 0) = num_unique_ids_shape;
   return Maybe<void>::Ok();
 }
 
@@ -155,19 +155,19 @@ REGISTER_USER_OP_GRAD("embedding_lookup_placeholder")
   const bool use_dynamic_memory_allocation = embedding::UseDynamicMemoryAllocation();
   if (ctx->has_output("embeddings", 0)) {
     if (use_dynamic_memory_allocation) {
-      *ctx->MutMutOutputShape("embeddings", 0) = Shape({1});
+      *ctx->MutOutputShape("embeddings", 0) = Shape({1});
     } else {
       DimVector embeddings_dim_vec = unique_ids_shape.dim_vec();
       embeddings_dim_vec.push_back(embedding_size);
-      *ctx->MutMutOutputShape("embeddings", 0) = Shape(embeddings_dim_vec);
+      *ctx->MutOutputShape("embeddings", 0) = Shape(embeddings_dim_vec);
     }
   }
   if (use_dynamic_memory_allocation) {
-    *ctx->MutMutOutputShape("unique_values", 0) = Shape({1});
+    *ctx->MutOutputShape("unique_values", 0) = Shape({1});
   } else {
     DimVector unique_values_dim_vec = unique_ids_shape.dim_vec();
     unique_values_dim_vec.push_back(line_size);
-    *ctx->MutMutOutputShape("unique_values", 0) = Shape(unique_values_dim_vec);
+    *ctx->MutOutputShape("unique_values", 0) = Shape(unique_values_dim_vec);
   }
 
   return Maybe<void>::Ok();
@@ -318,7 +318,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -346,7 +346,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 2) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -374,7 +374,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 3) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -402,7 +402,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 2) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -430,7 +430,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 3) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/one_embedding_ops.cpp
+++ b/oneflow/user/ops/one_embedding_ops.cpp
@@ -30,7 +30,7 @@ namespace oneflow {
   DimVector out_dim_vec = ids_shape.dim_vec();
   const int64_t embedding_size = ctx->Attr<int64_t>("embedding_size");
   out_dim_vec.push_back(embedding_size);
-  *ctx->OutputShape("embeddings", 0) = Shape(out_dim_vec);
+  *ctx->MutOutputShape("embeddings", 0) = Shape(out_dim_vec);
   return Maybe<void>::Ok();
 }
 
@@ -116,7 +116,7 @@ REGISTER_USER_OP_GRAD("embedding_lookup_placeholder")
   CHECK_EQ_OR_RETURN(unique_ids_shape, table_ids_shape)
       << "table_ids shape must equal to ids shape";
   CHECK_EQ_OR_RETURN(num_unique_ids_shape.elem_cnt(), 1);
-  *ctx->OutputShape("context", 0) = num_unique_ids_shape;
+  *ctx->MutOutputShape("context", 0) = num_unique_ids_shape;
   return Maybe<void>::Ok();
 }
 
@@ -155,19 +155,19 @@ REGISTER_USER_OP_GRAD("embedding_lookup_placeholder")
   const bool use_dynamic_memory_allocation = embedding::UseDynamicMemoryAllocation();
   if (ctx->has_output("embeddings", 0)) {
     if (use_dynamic_memory_allocation) {
-      *ctx->OutputShape("embeddings", 0) = Shape({1});
+      *ctx->MutOutputShape("embeddings", 0) = Shape({1});
     } else {
       DimVector embeddings_dim_vec = unique_ids_shape.dim_vec();
       embeddings_dim_vec.push_back(embedding_size);
-      *ctx->OutputShape("embeddings", 0) = Shape(embeddings_dim_vec);
+      *ctx->MutOutputShape("embeddings", 0) = Shape(embeddings_dim_vec);
     }
   }
   if (use_dynamic_memory_allocation) {
-    *ctx->OutputShape("unique_values", 0) = Shape({1});
+    *ctx->MutOutputShape("unique_values", 0) = Shape({1});
   } else {
     DimVector unique_values_dim_vec = unique_ids_shape.dim_vec();
     unique_values_dim_vec.push_back(line_size);
-    *ctx->OutputShape("unique_values", 0) = Shape(unique_values_dim_vec);
+    *ctx->MutOutputShape("unique_values", 0) = Shape(unique_values_dim_vec);
   }
 
   return Maybe<void>::Ok();
@@ -318,7 +318,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->OutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -346,7 +346,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 2) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->OutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -374,7 +374,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 3) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->OutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -402,7 +402,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 2) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->OutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -430,7 +430,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 3) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->OutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/one_embedding_ops.cpp
+++ b/oneflow/user/ops/one_embedding_ops.cpp
@@ -30,7 +30,7 @@ namespace oneflow {
   DimVector out_dim_vec = ids_shape.dim_vec();
   const int64_t embedding_size = ctx->Attr<int64_t>("embedding_size");
   out_dim_vec.push_back(embedding_size);
-  *ctx->MutOutputShape("embeddings", 0) = Shape(out_dim_vec);
+  *ctx->MutMutOutputShape("embeddings", 0) = Shape(out_dim_vec);
   return Maybe<void>::Ok();
 }
 
@@ -116,7 +116,7 @@ REGISTER_USER_OP_GRAD("embedding_lookup_placeholder")
   CHECK_EQ_OR_RETURN(unique_ids_shape, table_ids_shape)
       << "table_ids shape must equal to ids shape";
   CHECK_EQ_OR_RETURN(num_unique_ids_shape.elem_cnt(), 1);
-  *ctx->MutOutputShape("context", 0) = num_unique_ids_shape;
+  *ctx->MutMutOutputShape("context", 0) = num_unique_ids_shape;
   return Maybe<void>::Ok();
 }
 
@@ -155,19 +155,19 @@ REGISTER_USER_OP_GRAD("embedding_lookup_placeholder")
   const bool use_dynamic_memory_allocation = embedding::UseDynamicMemoryAllocation();
   if (ctx->has_output("embeddings", 0)) {
     if (use_dynamic_memory_allocation) {
-      *ctx->MutOutputShape("embeddings", 0) = Shape({1});
+      *ctx->MutMutOutputShape("embeddings", 0) = Shape({1});
     } else {
       DimVector embeddings_dim_vec = unique_ids_shape.dim_vec();
       embeddings_dim_vec.push_back(embedding_size);
-      *ctx->MutOutputShape("embeddings", 0) = Shape(embeddings_dim_vec);
+      *ctx->MutMutOutputShape("embeddings", 0) = Shape(embeddings_dim_vec);
     }
   }
   if (use_dynamic_memory_allocation) {
-    *ctx->MutOutputShape("unique_values", 0) = Shape({1});
+    *ctx->MutMutOutputShape("unique_values", 0) = Shape({1});
   } else {
     DimVector unique_values_dim_vec = unique_ids_shape.dim_vec();
     unique_values_dim_vec.push_back(line_size);
-    *ctx->MutOutputShape("unique_values", 0) = Shape(unique_values_dim_vec);
+    *ctx->MutMutOutputShape("unique_values", 0) = Shape(unique_values_dim_vec);
   }
 
   return Maybe<void>::Ok();
@@ -318,7 +318,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -346,7 +346,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 2) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -374,7 +374,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 3) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -402,7 +402,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 2) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -430,7 +430,7 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
   CHECK_NE_OR_RETURN(line_size, 0) << "should set attr line_size";
   CHECK_EQ_OR_RETURN(line_size, embedding_size * 3) << "get " << line_size << " " << embedding_size;
   const Shape& unique_embeddings_shape = ctx->InputShape("unique_embeddings", 0);
-  *ctx->MutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
+  *ctx->MutMutOutputShape("updated_unique_embeddings", 0) = unique_embeddings_shape;
   return Maybe<void>::Ok();
 }
 
@@ -462,14 +462,14 @@ Maybe<void> GetEmbeddingUpdateSbp(user_op::SbpContext* ctx) {
 }
 
 /*static*/ Maybe<void> IdShuffleCopyOutOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out_num_unique_matrix", 0) = ctx->InputShape("num_unique_matrix", 0);
-  *ctx->OutputShape("out_inverse_unique_partition_indices", 0) =
+  *ctx->MutOutputShape("out_num_unique_matrix", 0) = ctx->InputShape("num_unique_matrix", 0);
+  *ctx->MutOutputShape("out_inverse_unique_partition_indices", 0) =
       ctx->InputShape("inverse_unique_partition_indices", 0);
-  *ctx->OutputShape("out_cur_rank_num_unique", 0) = ctx->InputShape("cur_rank_num_unique", 0);
-  *ctx->OutputShape("out_cur_rank_unique_ids", 0) = ctx->InputShape("cur_rank_unique_ids", 0);
-  *ctx->OutputShape("out_cur_rank_unique_table_ids", 0) =
+  *ctx->MutOutputShape("out_cur_rank_num_unique", 0) = ctx->InputShape("cur_rank_num_unique", 0);
+  *ctx->MutOutputShape("out_cur_rank_unique_ids", 0) = ctx->InputShape("cur_rank_unique_ids", 0);
+  *ctx->MutOutputShape("out_cur_rank_unique_table_ids", 0) =
       ctx->InputShape("cur_rank_unique_table_ids", 0);
-  *ctx->OutputShape("out_cur_rank_inverse_indices", 0) =
+  *ctx->MutOutputShape("out_cur_rank_inverse_indices", 0) =
       ctx->InputShape("cur_rank_inverse_indices", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/ones_like_op.cpp
+++ b/oneflow/user/ops/ones_like_op.cpp
@@ -33,8 +33,8 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> OnesLikeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("like", 0);
-  *ctx->OutputStride("out", 0) = ctx->InputStride("like", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("like", 0);
+  *ctx->MutOutputStride("out", 0) = ctx->InputStride("like", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> OnesLikeOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/p2p_comm_op.cpp
+++ b/oneflow/user/ops/p2p_comm_op.cpp
@@ -48,7 +48,7 @@ Maybe<Symbol<Device>> GetRecvOutputDeivce(user_op::DeviceAndStreamInferContext* 
 
 /*static*/ Maybe<void> RecvOp::GetSbp(user_op::SbpContext* ctx) { UNIMPLEMENTED_THEN_RETURN(); }
 /*static*/ Maybe<void> RecvOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->Attr<Shape>("shape");
+  *ctx->MutOutputShape("out", 0) = ctx->Attr<Shape>("shape");
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> RecvOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/pad_op.cpp
+++ b/oneflow/user/ops/pad_op.cpp
@@ -40,7 +40,7 @@ namespace oneflow {
   FOR_RANGE(int64_t, i, 0, x_shape.NumAxes()) {
     y_dim_vec[i] = x_shape.At(i) + padding_before[i] + padding_after[i];
   }
-  *ctx->OutputShape("y", 0) = Shape(y_dim_vec);
+  *ctx->MutOutputShape("y", 0) = Shape(y_dim_vec);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> PadOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/padding_ops.cpp
+++ b/oneflow/user/ops/padding_ops.cpp
@@ -74,7 +74,7 @@ Maybe<void> GetOpGradSbpSignature(user_op::SbpContext* ctx) {
   y_dim_vec[h_idx] = h_x + padding[2] + padding[3];
   y_dim_vec[w_idx] = w_x + padding[0] + padding[1];
 
-  *ctx->OutputShape("y", 0) = Shape(y_dim_vec);
+  *ctx->MutOutputShape("y", 0) = Shape(y_dim_vec);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ReflectionPad2DOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -113,7 +113,7 @@ Maybe<void> GetOpGradSbpSignature(user_op::SbpContext* ctx) {
   dx_dim_vec[h_idx] = h_dy - padding[2] - padding[3];
   dx_dim_vec[w_idx] = w_dy - padding[0] - padding[1];
 
-  *ctx->OutputShape("dx", 0) = Shape(dx_dim_vec);
+  *ctx->MutOutputShape("dx", 0) = Shape(dx_dim_vec);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ReflectionPad2DGradOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -162,7 +162,7 @@ REGISTER_USER_OP_GRAD("reflection_pad2d")
   y_dim_vec[h_idx] = h_x + padding[2] + padding[3];
   y_dim_vec[w_idx] = w_x + padding[0] + padding[1];
 
-  *ctx->OutputShape("y", 0) = Shape(y_dim_vec);
+  *ctx->MutOutputShape("y", 0) = Shape(y_dim_vec);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ReplicationPad2DOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -201,7 +201,7 @@ REGISTER_USER_OP_GRAD("reflection_pad2d")
   dx_dim_vec[h_idx] = h_dy - padding[2] - padding[3];
   dx_dim_vec[w_idx] = w_dy - padding[0] - padding[1];
 
-  *ctx->OutputShape("dx", 0) = Shape(dx_dim_vec);
+  *ctx->MutOutputShape("dx", 0) = Shape(dx_dim_vec);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ReplicationPad2DGradOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/parallel_cast_op.cpp
+++ b/oneflow/user/ops/parallel_cast_op.cpp
@@ -23,7 +23,7 @@ namespace oneflow {
   return user_op::GetSbpFnUtil::DefaultBroadcastToBroadcast(ctx);
 }
 /*static*/ Maybe<void> ParallelCastOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/partial_fc_sample_op.cpp
+++ b/oneflow/user/ops/partial_fc_sample_op.cpp
@@ -111,11 +111,11 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> DistributedPartialFcSampleDisableBoxingOp::InferPhysicalTensorDesc(
     user_op::InferContext* ctx) {
-  *ctx->OutputShape("boxing_disabled_sampled_weight_diff", 0) =
+  *ctx->MutOutputShape("boxing_disabled_sampled_weight_diff", 0) =
       ctx->InputShape("sampled_weight_diff", 0);
   *ctx->OutputIsDynamic("boxing_disabled_sampled_weight_diff", 0) =
       ctx->InputIsDynamic("sampled_weight_diff", 0);
-  *ctx->OutputShape("boxing_disabled_sampled_label", 0) = ctx->InputShape("sampled_label", 0);
+  *ctx->MutOutputShape("boxing_disabled_sampled_label", 0) = ctx->InputShape("sampled_label", 0);
   *ctx->OutputIsDynamic("boxing_disabled_sampled_label", 0) =
       ctx->InputIsDynamic("sampled_label", 0);
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/prelu_op.cpp
+++ b/oneflow/user/ops/prelu_op.cpp
@@ -40,7 +40,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> PreluOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
-  Shape* y_shape = ctx->OutputShape("y", 0);
+  Shape* y_shape = ctx->MutOutputShape("y", 0);
   const Shape& alpha_shape = ctx->InputShape("alpha", 0);
   CHECK_EQ_OR_RETURN(alpha_shape.NumAxes(), 1);
   *y_shape = x_shape;
@@ -91,8 +91,8 @@ namespace oneflow {
 /*static*/ Maybe<void> PreluGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
-  Shape* alpha_diff_shape = ctx->OutputShape("alpha_diff", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
+  Shape* alpha_diff_shape = ctx->MutOutputShape("alpha_diff", 0);
   const Shape& alpha_shape = ctx->InputShape("alpha", 0);
   CHECK_EQ_OR_RETURN(alpha_shape.NumAxes(), 1);
   CHECK_OR_RETURN((alpha_shape.At(0) == x_shape.At(1)) || (alpha_shape.At(0) == 1));

--- a/oneflow/user/ops/quantization_op.cpp
+++ b/oneflow/user/ops/quantization_op.cpp
@@ -68,7 +68,7 @@ namespace oneflow {
     CHECK_EQ_OR_RETURN(zero_point_shape.elem_cnt(), in_shape.At(0));
   }
 
-  *ctx->OutputShape("out", 0) = in_shape;
+  *ctx->MutOutputShape("out", 0) = in_shape;
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> QuantizationOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/randperm_op.cpp
+++ b/oneflow/user/ops/randperm_op.cpp
@@ -27,7 +27,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> RandpermOp::GetSbp(user_op::SbpContext* ctx) { return Maybe<void>::Ok(); }
 /*static*/ Maybe<void> RandpermOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   int32_t n = ctx->Attr<int32_t>("n");
   CHECK_GE_OR_RETURN(n, 0) << Error::RuntimeError()
                            << "Trying to create tensor with negative dimension " << n << ":"
@@ -45,7 +45,7 @@ namespace oneflow {
       GetTensorSliceView4ParallelId(parallel_hierarchy, nd_sbp, logical_shape, parallel_id);
   const Shape& physical_shape = tensor_slice_view.shape();
 
-  *ctx->OutputShape("out", 0) = physical_shape;
+  *ctx->MutOutputShape("out", 0) = physical_shape;
 
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/reduce_ops.cpp
+++ b/oneflow/user/ops/reduce_ops.cpp
@@ -23,8 +23,8 @@ namespace oneflow {
 Maybe<void> InferTensorDescFn(user_op::InferContext* ctx) {
   const Shape& input_shape = ctx->InputShape("input_tensor", 0);
   const auto& reduce_axes = ctx->Attr<std::vector<int32_t>>("axis");
-  Shape* output_shape = ctx->OutputShape("output_tensor", 0);
-  Stride* output_stride = ctx->OutputStride("output_tensor", 0);
+  Shape* output_shape = ctx->MutOutputShape("output_tensor", 0);
+  Stride* output_stride = ctx->MutOutputStride("output_tensor", 0);
   // For 0-dim Tensor
   if (reduce_axes.empty()) {
     *output_shape = input_shape;

--- a/oneflow/user/ops/relu_op.cpp
+++ b/oneflow/user/ops/relu_op.cpp
@@ -27,7 +27,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> ReluOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("x", 0);
-  Shape* out_shape = ctx->OutputShape("y", 0);
+  Shape* out_shape = ctx->MutOutputShape("y", 0);
   *out_shape = in_shape;
   return Maybe<void>::Ok();
 }
@@ -53,7 +53,7 @@ namespace oneflow {
 /*static*/ Maybe<void> ReluGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& y_shape = ctx->InputShape("y", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == y_shape)
       << Error::RuntimeError() << "Tensors y and dy must have the same shape";
   *dx_shape = dy_shape;

--- a/oneflow/user/ops/repeat_op.cpp
+++ b/oneflow/user/ops/repeat_op.cpp
@@ -31,7 +31,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> RepeatOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/reshape_like_op.cpp
+++ b/oneflow/user/ops/reshape_like_op.cpp
@@ -44,7 +44,7 @@ namespace oneflow {
       << "The element number of the in tensor must be equal to the element number of the "
          "like tensor, "
       << "but got " << in_shape.elem_cnt() << " and " << like_shape.elem_cnt();
-  *ctx->OutputShape("out", 0) = like_shape;
+  *ctx->MutOutputShape("out", 0) = like_shape;
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ReshapeLikeOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/roi_align_op.cpp
+++ b/oneflow/user/ops/roi_align_op.cpp
@@ -37,7 +37,7 @@ namespace oneflow {
   CHECK_EQ(rois_shape.NumAxes(), 2);
   CHECK_EQ(rois_shape.At(1), 5);
   // y: (R, C, pool_h, pool_w)
-  *ctx->OutputShape("y", 0) = Shape({rois_shape.At(0), x_shape.At(1), pooled_h, pooled_w});
+  *ctx->MutOutputShape("y", 0) = Shape({rois_shape.At(0), x_shape.At(1), pooled_h, pooled_w});
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> RoiAlignOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -81,7 +81,7 @@ namespace oneflow {
   // y: (R, C, pool_h, pool_w)
   const Shape& y_shape = Shape({rois_shape.At(0), x_like_shape.At(1), pooled_h, pooled_w});
   CHECK_EQ_OR_RETURN(y_shape, dy_shape);
-  *ctx->OutputShape("dx", 0) = x_like_shape;
+  *ctx->MutOutputShape("dx", 0) = x_like_shape;
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> RoiAlignGradOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/roll_op.cpp
+++ b/oneflow/user/ops/roll_op.cpp
@@ -45,7 +45,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> RollOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  *ctx->OutputShape("out", 0) = in_shape;
+  *ctx->MutOutputShape("out", 0) = in_shape;
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> RollOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/same_padding_op.cpp
+++ b/oneflow/user/ops/same_padding_op.cpp
@@ -108,7 +108,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SamePaddingGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("x_like", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("x_like", 0);
   *ctx->OutputIsDynamic("dx", 0) = ctx->InputIsDynamic("x_like", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/scalar_logical_op.cpp
+++ b/oneflow/user/ops/scalar_logical_op.cpp
@@ -27,7 +27,7 @@ namespace oneflow {
     return Maybe<void>::Ok();                                                                    \
   }                                                                                              \
   /*static*/ Maybe<void> name##Op::InferLogicalTensorDesc(user_op::InferContext* ctx) {          \
-    *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);                                      \
+    *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);                                   \
     *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);                              \
     return Maybe<void>::Ok();                                                                    \
   }                                                                                              \

--- a/oneflow/user/ops/scalar_math_op.cpp
+++ b/oneflow/user/ops/scalar_math_op.cpp
@@ -42,7 +42,7 @@ Maybe<void> GetSbp4ScalarMul(user_op::SbpContext* ctx) {
 #define IMPLEMENT_SCALAR_MATH_OP_FUNCS(op_name, get_sbp_fn)                                        \
   /*static*/ Maybe<void> op_name##Op::GetSbp(user_op::SbpContext* ctx) { return get_sbp_fn(ctx); } \
   /*static*/ Maybe<void> op_name##Op::InferLogicalTensorDesc(user_op::InferContext* ctx) {         \
-    *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);                                        \
+    *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);                                     \
     *ctx->OutputIsDynamic("out", 0) = ctx->InputIsDynamic("in", 0);                                \
     return Maybe<void>::Ok();                                                                      \
   }                                                                                                \
@@ -71,7 +71,7 @@ IMPLEMENT_SCALAR_MATH_OP_FUNCS(ScalarReversePow, GetSbp4ScalarMath)
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ScalarPowGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("x", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ScalarPowGradOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -92,7 +92,7 @@ IMPLEMENT_SCALAR_MATH_OP_FUNCS(ScalarReversePow, GetSbp4ScalarMath)
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ScalarReversePowGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("x", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ScalarReversePowGradOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/search_sorted_op.cpp
+++ b/oneflow/user/ops/search_sorted_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> SearchSortedOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("values", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("values", 0);
   return Maybe<void>::Ok();
 }
 
@@ -54,7 +54,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> SearchSortedScalarOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = Shape({});
+  *ctx->MutOutputShape("out", 0) = Shape({});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/selu_op.cpp
+++ b/oneflow/user/ops/selu_op.cpp
@@ -26,7 +26,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SeluOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SeluOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -51,7 +51,7 @@ namespace oneflow {
 /*static*/ Maybe<void> SeluGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape)
       << Error::RuntimeError() << "Tensors dy and x must be the same shape";
   *dx_shape = dy_shape;

--- a/oneflow/user/ops/silu_op.cpp
+++ b/oneflow/user/ops/silu_op.cpp
@@ -26,7 +26,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SiluOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SiluOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -51,7 +51,7 @@ namespace oneflow {
 /*static*/ Maybe<void> SiluGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape) << Error::RuntimeError() << "The size of dy " << dy_shape
                                        << " must match the size of x " << x_shape;
   *dx_shape = dy_shape;

--- a/oneflow/user/ops/slice_op.cpp
+++ b/oneflow/user/ops/slice_op.cpp
@@ -170,7 +170,7 @@ bool IsFullSlice(int64_t start, int64_t stop, int64_t step, int64_t size) {
     const int64_t diff = stop - start - 1;
     dim_vec[i] = diff / step + 1;
   }
-  *ctx->OutputShape("y", 0) = Shape(dim_vec);
+  *ctx->MutOutputShape("y", 0) = Shape(dim_vec);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SliceOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -198,7 +198,7 @@ bool IsFullSlice(int64_t start, int64_t stop, int64_t step, int64_t size) {
   const int64_t parallel_id = ctx->parallel_ctx().parallel_id();
   const TensorSliceView& slice_view =
       GetTensorSliceView4ParallelId(parallel_hierarchy, y_nd_sbp, logical_shape, parallel_id);
-  *ctx->OutputShape("y", 0) = Shape(slice_view.shape());
+  *ctx->MutOutputShape("y", 0) = Shape(slice_view.shape());
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SliceOp::InferDataType(user_op::InferContext* ctx) {
@@ -253,7 +253,7 @@ bool IsFullSlice(int64_t start, int64_t stop, int64_t step, int64_t size) {
       << Error::RuntimeError()
       << "The size of step list must be equal to the dimension of ref tensor, "
       << "but got " << step_vec.size() << " and " << ndim;
-  *ctx->OutputShape("dx", 0) = like_shape;
+  *ctx->MutOutputShape("dx", 0) = like_shape;
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SliceGradOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/softmax_cross_entropy_op.cpp
+++ b/oneflow/user/ops/softmax_cross_entropy_op.cpp
@@ -51,7 +51,7 @@ namespace oneflow {
   FOR_RANGE(int64_t, i, 0, num_out_axes) {
     out_dim_vector.emplace_back(prediction_desc.shape().At(i));
   }
-  *ctx->OutputShape("prob", 0) = ctx->InputShape("prediction", 0);
+  *ctx->MutOutputShape("prob", 0) = ctx->InputShape("prediction", 0);
   *ctx->OutputIsDynamic("prob", 0) = ctx->InputIsDynamic("prediction", 0);
   user_op::TensorDesc* out_desc = ctx->OutputTensorDesc("out", 0);
   *out_desc->mut_is_dynamic() = prediction_desc.is_dynamic();
@@ -118,7 +118,7 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(label_desc.shape(), prob_desc.shape())
       << Error::RuntimeError() << "The size of label " << label_desc.shape()
       << " must match the size of prob " << prob_desc.shape();
-  *ctx->OutputShape("prediction_diff", 0) = ctx->InputShape("prob", 0);
+  *ctx->MutOutputShape("prediction_diff", 0) = ctx->InputShape("prob", 0);
   *ctx->OutputIsDynamic("prediction_diff", 0) = ctx->InputIsDynamic("prob", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/softmax_op.cpp
+++ b/oneflow/user/ops/softmax_op.cpp
@@ -29,7 +29,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SoftmaxOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SoftmaxOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -54,7 +54,7 @@ namespace oneflow {
 /*static*/ Maybe<void> SoftmaxGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& y_shape = ctx->InputShape("y", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == y_shape) << Error::RuntimeError() << "The size of dy " << dy_shape
                                        << " must match the size of y " << y_shape;
   *dx_shape = dy_shape;

--- a/oneflow/user/ops/softplus_op.cpp
+++ b/oneflow/user/ops/softplus_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> SoftplusOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 /* static */ Maybe<void> SoftplusGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape) << Error::RuntimeError() << "The size of dy " << dy_shape
                                        << " must match the size of x " << x_shape;
   *dx_shape = dy_shape;

--- a/oneflow/user/ops/softshrink_op.cpp
+++ b/oneflow/user/ops/softshrink_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> SoftShrinkOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 /* static */ Maybe<void> SoftShrinkGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& y_shape = ctx->InputShape("y", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == y_shape) << Error::RuntimeError() << "The size of dy " << dy_shape
                                        << " must match the size of y " << y_shape;
   *dx_shape = dy_shape;

--- a/oneflow/user/ops/softsign_op.cpp
+++ b/oneflow/user/ops/softsign_op.cpp
@@ -26,7 +26,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SoftsignOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SoftsignOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
@@ -51,7 +51,7 @@ namespace oneflow {
 /*static*/ Maybe<void> SoftsignGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape) << Error::RuntimeError() << "The size of dy " << dy_shape
                                        << " must match the size of x " << x_shape;
   *dx_shape = dy_shape;

--- a/oneflow/user/ops/sort_op.cpp
+++ b/oneflow/user/ops/sort_op.cpp
@@ -28,7 +28,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SortOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SortOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/sparse_cross_entropy_op.cpp
+++ b/oneflow/user/ops/sparse_cross_entropy_op.cpp
@@ -62,7 +62,7 @@ Maybe<void> InferGradTensorDescFn(user_op::InferContext* ctx) {
   CHECK_EQ_OR_RETURN(dy_desc.shape(), label_desc.shape())
       << Error::RuntimeError() << "The size of dy " << dy_desc.shape()
       << " must match the size of label " << label_desc.shape();
-  *ctx->OutputShape("prediction_diff", 0) = prediction_desc.shape();
+  *ctx->MutOutputShape("prediction_diff", 0) = prediction_desc.shape();
   *ctx->OutputIsDynamic("prediction_diff", 0) = prediction_desc.is_dynamic();
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/sparse_softmax_cross_entropy_op.cpp
+++ b/oneflow/user/ops/sparse_softmax_cross_entropy_op.cpp
@@ -43,7 +43,7 @@ Maybe<void> InferTensorDescFn(user_op::InferContext* ctx) {
   }
   *ctx->OutputIsDynamic("prob", 0) = prediction_desc.is_dynamic();
   // 'prob' is just for compute prediction's grad, prob's grad will be ignored
-  *ctx->OutputShape("prob", 0) = prediction_desc.shape();
+  *ctx->MutOutputShape("prob", 0) = prediction_desc.shape();
   user_op::TensorDesc* out_desc = ctx->OutputTensorDesc("out", 0);
   *out_desc->mut_is_dynamic() = prediction_desc.is_dynamic();
   *out_desc->mut_shape() = label_desc.shape();
@@ -75,7 +75,7 @@ Maybe<void> InferGradTensorDescFn(user_op::InferContext* ctx) {
   CHECK_EQ_OR_RETURN(dy_desc.shape(), label_desc.shape())
       << Error::RuntimeError() << "The size of dy " << dy_desc.shape()
       << " must match the size of label " << label_desc.shape();
-  *ctx->OutputShape("prediction_diff", 0) = prob_desc.shape();
+  *ctx->MutOutputShape("prediction_diff", 0) = prob_desc.shape();
   *ctx->OutputIsDynamic("prediction_diff", 0) = prob_desc.is_dynamic();
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/squeeze_op.cpp
+++ b/oneflow/user/ops/squeeze_op.cpp
@@ -63,7 +63,7 @@ Maybe<void> CheckAndLabelAxesToSqueezeMinusOne(const AxisVector& axes, DimVector
 }
 /*static*/ Maybe<void> SqueezeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   AxisVector fixed_axes_vec;
   JUST(TransformNegativeAxesToPositive(ctx->Attr<std::vector<int32_t>>("axes"), in_shape.NumAxes(),
                                        &fixed_axes_vec));

--- a/oneflow/user/ops/ssp_variable_proxy_op.cpp
+++ b/oneflow/user/ops/ssp_variable_proxy_op.cpp
@@ -31,8 +31,8 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> SspVariableProxyOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& var_shape = ctx->InputShape("var", 0);
-  *ctx->OutputShape("ref", 0) = var_shape;
-  *ctx->OutputShape("value", 0) = var_shape;
+  *ctx->MutOutputShape("ref", 0) = var_shape;
+  *ctx->MutOutputShape("value", 0) = var_shape;
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> SspVariableProxyOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/tf_pool_op.cpp
+++ b/oneflow/user/ops/tf_pool_op.cpp
@@ -51,7 +51,7 @@ TensorDescInferFn MakeFwTensorDescInferFn(const int32_t dim) {
 }
 
 Maybe<void> BwTensorDescInferFn(user_op::InferContext* ctx) {
-  *ctx->OutputShape("dx", 0) = ctx->InputShape("x", 0);
+  *ctx->MutOutputShape("dx", 0) = ctx->InputShape("x", 0);
   *ctx->OutputIsDynamic("dx", 0) = ctx->InputIsDynamic("x", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/tf_prelu_op.cpp
+++ b/oneflow/user/ops/tf_prelu_op.cpp
@@ -102,7 +102,7 @@ namespace oneflow {
   CHECK_EQ_OR_RETURN(dy_desc.data_type(), x_desc.data_type());
   *dx_desc->mut_shape() = x_desc.shape();
   *dx_desc->mut_is_dynamic() = x_desc.is_dynamic();
-  *ctx->OutputShape("alpha_diff", 0) = alpha_desc.shape();
+  *ctx->MutOutputShape("alpha_diff", 0) = alpha_desc.shape();
   *ctx->OutputIsDynamic("alpha_diff", 0) = alpha_desc.is_dynamic();
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/threshold_op.cpp
+++ b/oneflow/user/ops/threshold_op.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> ThresholdOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 /* static */ Maybe<void> ThresholdGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(dy_shape == x_shape);
   *dx_shape = dy_shape;
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/to_contiguous_op.cpp
+++ b/oneflow/user/ops/to_contiguous_op.cpp
@@ -24,8 +24,8 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> ToContiguousOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const user_op::TensorDesc& in_desc = ctx->InputTensorDesc("in", 0);
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
-  *ctx->OutputStride("out", 0) = Stride(in_desc.shape());
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputStride("out", 0) = Stride(in_desc.shape());
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ToContiguousOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/top_k_op.cpp
+++ b/oneflow/user/ops/top_k_op.cpp
@@ -29,7 +29,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> TopKOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& in_shape = ctx->InputShape("in", 0);
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   *out_shape = in_shape;
   out_shape->Set(in_shape.NumAxes() - 1, std::min(ctx->Attr<int32_t>("k"),
                                                   static_cast<int32_t>(in_shape.dim_vec().back())));

--- a/oneflow/user/ops/tuple_identity_op.cpp
+++ b/oneflow/user/ops/tuple_identity_op.cpp
@@ -26,7 +26,7 @@ namespace oneflow {
   const int64_t in_size = ctx->input_size("in");
   CHECK_EQ_OR_RETURN(ctx->output_size("out"), in_size);
   for (int64_t i = 0; i < in_size; ++i) {
-    *ctx->OutputShape("out", i) = ctx->InputShape("in", i);
+    *ctx->MutOutputShape("out", i) = ctx->InputShape("in", i);
     *ctx->IsDynamic4ArgNameAndIndex("out", i) = ctx->InputIsDynamic("in", i);
   }
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/two_stage_reduce_ops.cpp
+++ b/oneflow/user/ops/two_stage_reduce_ops.cpp
@@ -33,7 +33,7 @@ Maybe<void> InferReduceDeviceStageLogicalTensorDescFn(user_op::InferContext* ctx
   const Shape& input_shape = ctx->InputShape("in", 0);
   const auto& axis = ctx->Attr<std::vector<int32_t>>("axis");
   const int64_t num_axes = input_shape.NumAxes();
-  Shape* output_shape = ctx->OutputShape("out", 0);
+  Shape* output_shape = ctx->MutOutputShape("out", 0);
   if (axis.empty()) {
     *output_shape = Shape::Ones(num_axes);
   } else {
@@ -63,8 +63,8 @@ Maybe<void> InferReduceDeviceStageLogicalTensorDescFn(user_op::InferContext* ctx
     *output_shape = Shape(dim_vec);
   }
 
-  *ctx->OutputShape("mask", 0) = input_shape;
-  *ctx->OutputShape("count", 0) = *output_shape;
+  *ctx->MutOutputShape("mask", 0) = input_shape;
+  *ctx->MutOutputShape("count", 0) = *output_shape;
 
   return Maybe<void>::Ok();
 }
@@ -72,7 +72,7 @@ Maybe<void> InferReduceDeviceStageLogicalTensorDescFn(user_op::InferContext* ctx
 Maybe<void> InferReduceDeviceStagePhysicalTensorDescFn(user_op::InferContext* ctx) {
   const Shape& input_shape = ctx->InputShape("in", 0);
   const auto& axis = ctx->Attr<std::vector<int32_t>>("axis");
-  Shape* output_shape = ctx->OutputShape("out", 0);
+  Shape* output_shape = ctx->MutOutputShape("out", 0);
   if (axis.empty()) {
     *output_shape = Shape::Ones(input_shape.NumAxes());
   } else {
@@ -81,8 +81,8 @@ Maybe<void> InferReduceDeviceStagePhysicalTensorDescFn(user_op::InferContext* ct
     *output_shape = reduced_shape;
   }
 
-  *ctx->OutputShape("mask", 0) = input_shape;
-  *ctx->OutputShape("count", 0) = *output_shape;
+  *ctx->MutOutputShape("mask", 0) = input_shape;
+  *ctx->MutOutputShape("count", 0) = *output_shape;
 
   return Maybe<void>::Ok();
 }
@@ -96,7 +96,7 @@ Maybe<void> InferReduceDeviceStageGradDtypeFn(user_op::InferContext* ctx) {
 
 Maybe<void> InferReduceDeviceStageGradTensorDescFn(user_op::InferContext* ctx) {
   CHECK_EQ_OR_RETURN(ctx->InputShape("out_diff", 0), ctx->InputShape("count", 0));
-  *ctx->OutputShape("in_diff", 0) = ctx->InputShape("mask", 0);
+  *ctx->MutOutputShape("in_diff", 0) = ctx->InputShape("mask", 0);
   return Maybe<void>::Ok();
 }
 
@@ -114,7 +114,7 @@ Maybe<void> InferReduceGlobalStageTensorDescFn(user_op::InferContext* ctx) {
   CHECK_EQ_OR_RETURN(input_shape, device_count_shape);
   const auto& axis = ctx->Attr<std::vector<int32_t>>("axis");
   bool keepdims = ctx->Attr<bool>("keepdims");
-  Shape* output_shape = ctx->OutputShape("out", 0);
+  Shape* output_shape = ctx->MutOutputShape("out", 0);
   if (axis.empty()) {
     if (keepdims) {
       *output_shape = Shape::Ones(input_shape.NumAxes());
@@ -131,7 +131,7 @@ Maybe<void> InferReduceGlobalStageTensorDescFn(user_op::InferContext* ctx) {
     }
   }
 
-  *ctx->OutputShape("mask", 0) = input_shape;
+  *ctx->MutOutputShape("mask", 0) = input_shape;
 
   return Maybe<void>::Ok();
 }
@@ -149,7 +149,7 @@ Maybe<void> InferReduceGlobalStageGradTensorDescFn(user_op::InferContext* ctx) {
   const Shape& mask_shape = ctx->InputShape("mask", 0);
   const Shape& device_count_shape = ctx->InputShape("device_count", 0);
   CHECK_EQ_OR_RETURN(device_count_shape, mask_shape);
-  *ctx->OutputShape("in_diff", 0) = mask_shape;
+  *ctx->MutOutputShape("in_diff", 0) = mask_shape;
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/unfold_fold_op.cpp
+++ b/oneflow/user/ops/unfold_fold_op.cpp
@@ -58,7 +58,7 @@ Maybe<void> UnfoldTensorDescInferFn(user_op::InferContext* ctx) {
       * std::accumulate(kernel_size.begin(), kernel_size.end(), 1, std::multiplies<int>());
   y_shape.at(2) = std::accumulate(dhw_shape.begin(), dhw_shape.end(), 1, std::multiplies<int>());
 
-  *ctx->OutputShape("y", 0) = Shape(y_shape);
+  *ctx->MutOutputShape("y", 0) = Shape(y_shape);
   return Maybe<void>::Ok();
 }
 
@@ -118,7 +118,7 @@ Maybe<void> FoldTensorDescInferFn(user_op::InferContext* ctx) {
   y_shape.at(2) = output_size[0];
   y_shape.at(3) = output_size[1];
 
-  *ctx->OutputShape("y", 0) = Shape(y_shape);
+  *ctx->MutOutputShape("y", 0) = Shape(y_shape);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/unfold_tensor_op.cpp
+++ b/oneflow/user/ops/unfold_tensor_op.cpp
@@ -57,7 +57,7 @@ namespace oneflow {
       out_shape.at(d) = in_size_at_d;
     }
   }
-  *ctx->OutputShape("y", 0) = Shape(out_shape);
+  *ctx->MutOutputShape("y", 0) = Shape(out_shape);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> UnfoldTensorOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {

--- a/oneflow/user/ops/unsorted_segment_sum_op.cpp
+++ b/oneflow/user/ops/unsorted_segment_sum_op.cpp
@@ -52,7 +52,7 @@ namespace oneflow {
   const Shape& data_shape = ctx->InputShape("data", 0);
   const int64_t axis = ctx->Attr<int64_t>("axis");
   const int64_t num_segments = ctx->Attr<int64_t>("num_segments");
-  Shape* out_shape = ctx->OutputShape("out", 0);
+  Shape* out_shape = ctx->MutOutputShape("out", 0);
   const Shape& segment_ids_shape = ctx->InputShape("segment_ids", 0);
 
   DimVector dim_vec;
@@ -163,7 +163,7 @@ REGISTER_USER_OP_GRAD("unsorted_segment_sum")
   FOR_RANGE(int64_t, i, axis + 1, like_shape.NumAxes()) {
     CHECK_EQ_OR_RETURN(like_shape.At(i), data_shape.At(i + segment_ids_shape.NumAxes() - 1));
   }
-  *ctx->OutputShape("out", 0) = ctx->InputShape("like", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("like", 0);
   *ctx->IsDynamic4ArgNameAndIndex("out", 0) = ctx->InputIsDynamic("like", 0);
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/upsample_op.cpp
+++ b/oneflow/user/ops/upsample_op.cpp
@@ -244,7 +244,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> UpsampleLinear1DGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(ctx->Attr<std::string>("data_format") == "channels_first"
                   && dy_shape.NumAxes() == 3)
       << "upsample_linear_1d_grad only supports NCH";
@@ -269,7 +269,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> UpsampleNearest1DGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(ctx->Attr<std::string>("data_format") == "channels_first"
                   && dy_shape.NumAxes() == 3)
       << "upsample_nearest_1d_grad only supports NCH";
@@ -295,7 +295,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> UpsampleNearest2DGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(ctx->Attr<std::string>("data_format") == "channels_first"
                   && dy_shape.NumAxes() == 4)
       << "upsample_nearest_2d_grad only supports NCHW";
@@ -322,7 +322,7 @@ namespace oneflow {
 /*static*/ Maybe<void> UpsampleBilinear2DGradOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(ctx->Attr<std::string>("data_format") == "channels_first"
                   && dy_shape.NumAxes() == 4)
       << "upsample_bilinear_2d_grad only supports NCHW";
@@ -348,7 +348,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> UpsampleBicubic2DGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(ctx->Attr<std::string>("data_format") == "channels_first"
                   && dy_shape.NumAxes() == 4)
       << "upsample_bicubic_2d_grad only supports NCHW";
@@ -374,7 +374,7 @@ namespace oneflow {
 }
 /*static*/ Maybe<void> UpsampleNearest3DGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(ctx->Attr<std::string>("data_format") == "channels_first"
                   && dy_shape.NumAxes() == 5)
       << "upsample_nearest_3d_grad only supports NCDHW";
@@ -401,7 +401,7 @@ namespace oneflow {
 /*static*/ Maybe<void> UpsampleTrilinear3DGradOp::InferLogicalTensorDesc(
     user_op::InferContext* ctx) {
   const Shape& dy_shape = ctx->InputShape("dy", 0);
-  Shape* dx_shape = ctx->OutputShape("dx", 0);
+  Shape* dx_shape = ctx->MutOutputShape("dx", 0);
   CHECK_OR_RETURN(ctx->Attr<std::string>("data_format") == "channels_first"
                   && dy_shape.NumAxes() == 5)
       << "upsample_trilinear_3d_grad only supports NCDHW";

--- a/oneflow/user/ops/util_ops.cpp
+++ b/oneflow/user/ops/util_ops.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace oneflow {
 
 /* static */ Maybe<void> IsNanOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 
@@ -43,7 +43,7 @@ namespace oneflow {
 }
 
 /* static */ Maybe<void> IsInfOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("in", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("in", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/variance_op.cpp
+++ b/oneflow/user/ops/variance_op.cpp
@@ -27,7 +27,7 @@ Maybe<void> VarOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const AxisVector reduce_axes_vec = {reduce_axes.begin(), reduce_axes.end()};
   const Shape& reduce_shape = CreateReducedShape(input_shape, reduce_axes_vec);
   const bool keepdim = ctx->Attr<bool>("keepdim");
-  Shape* output_shape = ctx->OutputShape("output", 0);
+  Shape* output_shape = ctx->MutOutputShape("output", 0);
   if (keepdim) {
     *output_shape = reduce_shape;
   } else {

--- a/oneflow/user/ops/vector_matrix_product_op.cpp
+++ b/oneflow/user/ops/vector_matrix_product_op.cpp
@@ -26,7 +26,7 @@ Maybe<void> InferTensorDesc4VectorMatrixProduct(user_op::InferContext* ctx) {
   int64_t k = a.shape().At(0);
   CHECK_EQ_OR_RETURN(k, b.shape().At(0)) << "Dim K should be equal to vector b's dim0. ";
   int64_t n = b.shape().At(1);
-  *ctx->OutputShape("out", 0) = Shape({n});
+  *ctx->MutOutputShape("out", 0) = Shape({n});
   return Maybe<void>::Ok();
 }
 
@@ -45,7 +45,7 @@ Maybe<void> InferTensorDesc4VectorMatrixProductGradA(user_op::InferContext* ctx)
   */
   const user_op::TensorDesc& b = ctx->InputTensorDesc("b", 0);
   int64_t k = b.shape().At(0);
-  *ctx->OutputShape("dx", 0) = Shape({k});
+  *ctx->MutOutputShape("dx", 0) = Shape({k});
   return Maybe<void>::Ok();
 }
 
@@ -58,7 +58,7 @@ Maybe<void> InferTensorDesc4VectorMatrixProductGradB(user_op::InferContext* ctx)
   const user_op::TensorDesc& a = ctx->InputTensorDesc("a", 0);
   int64_t k = a.shape().At(0);
   int64_t n = dy.shape().At(0);
-  *ctx->OutputShape("dx", 0) = Shape({k, n});
+  *ctx->MutOutputShape("dx", 0) = Shape({k, n});
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/where_op.cpp
+++ b/oneflow/user/ops/where_op.cpp
@@ -81,11 +81,11 @@ Maybe<void> InferWhereTensorDesc(user_op::InferContext* ctx) {
   const Shape& x_shape = ctx->InputShape("x", 0);
   const Shape& y_shape = ctx->InputShape("y", 0);
   if (x_shape == y_shape && y_shape == cond_shape) {
-    *ctx->OutputShape("out", 0) = cond_shape;
+    *ctx->MutOutputShape("out", 0) = cond_shape;
   } else {
     Shape max_shape = *JUST(GetBroadcastShape(cond_shape, x_shape));
     max_shape = *JUST(GetBroadcastShape(max_shape, y_shape));
-    *ctx->OutputShape("out", 0) = max_shape;
+    *ctx->MutOutputShape("out", 0) = max_shape;
   }
   return Maybe<void>::Ok();
 }
@@ -94,10 +94,10 @@ Maybe<void> InferWhereXScalarTensorDesc(user_op::InferContext* ctx) {
   const Shape& cond_shape = ctx->InputShape("condition", 0);
   const Shape& y_shape = ctx->InputShape("y", 0);
   if (cond_shape == y_shape) {
-    *ctx->OutputShape("out", 0) = cond_shape;
+    *ctx->MutOutputShape("out", 0) = cond_shape;
   } else {
     Shape max_shape = *JUST(GetBroadcastShape(cond_shape, y_shape));
-    *ctx->OutputShape("out", 0) = max_shape;
+    *ctx->MutOutputShape("out", 0) = max_shape;
   }
   return Maybe<void>::Ok();
 }
@@ -106,16 +106,16 @@ Maybe<void> InferWhereYScalarTensorDesc(user_op::InferContext* ctx) {
   const Shape& cond_shape = ctx->InputShape("condition", 0);
   const Shape& x_shape = ctx->InputShape("x", 0);
   if (cond_shape == x_shape) {
-    *ctx->OutputShape("out", 0) = cond_shape;
+    *ctx->MutOutputShape("out", 0) = cond_shape;
   } else {
     Shape max_shape = *JUST(GetBroadcastShape(cond_shape, x_shape));
-    *ctx->OutputShape("out", 0) = max_shape;
+    *ctx->MutOutputShape("out", 0) = max_shape;
   }
   return Maybe<void>::Ok();
 }
 
 Maybe<void> InferWhereXYScalarTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("condition", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("condition", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/zero_like_op.cpp
+++ b/oneflow/user/ops/zero_like_op.cpp
@@ -33,7 +33,7 @@ namespace oneflow {
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ZeroLikeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
-  *ctx->OutputShape("out", 0) = ctx->InputShape("like", 0);
+  *ctx->MutOutputShape("out", 0) = ctx->InputShape("like", 0);
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ZeroLikeOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {


### PR DESCRIPTION
分离InferContext中的OutputShape和MutOutputShape、OutputStride和MutOutputStride接口，在接口上达到读写分离效果。