### PR TITLE
modify_atanh_test_precision

### DIFF
--- a/python/oneflow/test/modules/test_global_math_op_higher_derivative.py
+++ b/python/oneflow/test/modules/test_global_math_op_higher_derivative.py
@@ -21,7 +21,9 @@ import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
 
-def _global_math_op_grad_grad_impl(test_case, op_name, placement, sbp):
+def _global_math_op_grad_grad_impl(
+    test_case, op_name, placement, sbp, atol=1e-4, rtol=1e-4
+):
     x = (
         random_tensor(2, dim0=8, dim1=8, low=-2, high=2)
         .to_global(placement=placement, sbp=sbp)
@@ -35,8 +37,8 @@ def _global_math_op_grad_grad_impl(test_case, op_name, placement, sbp):
         np.allclose(
             x_grad.pytorch.detach().cpu().numpy(),
             x_grad.oneflow.detach().numpy(),
-            atol=1e-4,
-            rtol=1e-4,
+            atol=atol,
+            rtol=rtol,
             equal_nan=True,
         )
     )
@@ -46,8 +48,8 @@ def _global_math_op_grad_grad_impl(test_case, op_name, placement, sbp):
         np.allclose(
             x_grad_grad.pytorch.detach().cpu().numpy(),
             x_grad_grad.oneflow.detach().numpy(),
-            atol=1e-4,
-            rtol=1e-4,
+            atol=atol,
+            rtol=rtol,
             equal_nan=True,
         )
     )
@@ -58,8 +60,8 @@ def _global_math_op_grad_grad_impl(test_case, op_name, placement, sbp):
         np.allclose(
             dgrad.pytorch.detach().cpu().numpy(),
             dgrad.oneflow.detach().numpy(),
-            atol=1e-4,
-            rtol=1e-4,
+            atol=atol,
+            rtol=rtol,
             equal_nan=True,
         )
     )
@@ -136,7 +138,9 @@ class TestGlobalMathOpHigherDerivative(flow.unittest.TestCase):
     def test_global_atanh_grad_grad(test_case):
         for placement in all_placement():
             for sbp in all_sbp(placement, max_dim=2):
-                _global_math_op_grad_grad_impl(test_case, "atanh", placement, sbp)
+                _global_math_op_grad_grad_impl(
+                    test_case, "atanh", placement, sbp, atol=1e-3, rtol=1e-3
+                )
 
     @globaltest
     def test_global_erf_grad_grad(test_case):


### PR DESCRIPTION
- 解决 atanh 在 https://github.com/Oneflow-Inc/oneflow/actions/runs/3041811382/jobs/4900166354 出现的精度问题
- 问题原因:  atanh backward 在 x->+-1, 设备为 cuda 时计算误差较大，可以达到 1e-4
- 暂时增加 testcase 的比较精度

测试脚本，与 torch cpu/cuda 对比相对误差也可以达到 1e-4
```
import torch
import numpy as np
# import oneflow as torch

shape = (64, 64)
device = torch.device('cuda')

def calc_diff(input, device, op='atanh'):
    x = input.detach().clone().to(torch.device(device)).requires_grad_()
    y = eval(f'torch.{op}(x)')
    dx = torch.autograd.grad(y, x, torch.ones_like(y), True, True)[0]
    return dx
max_diff = np.array(0.)

for i in range(10000):
    input = torch.randn(shape)
    input = torch.randn(shape).sigmoid() * 0.5
    res_cpu = calc_diff(input, 'cpu').detach().cpu().numpy()
    res_gpu = calc_diff(input, 'cuda').detach().cpu().numpy()
    diff = np.max(np.abs((res_cpu-res_gpu)/res_cpu))

    if diff > max_diff:
        max_diff = diff
        print(diff)
print('max_idff: ', diff)        
```

kAtanhBackwardWithDyX 实现：
https://github.com/Oneflow-Inc/oneflow/blob/a9d6f7624ba00cfade5a14ffd3ebc5a27c3114ad/oneflow/core/ep/common/primitive/binary_functor.h#L422-L429
