### PR TITLE
tensor.copy_ support stride

### DIFF
--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -304,7 +304,8 @@ def _copy(self, other: Union[Tensor, np.ndarray]):
                 other = flow._C.broadcast_like(other, self)
                 if not self.is_contiguous():
                     # NOTE: slice_update support non-contiguous input tensor
-                    self[...] = other
+                    with flow.no_grad:
+                        self[...] = other
                 else:
                     flow._C.assign_local_tensor(self, other)
                 return

--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -302,7 +302,11 @@ def _copy(self, other: Union[Tensor, np.ndarray]):
             ), "Only local tensor can be assigned to local tensor."
             if self.device == other.device:
                 other = flow._C.broadcast_like(other, self)
-                flow._C.assign_local_tensor(self, other)
+                if not self.is_contiguous():
+                    # NOTE: slice_update support non-contiguous input tensor
+                    self[...] = other
+                else:
+                    flow._C.assign_local_tensor(self, other)
                 return
 
     # Possibility 2: `other` is a numpy array, or `self` and `other` are tensors on different devices/placements.

--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -323,8 +323,13 @@ def _copy(self, other: Union[Tensor, np.ndarray]):
                 other = flow._C.broadcast_like(other, self)
                 if not self.is_contiguous():
                     # NOTE: slice_update support non-contiguous input tensor
-                    with flow.no_grad:
+                    with flow.no_grad():
                         self[...] = other
+                    # requires_grad = self.requires_grad
+                    # if requires_grad:
+                    #     self.requires_grad=False
+                    # self[...] = other
+                    # self.requires_grad = requires_grad
                 else:
                     flow._C.assign_local_tensor(self, other)
                 return

--- a/python/oneflow/framework/tensor.py
+++ b/python/oneflow/framework/tensor.py
@@ -325,11 +325,6 @@ def _copy(self, other: Union[Tensor, np.ndarray]):
                     # NOTE: slice_update support non-contiguous input tensor
                     with flow.no_grad():
                         self[...] = other
-                    # requires_grad = self.requires_grad
-                    # if requires_grad:
-                    #     self.requires_grad=False
-                    # self[...] = other
-                    # self.requires_grad = requires_grad
                 else:
                     flow._C.assign_local_tensor(self, other)
                 return

--- a/python/oneflow/test/modules/test_copy.py
+++ b/python/oneflow/test/modules/test_copy.py
@@ -36,13 +36,22 @@ class Test_Copy_module(flow.unittest.TestCase):
         flow_base_grid[..., 0].copy_(flow_x_grid)
         test_case.assertTrue(np.allclose(torch_base_grid.numpy(), flow_base_grid.numpy()))
     
-    def test_non_contiguous_tensor_copy(test_case):
+    def test_non_contiguous_sliced_tensor_copy(test_case):
         torch_tensor = torch.arange(24, dtype=torch.float32).reshape(1,2,3,4)
         flow_tensor = flow.arange(24, dtype=flow.float32).reshape(1,2,3,4)
         torch_copy = torch.tensor([3.1415])
         flow_copy = flow.tensor([3.1415])
         torch_tensor[:,1:2,1:2,::2].copy_(torch_copy)
         flow_tensor[:,1:2,1:2,::2].copy_(flow_copy)
+        test_case.assertTrue(np.allclose(flow_tensor.numpy(), torch_tensor.numpy()))
+    
+    def test_non_contiguous_permuted_tensor_copy(test_case):
+        torch_tensor = torch.arange(24, dtype=torch.float32).reshape(1,2,3,4)
+        flow_tensor = flow.arange(24, dtype=flow.float32).reshape(1,2,3,4)
+        torch_copy = torch.tensor([3.1415])
+        flow_copy = flow.tensor([3.1415])
+        torch_tensor.permute(0, 2, 1, 3).copy_(torch_copy)
+        flow_tensor.permute(0, 2, 1, 3).copy_(flow_copy)
         test_case.assertTrue(np.allclose(flow_tensor.numpy(), torch_tensor.numpy()))
 
 

--- a/python/oneflow/test/modules/test_copy.py
+++ b/python/oneflow/test/modules/test_copy.py
@@ -33,9 +33,17 @@ class Test_Copy_module(flow.unittest.TestCase):
         torch_x_grid = ori_torch.ones(2)
         flow_x_grid = flow.ones(2)
         torch_base_grid[..., 0].copy_(torch_x_grid)
-        # TODO: copy op not support non-contiguous input tensor
-        flow_base_grid[..., 0].contiguous().copy_(flow_x_grid)
-        test_case.assertTrue(np.allclose(torch_base_grid.size(), flow_base_grid.size()))
+        flow_base_grid[..., 0].copy_(flow_x_grid)
+        test_case.assertTrue(np.allclose(torch_base_grid.numpy(), flow_base_grid.numpy()))
+    
+    def test_non_contiguous_tensor_copy(test_case):
+        torch_tensor = torch.arange(24, dtype=torch.float32).reshape(1,2,3,4)
+        flow_tensor = flow.arange(24, dtype=flow.float32).reshape(1,2,3,4)
+        torch_copy = torch.tensor([3.1415])
+        flow_copy = flow.tensor([3.1415])
+        torch_tensor[:,1:2,1:2,::2].copy_(torch_copy)
+        flow_tensor[:,1:2,1:2,::2].copy_(flow_copy)
+        test_case.assertTrue(np.allclose(flow_tensor.numpy(), torch_tensor.numpy()))
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_copy.py
+++ b/python/oneflow/test/modules/test_copy.py
@@ -34,20 +34,22 @@ class Test_Copy_module(flow.unittest.TestCase):
         flow_x_grid = flow.ones(2)
         torch_base_grid[..., 0].copy_(torch_x_grid)
         flow_base_grid[..., 0].copy_(flow_x_grid)
-        test_case.assertTrue(np.allclose(torch_base_grid.numpy(), flow_base_grid.numpy()))
-    
+        test_case.assertTrue(
+            np.allclose(torch_base_grid.numpy(), flow_base_grid.numpy())
+        )
+
     def test_non_contiguous_sliced_tensor_copy(test_case):
-        torch_tensor = torch.arange(24, dtype=torch.float32).reshape(1,2,3,4)
-        flow_tensor = flow.arange(24, dtype=flow.float32).reshape(1,2,3,4)
+        torch_tensor = torch.arange(24, dtype=torch.float32).reshape(1, 2, 3, 4)
+        flow_tensor = flow.arange(24, dtype=flow.float32).reshape(1, 2, 3, 4)
         torch_copy = torch.tensor([3.1415])
         flow_copy = flow.tensor([3.1415])
-        torch_tensor[:,1:2,1:2,::2].copy_(torch_copy)
-        flow_tensor[:,1:2,1:2,::2].copy_(flow_copy)
+        torch_tensor[:, 1:2, 1:2, ::2].copy_(torch_copy)
+        flow_tensor[:, 1:2, 1:2, ::2].copy_(flow_copy)
         test_case.assertTrue(np.allclose(flow_tensor.numpy(), torch_tensor.numpy()))
-    
+
     def test_non_contiguous_permuted_tensor_copy(test_case):
-        torch_tensor = torch.arange(24, dtype=torch.float32).reshape(1,2,3,4)
-        flow_tensor = flow.arange(24, dtype=flow.float32).reshape(1,2,3,4)
+        torch_tensor = torch.arange(24, dtype=torch.float32).reshape(1, 2, 3, 4)
+        flow_tensor = flow.arange(24, dtype=flow.float32).reshape(1, 2, 3, 4)
         torch_copy = torch.tensor([3.1415])
         flow_copy = flow.tensor([3.1415])
         torch_tensor.permute(0, 2, 1, 3).copy_(torch_copy)


### PR DESCRIPTION
- [x] fix tensor.copy_不支持non-contiguous tensor的bug，需求来源：https://github.com/Oneflow-Inc/OneCloud/issues/147#issuecomment-1194207285