### PR TITLE
Add clamp_min/max and inplace version functor

### DIFF
--- a/oneflow/api/python/framework/tensor_functions.cpp
+++ b/oneflow/api/python/framework/tensor_functions.cpp
@@ -261,7 +261,11 @@ DIRECT_PASS_FUNC(PyTensorObject_addcdiv_, functional::addcdiv_)
 DIRECT_PASS_FUNC(PyTensorObject_clip, functional::clip)
 DIRECT_PASS_FUNC(PyTensorObject_clip_, functional::clip_)
 DIRECT_PASS_FUNC(PyTensorObject_clamp, functional::clamp)
+DIRECT_PASS_FUNC(PyTensorObject_clamp_min, functional::clamp_min)
+DIRECT_PASS_FUNC(PyTensorObject_clamp_max, functional::clamp_max)
 DIRECT_PASS_FUNC(PyTensorObject_clamp_, functional::clamp_)
+DIRECT_PASS_FUNC(PyTensorObject_clamp_min_, functional::clamp_min_)
+DIRECT_PASS_FUNC(PyTensorObject_clamp_max_, functional::clamp_max_)
 DIRECT_PASS_FUNC(PyTensorObject_flatten, functional::flatten)
 DIRECT_PASS_FUNC(PyTensorObject_in_top_k, functional::in_top_k)
 DIRECT_PASS_FUNC(PyTensorObject_index_select, functional::index_select)
@@ -860,7 +864,11 @@ PyMethodDef PyTensorObject_extra_methods[] = {
     {"clip", (PyCFunction)PyTensorObject_clip, METH_VARARGS | METH_KEYWORDS, NULL},
     {"clip_", (PyCFunction)PyTensorObject_clip_, METH_VARARGS | METH_KEYWORDS, NULL},
     {"clamp", (PyCFunction)PyTensorObject_clamp, METH_VARARGS | METH_KEYWORDS, NULL},
+    {"clamp_min", (PyCFunction)PyTensorObject_clamp_min, METH_VARARGS | METH_KEYWORDS, NULL},
+    {"clamp_max", (PyCFunction)PyTensorObject_clamp_max, METH_VARARGS | METH_KEYWORDS, NULL},
     {"clamp_", (PyCFunction)PyTensorObject_clamp_, METH_VARARGS | METH_KEYWORDS, NULL},
+    {"clamp_min_", (PyCFunction)PyTensorObject_clamp_min_, METH_VARARGS | METH_KEYWORDS, NULL},
+    {"clamp_max_", (PyCFunction)PyTensorObject_clamp_max_, METH_VARARGS | METH_KEYWORDS, NULL},
     {"flatten", (PyCFunction)PyTensorObject_flatten, METH_VARARGS | METH_KEYWORDS, NULL},
     {"in_top_k", (PyCFunction)PyTensorObject_in_top_k, METH_VARARGS | METH_KEYWORDS, NULL},
     {"index_select", (PyCFunction)PyTensorObject_index_select, METH_VARARGS | METH_KEYWORDS, NULL},

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -1714,6 +1714,26 @@
     ["Tensor (Tensor input, Scalar min=None, Scalar max=None) => ClampInplace"]
   bind_python: true
 
+- name: "clamp_min"
+  signature:
+    ["Tensor (Tensor input, Scalar min) => ClampMin"]
+  bind_python: true
+
+- name: "clamp_min_"
+  signature:
+    ["Tensor (Tensor input, Scalar min) => ClampMinInplace"]
+  bind_python: true
+
+- name: "clamp_max"
+  signature:
+    ["Tensor (Tensor input, Scalar max) => ClampMax"]
+  bind_python: true
+
+- name: "clamp_max_"
+  signature:
+    ["Tensor (Tensor input, Scalar min) => ClampMaxInplace"]
+  bind_python: true
+
 - name: "clip"
   signature:
     ["Tensor (Tensor input, Scalar min=None, Scalar max=None) => Clip"]

--- a/oneflow/core/functional/impl/math_functor.cpp
+++ b/oneflow/core/functional/impl/math_functor.cpp
@@ -1234,11 +1234,39 @@ class ClampFunctor : public ClampBaseFunctor {
   }
 };
 
+class ClampMinFunctor : public ClampBaseFunctor {
+ public:
+  Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const Scalar& min) const {
+    return ClampBaseFunctor::operator()(x, min, NullOpt, false);
+  }
+};
+
+class ClampMaxFunctor : public ClampBaseFunctor {
+ public:
+  Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const Scalar& max) const {
+    return ClampBaseFunctor::operator()(x, NullOpt, max, false);
+  }
+};
+
 class ClampInplaceFunctor : public ClampBaseFunctor {
  public:
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const Optional<Scalar>& min,
                            const Optional<Scalar>& max) const {
     return ClampBaseFunctor::operator()(x, min, max, true);
+  }
+};
+
+class ClampMinInplaceFunctor : public ClampBaseFunctor {
+ public:
+  Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const Scalar& min) const {
+    return ClampBaseFunctor::operator()(x, min, NullOpt, true);
+  }
+};
+
+class ClampMaxInplaceFunctor : public ClampBaseFunctor {
+ public:
+  Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const Scalar& max) const {
+    return ClampBaseFunctor::operator()(x, NullOpt, max, true);
   }
 };
 
@@ -3070,7 +3098,11 @@ ONEFLOW_FUNCTION_LIBRARY(m) {
   m.add_functor<GlobalHannWindowFunctor>("GlobalHannWindow");
   m.add_functor<CastFunctor>("Cast");
   m.add_functor<ClampFunctor>("Clamp");
+  m.add_functor<ClampMinFunctor>("ClampMin");
+  m.add_functor<ClampMaxFunctor>("ClampMax");
   m.add_functor<ClampInplaceFunctor>("ClampInplace");
+  m.add_functor<ClampMinInplaceFunctor>("ClampMinInplace");
+  m.add_functor<ClampMaxInplaceFunctor>("ClampMaxInplace");
   m.add_functor<ClipFunctor>("Clip");
   m.add_functor<ClipInplaceFunctor>("ClipInplace");
   m.add_functor<SqrtSquareSumFunctor>("SqrtSquareSum");

--- a/python/oneflow/__init__.py
+++ b/python/oneflow/__init__.py
@@ -123,7 +123,7 @@ from oneflow._C import atan
 from oneflow._C import atan as arctan
 from oneflow._C import atan2
 from oneflow._C import ceil
-from oneflow._C import clamp, clamp_
+from oneflow._C import clamp, clamp_, clamp_min, clamp_min_, clamp_max, clamp_max_
 from oneflow._C import clip, clip_
 from oneflow._C import cos
 from oneflow._C import cosh

--- a/python/oneflow/framework/docstr/clamp.py
+++ b/python/oneflow/framework/docstr/clamp.py
@@ -67,6 +67,96 @@ add_docstr(
 )
 
 add_docstr(
+    oneflow.clamp_min,
+    """
+    Clamp all elements in :attr:`input` which are less than :attr:`min` to :attr:`min` and return
+    a resulting tensor:
+
+    .. math::
+        y_i = \max(min, x_i)
+
+    If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, args :attr:`min`
+    must be real numbers, otherwise they should be integers.
+
+    Args:
+        input (Tensor): the input tensor.
+        min (Number): lower-bound of the range to be clamped to.
+        out (Tensor, optional): the output tensor.
+
+    For example:
+
+
+    .. code-block:: python
+
+        >>> import oneflow as flow
+        >>> import numpy as np
+        >>> arr = np.array([0.2, 0.6, -1.5, -0.3])
+        >>> input = flow.Tensor(arr)
+        >>> output = flow.clamp_min(input, min=-0.5)
+        >>> output
+        tensor([ 0.2000,  0.5000, -0.5000, -0.3000], dtype=oneflow.float32)
+
+        >>> arr = np.array([0.2, 0.6, -1.5, -0.3])
+        >>> input = flow.Tensor(arr)
+        >>> output = flow.clamp_min(input, min=-2)
+        >>> output
+        tensor([ 0.2000,  0.6000, -1.5000, -0.3000], dtype=oneflow.float32)
+
+        >>> arr = np.array([0.2, 0.6, -1.5, -0.3])
+        >>> input = flow.Tensor(arr)
+        >>> output = flow.clamp_min(input, min=1)
+        >>> output
+        tensor([1., 1., 1., 1.], dtype=oneflow.float32)
+
+    """,
+)
+
+add_docstr(
+    oneflow.clamp_max,
+    """
+    Clamp all elements in :attr:`input` which are greater than :attr:`max` to :attr:`max` and return
+    a resulting tensor:
+
+    .. math::
+        y_i = \min(max, x_i)
+
+    If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, args :attr:`max`
+    must be real numbers, otherwise they should be integers.
+
+    Args:
+        input (Tensor): the input tensor.
+        max (Number): upper-bound of the range to be clamped to.
+        out (Tensor, optional): the output tensor.
+
+    For example:
+
+
+    .. code-block:: python
+
+        >>> import oneflow as flow
+        >>> import numpy as np
+        >>> arr = np.array([0.2, 0.6, -1.5, -0.3])
+        >>> input = flow.Tensor(arr)
+        >>> output = flow.clamp_max(input, max=-0.5)
+        >>> output
+        tensor([-0.5000, -0.5000, -1.5000, -0.5000], dtype=oneflow.float32)
+
+        >>> arr = np.array([0.2, 0.6, -1.5, -0.3])
+        >>> input = flow.Tensor(arr)
+        >>> output = flow.clamp_max(input, max=-2)
+        >>> output
+        tensor([-2., -2., -2., -2.], dtype=oneflow.float32)
+
+        >>> arr = np.array([0.2, 0.6, -1.5, -0.3])
+        >>> input = flow.Tensor(arr)
+        >>> output = flow.clamp_max(input, max=1)
+        >>> output
+        tensor([ 0.2000,  0.6000, -1.5000, -0.3000], dtype=oneflow.float32)
+
+    """,
+)
+
+add_docstr(
     oneflow.clip,
     """
     Alias for :func:`oneflow.clamp`. 

--- a/python/oneflow/test/modules/test_clamp.py
+++ b/python/oneflow/test/modules/test_clamp.py
@@ -162,5 +162,145 @@ class TestClampModule(flow.unittest.TestCase):
         return y
 
 
+def _test_clamp_min(test_case, shape, device):
+    input = flow.tensor(
+        np.random.randn(*shape), dtype=flow.float32, device=flow.device(device)
+    )
+    of_out = flow.clamp_min(input, 0.1)
+    np_out = np.clip(input.numpy(), 0.1, None)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-05, 1e-05))
+
+
+def _test_tensor_clamp_min(test_case, shape, device):
+    input = flow.tensor(
+        np.random.randn(*shape), dtype=flow.float32, device=flow.device(device)
+    )
+    of_out = input.clamp_min(0.1)
+    np_out = np.clip(input.numpy(), 0.1, None)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-05, 1e-05))
+
+
+def _test_clamp_min_integral(test_case, shape, device):
+    input = flow.tensor(np.random.randint(3, 10, shape), device=flow.device(device))
+    of_out = flow.clamp_min(input, 1)
+    np_out = np.clip(input.numpy(), 1, None)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-05, 1e-05))
+
+
+def _test_clamp_min_backward(test_case, shape, device):
+    x = flow.tensor(
+        np.random.randn(*shape),
+        dtype=flow.float32,
+        device=flow.device(device),
+        requires_grad=True,
+    )
+    y = flow.clamp_min(x, 0.1).sum()
+    y.backward()
+    test_case.assertTrue(
+        np.allclose(
+            x.grad.numpy(), _numpy_clamp_grad(x.numpy(), 0.1, None), 1e-05, 1e-05
+        )
+    )
+
+
+class TestClampMinModule(flow.unittest.TestCase):
+    def test_clamp_min(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["fun"] = [
+            _test_clamp_min,
+            _test_tensor_clamp_min,
+            _test_clamp_min_integral,
+            _test_clamp_min_backward,
+        ]
+        arg_dict["shape"] = [(2,), (2, 3), (2, 4, 5, 6)]
+        arg_dict["device"] = ["cpu", "cuda"]
+        for arg in GenArgList(arg_dict):
+            arg[0](test_case, *arg[1:])
+
+    @autotest(n=5)
+    def test_clamp_min_flow_with_random_data(test_case):
+        device = random_device()
+        input = random_tensor().to(device)
+        y = torch.clamp_min(input, min=random().to(float))
+        return y
+
+    @autotest(n=5, auto_backward=False, check_graph=True)
+    def test_clamp_min_with_0_size_data(test_case):
+        device = random_device()
+        x = random_tensor(4, 2, 1, 0, 3).to(device)
+        y = torch.clamp_min(x, min=random().to(float))
+        return y
+
+
+def _test_clamp_max(test_case, shape, device):
+    input = flow.tensor(
+        np.random.randn(*shape), dtype=flow.float32, device=flow.device(device)
+    )
+    of_out = flow.clamp_max(input, 0.5)
+    np_out = np.clip(input.numpy(), None, 0.5)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-05, 1e-05))
+
+
+def _test_tensor_clamp_max(test_case, shape, device):
+    input = flow.tensor(
+        np.random.randn(*shape), dtype=flow.float32, device=flow.device(device)
+    )
+    of_out = input.clamp_max(0.5)
+    np_out = np.clip(input.numpy(), None, 0.5)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-05, 1e-05))
+
+
+def _test_clamp_max_integral(test_case, shape, device):
+    input = flow.tensor(np.random.randint(3, 10, shape), device=flow.device(device))
+    of_out = flow.clamp_max(input, 1)
+    np_out = np.clip(input.numpy(), None, 1)
+    test_case.assertTrue(np.allclose(of_out.numpy(), np_out, 1e-05, 1e-05))
+
+
+def _test_clamp_max_backward(test_case, shape, device):
+    x = flow.tensor(
+        np.random.randn(*shape),
+        dtype=flow.float32,
+        device=flow.device(device),
+        requires_grad=True,
+    )
+    y = flow.clamp_max(x, 0.5).sum()
+    y.backward()
+    test_case.assertTrue(
+        np.allclose(
+            x.grad.numpy(), _numpy_clamp_grad(x.numpy(), None, 0.5), 1e-05, 1e-05
+        )
+    )
+
+
+class TestClampMaxModule(flow.unittest.TestCase):
+    def test_clamp_min(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["fun"] = [
+            _test_clamp_max,
+            _test_tensor_clamp_max,
+            _test_clamp_max_integral,
+            _test_clamp_max_backward,
+        ]
+        arg_dict["shape"] = [(2,), (2, 3), (2, 4, 5, 6)]
+        arg_dict["device"] = ["cpu", "cuda"]
+        for arg in GenArgList(arg_dict):
+            arg[0](test_case, *arg[1:])
+
+    @autotest(n=5)
+    def test_clamp_max_flow_with_random_data(test_case):
+        device = random_device()
+        input = random_tensor().to(device)
+        y = torch.clamp_max(input, max=random().to(float))
+        return y
+
+    @autotest(n=5, auto_backward=False, check_graph=True)
+    def test_clamp_max_with_0_size_data(test_case):
+        device = random_device()
+        x = random_tensor(4, 2, 1, 0, 3).to(device)
+        y = torch.clamp_max(x, max=random().to(float))
+        return y
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
背景：https://github.com/Oneflow-Inc/OneTeam/issues/1600
此PR完成了：
- 增加了 `clamp_min` , `clamp_max` , `clamp_min_` , `clamp_max_` 接口并增加了相应的文档和单元测试

实现方式：全部都在 functor 层调用 `ClampBaseFunctor` 实现