### PR TITLE
[WIP] ctc_loss support long input

### DIFF
--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -1202,7 +1202,7 @@
   bind_python: True
 
 - name: "ctc_loss"
-  signature: "Tensor (Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, Int64 max_target_length, Int32 blank, Bool zero_infinity, String reduction) => CtcLoss"
+  signature: "Tensor (Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, Int32 blank, Bool zero_infinity, String reduction) => CtcLoss"
   bind_python: True
 
 - name: "affine_grid"

--- a/oneflow/user/kernels/ctc_loss_kernel.cpp
+++ b/oneflow/user/kernels/ctc_loss_kernel.cpp
@@ -35,8 +35,8 @@ class CtcLossKernel final : public user_op::OpKernel {
 
     const T* log_probs_ptr = log_probs->dptr<T>();
     const int* targets_ptr = targets->dptr<int>();
-    const IDX* input_lengths_ptr = input_lengths->dptr<IDX>();
-    const IDX* target_lengths_ptr = target_lengths->dptr<IDX>();
+    const int64_t* input_lengths_ptr = input_lengths->dptr<int64_t>();
+    const int64_t* target_lengths_ptr = target_lengths->dptr<int64_t>();
     const int32_t blank = ctx->Attr<int32_t>("blank");
     const int64_t max_input_length = log_probs->shape_view().At(0);
     const int64_t batch_size = log_probs->shape_view().At(1);
@@ -91,8 +91,8 @@ class CtcLossGradKernel final : public user_op::OpKernel {
     const T* alpha_ptr = alpha->dptr<T>();
     const T* log_probs_ptr = log_probs->dptr<T>();
     const int* targets_ptr = targets->dptr<int>();
-    const IDX* input_lengths_ptr = input_lengths->dptr<IDX>();
-    const IDX* target_lengths_ptr = target_lengths->dptr<IDX>();
+    const int64_t* input_lengths_ptr = input_lengths->dptr<int64_t>();
+    const int64_t* target_lengths_ptr = target_lengths->dptr<int64_t>();
     const int32_t blank = ctx->Attr<int32_t>("blank");
     const bool zero_infinity = ctx->Attr<bool>("zero_infinity");
     const int64_t batch_size = log_probs->shape_view().At(1);

--- a/oneflow/user/kernels/ctc_loss_kernel_util.h
+++ b/oneflow/user/kernels/ctc_loss_kernel_util.h
@@ -24,7 +24,7 @@ namespace oneflow {
 template<DeviceType device_type, typename T, typename IDX>
 struct CtcLossKernelUtil final {
   static void CtcLossForward(ep::Stream* stream, const T* log_probs_ptr, const int* targets_ptr,
-                             const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
+                             const int64_t* input_lengths_ptr, const int64_t* target_lengths_ptr,
                              T* alpha_ptr, T* loss_ptr,
                              NdIndexOffsetHelper<int64_t, 3>& input_helper,
                              NdIndexOffsetHelper<int64_t, 3>& alpha_helper,
@@ -34,7 +34,7 @@ struct CtcLossKernelUtil final {
 
   static void CtcLossBackward(ep::Stream* stream, const T* grad_out_ptr, const T* loss_ptr,
                               const T* alpha_ptr, const T* log_probs_ptr, const int* targets_ptr,
-                              const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
+                              const int64_t* input_lengths_ptr, const int64_t* target_lengths_ptr,
                               T* beta_ptr, T* grad_ptr,
                               NdIndexOffsetHelper<int64_t, 3>& input_helper,
                               NdIndexOffsetHelper<int64_t, 3>& beta_helper,

--- a/python/oneflow/nn/modules/loss.py
+++ b/python/oneflow/nn/modules/loss.py
@@ -684,7 +684,7 @@ class CTCLoss(_Loss):
             targets,
             input_lengths,
             target_lengths,
-            max_target_length,
+            # max_target_length,
             self.blank,
             self.zero_infinity,
             self.reduction,

--- a/python/oneflow/test/modules/test_ctc_loss.py
+++ b/python/oneflow/test/modules/test_ctc_loss.py
@@ -192,6 +192,8 @@ def compare_with_np(
     assert device_type in ["cuda", "cpu"]
     assert reduction in ["none", "mean", "sum"]
     assert zero_infinity in [False, True]
+    import random
+    random.sample([flow.int32, flow.int64], 1)[0]
     log_probs = np.random.random(
         size=(max_input_length, batch_size, num_classes)
     ).astype(np.float32)
@@ -249,13 +251,13 @@ def compare_with_np(
     )
     input_lengths = flow.tensor(
         input_lengths,
-        dtype=flow.int32,
+        dtype=random.sample([flow.int32, flow.int64], 1)[0],
         requires_grad=False,
         device=flow.device(device_type),
     )
     target_lengths = flow.tensor(
         target_lengths,
-        dtype=flow.int32,
+        dtype=random.sample([flow.int32, flow.int64], 1)[0],
         requires_grad=False,
         device=flow.device(device_type),
     )


### PR DESCRIPTION
https://github.com/Oneflow-Inc/oneflow/pull/8888 的另一种实现

背景：https://github.com/Oneflow-Inc/OneCloud/issues/104#issuecomment-1156122806
概述：oneflow的ctc_loss不接受int64的target输入而torch能
实现：
- 直接在functor层cast，而不是注册kernel
- 删除了max_target_lengths参数，在functor里面计算