### PR TITLE
Add lr_scheduler: Cyclilc LR and OneCycle LR

### DIFF
--- a/oneflow/core/job/learning_rate_schedule_conf.proto
+++ b/oneflow/core/job/learning_rate_schedule_conf.proto
@@ -82,6 +82,18 @@ message CosineAnnealingWarmRestartsConf {
   required int64 restart_limit = 5;
 }
 
+message CyclicLRConf {
+  required double base_lr = 1;
+  required double max_lr = 2;
+  required int64 step_size_up = 3;
+  required int64 step_size_down = 4;
+  required int32 mode = 5;
+  required double gamma = 6;
+  required double scale_fn = 7;
+  required int32 scale_mode = 8;
+  required int64 step_size_total = 9;
+}
+
 message SequentialSchedulerConf {
   repeated LearningRateDecayConf schedulers = 1;
   repeated int64 milestones = 2;
@@ -108,5 +120,6 @@ message LearningRateDecayConf {
     ConstantLRConf constant_lr_conf = 2012;
     CosineAnnealingWarmRestartsConf cosine_annealing_warm_restarts_conf = 2013;
     SequentialSchedulerConf sequential_scheduler_conf = 2014;
+    CyclicLRConf cyclic_lr_conf = 2015;
   }
 }

--- a/oneflow/core/job/learning_rate_schedule_conf.proto
+++ b/oneflow/core/job/learning_rate_schedule_conf.proto
@@ -94,6 +94,16 @@ message CyclicLRConf {
   required int64 step_size_total = 9;
 }
 
+message OneCycleLRConf {
+  required double max_lr = 1;
+  required double div_factor = 2;
+  required double final_div_factor = 3;
+  required int64 total_steps = 4;
+  required bool three_phase = 5;
+  required double pct_start = 6;
+  required int32 anneal_strategy = 7;
+}
+
 message SequentialSchedulerConf {
   repeated LearningRateDecayConf schedulers = 1;
   repeated int64 milestones = 2;
@@ -121,5 +131,6 @@ message LearningRateDecayConf {
     CosineAnnealingWarmRestartsConf cosine_annealing_warm_restarts_conf = 2013;
     SequentialSchedulerConf sequential_scheduler_conf = 2014;
     CyclicLRConf cyclic_lr_conf = 2015;
+    OneCycleLRConf onecycle_lr_conf = 2016;
   }
 }

--- a/oneflow/core/kernel/learning_rate_schedule_kernel.cpp
+++ b/oneflow/core/kernel/learning_rate_schedule_kernel.cpp
@@ -204,6 +204,44 @@ double MultiStepLearningRate(const MultiStepConf& conf, double lr, int64_t cur_b
   return lr * std::pow(gamma, i);
 }
 
+double CyclicLearningRate(const CyclicLRConf& conf, const double lr_, int64_t cur_batch_num) {
+  double lr = 0;
+  double gamma = conf.gamma();
+  double base_lr = conf.base_lr();
+  double max_lr = conf.base_lr();
+  int64_t step_size_total = conf.step_size_total();
+  double step_up_ratio =
+      static_cast<double>(conf.step_size_up()) / static_cast<double>(step_size_total);
+  double offset_ratio =
+      static_cast<double>(cur_batch_num % step_size_total) / static_cast<double>(step_size_total);
+  double scale_factor = 0;
+  if (offset_ratio < step_up_ratio) {
+    scale_factor = offset_ratio / step_up_ratio;
+  } else {
+    scale_factor = (1 - offset_ratio) / (1 - step_up_ratio);
+  }
+
+  int32_t mode = conf.mode();
+  std::function<double(int)> scale_fn;
+  if (mode == 0) {  // "triangular"
+    scale_fn = [](int x) { return 1.0; };
+  } else if (mode == 1) {  // "triangular2"
+    scale_fn = [](int x) { return 1.0 / std::pow(2.0, (x - 1)); };
+  } else if (mode == 2) {  // "exp_range"
+    scale_fn = [&gamma](int x) { return std::pow(gamma, static_cast<double>(x)); };
+  }
+
+  int32_t scale_mode = conf.scale_mode();
+  double height = (max_lr - base_lr) * scale_factor;
+  if (scale_mode == 0) {  // "cycle"
+    int32_t cycle_num = 1.0 + cur_batch_num / step_size_total;
+    lr = base_lr + height * scale_fn(cycle_num);
+  } else {
+    lr = base_lr + height * scale_fn(cur_batch_num);
+  }
+  return lr;
+}
+
 double CosineAnnealingWarmRestartsLearningRate(const CosineAnnealingWarmRestartsConf& conf,
                                                const double base_lr, const int64_t step) {
   int64_t epoch_steps = conf.t_initial();
@@ -280,6 +318,8 @@ double GetDecayedLearningRate(const LearningRateDecayConf& conf, double lr, int6
                                                    cur_batch_num);
   } else if (conf.has_sequential_scheduler_conf()) {
     return SequentialScheduler(conf.sequential_scheduler_conf(), lr, cur_batch_num);
+  } else if (conf.has_cyclic_lr_conf()) {
+    return CyclicLearningRate(conf.cyclic_lr_conf(), lr, cur_batch_num);
   } else {
     UNIMPLEMENTED();
   }

--- a/python/oneflow/nn/optimizer/cyclic_lr.py
+++ b/python/oneflow/nn/optimizer/cyclic_lr.py
@@ -1,0 +1,236 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from typing import Callable
+from .optimizer import Optimizer
+from .lr_scheduler import LRScheduler
+
+
+class CyclicLR(LRScheduler):
+    r"""
+    The interface is consistent with PyTorch.
+
+    The documentation is referenced from:
+    https://pytorch.org/docs/1.10/generated/torch.optim.lr_scheduler.CyclicLR.html.
+
+    Sets the learning rate of each parameter group according to
+    cyclical learning rate policy (CLR). The policy cycles the learning
+    rate between two boundaries with a constant frequency, as detailed in
+    the paper `Cyclical Learning Rates for Training Neural Networks`_.
+    The distance between the two boundaries can be scaled on a per-iteration
+    or per-cycle basis.
+
+    Cyclical learning rate policy changes the learning rate after every batch.
+    `step` should be called after a batch has been used for training.
+
+    This class has three built-in policies, as put forth in the paper:
+
+    * "triangular": A basic triangular cycle without amplitude scaling.
+    * "triangular2": A basic triangular cycle that scales initial amplitude by half each cycle.
+    * "exp_range": A cycle that scales initial amplitude by :math:`\text{gamma}^{\text{cycle iterations}}`
+      at each cycle iteration.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        base_lr (float or list): Initial learning rate which is the
+            lower boundary in the cycle for each parameter group.
+        max_lr (float or list): Upper learning rate boundaries in the cycle
+            for each parameter group. Functionally,
+            it defines the cycle amplitude (max_lr - base_lr).
+            The lr at any cycle is the sum of base_lr
+            and some scaling of the amplitude; therefore
+            max_lr may not actually be reached depending on
+            scaling function.
+        step_size_up (int): Number of training iterations in the
+            increasing half of a cycle. Default: 2000
+        step_size_down (int): Number of training iterations in the
+            decreasing half of a cycle. If step_size_down is None,
+            it is set to step_size_up. Default: None
+        mode (str): One of {triangular, triangular2, exp_range}.
+            Values correspond to policies detailed above.
+            If scale_fn is not None, this argument is ignored.
+            Default: 'triangular'
+        gamma (float): Constant in 'exp_range' scaling function:
+            gamma**(cycle iterations)
+            Default: 1.0
+        scale_fn (function): Custom scaling policy defined by a single
+            argument lambda function, where
+            0 <= scale_fn(x) <= 1 for all x >= 0.
+            If specified, then 'mode' is ignored.
+            Default: None
+        scale_mode (str): {'cycle', 'iterations'}.
+            Defines whether scale_fn is evaluated on
+            cycle number or cycle iterations (training
+            iterations since start of cycle).
+            Default: 'cycle'
+        cycle_momentum (bool): If ``True``, momentum is cycled inversely
+            to learning rate between 'base_momentum' and 'max_momentum'.
+            Default: True
+        base_momentum (float or list): Lower momentum boundaries in the cycle
+            for each parameter group. Note that momentum is cycled inversely
+            to learning rate; at the peak of a cycle, momentum is
+            'base_momentum' and learning rate is 'max_lr'.
+            Default: 0.8
+        max_momentum (float or list): Upper momentum boundaries in the cycle
+            for each parameter group. Functionally,
+            it defines the cycle amplitude (max_momentum - base_momentum).
+            The momentum at any cycle is the difference of max_momentum
+            and some scaling of the amplitude; therefore
+            base_momentum may not actually be reached depending on
+            scaling function. Note that momentum is cycled inversely
+            to learning rate; at the start of a cycle, momentum is 'max_momentum'
+            and learning rate is 'base_lr'
+            Default: 0.9
+        last_step (int): The index of the last batch. This parameter is used when
+            resuming a training job. Since `step()` should be invoked after each
+            batch instead of after each epoch, this number represents the total
+            number of *batches* computed, not the total number of epochs computed.
+            When last_step=-1, the schedule is started from the beginning.
+            Default: -1
+        verbose (bool): If ``True``, prints a message to stdout for
+            each update. Default: ``False``.
+
+
+    .. _Cyclical Learning Rates for Training Neural Networks: https://arxiv.org/abs/1506.01186
+    """
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        base_lr: int,
+        max_lr: int,
+        step_size_up=2000,
+        step_size_down=None,
+        mode="triangular",
+        gamma=1.0,
+        scale_fn=None,
+        scale_mode="cycle",
+        cycle_momentum=True,
+        base_momentum=0.8,
+        max_momentum=0.9,
+        last_step: int = -1,
+        verbose: bool = False,
+    ):
+        if not isinstance(optimizer, Optimizer):
+            raise TypeError("{} is not an Optimizer".format(type(optimizer).__name__))
+
+        self.base_lr = base_lr
+        self.max_lr = max_lr
+        self.step_size_up = step_size_up
+        self.step_size_down = (
+            step_size_down if step_size_down is not None else step_size_up
+        )
+        self.step_size_total = self.step_size_up + self.step_size_down
+        self.step_up_ratio = step_size_up / self.step_size_total
+        self.mode = mode
+        self.gamma = gamma
+
+        if mode not in ("triangular", "triangular2", "exp_range") and scale_fn is None:
+            raise ValueError("mode is invalid and scale_fn is None")
+
+        if scale_fn is None:
+            if mode == "triangular":
+                self.scale_fn = lambda x: 1.0
+                self.scale_mode = "cycle"
+            elif mode == "triangular2":
+                self.scale_fn = lambda x: 1 / (2.0 ** (x - 1))
+                self.scale_mode = "cycle"
+            elif mode == "exp_range":
+                self.scale_fn: Callable[[int], float] = lambda x: gamma ** x
+                self.scale_mode = "iterations"
+        else:
+            self.scale_fn = scale_fn
+            self.scale_mode = scale_mode
+
+        self.cycle_momentum = cycle_momentum
+        if cycle_momentum:
+            if "momentum" not in optimizer._default_options:
+                raise ValueError(
+                    "optimizer must support momentum with `cycle_momentum` option enabled"
+                )
+
+            base_momentums = self._format_param(
+                "base_momentum", optimizer, base_momentum
+            )
+            if last_step == -1:
+                for momentum, group in zip(base_momentums, optimizer.param_groups):
+                    group["momentum"] = momentum
+            self.base_momentums = [
+                group["momentum"] for group in optimizer.param_groups
+            ]
+            self.max_momentums = self._format_param(
+                "max_momentum", optimizer, max_momentum
+            )
+
+        super().__init__(optimizer, last_step, verbose)
+
+    def _format_param(self, name, optimizer, param):
+        """Return correctly formatted lr/momentum for each param group."""
+        if isinstance(param, (list, tuple)):
+            if len(param) != len(optimizer.param_groups):
+                raise ValueError(
+                    "expected {} values for {}, got {}".format(
+                        len(optimizer.param_groups), name, len(param)
+                    )
+                )
+            return param
+        else:
+            return [param] * len(optimizer.param_groups)
+
+    def get_lr(self, base_lr, step):
+        offset_ratio = step % self.step_size_total / self.step_size_total
+        if offset_ratio <= self.step_up_ratio:
+            scale_factor = offset_ratio / self.step_up_ratio
+        else:
+            scale_factor = (1 - offset_ratio) / (1 - self.step_up_ratio)
+        height = (self.max_lr - self.base_lr) * scale_factor
+
+        if self.scale_mode == "cycle":
+            cycle_num = 1.0 + step // self.step_size_total
+            lr = self.base_lr + height * self.scale_fn(cycle_num)
+        else:
+            lr = self.base_lr + height * self.scale_fn(step)
+
+        if self.cycle_momentum:
+            momentums = []
+            for base_momentum, max_momentum in zip(
+                self.base_momentums, self.max_momentums
+            ):
+                base_height = (max_momentum - base_momentum) * scale_factor
+                if self.scale_mode == "cycle":
+                    momentum = max_momentum - base_height * self.scale_fn(cycle_num)
+                else:
+                    momentum = max_momentum - base_height * self.scale_fn(
+                        self.last_step
+                    )
+                momentums.append(momentum)
+            for param_group, momentum in zip(self.optimizer.param_groups, momentums):
+                param_group["momentum"] = momentum
+
+        return lr
+
+    def _generate_conf_for_graph(self, lr_conf):
+        lr_conf.cyclic_lr_conf.SetInParent()
+        cyclic_lr_conf = lr_conf.cyclic_lr_conf
+        cyclic_lr_conf.base_lr = self.base_lr
+        cyclic_lr_conf.max_lr = self.max_lr
+        cyclic_lr_conf.step_size_up = self.step_size_up
+        cyclic_lr_conf.step_size_down = self.step_size_down
+        cyclic_lr_conf.mode = self.mode
+        cyclic_lr_conf.gamma = self.gamma
+        cyclic_lr_conf.scale_fn = self.scale_fn
+        cyclic_lr_conf.scale_mode = self.scale_mode
+        cyclic_lr_conf.cycle_momentum = self.cycle_momentum
+        cyclic_lr_conf.base_momentum = self.base_momentums
+        cyclic_lr_conf.max_momentum = self.max_momentums

--- a/python/oneflow/nn/optimizer/onecycle_lr.py
+++ b/python/oneflow/nn/optimizer/onecycle_lr.py
@@ -1,0 +1,193 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import math
+from typing import Callable
+from .optimizer import Optimizer
+from .lr_scheduler import LRScheduler
+
+
+class OneCycleLR(LRScheduler):
+    """
+    """
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        max_lr,
+        total_steps=None,
+        epochs=None,
+        steps_per_epoch=None,
+        pct_start=0.3,
+        anneal_strategy="cos",
+        cycle_momentum=True,
+        base_momentum=0.85,
+        max_momentum=0.95,
+        div_factor=25.0,
+        final_div_factor=1e4,
+        three_phase=False,
+        last_step: int = -1,
+        verbose: bool = False,
+    ):
+        assert isinstance(optimizer, Optimizer)
+        self.optimizer = optimizer
+        self.max_lr = max_lr
+        if total_steps is None and (epochs is None or steps_per_epoch is None):
+            raise ValueError(
+                "You must define either total_steps OR (epochs AND steps_per_epoch)"
+            )
+        elif total_steps is not None:
+            if not isinstance(total_steps, int) or total_steps <= 0:
+                raise ValueError(
+                    "Expected positive integer total_steps, but got {}".format(
+                        total_steps
+                    )
+                )
+            self.total_steps = total_steps
+        else:
+            if not isinstance(epochs, int) or epochs <= 0:
+                raise ValueError(f"Expected positive integer epochs, but got {epochs}")
+            if not isinstance(steps_per_epoch, int) or steps_per_epoch <= 0:
+                raise ValueError(
+                    f"Expected positive integer steps_per_epoch, but got {steps_per_epoch}"
+                )
+            self.total_steps = epochs * steps_per_epoch
+
+        if pct_start < 0 or pct_start > 1 or not isinstance(pct_start, float):
+            raise ValueError(
+                f"Expected float between 0 and 1 pct_start, but got {pct_start}"
+            )
+
+        if anneal_strategy not in ["cos", "linear"]:
+            raise ValueError(
+                f"anneal_strategy must by one of 'cos' or 'linear', instead got {anneal_strategy}"
+            )
+        elif anneal_strategy == "cos":
+            self.anneal_func = lambda start, end, pct: end + (start - end) / 2.0 * (math.cos(math.pi * pct) + 1)
+        elif anneal_strategy == "linear":
+            self.anneal_func = lambda start, end, pct: (end - start) * pct + start
+
+        if three_phase:
+            self._schedule_phases = [
+                {
+                    "start_step": 0,
+                    "end_step": float(pct_start * self.total_steps) - 1,
+                    "start_lr": "initial_lr",
+                    "end_lr": "max_lr",
+                    "start_momentum": "max_momentum",
+                    "end_momentum": "base_momentum",
+                },
+                {
+                    "start_step": float(pct_start * self.total_steps) - 1,
+                    "end_step": float(2 * pct_start * self.total_steps) - 2,
+                    "start_lr": "max_lr",
+                    "end_lr": "initial_lr",
+                    "start_momentum": "base_momentum",
+                    "end_momentum": "max_momentum",
+                },
+                {
+                    "start_step": float(2 * pct_start * self.total_steps) - 2,
+                    "end_step": self.total_steps - 1,
+                    "start_lr": "initial_lr",
+                    "end_lr": "min_lr",
+                    "start_momentum": "max_momentum",
+                    "end_momentum": "max_momentum",
+                },
+            ]
+        else:
+            self._schedule_phases = [
+                {
+                    "start_step": 0,
+                    "end_step": float(pct_start * self.total_steps) - 1,
+                    "start_lr": "initial_lr",
+                    "end_lr": "max_lr",
+                    "start_momentum": "max_momentum",
+                    "end_momentum": "base_momentum",
+                },
+                {
+                    "start_step": float(pct_start * self.total_steps) - 1,
+                    "end_step": self.total_steps - 1,
+                    "start_lr": "max_lr",
+                    "end_lr": "min_lr",
+                    "start_momentum": "base_momentum",
+                    "end_momentum": "max_momentum",
+                },
+            ]
+
+        max_lrs = self._format_param('max_lr', self.optimizer, max_lr)
+        if last_step == -1:
+            for idx, group in enumerate(self.optimizer.param_groups):
+                group['initial_lr'] = max_lrs[idx] / div_factor
+                group['max_lr'] = max_lrs[idx]
+                group['min_lr'] = group['initial_lr'] / final_div_factor
+
+        # Initialize momentum variables
+        self.cycle_momentum = cycle_momentum
+        if self.cycle_momentum:
+            if 'momentum' not in self.optimizer._default_options and 'betas' not in self.optimizer._default_options:
+                raise ValueError('optimizer must support momentum with `cycle_momentum` option enabled')
+            self.use_beta1 = 'betas' in self.optimizer._default_options
+            max_momentums = self._format_param('max_momentum', optimizer, max_momentum)
+            base_momentums = self._format_param('base_momentum', optimizer, base_momentum)
+            if last_step == -1:
+                for m_momentum, b_momentum, group in zip(max_momentums, base_momentums, optimizer.param_groups):
+                    if self.use_beta1:
+                        _, beta2 = group['betas']
+                        group['betas'] = (m_momentum, beta2)
+                    else:
+                        group['momentum'] = m_momentum
+                    group['max_momentum'] = m_momentum
+                    group['base_momentum'] = b_momentum
+        super().__init__(optimizer, last_step, verbose)
+
+    def _format_param(self, name, optimizer, param):
+        """Return correctly formatted lr/momentum for each param group."""
+        if isinstance(param, (list, tuple)):
+            if len(param) != len(optimizer.param_groups):
+                raise ValueError("expected {} values for {}, got {}".format(
+                    len(optimizer.param_groups), name, len(param)))
+            return param
+        else:
+            return [param] * len(optimizer.param_groups)
+            
+    def get_lr(self, base_lr, step):
+        lrs = []
+        for group in self.optimizer.param_groups:
+            for i, phase in enumerate(self._schedule_phases):
+                start_step, end_step = phase['start_step'], phase['end_step']
+                if step <= end_step or i == len(self._schedule_phases) - 1:
+                    pct = (step - start_step) / (end_step - start_step)
+                    computed_lr = self.anneal_func(group[phase['start_lr']], group[phase['end_lr']], pct)
+                    if self.cycle_momentum:
+                        computed_momentum = self.anneal_func(group[phase['start_momentum']], group[phase['end_momentum']], pct)
+                    break
+
+            lrs.append(computed_lr)
+            if self.cycle_momentum:
+                if self.use_beta1:
+                    _, beta2 = group['betas']
+                    group['betas'] = (computed_momentum, beta2)
+                else:
+                    group['momentum'] = computed_momentum
+            
+        return lrs
+    
+    def step(self):
+        self.last_step += 1
+        lrs = self.get_lr(None, self.last_step)
+        self.update_lrs(lrs)
+
+    def _generate_conf_for_graph(self, lr_conf):
+        pass

--- a/python/oneflow/optim/lr_scheduler.py
+++ b/python/oneflow/optim/lr_scheduler.py
@@ -31,3 +31,4 @@ from oneflow.nn.optimizer.cosine_annealing_warm_restarts import (
 )
 from oneflow.nn.optimizer.chained_scheduler import ChainedScheduler
 from oneflow.nn.optimizer.sequential_lr import SequentialLR
+from oneflow.nn.optimizer.cyclic_lr import CyclicLR

--- a/python/oneflow/optim/lr_scheduler.py
+++ b/python/oneflow/optim/lr_scheduler.py
@@ -32,3 +32,4 @@ from oneflow.nn.optimizer.cosine_annealing_warm_restarts import (
 from oneflow.nn.optimizer.chained_scheduler import ChainedScheduler
 from oneflow.nn.optimizer.sequential_lr import SequentialLR
 from oneflow.nn.optimizer.cyclic_lr import CyclicLR
+from oneflow.nn.optimizer.onecycle_lr import OneCycleLR

--- a/python/oneflow/test/modules/test_lr_scheduler.py
+++ b/python/oneflow/test/modules/test_lr_scheduler.py
@@ -926,6 +926,7 @@ class CyclicLRTestCase(flow.unittest.TestCase):
             max_momentum=[random.random() / 2 + 0.5 for _ in range(num_models)],
         )
 
+
 def _test_onecycle_lr_scheduler(test_case, *args, **kwargs):
     num_iters = kwargs.get("num_iters", 10000)
     kwargs.pop("num_iters", None)
@@ -959,21 +960,42 @@ def _test_onecycle_lr_scheduler(test_case, *args, **kwargs):
         f"\ntorch_lrs: {torch_lrs}\nvs.\ncalculated lrs: {of_lrs}",
     )
 
+
 @flow.unittest.skip_unless_1n1d()
 class OneCycleLRTestCase(flow.unittest.TestCase):
     @autotest(n=10, check_graph=False)
     def test_default(test_case):
         num_models = random.randint(1, 5)
-        num_iters=random.randint(0, 10000)
+        num_iters = random.randint(0, 10000)
         _test_onecycle_lr_scheduler(
             test_case,
             num_models=num_models,
             num_iters=num_iters,
             max_lr=0.1,
             total_steps=num_iters,
+            pct_start=random.random() * 0.8 + 0.1,  # [0.1, 0.9]
+            anneal_strategy=random.choice(["cos", "linear"]),
+            div_factor=random.random() * 99 + 1,  # [1.0, 100.0]
+            final_div_factor=random.random() * 999 + 1,  # [1.0, 1000.0]
+            three_phase=random.choice([True, False]),
         )
 
-    
+    @autotest(n=10, check_graph=False)
+    def test_multi_max_lr(test_case):
+        num_models = random.randint(1, 5)
+        num_iters = random.randint(0, 10000)
+        _test_onecycle_lr_scheduler(
+            test_case,
+            num_models=num_models,
+            num_iters=num_iters,
+            max_lr=[random.random() for _ in range(num_models)],
+            total_steps=num_iters,
+            pct_start=random.random() * 0.8 + 0.1,  # [0.1, 0.9]
+            anneal_strategy=random.choice(["cos", "linear"]),
+            div_factor=random.random() * 99 + 1,  # [1.0, 100.0]
+            final_div_factor=random.random() * 999 + 1,  # [1.0, 1000.0]
+            three_phase=random.choice([True, False]),
+        )
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_lr_scheduler.py
+++ b/python/oneflow/test/modules/test_lr_scheduler.py
@@ -849,7 +849,7 @@ def _test_cyclic_lr_scheduler(test_case, *args, **kwargs):
     # oneflow
     models = [flow.nn.Linear(3, 3) for _ in range(num_models)]
     optimizer = flow.optim.SGD(
-        [{"params": x.parameters()} for x in models], lr=0.1, momentum=0.9
+        [{"params": x.parameters()} for x in models], lr=100, momentum=0.9
     )
     sch = flow.optim.lr_scheduler.CyclicLR(optimizer, **kwargs)
     of_lrs = [sch.get_last_lr()[0]]
@@ -860,7 +860,7 @@ def _test_cyclic_lr_scheduler(test_case, *args, **kwargs):
     # torch
     models = [torch.nn.Linear(3, 3) for _ in range(num_models)]
     optimizer = torch.optim.SGD(
-        [{"params": x.parameters()} for x in models], lr=0.1, momentum=0.9
+        [{"params": x.parameters()} for x in models], lr=100, momentum=0.9
     )
     sch = torch.optim.lr_scheduler.CyclicLR(optimizer, **kwargs)
     torch_lrs = [sch.get_last_lr()[0]]
@@ -876,7 +876,7 @@ def _test_cyclic_lr_scheduler(test_case, *args, **kwargs):
 
 @flow.unittest.skip_unless_1n1d()
 class CyclicLRTestCase(flow.unittest.TestCase):
-    @autotest(n=100, check_graph=False)
+    @autotest(n=10, check_graph=False)
     def test_default(test_case):
         _test_cyclic_lr_scheduler(
             test_case,
@@ -891,8 +891,8 @@ class CyclicLRTestCase(flow.unittest.TestCase):
             base_momentum=random.random() / 10,
             max_momentum=random.random() / 2 + 0.5,
         )
-    
-    @autotest(n=100, check_graph=False)
+
+    @autotest(n=10, check_graph=False)
     def test_gamma(test_case):
         _test_cyclic_lr_scheduler(
             test_case,
@@ -909,24 +909,71 @@ class CyclicLRTestCase(flow.unittest.TestCase):
             max_momentum=random.random() / 2 + 0.5,
         )
 
-    # @autotest(n=100, check_graph=False)
-    # def test_multi_lr(test_case):
-    #     num_models = random.randint(1, 5)
-    #     _test_cyclic_lr_scheduler(
-    #         test_case,
-    #         num_iters=10,
-    #         num_models=num_models,
-    #         base_lr=[random.random() / 10 for _ in range(num_models)],
-    #         max_lr=[random.random() / 2 + 0.5 for _ in range(num_models)],
-    #         step_size_up=random.randint(10, 2000),
-    #         step_size_down=random.randint(10, 2000),
-    #         mode=random.choice(["triangular", "triangular2", "exp_range"]),
-    #         cycle_momentum=random.choice([True, False]),
-    #         base_momentum=[random.random() / 10 for _ in range(num_models)],
-    #         max_momentum=[random.random() / 2 + 0.5 for _ in range(num_models)],
-    #     )
+    @autotest(n=10, check_graph=False)
+    def test_multi_lr(test_case):
+        num_models = random.randint(1, 5)
+        _test_cyclic_lr_scheduler(
+            test_case,
+            num_iters=10,
+            num_models=num_models,
+            base_lr=[random.random() / 10 for _ in range(num_models)],
+            max_lr=[random.random() / 2 + 0.5 for _ in range(num_models)],
+            step_size_up=random.randint(10, 2000),
+            step_size_down=random.randint(10, 2000),
+            mode=random.choice(["triangular", "triangular2", "exp_range"]),
+            cycle_momentum=random.choice([True, False]),
+            base_momentum=[random.random() / 10 for _ in range(num_models)],
+            max_momentum=[random.random() / 2 + 0.5 for _ in range(num_models)],
+        )
 
+def _test_onecycle_lr_scheduler(test_case, *args, **kwargs):
+    num_iters = kwargs.get("num_iters", 10000)
+    kwargs.pop("num_iters", None)
+    num_models = kwargs.get("num_models", 1)
+    kwargs.pop("num_models", None)
 
+    # oneflow
+    models = [flow.nn.Linear(3, 3) for _ in range(num_models)]
+    optimizer = flow.optim.SGD(
+        [{"params": x.parameters()} for x in models], lr=100, momentum=0.9
+    )
+    sch = flow.optim.lr_scheduler.OneCycleLR(optimizer, **kwargs)
+    of_lrs = [sch.get_last_lr()[0]]
+    for _ in range(num_iters):
+        sch.step()
+        of_lrs.append(sch.get_last_lr()[0])
+
+    # torch
+    models = [torch.nn.Linear(3, 3) for _ in range(num_models)]
+    optimizer = torch.optim.SGD(
+        [{"params": x.parameters()} for x in models], lr=100, momentum=0.9
+    )
+    sch = torch.optim.lr_scheduler.OneCycleLR(optimizer, **kwargs)
+    torch_lrs = [sch.get_last_lr()[0]]
+    for _ in range(num_iters):
+        sch.step()
+        torch_lrs.append(sch.get_last_lr()[0])
+
+    test_case.assertTrue(
+        np.allclose(of_lrs, torch_lrs),
+        f"\ntorch_lrs: {torch_lrs}\nvs.\ncalculated lrs: {of_lrs}",
+    )
+
+@flow.unittest.skip_unless_1n1d()
+class OneCycleLRTestCase(flow.unittest.TestCase):
+    @autotest(n=10, check_graph=False)
+    def test_default(test_case):
+        num_models = random.randint(1, 5)
+        num_iters=random.randint(0, 10000)
+        _test_onecycle_lr_scheduler(
+            test_case,
+            num_models=num_models,
+            num_iters=num_iters,
+            max_lr=0.1,
+            total_steps=num_iters,
+        )
+
+    
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

背景：espnet2需求
概述：增加了缺失的两个 Learning Rate Scheduler：Cyclic LR 和 OneCycle LR
注意事项：
在 torch 中，这两个 scheduler 有如下特点：
- 输入有 `lr` 和 `momentum` 相关参数，会在构造函数中覆盖掉 `optimizer.param_group` 的状态，比如 `momentum`、`initial_lr`等
- 输入 `lr` 时，支持输入 list，该 list 和 optimizer 的 `param_groups` 长度相同，相当于为每一个 `optimizer.param_groups` “定制”一个 `lr`，然后在 `get_lr()` 时会把输入的 lr list 和 `optimizer.param_groups` 用 `zip()` 合在一起，遍历所有 `optimizer.param_groups` ，返回一个等长的 lr list
- 支持在 step 时更新 optimizer 的 `momentum`

这些特点导致的后果是：

- 上面第一点的问题是，模型 resume 可能会受到影响
- 上面第二点的问题是，oneflow 的设计是 `get_lr()` 只能计算一个 lr 值，在父类的 `step` 函数中遍历 `optimizer.param_groups` 来更新 lr。这里为了支持输入 lr list，只能在子类中重写 `step` 函数来覆盖父类的 `step` 。
- 上面第三点的问题是，请教文骁之后，得知 oneflow 的 scheduler 在 graph 中，是不能拿到和修改 optimizer 的状态的。所以这两个 scheduler 在 graph 模式下，不支持动态修改 optimizer 的 `momentum`，这里在 `_generate_conf_for_graph` 中加了对应判断和抛出异常。