### PR TITLE
fix for docsv0.8

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -20,7 +20,7 @@ Containers
 .. autosummary::
     :toctree: generated
     :nosignatures:
-    :template: 
+    :template: classtemplate.rst
 
     Module
     Sequential
@@ -35,6 +35,7 @@ Convolution Layers
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.Conv1d 
     nn.Conv2d 
@@ -51,6 +52,7 @@ Pooling Layers
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.MaxPool1d 
     nn.MaxPool2d 
@@ -68,6 +70,7 @@ Padding Layers
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.ConstantPad1d 
     nn.ConstantPad2d 
@@ -113,6 +116,7 @@ Non-linear Activations (other)
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.Softmax
     nn.LogSoftmax
@@ -123,6 +127,7 @@ Normalization Layers
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.BatchNorm1d 
     nn.BatchNorm2d 
@@ -142,7 +147,7 @@ Recurrent Layers
 .. autosummary::
     :toctree: generated
     :nosignatures:
-    :template:
+    :template: classtemplate.rst
 
     nn.RNN
     nn.LSTM
@@ -157,7 +162,8 @@ Linear Layers
 .. autosummary::
     :toctree: generated
     :nosignatures:
-    
+    :template: classtemplate.rst
+
     nn.Identity
     nn.Linear
 
@@ -176,6 +182,7 @@ Sparse Layers
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.Embedding
 
@@ -185,7 +192,7 @@ Distance Functions
 .. autosummary::
     :toctree: generated
     :nosignatures:
-    :template:
+    :template: classtemplate.rst
 
     nn.CosineSimilarity
 
@@ -195,6 +202,7 @@ Loss Functions
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.BCELoss 
     nn.BCEWithLogitsLoss 
@@ -215,6 +223,7 @@ Vision Layers
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.PixelShuffle 
     nn.Upsample 
@@ -228,6 +237,7 @@ DataParallel Layers (multi-GPU, distributed)
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
     
     nn.parallel.DistributedDataParallel
 
@@ -240,6 +250,7 @@ From the ``oneflow.nn.utils`` module
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     clip_grad_norm_
     clip_grad_value_
@@ -252,6 +263,7 @@ Utility functions in other modules
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: classtemplate.rst
 
     nn.utils.rnn.PackedSequence
     nn.utils.rnn.pack_padded_sequence
@@ -262,6 +274,6 @@ Utility functions in other modules
 .. autosummary::
     :toctree: generated
     :nosignatures:
-    :template:
+    :template: classtemplate.rst
 
     nn.Flatten


### PR DESCRIPTION
# 修复 Module 相关文档后重复的 method 函数
![image](https://user-images.githubusercontent.com/48576019/179961618-1d78d315-29e0-41db-81a0-f10a9b05e6c6.png)
