### PR TITLE
Add error msg for local/global mismatch when loading state_dict

### DIFF
--- a/python/oneflow/nn/module.py
+++ b/python/oneflow/nn/module.py
@@ -712,11 +712,16 @@ class Module(object):
                     )
                     continue
                 if input_param.is_global != param.is_global:
+                    if param.is_global:
+                        help_msg = "Maybe you need to convert the param to globa, or set global_src_rank=0 when using flow.load to load model's state_dict"
+                    else:
+                        help_msg = "Maybe you need to convert your model to global."
                     error_msgs.append(
-                        'local / global mismatch for "{}":  param from checkpoint is {} tensor, but the param in current model is {} tensor.'.format(
+                        'local / global mismatch for "{}":  param from checkpoint is {} tensor, but the param in current model is {} tensor. {}'.format(
                             key,
                             "global" if input_param.is_global else "local",
                             "global" if param.is_global else "local",
+                            help_msg,
                         )
                     )
                     continue

--- a/python/oneflow/nn/module.py
+++ b/python/oneflow/nn/module.py
@@ -711,7 +711,10 @@ class Module(object):
                         )
                     )
                     continue
-                if isinstance(input_param, flow.Tensor) and input_param.is_global != param.is_global:
+                if (
+                    isinstance(input_param, flow.Tensor)
+                    and input_param.is_global != param.is_global
+                ):
                     if param.is_global:
                         help_msg = "Maybe you need to convert the checkpoint param to global, or set global_src_rank=0 when using flow.load to load model's state_dict"
                     else:

--- a/python/oneflow/nn/module.py
+++ b/python/oneflow/nn/module.py
@@ -711,6 +711,16 @@ class Module(object):
                         )
                     )
                     continue
+                if input_param.is_global != param.is_global:
+                    error_msgs.append(
+                        'local / global mismatch for "{}":  param from checkpoint is {} tensor, but the param in current model is {} tensor.'.format(
+                            key,
+                            "global" if input_param.is_global else "local",
+                            "global" if param.is_global else "local",
+                        )
+                    )
+                    continue
+
                 try:
                     with flow.no_grad():
                         param.copy_(input_param)

--- a/python/oneflow/nn/module.py
+++ b/python/oneflow/nn/module.py
@@ -713,7 +713,7 @@ class Module(object):
                     continue
                 if input_param.is_global != param.is_global:
                     if param.is_global:
-                        help_msg = "Maybe you need to convert the param to globa, or set global_src_rank=0 when using flow.load to load model's state_dict"
+                        help_msg = "Maybe you need to convert the param to global, or set global_src_rank=0 when using flow.load to load model's state_dict"
                     else:
                         help_msg = "Maybe you need to convert your model to global."
                     error_msgs.append(

--- a/python/oneflow/nn/module.py
+++ b/python/oneflow/nn/module.py
@@ -711,7 +711,7 @@ class Module(object):
                         )
                     )
                     continue
-                if input_param.is_global != param.is_global:
+                if isinstance(input_param, flow.Tensor) and input_param.is_global != param.is_global:
                     if param.is_global:
                         help_msg = "Maybe you need to convert the checkpoint param to global, or set global_src_rank=0 when using flow.load to load model's state_dict"
                     else:

--- a/python/oneflow/nn/module.py
+++ b/python/oneflow/nn/module.py
@@ -713,7 +713,7 @@ class Module(object):
                     continue
                 if input_param.is_global != param.is_global:
                     if param.is_global:
-                        help_msg = "Maybe you need to convert the param to global, or set global_src_rank=0 when using flow.load to load model's state_dict"
+                        help_msg = "Maybe you need to convert the checkpoint param to global, or set global_src_rank=0 when using flow.load to load model's state_dict"
                     else:
                         help_msg = "Maybe you need to convert your model to global."
                     error_msgs.append(


### PR DESCRIPTION
背景：https://github.com/Oneflow-Inc/OneCloud/issues/70#issuecomment-1077397584
概述：module 的 `load_state_dict` 报错信息不太友好，并且没有检查 checkpoint 和 model 参数的 `is_global` 是否匹配，导致用户的 global model 加载 local state_dict 时，报错会被后面的 try except 捕捉到，返回一些无法提炼重要信息的错误内容

![image](https://user-images.githubusercontent.com/53533850/183797605-094bd360-23da-4e29-bf71-b48bf285a4fc.png)

实现：在 module.py 的 `load_state_dict` 遍历加载参数时，增加了两者间 `is_global` 是否匹配的检查，防止在后面的 try except 报错，并且增加了对应的帮助信息，告诉用户如何更改代码来防止错误
![image](https://user-images.githubusercontent.com/53533850/183798277-562d2821-cec1-42cb-975d-fca10bbee34b.png)

一些复现代码：
```python
import oneflow as flow
model = flow.nn.Sequential(
    flow.nn.Linear(3, 3),
    flow.nn.Linear(3, 3),
)
import tempfile
with tempfile.TemporaryDirectory() as tmpdirname:
    flow.save(model.state_dict(), tmpdirname)
    model = flow.nn.Sequential(
        flow.nn.Linear(3, 3),
        flow.nn.Linear(3, 3),
    ).to_global(sbp=flow.sbp.broadcast, placement=flow.env.all_device_placement("cuda"))
    model.load_state_dict(flow.load(tmpdirname,))
```