### PR TITLE
enable sync vm mode for lazy kernel

### DIFF
--- a/oneflow/core/kernel/kernel.cpp
+++ b/oneflow/core/kernel/kernel.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "oneflow/core/kernel/kernel.h"
 #include "oneflow/core/kernel/runtime_blob_shape_infer_helper.h"
 #include "oneflow/core/kernel/kernel_observer.h"
+#include "oneflow/core/vm/sync_vm_mode_guard.h"
 
 namespace oneflow {
 
@@ -43,11 +44,13 @@ void Kernel::InitBase(const KernelConf& kernel_conf) {
 }
 
 void Kernel::Init(const KernelConf& kernel_conf, KernelContext* ctx) {
+  SyncVmModeGuard guard(SyncVmMode::kEnable);
   InitBase(kernel_conf);
   VirtualKernelInit(ctx);
 }
 
 void Kernel::Launch(KernelContext* ctx) const {
+  SyncVmModeGuard guard(SyncVmMode::kEnable);
   ctx->WillForward(ctx, this);
   Forward(ctx);
   ctx->DidForward(ctx, this);


### PR DESCRIPTION
lazy kernel也需要加上sync vm mode。某些芯片厂商在kernel运行时可能会fork子进程，如果没有sync vm mode就会死锁。