### PR TITLE
fix dynamic_loss_scale_schedule ods and adjust the round trip pass order

### DIFF
--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -1032,13 +1032,16 @@ Maybe<void> LazyJobBuildAndInferCtx::Complete() {
 #endif
     JUST(DoPass("PruneAmpWhiteIdentityOpPass"));
     JUST(DoPass("OptimizerPlacementOptimizationPass"));
+#ifdef WITH_MLIR
+    JUST(DoPass("IRRoundTripBeforeAD"));
+#endif  // WITH_MLIR
+    // run DynamicLossScaleSchedulePass, AutoTrainStep and AutoLearningRate
+    // after IRRoundTripBeforeAD since IRRoundTripBeforeAD will do DCE
+    // optimization which could eliminate the nodes inserted by them
     JUST(DoPass("DynamicLossScaleSchedulePass"));
     JUST(DoPass("AutoTrainStep"));
     JUST(DoPass("AutoLearningRate"));
     JUST(DoPass("QuantAwareTraining"));
-#ifdef WITH_MLIR
-    JUST(DoPass("IRRoundTripBeforeAD"));
-#endif  // WITH_MLIR
     JUST(DoPass("GenerateBackwardAndOptimizerOpConfs"));
     JUST(DoPass("ReplaceEmbeddingOps"));
     JUST(DoPass("FuseEmbeddingShuffleInteractionPass"));

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -3704,7 +3704,7 @@ def OneFlow_CtcLossGradOp : OneFlow_BaseOp<"ctc_loss_grad", [NoSideEffect, Decla
   let has_data_type_infer_fn = 1;
 }
 
-def OneFlow_DynamicLossScaleScheduleOp : OneFlow_BaseOp<"dynamic_loss_scale_schedule", [NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+def OneFlow_DynamicLossScaleScheduleOp : OneFlow_BaseOp<"dynamic_loss_scale_schedule", [DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
     OneFlow_Tensor:$count_not_finite,
     OneFlow_Tensor:$loss_scale,


### PR DESCRIPTION
这个PR修复了一下AMP在开启MLIR优化之后可能不收敛的问题，主要有两个原因，
- dynamic loss scale schedule被定义为NoSideEffect，MLIR会把它给消除掉
- oneflow dynamic loss scale相关的几个pass插入了一些非终止节点，这些也会被MLIR给优化掉