### PR TITLE
fix like op infer dtype

### DIFF
--- a/oneflow/user/ops/broadcast_like_op.cpp
+++ b/oneflow/user/ops/broadcast_like_op.cpp
@@ -120,7 +120,7 @@ Maybe<void> InferTensorDesc(user_op::InferContext* ctx) {
 }
 
 /* static */ Maybe<void> BroadcastLikeOp::InferDataType(user_op::InferContext* ctx) {
-  ctx->SetOutputDType("y", 0, ctx->InputDType("like", 0));
+  ctx->SetOutputDType("y", 0, ctx->InputDType("x", 0));
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/reduce_like_ops.cpp
+++ b/oneflow/user/ops/reduce_like_ops.cpp
@@ -84,11 +84,7 @@ namespace oneflow {
   return InferLogicalTensorDesc(ctx);
 }
 /*static*/ Maybe<void> ReduceSumLikeOp::InferDataType(user_op::InferContext* ctx) {
-  const user_op::TensorDesc& x_tensor = ctx->InputTensorDesc("x", 0);
-  const user_op::TensorDesc& like_tensor = ctx->InputTensorDesc("like", 0);
-  CHECK_EQ_OR_RETURN(x_tensor.data_type(), like_tensor.data_type())
-      << Error::TypeError() << "Tensors x and like must have the same type";
-  ctx->SetOutputDType("y", 0, like_tensor.data_type());
+  ctx->SetOutputDType("y", 0, ctx->InputDType("x", 0));
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> ReduceSumLikeOp::ModifyInputArg(

--- a/oneflow/user/ops/unsorted_segment_sum_op.cpp
+++ b/oneflow/user/ops/unsorted_segment_sum_op.cpp
@@ -156,7 +156,7 @@ namespace oneflow {
   const user_op::TensorDesc& like = ctx->InputTensorDesc("like", 0);
   CHECK_EQ_OR_RETURN(data.data_type(), like.data_type());
   CHECK_OR_RETURN(IsIndexDataType(ctx->InputDType("segment_ids", 0)));
-  ctx->SetOutputDType("out", 0, ctx->InputDType("like", 0));
+  ctx->SetOutputDType("out", 0, ctx->InputDType("data", 0));
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> UnsortedSegmentSumLikeOp::ModifyInputArg(


### PR DESCRIPTION
修复like类op类型推导，out的dtype应该等于in的dtype而不是like的dtype