### PR TITLE
Fix SinkTick op GetSbp and revert some check

### DIFF
--- a/oneflow/core/job/sbp_parallel.cpp
+++ b/oneflow/core/job/sbp_parallel.cpp
@@ -105,7 +105,7 @@ bool IsSbpSignatureContaining(const SbpSignature& bigger, const SbpSignature& sm
   auto& bn2sbp = bigger.bn_in_op2sbp_parallel();
   for (const auto& pair : smaller.bn_in_op2sbp_parallel()) {
     if (pair.second.parallel_type_case() == SbpParallel::PARALLEL_TYPE_NOT_SET) { continue; }
-    if (bn2sbp.find(pair.first) == bn2sbp.end()) { return false; }
+    CHECK(bn2sbp.find(pair.first) != bn2sbp.end()) << pair.first;
     if (bn2sbp.at(pair.first) != pair.second) { return false; }
   }
   return true;

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -599,21 +599,8 @@ Maybe<void> Operator::InferSbpSignature(
     CalcOrderValue4SbpSig = [](const SbpSignature&) -> int32_t { return 0; };
   }
 
-  if (op_parallel_desc_->parallel_num() >= 1) {
-    JUST(InferSbpSignature(infered_sbp_signature, sbp_sig_conf, CalcOrderValue4SbpSig,
-                           SbpInferHint4Ibn, *op_parallel_desc_));
-
-    if (op_parallel_desc_->parallel_num() == 1) {
-      auto* bn2sbp = infered_sbp_signature->mutable_bn_in_op2sbp_parallel();
-      for (const auto& obn : output_bns()) {
-        if ((*bn2sbp)[obn].parallel_type_case() == SbpParallel::PARALLEL_TYPE_NOT_SET) {
-          (*bn2sbp)[obn].mutable_broadcast_parallel();
-        }
-      }
-    }
-  } else {
-    UNIMPLEMENTED();
-  }
+  JUST(InferSbpSignature(infered_sbp_signature, sbp_sig_conf, CalcOrderValue4SbpSig,
+                         SbpInferHint4Ibn, *op_parallel_desc_));
 
   return Maybe<void>::Ok();
 }

--- a/oneflow/core/operator/sink_tick_op.cpp
+++ b/oneflow/core/operator/sink_tick_op.cpp
@@ -49,7 +49,10 @@ Maybe<void> SinkTickOp::InferOutBlobDescs(
 }
 
 Maybe<void> SinkTickOp::GetSbpSignatures(SbpSignatureList* sbp_sig_list) const {
-  SbpSignatureBuilder().Broadcast(input_bns()).Build(sbp_sig_list->mutable_sbp_signature()->Add());
+  SbpSignatureBuilder()
+      .Broadcast(input_bns())
+      .Broadcast(output_bns())
+      .Build(sbp_sig_list->mutable_sbp_signature()->Add());
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
- 比较 sbp 包含关系时，smaller 中的元素必须在 bigger 中包含的 CHECK 是必要的，这里 revert 了修改
- 根本原因是 SinkTick 的 GetSbp 函数中没有给 out 赋 sbp，导致后面的 CHECK 出错