### PR TITLE
Support partial requires_grad inputs

### DIFF
--- a/oneflow/api/python/autograd/autograd_function.cpp
+++ b/oneflow/api/python/autograd/autograd_function.cpp
@@ -52,7 +52,8 @@ Maybe<one::TensorTuple> UnpackTensorTuple(const py::object& input) {
       }
     }
   } else {
-    return Error::RuntimeError() << "Only support tensor or list of tensors";
+    return Error::RuntimeError()
+           << "autograd.Function's output only support tensor or list of tensors";
   }
   return tp;
 }

--- a/oneflow/core/framework/op_expr.cpp
+++ b/oneflow/core/framework/op_expr.cpp
@@ -824,7 +824,9 @@ Maybe<OpExprGradClosure> SelectTopNOpExpr::GetOrCreateOpGradClosure() const {
 void FunctionOpExpr::reset_state() const { state_.reset(new FunctionAutoGradCaptureState); }
 
 Maybe<OpExprGradClosure> FunctionOpExpr::GetOrCreateOpGradClosure() const {
-  if (!op_grad_func_) { op_grad_func_.reset(new FunctionOpExprGradFunction(backward_fn_)); }
+  if (!op_grad_func_) {
+    op_grad_func_.reset(new FunctionOpExprGradFunction(func_name_, backward_fn_));
+  }
   return std::make_shared<OpExprGradClosure>(op_grad_func_, state_);
 }
 

--- a/oneflow/core/framework/op_expr_grad_function.h
+++ b/oneflow/core/framework/op_expr_grad_function.h
@@ -165,8 +165,7 @@ class FunctionOpExprGradFunction final : public OpExprGradFunctionIf {
     FunctionAutoGradCaptureState* func_ctx = dynamic_cast<FunctionAutoGradCaptureState*>(ctx);
     func_ctx->input_requires_grad.resize(inputs.size());
     for (int i = 0; i < inputs.size(); ++i) {
-      func_ctx->input_requires_grad[i] = false;
-      if (inputs.at(i)->requires_grad()) { func_ctx->input_requires_grad[i] = true; }
+      func_ctx->input_requires_grad[i] = inputs.at(i)->requires_grad();
     }
     return Maybe<void>::Ok();
   }

--- a/python/oneflow/test/modules/test_autograd_function.py
+++ b/python/oneflow/test/modules/test_autograd_function.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import re
+
 import unittest
 
 import numpy as np
@@ -109,6 +111,55 @@ class TestAutogradFunction(flow.unittest.TestCase):
         c.sum().backward()
         test_case.assertTrue(np.allclose(a.grad.numpy(), np_arr1))
         test_case.assertTrue(np.allclose(b.grad.numpy(), np_arr0))
+
+    @flow.unittest.skip_unless_1n1d()
+    def test_partial_inputs_requires_grad(test_case):
+        class MyModule(autograd.Function):
+            @staticmethod
+            def forward(ctx, x, y, z):
+                return x + y + z
+
+            @staticmethod
+            def backward(ctx, out_grad):
+                return None, out_grad, None
+
+        x = flow.randn(4, 5)
+        y = flow.randn(4, 5).requires_grad_()
+        z = flow.randn(4, 5)
+        # forward
+        res = MyModule.apply(x, y, z)
+        test_case.assertTrue(
+            np.allclose(res.numpy(), x.numpy() + y.numpy() + z.numpy())
+        )
+        # backward
+        res.sum().backward()
+        test_case.assertIsNone(x.grad)
+        test_case.assertTrue(np.allclose(y.grad.numpy(), np.ones((4, 5))))
+        test_case.assertIsNone(z.grad)
+
+    @flow.unittest.skip_unless_1n1d()
+    def test_backward_error_message(test_case):
+        class MyModule(autograd.Function):
+            @staticmethod
+            def forward(ctx, x, y, z):
+                return x + y + z
+
+            @staticmethod
+            def backward(ctx, out_grad):
+                return None, out_grad
+
+        x = flow.randn(4, 5)
+        y = flow.randn(4, 5).requires_grad_()
+        z = flow.randn(4, 5)
+        res = MyModule.apply(x, y, z)
+        with test_case.assertRaises(Exception) as exp:
+            res.sum().backward()
+        test_case.assertIsNotNone(
+            re.search(
+                r"RuntimeError: function MyModule returned an incorrect number of gradients \(expected \d, got \d\)",
+                str(exp.exception),
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```python
import oneflow as flow

class NewModule(flow.autograd.Function):
    @staticmethod
    def forward(ctx, x, y, z):
        return x + y + z

    @staticmethod
    def backward(ctx, grad_output):
        return None, grad_output, None

m = NewModule()

x = flow.ones(2, 3)
y = flow.ones(2, 3).requires_grad_()
z = flow.ones(2, 3)

res = m.apply(x, y, z)
print(res)
res.sum().backward()
```

支持部分输入 requires_grad=False，并对齐一些检察的报错信息。