### PR TITLE
fix_global_tensor_detach_bug

### DIFF
--- a/oneflow/core/framework/tensor_impl.h
+++ b/oneflow/core/framework/tensor_impl.h
@@ -333,8 +333,8 @@ class EagerGlobalTensorImpl final : public GlobalTensorImpl {
   Maybe<GlobalTensorImpl> detach() const override;
 
  private:
-  EagerGlobalTensorImpl(Symbol<GlobalTensorMeta> global_tensor_meta, bool requires_grad,
-                        bool is_leaf, const std::shared_ptr<LocalTensor>& cur_rank_phy_tensor);
+  EagerGlobalTensorImpl(Symbol<GlobalTensorMeta> global_tensor_meta,
+                        const std::shared_ptr<LocalTensor>& cur_rank_phy_tensor);
 
   std::shared_ptr<LocalTensor> cur_rank_phy_tensor_;
 };

--- a/python/oneflow/test/tensor/test_tensor_part_2.py
+++ b/python/oneflow/test/tensor/test_tensor_part_2.py
@@ -1056,11 +1056,11 @@ class TestTensorNumpy(flow.unittest.TestCase):
         return z
 
     @flow.unittest.skip_unless_1n2d()
-    @autotest(n=5)
+    @globaltest
     def test_global_tensor_detach(test_case):
-        device = random_device()
+        device = random_device().value()
         placement = flow.placement(device, [0, 1])
-        a = flow.ones(2, 3).to_global(placement, flow.sbp.broadcast)
+        a = flow.ones(4, 8).to_global(placement, flow.sbp.broadcast)
         test_case.assertTrue(a.is_leaf)
         b = a.float().clone().detach()
         test_case.assertTrue(b.is_leaf)

--- a/python/oneflow/test/tensor/test_tensor_part_2.py
+++ b/python/oneflow/test/tensor/test_tensor_part_2.py
@@ -1055,6 +1055,16 @@ class TestTensorNumpy(flow.unittest.TestCase):
         z = x.repeat_interleave(y, 1, output_size=2)
         return z
 
+    @flow.unittest.skip_unless_1n2d()
+    @autotest(n=5)
+    def test_global_tensor_detach(test_case):
+        device = random_device()
+        placement = flow.placement(device, [0, 1])
+        a = flow.ones(2, 3).to_global(placement, flow.sbp.broadcast)
+        test_case.assertTrue(a.is_leaf)
+        b = a.float().clone().detach()
+        test_case.assertTrue(b.is_leaf)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
修复 https://github.com/Oneflow-Inc/oneflow/issues/9130 中的错误

```python
cuda_placement = flow.placement("cuda", [0, 1])
cpu_placement = flow.placement("cpu", [0, 1])
B = flow.sbp.broadcast

a = flow.ones(2, 3).to_global(cuda_placement, B)  # cuda placement/cpu placement 都能复现问题
if flow.env.get_rank() == 0:
    print(f"{a.is_leaf=}")  # True

b = a.float().clone().detach()
if flow.env.get_rank() == 0:
    print(f"{b.is_leaf=}")  # False but expect True
```