### PR TITLE
Fix PrunePinnedIdentityOpPass is_train

### DIFF
--- a/oneflow/core/ep/cuda/primitive/unary_functor.cuh
+++ b/oneflow/core/ep/cuda/primitive/unary_functor.cuh
@@ -125,6 +125,21 @@ struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kAbs, half, half> {
   }
 };
 
+#if CUDA_VERSION >= 11000
+template<>
+struct UnaryFunctor<DeviceType::kCUDA, UnaryOp::kAbs, nv_bfloat16, nv_bfloat16> {
+  OF_DEVICE_FUNC UnaryFunctor(Scalar attr0, Scalar attr1) {}
+
+  __device__ nv_bfloat16 operator()(nv_bfloat16 src) const {
+#if CUDA_ARCH >= 800
+    return __habs(src);
+#else
+    return __float2bfloat16(abs(__bfloat162float(src)));
+#endif  // CUDA_ARCH >= 800
+  }
+};
+#endif  // CUDA_VERSION >= 11000
+
 #define SPECIALIZATION_PSEUDO_HALF_UNARY_FUNCTOR(op)                                         \
   template<>                                                                                 \
   struct UnaryFunctor<DeviceType::kCUDA, op, half, half> {                                   \

--- a/oneflow/core/job_rewriter/prune_pinned_identity_op_pass.cpp
+++ b/oneflow/core/job_rewriter/prune_pinned_identity_op_pass.cpp
@@ -64,9 +64,9 @@ Maybe<std::string> PrunePinnedIdentityOp(JobBuilder* job_builder, const OpGraph&
 }
 
 Maybe<void> PrunePinnedIdentityOpPass::Apply(Job* job, JobPassCtx* ctx) const {
+  if (!job->job_conf().has_train_conf()) { return Maybe<void>::Ok(); }
   const OpGraph op_graph(*job);
   JobBuilder job_builder(job);
-
   HashMap<std::string, std::string> pruned_lbns;
   TrainConf* train_conf = job->mutable_job_conf()->mutable_train_conf();
   // prune loss pinned identity


### PR DESCRIPTION
PrunePinnedIdentityOpPass 中直接调用 mutable_train_conf 导致非 train job 被设置为 train job