### PR TITLE
Part-4: merge acc op in to chain for reuse memory acc input

### DIFF
--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -387,7 +387,16 @@ void ForEachOpGraphNecessaryCtrlEdge(
         if (dst_time_shape == nullptr) {
           dst_time_shape = CHECK_JUST(dst->op().GetOpTimeShape()).get();
         }
-        CHECK_EQ(src_time_shape->elem_cnt(), dst_time_shape->elem_cnt());
+        if (src_time_shape->elem_cnt() != dst_time_shape->elem_cnt()) {
+          // NOTE(chengcheng): acc op node can be merged and add ctrl edge.
+          CHECK(src->op().op_conf().has_user_conf()
+                && src->op().op_conf().user_conf().op_type_name() == "acc");
+          const Shape* src_input_time_shape =
+              CHECK_JUST(src->op().GetInputBlobFastestTimeShape()).get();
+          CHECK_EQ(src_input_time_shape->elem_cnt(), dst_time_shape->elem_cnt());
+        } else {
+          CHECK_EQ(src_time_shape->elem_cnt(), dst_time_shape->elem_cnt());
+        }
         Handler(src, dst);
       }
     }


### PR DESCRIPTION
Acc op 也可以合并到 chain 里。只要控制边控制的合理的话。 这样有一个好处， 就是原来 acc 消费的 tensor 的生命周期会被延长，因为 acc 是 chain 外的节点，消费会使得原有 tensor 的生命周期延迟到 chain 结束 （假设了 chain 执行的事务性）。 如果 acc 是 chain 里的节点，虽然 acc 本省没法复用内存，但是 acc 的 input 的生命周期被缩短了，即立马执行以后就可以释放。 可以节省显存。


但我本地实测却发现并没有节省显存。实际 debug 发现， 虽然 acc 的 input 的生命周期都确实被缩短了。但是因为 acc 是 bw 阶段的 tensor， 实际上此时的内存峰值（loss 处）已经过去了，即使缩短了 acc 的 input 生命周期，也无法降低峰值，因此才会显得没有效果。


日志：

### before： 

chain 原有 325 op：

![image](https://user-images.githubusercontent.com/12186261/188906911-9a81c4d6-bf63-453a-8676-63acaacba36e.png)


```
In placement: cuda-@0:0-@1:1-@2:2-@3:3 logical_chain_id: 0 has op num = 325
...
ChainId: 1 order: 156 op_name: model.cls_head.seq_relationship-matmul-201 global_order: 430                                                                    
ChainId: 1 order: 157 op_name: model.cls_head.seq_relationship-matmul-200 global_order: 432
ChainId: 1 order: 158 op_name: model.cls_head.seq_relationship-reduce_sum_like-196 global_order: 433
ChainId: 1 order: 159 op_name: model.cls_head.loss_func.lm_loss-reshape-194-out_0-cast_h2f global_order: 435
```
其中： model.cls_head.seq_relationship.weight-acc-205 消费了 model.cls_head.seq_relationship-matmul-201

比较 acc input ：  model.cls_head.seq_relationship-matmul-201 的生命周期：

```
In Chunk id: 2, MemBlock id: 7 Order: 186 ,duration: 169 ,size: 0.0016 MiB, name: model.cls_head.seq_relationship-matmul-201/out_0                                      
shape: (2,384) ,dtype: kFloat16 ,alloc_order: 156 ,free_order: 324
```


### after:

acc 加入以后，为： 

![image](https://user-images.githubusercontent.com/12186261/188907030-47396074-1476-4d97-b2a9-c51ace163532.png)

```
In placement: cuda-@0:0-@1:1-@2:2-@3:3 logical_chain_id: 0 has op num = 363
...
ChainId: 1 order: 156 op_name: model.cls_head.seq_relationship-matmul-201 global_order: 430
ChainId: 1 order: 157 op_name: model.cls_head.seq_relationship.weight-acc-205 global_order: 431
ChainId: 1 order: 158 op_name: model.cls_head.seq_relationship-matmul-200 global_order: 432
ChainId: 1 order: 159 op_name: model.cls_head.seq_relationship-reduce_sum_like-196 global_order: 433
ChainId: 1 order: 160 op_name: model.cls_head.seq_relationship.bias-acc-202 global_order: 434
ChainId: 1 order: 161 op_name: model.cls_head.loss_func.lm_loss-reshape-194-out_0-cast_h2f global_order: 435
```


比较 acc input ：  model.cls_head.seq_relationship-matmul-201 的生命周期：

```
In Chunk id: 3, MemBlock id: 1 Order: 186 ,duration: 2 ,size: 0.0016 MiB, name: model.cls_head.seq_relationship-matmul-201/out_0                                        
shape: (2,384) ,dtype: kFloat16 ,alloc_order: 156 ,free_order: 157
```

duration 从  169 缩短到了 2 。符合预期。但是总体的显存开销：

### before：

```
In Device: 0 Chunk id: 2 MemBlock id: 7 has num = 489 tensor with mem size = 631.584
```

### after:

```
In Device: 0 Chunk id: 3 MemBlock id: 1 has num = 489 tensor with mem size = 631.584
```

却是完全一样的