### PR TITLE
move_storage_offset_to_tensor_impl

### DIFF
--- a/oneflow/api/python/functional/tensor_api.cpp
+++ b/oneflow/api/python/functional/tensor_api.cpp
@@ -280,7 +280,7 @@ class LocalTensorSharedNumpyDataFunctor {
     DataType data_type = JUST(numpy::GetOFDataTypeFromNpArray(array));
     Symbol<Device> device = JUST(Device::New("cpu"));
 
-    auto tensor_meta = SymbolOf(LocalTensorMeta(shape, stride, data_type, device, 0));
+    auto tensor_meta = SymbolOf(LocalTensorMeta(shape, stride, data_type, device));
 
     // Build TensorBuffer
     const auto& Free = [array](char* dptr) {

--- a/oneflow/core/common/env_var/eager.h
+++ b/oneflow/core/common/env_var/eager.h
@@ -24,5 +24,9 @@ namespace oneflow {
 // use infer cache in naive local op interpret.
 DEFINE_THREAD_LOCAL_ENV_BOOL(ONEFLOW_EAGER_ENABLE_LOCAL_INFER_CACHE, true);
 
+// NOTE: use env variable 'ONEFLOW_EAGER_TENSOR_INFER_CACHE_SIZE' indicate the size of
+// infer cache in op interpret.
+DEFINE_THREAD_LOCAL_ENV_INTEGER(ONEFLOW_EAGER_TENSOR_INFER_CACHE_SIZE, 128 * 1024);
+
 }  // namespace oneflow
 #endif  // ONEFLOW_CORE_COMMON_ENV_VAR_EAGER_H_

--- a/oneflow/core/common/tensor_meta.cpp
+++ b/oneflow/core/common/tensor_meta.cpp
@@ -46,59 +46,51 @@ size_t MutTensorMeta::CalcHashValue() const {
 LocalTensorMeta::LocalTensorMeta()
     : TensorMeta(std::make_shared<const Shape>(), std::make_shared<const Stride>(),
                  DataType::kInvalidDataType),
-      device_(Symbol<Device>()),
-      storage_offset_(0) {}
+      device_(Symbol<Device>()) {}
 
 LocalTensorMeta::LocalTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
                                  Symbol<Device> device)
-    : TensorMeta(shape, std::make_shared<const Stride>(*shape), dtype),
-      device_(device),
-      storage_offset_(0) {}
+    : TensorMeta(shape, std::make_shared<const Stride>(*shape), dtype), device_(device) {}
 
 LocalTensorMeta::LocalTensorMeta(const std::shared_ptr<const Shape>& shape,
                                  const std::shared_ptr<const Stride>& stride, DataType dtype,
-                                 Symbol<Device> device, int64_t storage_offset)
-    : TensorMeta(shape, stride, dtype), device_(device), storage_offset_(storage_offset) {}
+                                 Symbol<Device> device)
+    : TensorMeta(shape, stride, dtype), device_(device) {}
 
 bool LocalTensorMeta::operator==(const LocalTensorMeta& other) const {
   // It's correct to ignore is_dynamic_ field.
   return *this->shape_ptr() == *other.shape_ptr() && this->dtype() == other.dtype()
-         && this->device() == other.device() && this->stride() == other.stride()
-         && this->storage_offset() == other.storage_offset();
+         && this->device() == other.device() && this->stride() == other.stride();
 }
 
 size_t LocalTensorMeta::CalcHashValue() const {
   // It's correct to ignore is_dynamic_ field.
-  return Hash(*shape_ptr(), dtype(), device(), stride(), storage_offset());
+  return Hash(*shape_ptr(), dtype(), device(), stride());
 }
 
 MutLocalTensorMeta::MutLocalTensorMeta()
     : MutTensorMeta(std::make_shared<const Shape>(), std::make_shared<const Stride>(),
                     kInvalidDataType),
-      device_(Symbol<Device>()),
-      storage_offset_(0) {}
+      device_(Symbol<Device>()) {}
 
 MutLocalTensorMeta::MutLocalTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype,
                                        Symbol<Device> device)
-    : MutTensorMeta(shape, std::make_shared<const Stride>(*shape), dtype),
-      device_(device),
-      storage_offset_(0) {}
+    : MutTensorMeta(shape, std::make_shared<const Stride>(*shape), dtype), device_(device) {}
 
 MutLocalTensorMeta::MutLocalTensorMeta(const std::shared_ptr<const Shape>& shape,
                                        const std::shared_ptr<const Stride>& stride, DataType dtype,
-                                       Symbol<Device> device, int64_t storage_offset)
-    : MutTensorMeta(shape, stride, dtype), device_(device), storage_offset_(storage_offset) {}
+                                       Symbol<Device> device)
+    : MutTensorMeta(shape, stride, dtype), device_(device) {}
 
 bool MutLocalTensorMeta::operator==(const MutLocalTensorMeta& other) const {
   // It's correct to ignore is_dynamic_ field.
   return *this->shape_ptr() == *other.shape_ptr() && this->dtype() == other.dtype()
-         && *this->device() == *other.device() && this->stride() == other.stride()
-         && this->storage_offset() == other.storage_offset();
+         && *this->device() == *other.device() && this->stride() == other.stride();
 }
 
 size_t MutLocalTensorMeta::CalcHashValue() const {
   // It's correct to ignore is_dynamic_ field.
-  return Hash(*shape_ptr(), dtype(), *device(), stride(), storage_offset());
+  return Hash(*shape_ptr(), dtype(), *device(), stride());
 }
 
 bool GlobalTensorMeta::operator==(const GlobalTensorMeta& other) const {

--- a/oneflow/core/common/tensor_meta.h
+++ b/oneflow/core/common/tensor_meta.h
@@ -129,11 +129,10 @@ class LocalTensorMeta : public TensorMeta {
   LocalTensorMeta(const std::shared_ptr<const Shape>& shape, DataType dtype, Symbol<Device> device);
   LocalTensorMeta(const std::shared_ptr<const Shape>& shape,
                   const std::shared_ptr<const Stride>& stride, DataType dtype,
-                  Symbol<Device> device, int64_t storage_offset);
+                  Symbol<Device> device);
   virtual ~LocalTensorMeta() = default;
 
   const Symbol<Device>& device() const { return device_; }
-  int64_t storage_offset() const { return storage_offset_; }
 
   bool operator==(const LocalTensorMeta& other) const;
   size_t CalcHashValue() const;
@@ -142,7 +141,6 @@ class LocalTensorMeta : public TensorMeta {
 
  private:
   Symbol<Device> device_;
-  int64_t storage_offset_;
 };
 
 class MutLocalTensorMeta : public MutTensorMeta {
@@ -154,14 +152,12 @@ class MutLocalTensorMeta : public MutTensorMeta {
                      Symbol<Device> device);
   MutLocalTensorMeta(const std::shared_ptr<const Shape>& shape,
                      const std::shared_ptr<const Stride>& stride, DataType dtype,
-                     Symbol<Device> device, int64_t storage_offset);
+                     Symbol<Device> device);
   virtual ~MutLocalTensorMeta() = default;
 
   const Symbol<Device>& device() const { return device_; }
-  int64_t storage_offset() const { return storage_offset_; }
 
   Symbol<Device>* mut_device() { return &device_; }
-  void set_storage_offset(int64_t offset) { storage_offset_ = offset; }
 
   bool operator==(const MutLocalTensorMeta& other) const;
   size_t CalcHashValue() const;
@@ -170,7 +166,6 @@ class MutLocalTensorMeta : public MutTensorMeta {
 
  private:
   Symbol<Device> device_;
-  int64_t storage_offset_;
 };
 
 class GlobalTensorMeta : public TensorMeta {

--- a/oneflow/core/framework/global_tensor_infer_cache.cpp
+++ b/oneflow/core/framework/global_tensor_infer_cache.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "oneflow/core/framework/op_expr.h"
 #include "oneflow/core/framework/user_op_registry_manager.h"
 #include "oneflow/core/common/container_util.h"
+#include "oneflow/core/common/env_var/eager.h"
 
 namespace oneflow {
 namespace one {
@@ -349,6 +350,9 @@ Maybe<const GlobalTensorInferResult> GlobalTensorInferCache::GetOrInfer(
     const GlobalTensorMetaInferArgs& infer_args) {
   auto iter = cache_.find(infer_args);
   if (iter == cache_.end()) {
+    if (unlikely(cache_.size() >= ThreadLocalEnvInteger<ONEFLOW_EAGER_TENSOR_INFER_CACHE_SIZE>())) {
+      cache_.clear();
+    }
     const auto& user_op_expr = user_op_expr_.lock();
     CHECK_OR_RETURN(static_cast<bool>(user_op_expr));
     const auto& output_tensor_metas = JUST(Infer(*user_op_expr, infer_args));
@@ -361,6 +365,10 @@ Maybe<const GlobalTensorInferResult> GlobalTensorInferCache::GetOrInfer(
     const SrcOpGlobalTensorMetaInferArgs& infer_args) {
   auto iter = src_op_cache_.find(infer_args);
   if (iter == src_op_cache_.end()) {
+    if (unlikely(src_op_cache_.size()
+                 >= ThreadLocalEnvInteger<ONEFLOW_EAGER_TENSOR_INFER_CACHE_SIZE>())) {
+      src_op_cache_.clear();
+    }
     const auto& user_op_expr = user_op_expr_.lock();
     CHECK_OR_RETURN(static_cast<bool>(user_op_expr));
     const auto& output_tensor_metas = JUST(Infer(*user_op_expr, infer_args));

--- a/oneflow/core/framework/local_tensor_infer_cache.cpp
+++ b/oneflow/core/framework/local_tensor_infer_cache.cpp
@@ -183,8 +183,7 @@ Maybe<void> LocalTensorMetaInferArgs::InitInputLocalTensorMetas(const TensorTupl
     CHECK_OR_RETURN(static_cast<bool>(output_mut_metas.at(i).device())) << "device not infered";
     mut_output_tensor_metas->at(i) = SymbolOf(
         LocalTensorMeta(output_mut_metas.at(i).shape_ptr(), output_mut_metas.at(i).stride_ptr(),
-                        output_mut_metas.at(i).data_type(), output_mut_metas.at(i).device(),
-                        output_mut_metas.at(i).storage_offset()));
+                        output_mut_metas.at(i).data_type(), output_mut_metas.at(i).device()));
   }
   return std::shared_ptr<const LocalTensorInferResult>(std::move(result));
 }
@@ -194,6 +193,10 @@ Maybe<const LocalTensorInferResult> LocalTensorInferCache::GetOrInfer(
   if (ThreadLocalEnvBool<ONEFLOW_EAGER_ENABLE_LOCAL_INFER_CACHE>()) {
     auto iter = cache_.find(infer_args);
     if (iter == cache_.end()) {
+      if (unlikely(cache_.size()
+                   >= ThreadLocalEnvInteger<ONEFLOW_EAGER_TENSOR_INFER_CACHE_SIZE>())) {
+        cache_.clear();
+      }
       const auto& user_op_expr = user_op_expr_.lock();
       CHECK_OR_RETURN(static_cast<bool>(user_op_expr));  // NOLINT
       const auto& output_tensor_metas = JUST(Infer(*user_op_expr, infer_args));

--- a/oneflow/core/framework/op_interpreter/eager_local_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/eager_local_op_interpreter.cpp
@@ -103,8 +103,7 @@ Maybe<void> NaiveInterpret(const UserOpExpr& user_op_expr, const TensorTuple& in
           mut_tensor_meta = std::make_shared<MutLocalTensorMeta>(
               std::make_shared<Shape>(output_tensor_metas.at(i)->shape()),
               std::make_shared<Stride>(output_tensor_metas.at(i)->stride()),
-              output_tensor_metas.at(i)->dtype(), output_tensor_metas.at(i)->device(),
-              output_tensor_metas.at(i)->storage_offset());
+              output_tensor_metas.at(i)->dtype(), output_tensor_metas.at(i)->device());
         }
       }
       std::shared_ptr<EagerLocalTensorImpl> tensor_impl =
@@ -145,12 +144,13 @@ Maybe<void> NaiveInterpret(const UserOpExpr& user_op_expr, const TensorTuple& in
     }));
     JUST(btb->WaitUntilCntEqualZero(VirtualMachine::GetPredicatorNoMoreInstructionsFinished()));
     const auto& mut_tensor_meta = const_cast<EagerLocalTensorImpl*>(tensor_impl)->mut_tensor_meta();
-    Symbol<LocalTensorMeta> new_tensor_meta = SymbolOf(LocalTensorMeta(
-        std::make_shared<Shape>(mut_tensor_meta->shape()),
-        std::make_shared<Stride>(mut_tensor_meta->stride()), mut_tensor_meta->dtype(),
-        mut_tensor_meta->device(), mut_tensor_meta->storage_offset()));
+    Symbol<LocalTensorMeta> new_tensor_meta =
+        SymbolOf(LocalTensorMeta(std::make_shared<Shape>(mut_tensor_meta->shape()),
+                                 std::make_shared<Stride>(mut_tensor_meta->stride()),
+                                 mut_tensor_meta->dtype(), mut_tensor_meta->device()));
     std::shared_ptr<EagerLocalTensorImpl> final_tensor_impl =
-        std::make_shared<EagerLocalTensorImpl>(JUST(tensor_impl->tensor_storage()), false, false);
+        std::make_shared<EagerLocalTensorImpl>(JUST(tensor_impl->tensor_storage()),
+                                               JUST(tensor_impl->storage_offset()), false, false);
     JUST(final_tensor_impl->InitEagerBlobObject(
         new_tensor_meta,
         JUST(JUST(outputs->at(index)->eager_blob_object())->compute_local_dep_object())));

--- a/oneflow/core/framework/tensor_impl.cpp
+++ b/oneflow/core/framework/tensor_impl.cpp
@@ -67,11 +67,11 @@ Maybe<LocalTensorImpl> LazyLocalTensorImpl::detach() const {
   return std::shared_ptr<LocalTensorImpl>(detached_impl);
 }
 
-EagerLocalTensorImpl::EagerLocalTensorImpl() : LocalTensorImpl(false, false) {}
-
 EagerLocalTensorImpl::EagerLocalTensorImpl(const std::shared_ptr<TensorStorage>& tensor_storage,
-                                           bool requires_grad, bool is_leaf)
-    : LocalTensorImpl(requires_grad, is_leaf), tensor_storage_(tensor_storage) {}
+                                           int64_t storage_offset, bool requires_grad, bool is_leaf)
+    : LocalTensorImpl(requires_grad, is_leaf),
+      tensor_storage_(tensor_storage),
+      storage_offset_(storage_offset) {}
 
 EagerLocalTensorImpl::~EagerLocalTensorImpl() {}
 

--- a/oneflow/core/framework/tensor_impl.h
+++ b/oneflow/core/framework/tensor_impl.h
@@ -220,12 +220,16 @@ class LazyLocalTensorImpl final : public LocalTensorImpl {
 class EagerLocalTensorImpl final : public LocalTensorImpl {
  public:
   OF_DISALLOW_COPY_AND_MOVE(EagerLocalTensorImpl);
-  EagerLocalTensorImpl();
+  EagerLocalTensorImpl()
+      : EagerLocalTensorImpl(std::shared_ptr<TensorStorage>(), 0, false, false) {}
   EagerLocalTensorImpl(const std::shared_ptr<TensorStorage>& tensor_storage, bool requires_grad,
-                       bool is_leaf);
+                       bool is_leaf)
+      : EagerLocalTensorImpl(tensor_storage, 0, requires_grad, is_leaf) {}
+  EagerLocalTensorImpl(const std::shared_ptr<TensorStorage>& tensor_storage, int64_t storage_offset,
+                       bool requires_grad, bool is_leaf);
 
   EagerLocalTensorImpl(bool requires_grad, bool is_leaf)
-      : EagerLocalTensorImpl(std::shared_ptr<TensorStorage>(), requires_grad, is_leaf) {}
+      : EagerLocalTensorImpl(std::shared_ptr<TensorStorage>(), 0, requires_grad, is_leaf) {}
   ~EagerLocalTensorImpl() override;
 
   const std::shared_ptr<const MutLocalTensorMeta>& mut_tensor_meta() override;
@@ -249,9 +253,10 @@ class EagerLocalTensorImpl final : public LocalTensorImpl {
     return tensor_storage_;
   }
   Maybe<bool> has_eager_blob_object() const override { return eager_blob_object_.get(); }
-  Maybe<int64_t> storage_offset() const override { return tensor_meta()->storage_offset(); }
+  Maybe<int64_t> storage_offset() const override { return storage_offset_; }
   // Setters
   TensorStorage* mut_tensor_storage() { return tensor_storage_.get(); }
+  void set_storage_offset(int64_t offset) { storage_offset_ = offset; }
 
   Maybe<void> InitEagerBlobObject(
       const Symbol<one::LocalTensorMeta>& local_tensor_meta,
@@ -273,6 +278,7 @@ class EagerLocalTensorImpl final : public LocalTensorImpl {
   Maybe<void> set_eager_blob_object(std::shared_ptr<vm::EagerBlobObject> eager_blob_object);
 
   std::shared_ptr<TensorStorage> tensor_storage_;
+  int64_t storage_offset_;
   std::shared_ptr<vm::EagerBlobObject> eager_blob_object_;
 };
 

--- a/oneflow/core/framework/tensor_methods.cpp
+++ b/oneflow/core/framework/tensor_methods.cpp
@@ -65,15 +65,15 @@ Maybe<Tensor> BasicView(const std::shared_ptr<Tensor>& input, const Shape& targe
   auto device = JUST(input->device());
   auto tensor_meta = SymbolOf(LocalTensorMeta(std::make_shared<Shape>(target_shape),
                                               std::make_shared<Stride>(target_stride),
-                                              input->dtype()->data_type(), device, storage_offset));
+                                              input->dtype()->data_type(), device));
 
   CHECK_OR_RETURN(JUST(input->has_eager_blob_object()));
   // new output tensor
   const auto& blob_object = JUST(input->eager_blob_object());
   bool requires_grad = (autograd::GradMode::is_enabled() && input->requires_grad());
-  auto tensor_impl =
-      std::make_shared<EagerLocalTensorImpl>(JUST(input->tensor_storage()), requires_grad,
-                                             /*is_leaf=*/!requires_grad);
+  auto tensor_impl = std::make_shared<EagerLocalTensorImpl>(JUST(input->tensor_storage()),
+                                                            storage_offset, requires_grad,
+                                                            /*is_leaf=*/!requires_grad);
   JUST(
       tensor_impl->InitEagerBlobObject(tensor_meta, JUST(blob_object->compute_local_dep_object())));
 

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -1443,12 +1443,13 @@ class InplaceToContiguousFunctor {
     const auto& blob_object = JUST(input->eager_blob_object());
     Symbol<LocalTensorMeta> old_tensor_meta = JUST(input->local_tensor_meta());
 
-    Symbol<LocalTensorMeta> new_tensor_meta = SymbolOf(LocalTensorMeta(
-        std::make_shared<Shape>(old_tensor_meta->shape()), stride, old_tensor_meta->dtype(),
-        old_tensor_meta->device(), old_tensor_meta->storage_offset()));
+    Symbol<LocalTensorMeta> new_tensor_meta =
+        SymbolOf(LocalTensorMeta(std::make_shared<Shape>(old_tensor_meta->shape()), stride,
+                                 old_tensor_meta->dtype(), old_tensor_meta->device()));
 
     std::shared_ptr<EagerLocalTensorImpl> final_tensor_impl =
         std::make_shared<EagerLocalTensorImpl>(JUST(input->tensor_storage()),
+                                               JUST(input->storage_offset()),
                                                input->requires_grad(), input->is_leaf());
     JUST(final_tensor_impl->set_retain_grad(input->retain_grad()));
     JUST(final_tensor_impl->InitEagerBlobObject(new_tensor_meta,


### PR DESCRIPTION
将 LocalTensorMeta上的storage_offset成员迁移到 EagerLocalTensorImpl，storage_offset是与存储相关的变量，放在TensorMeta上不是很合适，storage_offset的多样性还会导致系统内缓存大量的Symbol，从而引起内存爆增， 如 https://github.com/Oneflow-Inc/oneflow/issues/8958#issuecomment-1220217521 中描述。
迁移后测试下面代码，内存由12G+降到了2.85G：

```python
import oneflow as flow
import oneflow.nn as nn

A = flow.Tensor(16000000, 11, device="cuda")
A.numpy()
print(A.shape)

for i in range(A.shape[0]):
  A[i]
```