### PR TITLE
modify broadcast_like_op.cpp about sbp

### DIFF
--- a/oneflow/user/ops/broadcast_like_op.cpp
+++ b/oneflow/user/ops/broadcast_like_op.cpp
@@ -21,22 +21,66 @@ namespace oneflow {
 
 namespace {
 
+bool IsAxesLegal(const AxisVector& axis_vec, const Shape& like_shape, const Shape& in_shape) {
+  Shape reduced_like_shape = CreateReducedShape(like_shape, axis_vec);
+  if (like_shape.NumAxes() > in_shape.NumAxes()) {
+    std::vector<int64_t> in_shape_vec;
+    in_shape_vec.reserve(in_shape.NumAxes());
+    std::vector<int64_t> like_shape_vec;
+    like_shape_vec.reserve(reduced_like_shape.NumAxes());
+    for (const int64_t& dim : in_shape.dim_vec()) {
+      if (dim != 1) { in_shape_vec.emplace_back(dim); }
+    }
+    for (const int64_t& dim : reduced_like_shape.dim_vec()) {
+      if (dim != 1) { like_shape_vec.emplace_back(dim); }
+    }
+    if (in_shape_vec.size() > like_shape_vec.size()) {
+      return false;
+    } else {
+      return std::equal(in_shape_vec.begin(), in_shape_vec.end(), like_shape_vec.begin());
+    }
+  }
+  return reduced_like_shape.dim_vec() == in_shape.dim_vec();
+}
+std::vector<bool> MakePredicatorIsReducedAxisVec(const Shape& like_shape, const Shape& x_shape,
+                                                 const std::vector<int>& reduced_axes) {
+  int32_t x_num_axes = x_shape.NumAxes();
+  int32_t like_num_axes = like_shape.NumAxes();
+  std::vector<bool> IsReducedAxis(like_num_axes, false);
+  if (x_num_axes + reduced_axes.size() == like_num_axes) {
+    for (const int32_t c : reduced_axes) { IsReducedAxis[c] = true; }
+  } else {
+    int32_t like_dim = 0;
+    int32_t x_dim = 0;
+    while (like_dim < like_num_axes && x_dim < x_num_axes) {
+      if (x_shape.at(x_dim) == 1 || x_shape.at(x_dim) == like_shape.at(like_dim)) {
+        x_dim++;
+        like_dim++;
+      } else {
+        IsReducedAxis[like_dim] = true;
+        like_dim++;
+      }
+    }
+    for (int i = like_dim; i < like_num_axes; i++) { IsReducedAxis[i] = true; }
+  }
+  return IsReducedAxis;
+}
 Maybe<void> GetSbpSignatures(user_op::SbpContext* ctx) {
   const auto& x_shape = ctx->LogicalTensorDesc4InputArgNameAndIndex("x", 0).shape();
   const auto& like_shape = ctx->LogicalTensorDesc4InputArgNameAndIndex("like", 0).shape();
   int32_t x_num_axes = x_shape.NumAxes();
   int32_t like_num_axes = like_shape.NumAxes();
   const auto& reduced_axes = ctx->Attr<std::vector<int32_t>>("broadcast_axes");
-  if (x_num_axes != like_num_axes && (x_num_axes + reduced_axes.size() != like_num_axes)) {
+  const AxisVector axis_vec = {reduced_axes.begin(), reduced_axes.end()};
+  if (!IsAxesLegal(axis_vec, like_shape, x_shape)) {
     return Error::RuntimeError() << "Can not broadcast shape " << x_shape.ToString() << " to "
                                  << like_shape.ToString();
   }
-  HashSet<int32_t> conf_axes;
-  ReduceSbpUtil::GetRegularAxes(like_num_axes, reduced_axes, &conf_axes);
-  auto IsReducedAxis = ReduceSbpUtil::MakePredicatorIsReducedAxis(conf_axes, like_num_axes);
+
+  const auto IsReducedAxis = MakePredicatorIsReducedAxisVec(like_shape, x_shape, reduced_axes);
   int32_t num_reduced_axis = 0;
   FOR_RANGE(int64_t, i, 0, like_num_axes) {
-    if (IsReducedAxis(i)) {
+    if (IsReducedAxis[i]) {
       ctx->NewBuilder()
           .Broadcast(user_op::OpArg("x", 0))
           .Split(user_op::OpArg("like", 0), i)
@@ -65,23 +109,17 @@ Maybe<void> GetSbpSignatures(user_op::SbpContext* ctx) {
   return Maybe<void>::Ok();
 }
 
-bool IsAxesLegal(const AxisVector& axis_vec, const Shape& like_shape, const Shape& in_shape) {
-  Shape reduced_shape = CreateReducedShape(like_shape, axis_vec);
-  if (like_shape.NumAxes() > in_shape.NumAxes()) {
-    reduced_shape = reduced_shape.RemoveOnes(axis_vec);
-  }
-  return reduced_shape.dim_vec() == in_shape.dim_vec();
-}
-
 Maybe<void> InferTensorDesc(user_op::InferContext* ctx) {
   const auto& broadcast_axes = ctx->Attr<std::vector<int32_t>>("broadcast_axes");
   CHECK_OR_RETURN(!broadcast_axes.empty());
   const Shape& in_shape = ctx->InputShape("x", 0);
   const Shape& like_shape = ctx->InputShape("like", 0);
-  Shape* out_shape = ctx->OutputShape("y", 0);
-  Stride* out_stride = ctx->OutputStride("y", 0);
+  Shape* out_shape = ctx->MutOutputShape("y", 0);
+  Stride* out_stride = ctx->MutOutputStride("y", 0);
   const AxisVector axis_vec = {broadcast_axes.begin(), broadcast_axes.end()};
-  CHECK_OR_RETURN(IsAxesLegal(axis_vec, like_shape, in_shape));
+  CHECK_OR_RETURN(IsAxesLegal(axis_vec, like_shape, in_shape))
+      << Error::RuntimeError() << "Invalid input parameter: like shape:" << like_shape.ToString()
+      << ", in shape:" << in_shape.ToString() << ", axis_vec size:" << axis_vec.size();
   *out_shape = like_shape;
   *out_stride = Stride(like_shape);
   return Maybe<void>::Ok();
@@ -110,7 +148,7 @@ Maybe<void> InferTensorDesc(user_op::InferContext* ctx) {
 }
 
 /* static */ Maybe<void> BroadcastLikeOp::InferDataType(user_op::InferContext* ctx) {
-  *ctx->OutputDType("y", 0) = ctx->InputDType("like", 0);
+  *ctx->MutOutputDType("y", 0) = ctx->InputDType("like", 0);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/reduce_like_ops.cpp
+++ b/oneflow/user/ops/reduce_like_ops.cpp
@@ -28,6 +28,7 @@ namespace oneflow {
     const auto& reduced_axes = ctx->Attr<std::vector<int32_t>>("axis");
     ReduceSbpUtil::GetRegularAxes(num_axes, reduced_axes, &conf_axes);
   }
+  
   const auto& like_num_axes =
       ctx->LogicalTensorDesc4InputArgNameAndIndex("like", 0).shape().NumAxes();
   const bool keep_dims = (num_axes == like_num_axes);

--- a/oneflow/user/ops/reduce_like_ops.cpp
+++ b/oneflow/user/ops/reduce_like_ops.cpp
@@ -28,16 +28,9 @@ namespace oneflow {
     const auto& reduced_axes = ctx->Attr<std::vector<int32_t>>("axis");
     ReduceSbpUtil::GetRegularAxes(num_axes, reduced_axes, &conf_axes);
   }
-
   const auto& like_num_axes =
       ctx->LogicalTensorDesc4InputArgNameAndIndex("like", 0).shape().NumAxes();
   const bool keep_dims = (num_axes == like_num_axes);
-  if (!keep_dims) {
-    CHECK_EQ_OR_RETURN(conf_axes.size(), num_axes - like_num_axes)
-        << Error::RuntimeError()
-        << "The size of axis list must be equal to the difference of the dimension "
-        << "between x tensor and like tensor";
-  }
   auto IsReducedAxis = ReduceSbpUtil::MakePredicatorIsReducedAxis(conf_axes, num_axes);
   int64_t num_reduced_axes = 0;
   FOR_RANGE(int64_t, i, 0, num_axes) {


### PR DESCRIPTION
- 删除reduce_like_ops文件中getsbp函数里面的输入参数检查；该检查是判断axis_vec里面指向的维数是否是like应该降维的维数，但是这里没有区分降维和降shape（5->1的情况），是https://github.com/Oneflow-Inc/OneTeam/issues/1577 的报错原因。
- reduce_like_ops的输入参数合法性检查在前面已经做过，因此可以删除
