### PR TITLE
Support slice update kernel with stride（support copy contiguous memory）

### DIFF
--- a/oneflow/core/common/nd_index_offset_helper.h
+++ b/oneflow/core/common/nd_index_offset_helper.h
@@ -24,7 +24,7 @@ namespace oneflow {
 template<typename T, int N>
 class NdIndexOffsetHelper {
  public:
-  NdIndexOffsetHelper() {}
+  OF_DEVICE_FUNC NdIndexOffsetHelper() = default;
   template<class... Ts>
   OF_DEVICE_FUNC explicit NdIndexOffsetHelper(T d0, Ts... dims) {
     constexpr int n = 1 + sizeof...(dims);
@@ -53,15 +53,14 @@ class NdIndexOffsetHelper {
     InitStrides(dims_arr, n);
   }
 
-  ~NdIndexOffsetHelper() = default;
+  virtual ~NdIndexOffsetHelper() = default;
 
   OF_DEVICE_FUNC T NdIndexToOffset(const T* index) const {
     T offset = 0;
 #ifdef __CUDA_ARCH__
 #pragma unroll
 #endif
-    for (int i = 0; i < N - 1; ++i) { offset += index[i] * stride_[i]; }
-    offset += index[N - 1];
+    for (int i = 0; i < N; ++i) { offset += index[i] * stride_[i]; }
     return offset;
   }
 
@@ -146,13 +145,43 @@ class NdIndexOffsetHelper {
 
   OF_DEVICE_FUNC constexpr int Size() const { return N; }
 
- private:
+ protected:
   OF_DEVICE_FUNC void InitStrides(const T* dims, const int n) {
     for (int i = n - 1; i < N; ++i) { stride_[i] = 1; }
     for (int i = n - 2; i >= 0; --i) { stride_[i] = dims[i + 1] * stride_[i + 1]; }
   }
 
   T stride_[N];
+};
+
+template<typename T, int N>
+class NdIndexStrideOffsetHelper : public NdIndexOffsetHelper<T, N> {
+ public:
+  OF_DEVICE_FUNC NdIndexStrideOffsetHelper() = default;
+  OF_DEVICE_FUNC explicit NdIndexStrideOffsetHelper(const T* strides) {
+    for (int i = 0; i < N; ++i) { stride_[i] = strides[i]; }
+  }
+
+  template<typename U>
+  OF_DEVICE_FUNC explicit NdIndexStrideOffsetHelper(const U* strides) {
+    for (int i = 0; i < N; ++i) { stride_[i] = static_cast<T>(strides[i]); }
+  }
+
+  OF_DEVICE_FUNC explicit NdIndexStrideOffsetHelper(const T* strides, int n) {
+    for (int i = 0; i < N; ++i) {
+      if (i < n) { stride_[i] = strides[i]; }
+    }
+  }
+
+  template<typename U>
+  OF_DEVICE_FUNC explicit NdIndexStrideOffsetHelper(const U* strides, int n) {
+    for (int i = 0; i < N; ++i) {
+      if (i < n) { stride_[i] = static_cast<T>(strides[i]); }
+    }
+  }
+
+ private:
+  using NdIndexOffsetHelper<T, N>::stride_;
 };
 
 }  // namespace oneflow

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -3240,7 +3240,7 @@ def OneFlow_SliceOp : OneFlow_BaseOp<"slice", [NoSideEffect, DeclareOpInterfaceM
   let has_data_type_infer_fn = 1;
 }
 
-def OneFlow_SliceUpdateOp : OneFlow_BaseOp<"slice_update", [DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+def OneFlow_SliceUpdateOp : OneFlow_BaseOp<"slice_update", [SupportNonContiguous,DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
     OneFlow_Tensor:$ref,
     OneFlow_Tensor:$value

--- a/oneflow/user/kernels/slice_kernel.cpp
+++ b/oneflow/user/kernels/slice_kernel.cpp
@@ -251,10 +251,13 @@ void WriteSlice(user_op::KernelComputeContext* ctx, const user_op::Tensor* src,
 
   SliceParams large_slice_param;
   SliceParams small_slice_param;
+  std::copy(large->stride().begin(), large->stride().end(), large_slice_param.stride);
   ConstructSliceParamsLarge(slice_ctx, positive_start_vec, positive_stop_vec, step_attr,
                             large->shape_view(), &large_slice_param);
+  std::copy(small->stride().begin(), small->stride().end(), small_slice_param.stride);
   ConstructSliceParamsSmall(slice_ctx, positive_start_vec, positive_stop_vec, step_attr,
                             small->shape_view(), &small_slice_param);
+
   CHECK_EQ(large_slice_param.elem_cnt(), small_slice_param.elem_cnt());
   if (from_large_to_small) {
     if (small_slice_param.elem_cnt() == small->shape_view().elem_cnt()) {

--- a/oneflow/user/kernels/slice_util.cpp
+++ b/oneflow/user/kernels/slice_util.cpp
@@ -96,8 +96,8 @@ struct SliceKernelUtil<DeviceType::kCPU, T> {
       entire_offset_vec[i] = entire_offset;
       sliced_offset_vec[i] = sliced_offset;
       if (IsContinuous && i > 0
-          && (entire_offset_vec[i] - 1 != entire_offset_vec[i]
-              || sliced_offset_vec[i] - 1 != sliced_offset_vec[i])) {
+          && (entire_offset_vec[i] - 1 != entire_offset_vec[i - 1]
+              || sliced_offset_vec[i] - 1 != sliced_offset_vec[i - 1])) {
         IsContinuous = false;
       }
     }

--- a/oneflow/user/kernels/slice_util.h
+++ b/oneflow/user/kernels/slice_util.h
@@ -42,6 +42,7 @@ constexpr size_t kSliceMaxDims = 8;
 struct SliceParams {
   int64_t ndim = 0;
   int64_t dims[kSliceMaxDims]{0};
+  int64_t stride[kSliceMaxDims]{0};
   int64_t start[kSliceMaxDims]{0};
   int64_t step[kSliceMaxDims]{0};
   int64_t size[kSliceMaxDims]{0};
@@ -66,7 +67,7 @@ struct SliceParams {
     std::stringstream ss("SliceParams:");
     for (int i = 0; i < ndim; ++i) {
       ss << "\n\tdim: " << i << ", start: " << start[i] << ", step: " << step[i]
-         << ", size: " << size[i] << ", dims: " << dims[i];
+         << ", stride: " << stride[i] << ", size: " << size[i] << ", dims: " << dims[i];
     }
     return ss.str();
   }

--- a/python/oneflow/test/modules/test_slice.py
+++ b/python/oneflow/test/modules/test_slice.py
@@ -51,15 +51,13 @@ def _test_slice_1_dim(test_case, device):
     x = flow.tensor(np_arr, device=flow.device(device))
     test_case.assertTrue(np.allclose(x[1].numpy(), np_arr[1], 1e-05, 1e-05))
     test_case.assertTrue(np.allclose(x[99].numpy(), np_arr[99], 1e-05, 1e-05))
-    test_case.assertTrue(np.allclose(
-        x[0:2].numpy(), np_arr[0:2], 1e-05, 1e-05))
+    test_case.assertTrue(np.allclose(x[0:2].numpy(), np_arr[0:2], 1e-05, 1e-05))
 
 
 def _test_slice_3_dim(test_case, device):
     np_arr = np.random.randn(2, 3, 4).astype(np.float32)
     x = flow.tensor(np_arr, device=flow.device(device))
-    test_case.assertTrue(np.allclose(
-        x[:, 0].numpy(), np_arr[:, 0], 1e-05, 1e-05))
+    test_case.assertTrue(np.allclose(x[:, 0].numpy(), np_arr[:, 0], 1e-05, 1e-05))
 
 
 def _test_slice_4_dim(test_case, device):
@@ -98,14 +96,10 @@ def _test_slice_with_int_index(test_case, device):
 def _test_slice_negative_index(test_case, device):
     np_arr = np.random.randn(4, 5, 6)
     x = flow.tensor(np_arr, dtype=flow.float32, device=flow.device(device))
-    test_case.assertTrue(np.allclose(
-        x[-1].numpy(), np_arr[-1], 0.0001, 0.0001))
-    test_case.assertTrue(np.allclose(
-        x[-2].numpy(), np_arr[-2], 0.0001, 0.0001))
-    test_case.assertTrue(np.allclose(
-        x[-3].numpy(), np_arr[-3], 0.0001, 0.0001))
-    test_case.assertTrue(np.allclose(
-        x[-4].numpy(), np_arr[-4], 0.0001, 0.0001))
+    test_case.assertTrue(np.allclose(x[-1].numpy(), np_arr[-1], 0.0001, 0.0001))
+    test_case.assertTrue(np.allclose(x[-2].numpy(), np_arr[-2], 0.0001, 0.0001))
+    test_case.assertTrue(np.allclose(x[-3].numpy(), np_arr[-3], 0.0001, 0.0001))
+    test_case.assertTrue(np.allclose(x[-4].numpy(), np_arr[-4], 0.0001, 0.0001))
 
 
 def _test_slice_ellipsis_type(test_case, device):
@@ -217,8 +211,7 @@ class TestSliceUpdate(flow.unittest.TestCase):
     def test_slice_update_grad_graph(test_case):
         x = np.array([1, 1, 1, 1, 1]).astype(np.float32)
         input = flow.tensor(x, requires_grad=True)
-        update = flow.tensor(np.array([2, 3, 4]).astype(
-            np.float32), requires_grad=True)
+        update = flow.tensor(np.array([2, 3, 4]).astype(np.float32), requires_grad=True)
         output = np.array([1.0, 2.0, 3.0, 4.0, 1.0])
 
         class TestModule(flow.nn.Module):
@@ -230,7 +223,7 @@ class TestSliceUpdate(flow.unittest.TestCase):
             def forward(self, ref, value):
                 x = ref + self.ref_grad
                 y = value + self.value_grad
-                return flow._C.slice_update(x, y, [1, ], [4, ], [1, ])
+                return flow._C.slice_update(x, y, [1,], [4,], [1,])
 
         test_m = TestModule()
         of_sgd = flow.optim.SGD(test_m.parameters(), lr=1.0, momentum=0.0)

--- a/python/oneflow/test/modules/test_slice.py
+++ b/python/oneflow/test/modules/test_slice.py
@@ -51,13 +51,15 @@ def _test_slice_1_dim(test_case, device):
     x = flow.tensor(np_arr, device=flow.device(device))
     test_case.assertTrue(np.allclose(x[1].numpy(), np_arr[1], 1e-05, 1e-05))
     test_case.assertTrue(np.allclose(x[99].numpy(), np_arr[99], 1e-05, 1e-05))
-    test_case.assertTrue(np.allclose(x[0:2].numpy(), np_arr[0:2], 1e-05, 1e-05))
+    test_case.assertTrue(np.allclose(
+        x[0:2].numpy(), np_arr[0:2], 1e-05, 1e-05))
 
 
 def _test_slice_3_dim(test_case, device):
     np_arr = np.random.randn(2, 3, 4).astype(np.float32)
     x = flow.tensor(np_arr, device=flow.device(device))
-    test_case.assertTrue(np.allclose(x[:, 0].numpy(), np_arr[:, 0], 1e-05, 1e-05))
+    test_case.assertTrue(np.allclose(
+        x[:, 0].numpy(), np_arr[:, 0], 1e-05, 1e-05))
 
 
 def _test_slice_4_dim(test_case, device):
@@ -96,10 +98,14 @@ def _test_slice_with_int_index(test_case, device):
 def _test_slice_negative_index(test_case, device):
     np_arr = np.random.randn(4, 5, 6)
     x = flow.tensor(np_arr, dtype=flow.float32, device=flow.device(device))
-    test_case.assertTrue(np.allclose(x[-1].numpy(), np_arr[-1], 0.0001, 0.0001))
-    test_case.assertTrue(np.allclose(x[-2].numpy(), np_arr[-2], 0.0001, 0.0001))
-    test_case.assertTrue(np.allclose(x[-3].numpy(), np_arr[-3], 0.0001, 0.0001))
-    test_case.assertTrue(np.allclose(x[-4].numpy(), np_arr[-4], 0.0001, 0.0001))
+    test_case.assertTrue(np.allclose(
+        x[-1].numpy(), np_arr[-1], 0.0001, 0.0001))
+    test_case.assertTrue(np.allclose(
+        x[-2].numpy(), np_arr[-2], 0.0001, 0.0001))
+    test_case.assertTrue(np.allclose(
+        x[-3].numpy(), np_arr[-3], 0.0001, 0.0001))
+    test_case.assertTrue(np.allclose(
+        x[-4].numpy(), np_arr[-4], 0.0001, 0.0001))
 
 
 def _test_slice_ellipsis_type(test_case, device):
@@ -168,6 +174,13 @@ class TestSliceUpdate(flow.unittest.TestCase):
         input[-1] = 1
         test_case.assertTrue(np.array_equal(input.numpy(), np_arr))
 
+    def test_slice_update_with_discontinuous_tensor(test_case):
+        np_tensor = flow.tensor([[1, 1, 1], [0, 1, 2]])
+        x_flow = flow.ones(6).to(flow.float32).view(3, 2).T
+        y_flow = flow.arange(3).reshape(3, 1).to(flow.float32).T
+        x_flow[1:, :3] = y_flow
+        test_case.assertTrue(np.array_equal(np_tensor.numpy(), x_flow.numpy()))
+
     def test_slice_update_negative_index_graph(test_case):
         np_arr = np.zeros(shape=(2, 3, 4))
         input = flow.tensor(np_arr, dtype=flow.float32)
@@ -204,7 +217,8 @@ class TestSliceUpdate(flow.unittest.TestCase):
     def test_slice_update_grad_graph(test_case):
         x = np.array([1, 1, 1, 1, 1]).astype(np.float32)
         input = flow.tensor(x, requires_grad=True)
-        update = flow.tensor(np.array([2, 3, 4]).astype(np.float32), requires_grad=True)
+        update = flow.tensor(np.array([2, 3, 4]).astype(
+            np.float32), requires_grad=True)
         output = np.array([1.0, 2.0, 3.0, 4.0, 1.0])
 
         class TestModule(flow.nn.Module):
@@ -216,7 +230,7 @@ class TestSliceUpdate(flow.unittest.TestCase):
             def forward(self, ref, value):
                 x = ref + self.ref_grad
                 y = value + self.value_grad
-                return flow._C.slice_update(x, y, [1,], [4,], [1,])
+                return flow._C.slice_update(x, y, [1, ], [4, ], [1, ])
 
         test_m = TestModule()
         of_sgd = flow.optim.SGD(test_m.parameters(), lr=1.0, momentum=0.0)


### PR DESCRIPTION
- 在https://github.com/Oneflow-Inc/oneflow/pull/8810 的基础上改进，修改的地方在slice_util.cpp文件中
- 判断slice_update的输入张量的内存是否是连续的，非连续的情况需要拷贝多次；连续的话可以一整块拷贝，从而减少拷贝的次数，降低程序运行开销。
- 增加相关测试