### PR TITLE
fix bug in cosine_similarity when inputs have different dims

### DIFF
--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -2647,8 +2647,8 @@ class CosineSimilarityFunctor {
         int64_t offset = max_shape.NumAxes() - 1 - i;
         int64_t dim_x = x_shape.NumAxes() - 1 - offset;
         int64_t dim_y = y_shape.NumAxes() - 1 - offset;
-        int64_t size_x = (dim_x >= 0) ? x_shape.At(i) : 1;
-        int64_t size_y = (dim_y >= 0) ? y_shape.At(i) : 1;
+        int64_t size_x = (dim_x >= 0) ? x_shape.At(dim_x) : 1;
+        int64_t size_y = (dim_y >= 0) ? y_shape.At(dim_y) : 1;
         if (!(size_x == size_y || size_x == 1 || size_y == 1)) {
           return Error::RuntimeError()
                  << "The size of tensor a (" << size_x << ") must match the size of tensor b ("

--- a/python/oneflow/test/modules/test_cosine_similarity.py
+++ b/python/oneflow/test/modules/test_cosine_similarity.py
@@ -49,6 +49,16 @@ class TestCosineSimilarity(flow.unittest.TestCase):
         output = torch.nn.functional.cosine_similarity(a, b, dim=1, eps=1e-6)
         return output
 
+    @autotest(n=3)
+    def test_cosine_similartiy_module_with_nonequal_dim_data(test_case):
+        device = random_device()
+        a = random_tensor(ndim=2, dim0=10, dim1=128).to(device)
+        b = random_tensor(ndim=3, dim0=10, dim1=10, dim2=128).to(device)
+        cos = torch.nn.CosineSimilarity(dim=-1, eps=1e-6).to(device)
+        cos.train(random())
+        output = cos(a, b)
+        return output
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
背景：https://github.com/Oneflow-Inc/OneCloud/issues/136#issuecomment-1194951405
问题概述：cosine_similarity 中，当两个输入的 dims 不同时，会报错。

PR的实现：
在cosine_similarity的实现中，当两个输入的shape不同时，会遍历两个shape，来生成一个max_shape，然后将两个输入都expand成该max_shape再进行后续计算。这里遍历的时候，下标写错了，导致访问越界。

torch的实现：
cosine_similarity的处理：
https://github.com/pytorch/pytorch/blob/62c8d30f9f6715d0b60d78fb5f5913a2f3bd185b/aten/src/ATen/native/Distance.cpp#L275-L280
生成max_shape的处理：
https://github.com/pytorch/pytorch/blob/62c8d30f9f6715d0b60d78fb5f5913a2f3bd185b/aten/src/ATen/ExpandUtils.cpp#L17-L43