### PR TITLE
Support TensorScatterNdUpdate non-contiguous kernel

### DIFF
--- a/oneflow/core/framework/tensor_meta.cpp
+++ b/oneflow/core/framework/tensor_meta.cpp
@@ -81,8 +81,20 @@ bool IsContiguous(const Shape& shape, const Stride& stride) {
 }
 
 bool IsContiguous(const ShapeView& shape_view, const Stride& stride) {
-  Shape shape(shape_view);
-  return IsContiguous(shape, stride);
+  if (shape_view.NumAxes() < 1 || shape_view.elem_cnt() <= 1) { return true; }
+  int64_t dim = shape_view.NumAxes();
+  int64_t expected_stride = 1;
+  bool contig_if_nonempty = true;
+  for (int64_t i = dim - 1; i >= 0; --i) {
+    // Contiguous by default when any dim is equal to zero
+    // https://stackoverflow.com/questions/31681324/identify-contiguous-segments-of-a-non-contiguous-numpy-array
+    if (shape_view.At(i) == 0) { return true; }
+    if (contig_if_nonempty && shape_view.At(i) != 1) {
+      if (stride.at(i) != expected_stride) { contig_if_nonempty = false; }
+      expected_stride *= shape_view.At(i);
+    }
+  }
+  return contig_if_nonempty;
 }
 
 }  // namespace one

--- a/oneflow/core/framework/tensor_meta.cpp
+++ b/oneflow/core/framework/tensor_meta.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "oneflow/core/framework/tensor_meta.h"
 #include "oneflow/core/common/stride.h"
 #include "oneflow/core/framework/device.h"
+#include "oneflow/core/common/shape_view.h"
 
 namespace oneflow {
 namespace one {
@@ -77,6 +78,11 @@ bool IsContiguous(const Shape& shape, const Stride& stride) {
     }
   }
   return contig_if_nonempty;
+}
+
+bool IsContiguous(const ShapeView& shape_view, const Stride& stride) {
+  Shape shape(shape_view);
+  return IsContiguous(shape, stride);
 }
 
 }  // namespace one

--- a/oneflow/core/framework/tensor_meta.cpp
+++ b/oneflow/core/framework/tensor_meta.cpp
@@ -64,20 +64,8 @@ size_t GlobalTensorMeta::CalcHashValue() const {
 }
 
 bool IsContiguous(const Shape& shape, const Stride& stride) {
-  if (!shape.is_initialized() || shape.NumAxes() < 1 || shape.elem_cnt() <= 1) { return true; }
-  int64_t dim = shape.NumAxes();
-  int64_t expected_stride = 1;
-  bool contig_if_nonempty = true;
-  for (int64_t i = dim - 1; i >= 0; --i) {
-    // Contiguous by default when any dim is equal to zero
-    // https://stackoverflow.com/questions/31681324/identify-contiguous-segments-of-a-non-contiguous-numpy-array
-    if (shape.At(i) == 0) { return true; }
-    if (contig_if_nonempty && shape.At(i) != 1) {
-      if (stride.at(i) != expected_stride) { contig_if_nonempty = false; }
-      expected_stride *= shape.At(i);
-    }
-  }
-  return contig_if_nonempty;
+  if (!shape.is_initialized()) { return true; }
+  return IsContiguous(ShapeView(shape), stride);
 }
 
 bool IsContiguous(const ShapeView& shape_view, const Stride& stride) {

--- a/oneflow/core/framework/tensor_meta.h
+++ b/oneflow/core/framework/tensor_meta.h
@@ -31,6 +31,7 @@ class ParallelDesc;
 namespace one {
 
 bool IsContiguous(const Shape& shape, const Stride& stride);
+bool IsContiguous(const ShapeView& shape_view, const Stride& stride);
 
 class TensorMeta : public user_op::TensorDesc {
  public:

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -1103,14 +1103,15 @@ class TensorScatterNdUpdateFunctor {
                            const std::shared_ptr<one::Tensor>& updates, bool inplace) const {
     CHECK_OR_RETURN(*tensor->dtype() == *updates->dtype())
         << Error::RuntimeError() << "The dtype of tensor and updates must be same.";
+    std::shared_ptr<Tensor> contiguous_index = JUST(functional::ToContiguous(indices));
     if (inplace) {
       JUST(CheckInplaceValid(tensor));
       auto outputs = std::make_shared<TensorTuple>(1);
       outputs->at(0) = tensor;
-      JUST(OpInterpUtil::Dispatch(*op_, {tensor, indices, updates}, outputs.get()));
+      JUST(OpInterpUtil::Dispatch(*op_, {tensor, contiguous_index, updates}, outputs.get()));
       return outputs->at(0);
     } else {
-      return OpInterpUtil::Dispatch<Tensor>(*op_, {tensor, indices, updates});
+      return OpInterpUtil::Dispatch<Tensor>(*op_, {tensor, contiguous_index, updates});
     }
   }
 

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -3328,7 +3328,7 @@ def OneFlow_TensorScatterNdAddOp : OneFlow_BaseOp<"tensor_scatter_nd_add", [NoSi
   let has_input_arg_modify_fn = 1;
 }
 
-def OneFlow_TensorScatterNdUpdateOp : OneFlow_BaseOp<"tensor_scatter_nd_update", [NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+def OneFlow_TensorScatterNdUpdateOp : OneFlow_BaseOp<"tensor_scatter_nd_update", [NoSideEffect, SupportNonContiguous, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
     OneFlow_Tensor:$params,
     OneFlow_Tensor:$updates,

--- a/oneflow/user/kernels/nd_index_slice_kernels.cpp
+++ b/oneflow/user/kernels/nd_index_slice_kernels.cpp
@@ -19,7 +19,7 @@ namespace oneflow {
 
 template<typename T, typename I>
 struct GatherNdFunctor<DeviceType::kCPU, T, I> final {
-  void operator()(ep::Stream* stream, const NdIndexSliceArgs<T, I>& args, const I* indices,
+  void operator()(ep::Stream* stream, const NdIndexSliceArgs& args, const I* indices,
                   const T* dense, T* slices) const {
     DoGatherNd(args.num_slices * args.slice_size, args.slice_size, args.index_ndims,
                args.dense_shape, indices, dense, slices);
@@ -28,7 +28,7 @@ struct GatherNdFunctor<DeviceType::kCPU, T, I> final {
 
 template<typename T, typename I>
 struct ScatterNdAddFunctor<DeviceType::kCPU, T, I> final {
-  void operator()(ep::Stream* stream, const NdIndexSliceArgs<T, I>& args, const I* indices,
+  void operator()(ep::Stream* stream, const NdIndexSliceArgs& args, const I* indices,
                   const T* slices, T* dense) const {
     DoScatterNdAdd<DeviceType::kCPU>(args.num_slices * args.slice_size, args.slice_size,
                                      args.index_ndims, args.dense_shape, indices, slices, dense);
@@ -37,7 +37,7 @@ struct ScatterNdAddFunctor<DeviceType::kCPU, T, I> final {
 
 template<typename T, typename I>
 struct ScatterNdUpdateFunctor<DeviceType::kCPU, T, I> final {
-  void operator()(ep::Stream* stream, const NdIndexSliceArgs<T, I>& args, const I* indices,
+  void operator()(ep::Stream* stream, const NdIndexSliceArgs& args, const I* indices,
                   const T* slices, T* dense) const {
     DoScatterNdUpdate<DeviceType::kCPU>(args.num_slices * args.slice_size, args.slice_size,
                                         args.index_ndims, args.dense_shape, indices, slices, dense);
@@ -45,9 +45,18 @@ struct ScatterNdUpdateFunctor<DeviceType::kCPU, T, I> final {
 };
 
 template<typename T, typename I>
+struct ScatterNdUpdateWithStrideFunctor<DeviceType::kCPU, T, I> final {
+  void operator()(ep::Stream* stream, const NdIndexSliceArgs& args, const I* indices,
+                  const T* slices, T* dense) const {
+    DoScatterNdUpdateWithStride<DeviceType::kCPU>(args.num_slices * args.slice_size, args, indices,
+                                                  slices, dense);
+  }
+};
+
+template<typename T, typename I>
 struct FillByNdIndexFunctor<DeviceType::kCPU, T, I> final {
-  void operator()(ep::Stream* stream, const NdIndexSliceArgs<T, I>& args, const I* indices,
-                  T* dense, T value) const {
+  void operator()(ep::Stream* stream, const NdIndexSliceArgs& args, const I* indices, T* dense,
+                  T value) const {
     DoFillByNdIndex(args.num_slices * args.slice_size, args.slice_size, args.index_ndims,
                     args.dense_shape, indices, dense, value);
   }

--- a/oneflow/user/kernels/nd_index_slice_kernels.h
+++ b/oneflow/user/kernels/nd_index_slice_kernels.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define ONEFLOW_USER_KERNELS_ND_INDEX_SLICE_KERNELS_H_
 
 #include "oneflow/user/kernels/nd_index_slice_util.h"
+#include "oneflow/core/framework/tensor_meta.h"
 
 namespace oneflow {
 
@@ -74,7 +75,7 @@ void GatherNdKernel<device_type, T, I>::Compute(user_op::KernelComputeContext* c
   const user_op::Tensor* params = ctx->Tensor4ArgNameAndIndex("params", 0);
   user_op::Tensor* out = ctx->Tensor4ArgNameAndIndex("out", 0);
   if (indices->shape_view().elem_cnt() == 0) { return; }
-  auto args = ConstructNdIndexSliceArgs<T, I>(*params, *out, *indices);
+  auto args = ConstructNdIndexSliceArgs(*params, *out, *indices);
   GatherNdFunctor<device_type, T, I>()(ctx->stream(), args, indices->dptr<I>(), params->dptr<T>(),
                                        out->mut_dptr<T>());
 }
@@ -87,7 +88,7 @@ void ScatterNdKernel<device_type, T, I>::Compute(user_op::KernelComputeContext* 
   size_t out_bytes_size = out->shape_view().elem_cnt() * GetSizeOfDataType(out->data_type());
   Memset<device_type>(ctx->stream(), out->mut_dptr<T>(), 0, out_bytes_size);
   if (indices->shape_view().elem_cnt() == 0) { return; }
-  auto args = ConstructNdIndexSliceArgs<T, I>(*out, *updates, *indices);
+  auto args = ConstructNdIndexSliceArgs(*out, *updates, *indices);
   ScatterNdAddFunctor<device_type, T, I>()(ctx->stream(), args, indices->dptr<I>(),
                                            updates->dptr<T>(), out->mut_dptr<T>());
 }
@@ -102,9 +103,15 @@ void TensorScatterNdUpdateKernel<device_type, T, I>::Compute(
   size_t out_bytes_size = out->shape_view().elem_cnt() * GetSizeOfDataType(out->data_type());
   Memcpy<device_type>(ctx->stream(), out->mut_dptr<T>(), params->dptr<T>(), out_bytes_size);
   if (indices->shape_view().elem_cnt() == 0) { return; }
-  auto args = ConstructNdIndexSliceArgs<T, I>(*params, *updates, *indices);
-  ScatterNdUpdateFunctor<device_type, T, I>()(ctx->stream(), args, indices->dptr<I>(),
-                                              updates->dptr<T>(), out->mut_dptr<T>());
+  auto args = ConstructNdIndexSliceArgs(*params, *updates, *indices);
+  if (one::IsContiguous(params->shape_view(), params->stride())
+      && one::IsContiguous(updates->shape_view(), updates->stride())) {
+    ScatterNdUpdateFunctor<device_type, T, I>()(ctx->stream(), args, indices->dptr<I>(),
+                                                updates->dptr<T>(), out->mut_dptr<T>());
+  } else {
+    ScatterNdUpdateWithStrideFunctor<device_type, T, I>()(ctx->stream(), args, indices->dptr<I>(),
+                                                          updates->dptr<T>(), out->mut_dptr<T>());
+  }
 }
 
 template<DeviceType device_type, typename T, typename I>
@@ -117,7 +124,7 @@ void TensorScatterNdAddKernel<device_type, T, I>::Compute(
   size_t out_bytes_size = out->shape_view().elem_cnt() * GetSizeOfDataType(out->data_type());
   Memcpy<device_type>(ctx->stream(), out->mut_dptr<T>(), params->dptr<T>(), out_bytes_size);
   if (indices->shape_view().elem_cnt() == 0) { return; }
-  auto args = ConstructNdIndexSliceArgs<T, I>(*params, *updates, *indices);
+  auto args = ConstructNdIndexSliceArgs(*params, *updates, *indices);
   ScatterNdAddFunctor<device_type, T, I>()(ctx->stream(), args, indices->dptr<I>(),
                                            updates->dptr<T>(), out->mut_dptr<T>());
 }

--- a/oneflow/user/ops/nd_index_slice_ops.cpp
+++ b/oneflow/user/ops/nd_index_slice_ops.cpp
@@ -76,6 +76,7 @@ Maybe<void> InferTensorScatterNdOptTensorDesc(user_op::InferContext* ctx) {
   const Shape& indices_shape = ctx->InputShape("indices", 0);
   JUST(CheckScatterNdShape(params_shape, indices_shape, updates_shape));
   *ctx->OutputShape("out", 0) = params_shape;
+  *ctx->OutputStride("out", 0) = ctx->InputStride("params", 0);
   return Maybe<void>::Ok();
 }
 

--- a/python/oneflow/test/modules/test_tensor_scatter_nd_update.py
+++ b/python/oneflow/test/modules/test_tensor_scatter_nd_update.py
@@ -37,6 +37,28 @@ def _test_tensor_scatter_nd_update(test_case, device):
     test_case.assertTrue(np.allclose(output.numpy(), np_out, 0.0001, 0.0001))
 
 
+def _test_tensor_scatter_nd_update_with_non_contiguous_input(test_case, device):
+    # non-contiguous tensor with shape (2, 3, 4)
+    origin = flow.tensor(
+        np.ones((4, 3, 2)), dtype=flow.float, device=flow.device(device)
+    ).permute(2, 1, 0)
+    # indices with shape (3, 2)
+    indices = flow.tensor(
+        np.array([[0, 0], [1, 0], [1, 1]]), dtype=flow.int, device=flow.device(device)
+    )
+    # non-contiguous update with shape (3, 4)
+    update = flow.tensor(
+        np.zeros((4, 3)), dtype=flow.float, device=flow.device(device)
+    ).T
+    output = flow.tensor_scatter_nd_update(origin, indices, update)
+
+    np_res = np.ones((2, 3, 4))
+    np_res[0, 0] = 0
+    np_res[1, 0] = 0
+    np_res[1, 1] = 0
+    test_case.assertTrue(np.array_equal(output.numpy(), np_res))
+
+
 def _test_tensor_scatter_nd_update_t(test_case, device):
     origin = flow.tensor(
         np.arange(15).reshape(5, 3), dtype=flow.float, device=flow.device(device)
@@ -92,6 +114,7 @@ class TestTensorScatterNdUpdate(flow.unittest.TestCase):
         arg_dict = OrderedDict()
         arg_dict["test_fun"] = [
             _test_tensor_scatter_nd_update,
+            _test_tensor_scatter_nd_update_with_non_contiguous_input,
             _test_tensor_scatter_nd_update_t,
             _test_tensor_scatter_nd_update_backward,
         ]


### PR DESCRIPTION
支持了 non-contiguous 的 TensorScatterNdUpdate，这下 combined masked setitem 基本就支持完全了：

```python
import oneflow as flow

a = flow.ones(2, 3, 4).permute(2, 1, 0)
c = flow.tensor([False,True,False,True])
# d = flow.tensor([False,True,False])
e = flow.tensor([False,True])

b = flow.zeros(3, 2).T
a[c, :, e] = b
print(a.numpy())
```