### PR TITLE
add unsqueeze_multiple_op

### DIFF
--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -917,7 +917,7 @@
   bind_python: True
 
 - name: "unsqueeze_multiple"
-  signature: "Tensor (Tensor input, Int32List[1] dim, Int32 dims) => UnsqueezeMultiple"
+  signature: "Tensor (Tensor input, Int32List dim, Int32 dims) => UnsqueezeMultiple"
   bind_python: False
   
 - name: "squeeze"

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -913,7 +913,7 @@
   bind_python: True
 
 - name: "unsqueeze_multiple"
-  signature: "Tensor (Tensor input, Int32List[1] dim,Int32 dims) => UnsqueezeMultiple"
+  signature: "Tensor (Tensor input, Int32List[1] dim, Int32 dims) => UnsqueezeMultiple"
   bind_python: False
   
 - name: "squeeze"

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -912,6 +912,10 @@
   signature: "Tensor (Tensor input, Int32 dim) => Unsqueeze"
   bind_python: True
 
+- name: "unsqueeze_multiple"
+  signature: "Tensor (Tensor input, Int32List[1] dim,Int32 dims) => UnsqueezeMultiple"
+  bind_python: False
+  
 - name: "squeeze"
   signature: [
     "Tensor (Tensor x, Int32List[1] dim=None) => Squeeze",

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -696,18 +696,18 @@ class UnsqueezeMultipleFunctor {
       // Unsqueeze is called several times to extend the dimension when the View mechanism is
       // enabled. Otherwise, calculate the target shape and call reshape.
       if (view::IsViewApplicable(tensor)) {
-        for (int32_t dim = 0; dim < n_dims; dim++) {
-          if ((*dims_to_unsqueeze)[dim]) { tensor = JUST(view::Unsqueeze(tensor, dim)); }
+        for (int32_t i = 0; i < n_dims; i++) {
+          if ((*dims_to_unsqueeze)[i]) { tensor = JUST(view::Unsqueeze(tensor, i)); }
         }
       } else {
         std::vector<int64_t> target_dims(n_dims, 0);
         int32_t tensor_index = 0;
-        for (int32_t dim = 0; dim < n_dims; dim++) {
-          if ((*dims_to_unsqueeze)[dim]) {
-            target_dims[dim] = 1;
+        for (int32_t i = 0; i < n_dims; i++) {
+          if ((*dims_to_unsqueeze)[i]) {
+            target_dims[i] = 1;
           } else {
             CHECK_LT_OR_RETURN(tensor_index, tensor->ndim());  // NOLINT(maybe-need-error-msg)
-            target_dims[dim] = tensor->shape()->at(tensor_index);
+            target_dims[i] = tensor->shape()->at(tensor_index);
             tensor_index++;
           }
         }
@@ -717,9 +717,6 @@ class UnsqueezeMultipleFunctor {
       return tensor;
     }
   }
-
- private:
-  std::shared_ptr<OpExpr> op_;
 };
 
 class SqueezeFunctor {

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -680,6 +680,48 @@ class ExpandDimsFunctor {
   std::shared_ptr<OpExpr> op_;
 };
 
+class UnsqueezeMultipleFunctor {
+ public:
+  UnsqueezeMultipleFunctor() {}
+  Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const std::vector<int32_t>& dim,
+                           const int32_t& n_dims) const {
+    if (dim.size() == 0 || x->ndim() == n_dims) {
+      return x;
+    } else if (dim.size() == 1) {
+      return JUST(functional::Unsqueeze(x, JUST(VectorAt(dim, 0))));
+    } else {
+      std::shared_ptr<Tensor> tensor = x;
+      const auto& dims_to_unsqueeze = JUST(dim_list_to_bitset(dim, n_dims));
+
+      // Unsqueeze is called several times to extend the dimension when the View mechanism is
+      // enabled. Otherwise, calculate the target shape and call reshape.
+      if (view::IsViewApplicable(tensor)) {
+        for (int32_t dim = 0; dim < n_dims; dim++) {
+          if ((*dims_to_unsqueeze)[dim]) { tensor = JUST(view::Unsqueeze(tensor, dim)); }
+        }
+      } else {
+        std::vector<int64_t> target_dims(n_dims, 0);
+        int32_t tensor_index = 0;
+        for (int32_t dim = 0; dim < n_dims; dim++) {
+          if ((*dims_to_unsqueeze)[dim]) {
+            target_dims[dim] = 1;
+          } else {
+            CHECK_LT_OR_RETURN(tensor_index, tensor->ndim());  // NOLINT(maybe-need-error-msg)
+            target_dims[dim] = tensor->shape()->at(tensor_index);
+            tensor_index++;
+          }
+        }
+        Shape infered_shape(DimVector(target_dims.begin(), target_dims.end()));
+        tensor = JUST(functional::Reshape(tensor, infered_shape));
+      }
+      return tensor;
+    }
+  }
+
+ private:
+  std::shared_ptr<OpExpr> op_;
+};
+
 class SqueezeFunctor {
  public:
   SqueezeFunctor() {
@@ -3134,6 +3176,7 @@ ONEFLOW_FUNCTION_LIBRARY(m) {
   m.add_functor<impl::ExpandGradFunctor>("ExpandGrad");
   m.add_functor<impl::ExpandDimsFunctor>("ExpandDims");
   m.add_functor<impl::ExpandDimsFunctor>("Unsqueeze");
+  m.add_functor<impl::UnsqueezeMultipleFunctor>("UnsqueezeMultiple");
   m.add_functor<impl::SqueezeFunctor>("Squeeze");
   m.add_functor<impl::RollFunctor>("Roll");
   m.add_functor<impl::GatherFunctor>("Gather");


### PR DESCRIPTION
- 搬运`pytorch`的`unsqueeze_multiple`算子和相关公共函数
- 支持view机制