### PR TITLE
Add tensor.bool() api

### DIFF
--- a/docs/source/tensor.rst
+++ b/docs/source/tensor.rst
@@ -193,6 +193,7 @@ Tensor class reference
     Tensor.atanh
     Tensor.backward
     Tensor.bmm
+    Tensor.bool
     Tensor.byte
     Tensor.cast
     Tensor.ceil

--- a/oneflow/api/python/framework/tensor_functions.cpp
+++ b/oneflow/api/python/framework/tensor_functions.cpp
@@ -575,6 +575,7 @@ REDUCE_FUNC(PyTensorObject_mean, functional::reduce_mean, functional::ReduceMean
     END_HANDLE_ERRORS                                                      \
   }
 
+DATATYPE_FUNC(PyTensorObject_bool, DType::Bool());
 DATATYPE_FUNC(PyTensorObject_int, DType::Int32());
 DATATYPE_FUNC(PyTensorObject_long, DType::Int64());
 DATATYPE_FUNC(PyTensorObject_half, DType::Float16());
@@ -830,6 +831,7 @@ PyMethodDef PyTensorObject_extra_methods[] = {
     {"addcdiv", (PyCFunction)PyTensorObject_addcdiv, METH_VARARGS | METH_KEYWORDS, NULL},
     {"addcdiv_", (PyCFunction)PyTensorObject_addcdiv_, METH_VARARGS | METH_KEYWORDS, NULL},
     {"matmul", (PyCFunction)PyTensorObject_matmul, METH_VARARGS | METH_KEYWORDS, NULL},
+    {"bool", PyTensorObject_bool, METH_NOARGS, NULL},
     {"int", PyTensorObject_int, METH_NOARGS, NULL},
     {"long", PyTensorObject_long, METH_NOARGS, NULL},
     {"half", PyTensorObject_half, METH_NOARGS, NULL},

--- a/python/oneflow/framework/docstr/tensor.py
+++ b/python/oneflow/framework/docstr/tensor.py
@@ -1975,8 +1975,30 @@ add_docstr(
 )
 
 add_docstr(
+    oneflow.Tensor.bool,
+    r"""``Tensor.bool()`` is equivalent to ``Tensor.to(oneflow.bool)``. See :class:`oneflow.Tensor.to()`.
+
+    Args:
+        input  (Tensor): the input tensor.
+
+    For example:
+
+    .. code-block:: python
+
+        >>> import oneflow as flow
+        >>> import numpy as np
+
+        >>> input = flow.tensor(np.random.randn(1, 2, 3), dtype=flow.float32)
+        >>> input = input.bool()
+        >>> input.dtype
+        oneflow.bool
+
+    """,
+)
+
+add_docstr(
     oneflow.Tensor.int,
-    r"""`Tensor.int()` is equivalent to `Tensor.to(flow.int32)`. See to().
+    r"""``Tensor.int()`` is equivalent to ``Tensor.to(flow.int32)``. See to().
 
     Args:
         input  (Tensor): the input tensor.
@@ -1997,7 +2019,7 @@ add_docstr(
 
 add_docstr(
     oneflow.Tensor.long,
-    r"""`Tensor.long()` is equivalent to `Tensor.to(flow.int64)`. See to().
+    r"""``Tensor.long()`` is equivalent to ``Tensor.to(flow.int64)``. See to().
 
     Args:
         input  (Tensor): the input tensor.
@@ -2018,7 +2040,7 @@ add_docstr(
 
 add_docstr(
     oneflow.Tensor.float,
-    r"""`Tensor.float()` is equivalent to `Tensor.to(flow.float32)`. See to().
+    r"""``Tensor.float()`` is equivalent to ``Tensor.to(flow.float32)``. See to().
 
     Args:
         input  (Tensor): the input tensor.
@@ -2039,7 +2061,7 @@ add_docstr(
 
 add_docstr(
     oneflow.Tensor.double,
-    r"""`Tensor.double()` is equivalent to `Tensor.to(flow.float64)`. See to().
+    r"""``Tensor.double()`` is equivalent to ``Tensor.to(flow.float64)``. See to().
 
     Args:
         input  (Tensor): the input tensor.

--- a/python/oneflow/test/modules/test_tensor_ops.py
+++ b/python/oneflow/test/modules/test_tensor_ops.py
@@ -221,6 +221,30 @@ class TestTensorOps(flow.unittest.TestCase):
         y = x.double()
         return y
 
+    @autotest(n=20, auto_backward=False, rtol=1e-4, atol=1e-4, check_graph=True)
+    def test_bool(test_case):
+        device = random_device()
+        x = random_tensor().to(device)
+        y = x.bool()
+        return y
+
+    @autotest(n=20, auto_backward=False, rtol=1e-4, atol=1e-4, check_graph=True)
+    def test_bool_0dim(test_case):
+        device = random_device()
+        x = random_tensor(ndim=0).to(device)
+        y = x.bool()
+        return y
+
+    @autotest(n=5, auto_backward=False)
+    def test_bool_with_non_contiguous_input(test_case):
+        device = random_device()
+        permute_list = list(range(4))
+        shuffle(permute_list)
+        input = random_tensor(ndim=4).to(device)
+        x = input.permute(permute_list)
+        y = x.bool()
+        return y
+
     # Not check graph because of 2 reason.
     # Reason 1, nn.Graph.build()'s input/output item only support types: Tensor/None.
     # Reason 2, This op needs to convert the EagerTensor to a numpy array，so this op only supports eager mode.


### PR DESCRIPTION
解决 https://github.com/Oneflow-Inc/oneflow/issues/9031 中的问题
概述：增加了 Tensor.bool() 接口，具体实现等价于 `Tensor.to(oneflow.bool)` 。然后顺便优化了其他同类型接口文档的显示。


文档如下：

![image](https://user-images.githubusercontent.com/53533850/187707552-ab5ac4a7-04a7-4f0d-8ca4-c0492953a213.png)
