### PR TITLE
Remove disable chain merge optimizer subgraph with fw/bw pass

### DIFF
--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -68,17 +68,6 @@ std::string GetOpConfCalculationPassName(const OperatorConf& op_conf) {
   return scope.scope_proto().calculation_pass_name();
 }
 
-bool IsOptimizerPassOp(const Operator* op) {
-  // NOTE(chengcheng): use scope::calculation_pass_name instead of area_id to not merge optimizer
-  // ops with fw/bw ops
-  if (!op->op_conf().has_scope_symbol_id()) {
-    // NOTE(chengcheng): Some system op insert to OpGraph may not set scope_symbol_id, it MUST NOT
-    // optimizer subgraph ops.
-    return false;
-  }
-  return GetOpConfCalculationPassName(op->op_conf()) == kOptimizerPass;
-}
-
 bool IsSubsetTickOpConf(const OperatorConf& op_conf) {
   return op_conf.has_src_subset_tick_conf() || op_conf.has_dst_subset_tick_conf();
 }

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -102,11 +102,6 @@ bool IsSpecialOpNotConsiderMergeInChain(const Operator* op) {
       return true;
     }
   }
-  // NOTE(chengcheng): ONLY nccl_use_compute_stream = false will exclude optimizer pass ops
-  if (!Singleton<ResourceDesc, ForSession>::Get()->nccl_use_compute_stream()
-      && IsOptimizerPassOp(op)) {
-    return true;
-  }
   return false;
 }
 

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -57,17 +57,6 @@ bool IsConnectToTickOp(const TaskNode* node) {
   return false;
 }
 
-std::string GetOpConfCalculationPassName(const OperatorConf& op_conf) {
-  CHECK(op_conf.has_scope_symbol_id());
-  int64_t scope_symbol_id = op_conf.scope_symbol_id();
-  CHECK(Singleton<symbol::Storage<Scope>>::Get()->Has(scope_symbol_id))
-      << " Error! op : \n " << op_conf.DebugString()
-      << " has error scope_symbol_id = " << scope_symbol_id
-      << " which cannot find in Singleton<symbol::Storage<Scope>>::Get()\n";
-  const Scope& scope = Singleton<symbol::Storage<Scope>>::Get()->Get(scope_symbol_id);
-  return scope.scope_proto().calculation_pass_name();
-}
-
 bool IsSubsetTickOpConf(const OperatorConf& op_conf) {
   return op_conf.has_src_subset_tick_conf() || op_conf.has_dst_subset_tick_conf();
 }


### PR DESCRIPTION
移除一个过渡优化：

之前在 Chain 合并算法中，沿袭了远古的设计： Optimizer 子图不与 Fw/Bw 子图合并。（如果 nccl use compute stream = true 下，则没有这个限制）。
但这个约束的原因难以考究， 是 Optimizer 子图里的 nccl （Collective Boxing） 的存在，导致如果 Optimizer 子图 前半部分 与 Fw/Bw 合并在一起以后 nccl 有性能问题，还是死锁风险？  @liujuncheng 

fixed: https://github.com/Oneflow-Inc/OneTeam/issues/1676