### PR TITLE
Refine JUST(...JUST...) stack msg

### DIFF
--- a/oneflow/core/common/just.h
+++ b/oneflow/core/common/just.h
@@ -115,7 +115,7 @@ typename std::remove_const<typename std::remove_reference<T>::type>::type&& Remo
           ::oneflow::private_details::JustGetError(_just_value_to_check_),                   \
           [](const char* function) {                                                         \
             thread_local static auto frame = ::oneflow::SymbolOf(::oneflow::ErrorStackFrame( \
-                __FILE__, __LINE__, function, OF_PP_STRINGIZE(__VA_ARGS__)));                \
+                __FILE__, __LINE__, function, #__VA_ARGS__));                \
             return frame;                                                                    \
           }(__FUNCTION__));                                                                  \
     }                                                                                        \
@@ -127,7 +127,7 @@ typename std::remove_const<typename std::remove_reference<T>::type>::type&& Remo
     auto&& _just_value_to_check_ = __JustStackCheckWrapper__(__VA_ARGS__);              \
     if (!::oneflow::private_details::JustIsOk(_just_value_to_check_)) {                 \
       thread_local static auto frame = ::oneflow::SymbolOf(::oneflow::ErrorStackFrame(  \
-          __FILE__, __LINE__, _just_closure_func_name_, OF_PP_STRINGIZE(__VA_ARGS__))); \
+          __FILE__, __LINE__, _just_closure_func_name_, #__VA_ARGS__)); \
       LOG(FATAL) << ::oneflow::GetFormatedSerializedError(                              \
           ::oneflow::private_details::JustErrorAddStackFrame(                           \
               ::oneflow::private_details::JustGetError(_just_value_to_check_), frame)); \
@@ -144,10 +144,10 @@ typename std::remove_const<typename std::remove_reference<T>::type>::type&& Remo
           ::oneflow::Error(::oneflow::private_details::JustGetError(_just_value_to_check_))      \
               .AddStackFrame([](const char* function) {                                          \
                 thread_local static auto frame = ::oneflow::SymbolOf(::oneflow::ErrorStackFrame( \
-                    __FILE__, __LINE__, function, OF_PP_STRINGIZE(value)));                      \
+                    __FILE__, __LINE__, function, #value));                      \
                 return frame;                                                                    \
               }(__FUNCTION__)),                                                                  \
-          "\nError message from " __FILE__, ":", __LINE__, "\n\t", OF_PP_STRINGIZE(value), ": ", \
+          "\nError message from " __FILE__, ":", __LINE__, "\n\t", #value, ": ", \
           __VA_ARGS__, "\n");                                                                    \
     }                                                                                            \
     std::forward<decltype(_just_value_to_check_)>(_just_value_to_check_);                        \
@@ -158,12 +158,12 @@ typename std::remove_const<typename std::remove_reference<T>::type>::type&& Remo
     auto&& _just_value_to_check_ = (value);                                                     \
     if (!::oneflow::private_details::JustIsOk(_just_value_to_check_)) {                         \
       thread_local static auto frame = ::oneflow::SymbolOf(::oneflow::ErrorStackFrame(          \
-          __FILE__, __LINE__, _just_closure_func_name_, OF_PP_STRINGIZE(value)));               \
+          __FILE__, __LINE__, _just_closure_func_name_, #value));               \
       LOG(FATAL) << ::oneflow::GetFormatedSerializedError(                                      \
           ::oneflow::private_details::JustErrorAddFrameMessage(                                 \
               ::oneflow::Error(::oneflow::private_details::JustGetError(_just_value_to_check_)) \
                   .AddStackFrame(frame),                                                        \
-              "\nError message from " __FILE__, ":", __LINE__, "\n\t", OF_PP_STRINGIZE(value),  \
+              "\nError message from " __FILE__, ":", __LINE__, "\n\t", #value,  \
               ": ", __VA_ARGS__, "\n")                                                          \
               .stacked_error());                                                                \
     }                                                                                           \


### PR DESCRIPTION
对于有有宏嵌套的代码，如两个 JUST 嵌套：
```
std::shared_ptr<Tensor> tensor = JUST(
      functional::Empty(shape, JUST(DType::Get(data_type)), device_, /*pin_memory=*/pin_memory));
```

之前的 Stringify 写法 OF_PP_STRINGIZE 会展开 JUST 后，再 Stringify，导致 stack 展示了 被嵌套的JUST 展开后的冗余内容，在 JUST 这里不适合：

```
RuntimeError: Check failed: false 
  File "/home/xuxiaoyu/dev/oneflow/oneflow/api/python/utils/tensor_utils.cpp", line 193, in MakeLocalTensorFromData
    functional::Empty(shape, ::oneflow::private_details ... Data_YouAreNotAllowedToCallThisFuncOutsideThisFile(), device_, pin_memory)
```

新写法，可以直接 Stringify，不展开 JUST：
```
File "/home/xuxiaoyu/dev/oneflow/oneflow/api/python/utils/tensor_utils.cpp", line 193, in MakeLocalTensorFromData
    functional::Empty(shape, JUST(DType::Get(data_type)), device_, pin_memory)
```