### PR TITLE
support free eager tensor in graph state dict

### DIFF
--- a/python/oneflow/nn/graph/graph.py
+++ b/python/oneflow/nn/graph/graph.py
@@ -364,7 +364,7 @@ class Graph(object):
             assert len(additional_var_names) == len(additional_var_tensors)
             for i in range(len(additional_var_names)):
                 additional_tensor = additional_var_tensors[i]
-                if not self._is_global_view:
+                if not self._is_global_view and additional_tensor.is_global:
                     additional_tensor = additional_tensor.to_local()
                 destination[additional_var_names[i]] = additional_tensor
         else:


### PR DESCRIPTION
在下面的pr进行了功能测试，现在带free eager tensor的onnx模型可以正常导出了。

https://github.com/Oneflow-Inc/oneflow_convert/pull/89

<img width="1116" alt="图片" src="https://user-images.githubusercontent.com/35585791/189867969-f9126b61-6ebc-4f73-8961-526f21d51357.png">

