### PR TITLE
Feat full auto parallel

### DIFF
--- a/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
@@ -36,6 +36,7 @@ limitations under the License.
 #include "oneflow/core/framework/tensor_tuple.h"
 #include "oneflow/core/framework/user_op_registry.h"
 #include "oneflow/core/framework/nd_sbp.h"
+#include "oneflow/core/job/job_desc.h"
 #include "oneflow/core/job/lazy_mode.h"
 #include "oneflow/core/operator/operator.h"
 #include "oneflow/core/job/sbp_parallel.h"
@@ -104,10 +105,12 @@ Maybe<void> CheckTensorMatchAttr(const std::shared_ptr<Tensor>& tensor,
     auto nd_sbp_it = nd_sbp_sign_map.find(bn_in_op);
     CHECK_OR_RETURN(nd_sbp_it != nd_sbp_sign_map.end())
         << "nd_sbp of " << bn_in_op << " not found in op " << op_attribute.op_conf().name();
-    NdSbp nd_sbp(nd_sbp_it->second);
-    CHECK_OR_RETURN(JUST(tensor->nd_sbp()) == SymbolOf(nd_sbp))
-        << "The input sbp is not valid for an inplace operation, please try to use non-inplace. "
-        << NdSbpToString(JUST(tensor->nd_sbp())) << " vs " << NdSbpToString(nd_sbp);
+    if (!GlobalJobDesc().enable_auto_parallel()) {
+      NdSbp nd_sbp(nd_sbp_it->second);
+      CHECK_OR_RETURN(JUST(tensor->nd_sbp()) == SymbolOf(nd_sbp))
+          << "The input sbp is not valid for an inplace operation, please try to use non-inplace. "
+          << NdSbpToString(JUST(tensor->nd_sbp())) << " vs " << NdSbpToString(nd_sbp);
+    }
     CHECK_OR_RETURN(JUST(tensor->parallel_desc())  // NOLINT(maybe-need-error-msg)
                     == SymbolOf(*parallel_desc));  // NOLINT(maybe-need-error-msg)
   }

--- a/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
@@ -105,6 +105,9 @@ Maybe<void> CheckTensorMatchAttr(const std::shared_ptr<Tensor>& tensor,
     auto nd_sbp_it = nd_sbp_sign_map.find(bn_in_op);
     CHECK_OR_RETURN(nd_sbp_it != nd_sbp_sign_map.end())
         << "nd_sbp of " << bn_in_op << " not found in op " << op_attribute.op_conf().name();
+    // Only check the nd_sbp if auto parallel is not enable,
+    // since the semi-auto parallellism rule might have inconsistency with the auto-parallel
+    // strategy.
     if (!GlobalJobDesc().enable_auto_parallel()) {
       NdSbp nd_sbp(nd_sbp_it->second);
       CHECK_OR_RETURN(JUST(tensor->nd_sbp()) == SymbolOf(nd_sbp))

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -562,10 +562,10 @@ Maybe<OpAttribute> JobBuildAndInferCtx::AddAndInferOp(const OperatorConf& op_con
 
   // infer nd_sbp signature
   NdSbpSignature nd_sbp_sig_conf;
-  if (!job_desc->enable_auto_parallel()) {
-    nd_sbp_sig_conf = *JUST(InitConstraitNdSbpSignature(*op, ibn2disable_boxing));
-  } else {
+  if (job_desc->enable_auto_parallel()) {
     InitBroadcastNdSbpSignature(&nd_sbp_sig_conf, ibn2disable_boxing);
+  } else {
+    nd_sbp_sig_conf = *JUST(InitConstraitNdSbpSignature(*op, ibn2disable_boxing));
   }
   // Override constrait nd_sbp if sbp hint is given
   if (!sbp_sig_conf.bn_in_op2sbp_parallel().empty()) {

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -550,6 +550,8 @@ Maybe<OpAttribute> JobBuildAndInferCtx::AddAndInferOp(const OperatorConf& op_con
 
   // infer nd_sbp signature
   NdSbpSignature nd_sbp_sig_conf;
+  // Only infer nd_sbp signature if auto parallel is not enable,
+  // since the semi-auto parallellism rule might have inconsistency with the auto-parallel strategy.
   if (!job_desc->enable_auto_parallel()) {
     nd_sbp_sig_conf = *JUST(InitConstraitNdSbpSignature(*op, ibn2disable_boxing));
   }

--- a/oneflow/core/job/job_desc.h
+++ b/oneflow/core/job/job_desc.h
@@ -60,6 +60,7 @@ class JobDesc final {
   bool prune_parallel_cast_ops() const { return job_conf_.prune_parallel_cast_ops(); }
   bool prune_cast_to_static_shape_ops() const { return job_conf_.prune_cast_to_static_shape_ops(); }
   bool prune_amp_white_identity_ops() const { return job_conf_.prune_amp_white_identity_ops(); }
+  bool enable_auto_parallel() const { return job_conf_.enable_auto_parallel(); }
   int64_t cudnn_buf_limit_mbyte() const { return job_conf_.cudnn_buf_limit_mbyte(); }
 
 #define DEFINE_FUNCTION_CONFIG_GETTER(T, func_name, field_name) \


### PR DESCRIPTION
Use B for inplace op and remove the check for sbp while turning the auto parallelism on.

## 问题背景
我们在测试Alexnet打开自动并行以后，发现2卡的情形能过4卡过不了。
这个Alexnet原本是单卡的script，我们拿来直接用到2卡，发现能丝滑地跑过。
但是放到4卡上就不行了。为什么呢？
原来是training跑过了，在evaluation的时候由于training给的参数是S1的，导致一个矩阵乘给出的输出是P，然后半自动推导往下传到了一个inplace relu 的op上（这时候还没有跑到自动并行），然而这个inplace relu op既不接受P也不允许boxing，所以导致了出错。

单单训练或者evalutation都是没问题的，因为初始的推导是按照用户配置来的，如果出了问题就说明用户配的不对。
但是现在是2个job加一起，第二个job受到了第一个job的影响。
如果不开自动并行没问题（单机的code，SBP全是B，没有任何问题），但是开了自动并行就挂，这肯定不行。

## 修复尝试
第一次修复尝试，如果打开了自动并行，给这些inplace op都推成B。
结果是推导的时候确实没问题，但是推导完成了在lazy_op_interpreter的一个检查报了错。
第二次修复尝试，如果打开自动并行，就把检查SBP的部分去掉
因为反正自动并行后面会把sbp 弄好的，在早期的检查没有意义。

## 结果
跑通了
并且在AlexNet跟libai的bert测试了加上这一段代码前后推导的SBP有无区别： 答案是没有区别，完全一样，不会在非全自动时吃掉用户配置的SBP，可以放心食用。

所以即使用户瞎配SBP，只要打开了自动并行，一样能搜，不会说前面就给你报错了。
更有甚者，只要打开了全自动，肯定给你找出个结果来。