### PR TITLE
Recompute cost with time shape

### DIFF
--- a/oneflow/core/auto_parallel/sbp_constructor.cpp
+++ b/oneflow/core/auto_parallel/sbp_constructor.cpp
@@ -234,7 +234,9 @@ Maybe<void> SbpConstructor::InitComputationCost(const OpGraph& op_graph) {
       if (comp_cost > GetValidMaxCopyCost()) {
         sbp_node->cost_.at(sbp_id) = comp_cost;
       } else {
-        sbp_node->cost_.at(sbp_id) = cost_ratio_ * comp_cost;
+        sbp_node->cost_.at(sbp_id) =
+            cost_ratio_ * comp_cost
+            * JUST(op_node->op().GetInputOutputFastestTimeShape())->elem_cnt();
       }
     }
     return Maybe<void>::Ok();

--- a/oneflow/core/auto_parallel/sbp_edge.cpp
+++ b/oneflow/core/auto_parallel/sbp_edge.cpp
@@ -270,9 +270,15 @@ void SbpEdge::InitializeCopyCost(const std::string& ibn, bool compute_cost,
         const NdSbp& sbp_consumer = consumer_sbp_bn_in_op2sbp_parallel.at(ibn);
 
         // compute copy cost for a specific logical blob
-        cost_[sbp_id_producer][sbp_id_consumer] += CHECK_JUST(ComputeCopyCostWithMiddleNodes(
+        double curr_edge_cost = CHECK_JUST(ComputeCopyCostWithMiddleNodes(
             sbp_producer, sbp_consumer, logical_blob_desc, producer_parallel_desc,
             consumer_parallel_desc, is_same_sbp));
+        if (curr_edge_cost < GetValidMaxCopyCost()) {
+          cost_[sbp_id_producer][sbp_id_consumer] +=
+              CHECK_JUST(producer->op().GetOpTimeShape())->elem_cnt() * curr_edge_cost;
+        } else {
+          cost_[sbp_id_producer][sbp_id_consumer] = curr_edge_cost;
+        }
       }
     }
   }


### PR DESCRIPTION
In the design of GradAcc, an operator or a transfer might be executed multiple times.
As a result, the corresponding cost needs to be multiplied by the execution times.
Thanks for the discussion with @chengtbf 