### PR TITLE
fix_ctc_loss_error_with_float_target_input

### DIFF
--- a/oneflow/core/autograd/gradient_funcs/ctc_loss.cpp
+++ b/oneflow/core/autograd/gradient_funcs/ctc_loss.cpp
@@ -57,7 +57,7 @@ Maybe<void> CTCLoss::Capture(CTCLossCaptureState* ctx, const TensorTuple& inputs
 
   ComposedAttrMap composed_attrs(attrs, base_attrs_);
   ctx->max_target_length = JUST(composed_attrs.GetAttr<int64_t>("max_target_length"));
-  ctx->blank = JUST(composed_attrs.GetAttr<int32_t>("blank"));
+  ctx->blank = JUST(composed_attrs.GetAttr<int64_t>("blank"));
   ctx->zero_infinity = JUST(composed_attrs.GetAttr<bool>("zero_infinity"));
 
   CHECK_EQ_OR_RETURN(inputs.size(), 4);       // NOLINT(maybe-need-error-msg)

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -1229,7 +1229,7 @@
   bind_python: True
 
 - name: "ctc_loss"
-  signature: "Tensor (Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, Int64 max_target_length, Int32 blank, Bool zero_infinity, String reduction) => CtcLoss"
+  signature: "Tensor (Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, Int64 max_target_length, Int64 blank, Bool zero_infinity, String reduction) => CtcLoss"
   bind_python: True
 
 - name: "affine_grid"
@@ -1342,7 +1342,7 @@
 
 - name: "ctc_loss_grad"
   signature: "Tensor (Tensor loss_grad, Tensor log_probs, Tensor targets,
-    Tensor input_lengths, Tensor target_lengths, Tensor loss, Tensor alpha, Int32 blank, Bool zero_infinity, Int64 max_target_length) => CtcLossGrad"
+    Tensor input_lengths, Tensor target_lengths, Tensor loss, Tensor alpha, Int64 blank, Bool zero_infinity, Int64 max_target_length) => CtcLossGrad"
   bind_python: False
 
 - name: "adaptive_avg_pool1d"

--- a/oneflow/core/functional/impl/nn_grad_functor.cpp
+++ b/oneflow/core/functional/impl/nn_grad_functor.cpp
@@ -726,10 +726,20 @@ class CtcLossGradFunctor {
                            const std::shared_ptr<one::Tensor>& input_lengths,
                            const std::shared_ptr<one::Tensor>& target_lengths,
                            const std::shared_ptr<one::Tensor>& loss,
-                           const std::shared_ptr<one::Tensor>& alpha, const int32_t& blank,
+                           const std::shared_ptr<one::Tensor>& alpha, const int64_t& blank,
                            const bool& zero_infinity, const int64_t& max_target_length) const {
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("blank", "zero_infinity", "max_target_length");
     attrs.SetAllAttrs(blank, zero_infinity, max_target_length);
+    if (targets->dtype()->data_type() == DataType::kInt32) {
+      return OpInterpUtil::Dispatch<one::Tensor>(
+          *op_, {grad_out, log_probs, targets, input_lengths, target_lengths, loss, alpha}, attrs);
+    } else {
+      return OpInterpUtil::Dispatch<one::Tensor>(
+          *op_,
+          {grad_out, log_probs, JUST(functional::Cast(targets, DType::Int64(), false)),
+           input_lengths, target_lengths, loss, alpha},
+          attrs);
+    }
     return OpInterpUtil::Dispatch<one::Tensor>(
         *op_, {grad_out, log_probs, targets, input_lengths, target_lengths, loss, alpha}, attrs);
   }

--- a/oneflow/user/kernels/ctc_loss_kernel.cpp
+++ b/oneflow/user/kernels/ctc_loss_kernel.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 namespace oneflow {
 
-template<DeviceType device_type, typename T, typename IDX>
+template<DeviceType device_type, typename T, typename TARGET, typename IDX>
 class CtcLossKernel final : public user_op::OpKernel {
  public:
   CtcLossKernel() = default;
@@ -34,10 +34,10 @@ class CtcLossKernel final : public user_op::OpKernel {
     user_op::Tensor* alpha = ctx->Tensor4ArgNameAndIndex("alpha", 0);
 
     const T* log_probs_ptr = log_probs->dptr<T>();
-    const int* targets_ptr = targets->dptr<int>();
+    const TARGET* targets_ptr = targets->dptr<TARGET>();
     const IDX* input_lengths_ptr = input_lengths->dptr<IDX>();
     const IDX* target_lengths_ptr = target_lengths->dptr<IDX>();
-    const int32_t blank = ctx->Attr<int32_t>("blank");
+    const int64_t blank = ctx->Attr<int64_t>("blank");
     const int64_t max_input_length = log_probs->shape_view().At(0);
     const int64_t batch_size = log_probs->shape_view().At(1);
     const int64_t num_labels = log_probs->shape_view().At(2);
@@ -49,7 +49,7 @@ class CtcLossKernel final : public user_op::OpKernel {
                                                  2 * max_target_length + 1);
     T* loss_ptr = loss->mut_dptr<T>();
     T* alpha_ptr = alpha->mut_dptr<T>();
-    CtcLossKernelUtil<device_type, T, IDX>::CtcLossForward(
+    CtcLossKernelUtil<device_type, T, TARGET, IDX>::CtcLossForward(
         ctx->stream(), log_probs_ptr, targets_ptr, input_lengths_ptr, target_lengths_ptr, alpha_ptr,
         loss_ptr, input_helper, alpha_helper, batch_size, max_input_length, max_target_length,
         blank, targets_ndim);
@@ -57,18 +57,20 @@ class CtcLossKernel final : public user_op::OpKernel {
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-#define REGISTER_CTC_LOSS_KERNEL(device, dtype, idx_dtype)                                        \
-  REGISTER_USER_KERNEL("ctc_loss")                                                                \
-      .SetCreateFn<CtcLossKernel<device, OF_PP_PAIR_FIRST(dtype), OF_PP_PAIR_FIRST(idx_dtype)>>() \
-      .SetIsMatchedHob(                                                                           \
-          (user_op::HobDeviceType() == device)                                                    \
-          && (user_op::HobDataType("log_probs", 0) == OF_PP_PAIR_SECOND(dtype))                   \
+#define REGISTER_CTC_LOSS_KERNEL(device, dtype, target_type, idx_dtype)                          \
+  REGISTER_USER_KERNEL("ctc_loss")                                                               \
+      .SetCreateFn<CtcLossKernel<device, OF_PP_PAIR_FIRST(dtype), OF_PP_PAIR_FIRST(target_type), \
+                                 OF_PP_PAIR_FIRST(idx_dtype)>>()                                 \
+      .SetIsMatchedHob(                                                                          \
+          (user_op::HobDeviceType() == device)                                                   \
+          && (user_op::HobDataType("log_probs", 0) == OF_PP_PAIR_SECOND(dtype))                  \
+          && (user_op::HobDataType("targets", 0) == OF_PP_PAIR_SECOND(target_type))              \
           && (user_op::HobDataType("input_lengths", 0) == OF_PP_PAIR_SECOND(idx_dtype)));
 
 OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_CTC_LOSS_KERNEL, DEVICE_TYPE_SEQ, FLOATING_DATA_TYPE_SEQ,
-                                 INDEX_DATA_TYPE_SEQ)
+                                 INDEX_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ)
 
-template<DeviceType device_type, typename T, typename IDX>
+template<DeviceType device_type, typename T, typename TARGET, typename IDX>
 class CtcLossGradKernel final : public user_op::OpKernel {
  public:
   CtcLossGradKernel() = default;
@@ -90,10 +92,10 @@ class CtcLossGradKernel final : public user_op::OpKernel {
     const T* loss_ptr = loss->dptr<T>();
     const T* alpha_ptr = alpha->dptr<T>();
     const T* log_probs_ptr = log_probs->dptr<T>();
-    const int* targets_ptr = targets->dptr<int>();
+    const TARGET* targets_ptr = targets->dptr<TARGET>();
     const IDX* input_lengths_ptr = input_lengths->dptr<IDX>();
     const IDX* target_lengths_ptr = target_lengths->dptr<IDX>();
-    const int32_t blank = ctx->Attr<int32_t>("blank");
+    const int64_t blank = ctx->Attr<int64_t>("blank");
     const bool zero_infinity = ctx->Attr<bool>("zero_infinity");
     const int64_t batch_size = log_probs->shape_view().At(1);
     const int64_t num_labels = log_probs->shape_view().At(2);
@@ -106,7 +108,7 @@ class CtcLossGradKernel final : public user_op::OpKernel {
                                                 2 * max_target_length + 1);
     T* grad_ptr = grad->mut_dptr<T>();
     T* beta_ptr = tmp_buffer->mut_dptr<T>();
-    CtcLossKernelUtil<device_type, T, IDX>::CtcLossBackward(
+    CtcLossKernelUtil<device_type, T, TARGET, IDX>::CtcLossBackward(
         ctx->stream(), grad_out_ptr, loss_ptr, alpha_ptr, log_probs_ptr, targets_ptr,
         input_lengths_ptr, target_lengths_ptr, beta_ptr, grad_ptr, input_helper, beta_helper,
         batch_size, max_input_length, max_target_length, num_labels, blank, zero_infinity,
@@ -115,23 +117,25 @@ class CtcLossGradKernel final : public user_op::OpKernel {
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
 };
 
-#define REGISTER_CTC_LOSS_BACKWARD_KERNEL(device, dtype, idx_dtype)                          \
-  REGISTER_USER_KERNEL("ctc_loss_grad")                                                      \
-      .SetCreateFn<                                                                          \
-          CtcLossGradKernel<device, OF_PP_PAIR_FIRST(dtype), OF_PP_PAIR_FIRST(idx_dtype)>>() \
-      .SetIsMatchedHob(                                                                      \
-          (user_op::HobDeviceType() == device)                                               \
-          && (user_op::HobDataType("log_probs", 0) == OF_PP_PAIR_SECOND(dtype))              \
-          && (user_op::HobDataType("input_lengths", 0) == OF_PP_PAIR_SECOND(idx_dtype)))     \
-      .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                                    \
-        const Shape& log_probs_shape = ctx->InputShape("log_probs", 0);                      \
-        const int64_t max_target_length = ctx->Attr<int64_t>("max_target_length");           \
-        int64_t elem_cnt =                                                                   \
-            log_probs_shape.At(1) * log_probs_shape.At(0) * (2 * max_target_length + 1);     \
-        return elem_cnt * sizeof(OF_PP_PAIR_FIRST(dtype));                                   \
+#define REGISTER_CTC_LOSS_BACKWARD_KERNEL(device, dtype, target_type, idx_dtype)            \
+  REGISTER_USER_KERNEL("ctc_loss_grad")                                                     \
+      .SetCreateFn<                                                                         \
+          CtcLossGradKernel<device, OF_PP_PAIR_FIRST(dtype), OF_PP_PAIR_FIRST(target_type), \
+                            OF_PP_PAIR_FIRST(idx_dtype)>>()                                 \
+      .SetIsMatchedHob(                                                                     \
+          (user_op::HobDeviceType() == device)                                              \
+          && (user_op::HobDataType("log_probs", 0) == OF_PP_PAIR_SECOND(dtype))             \
+          && (user_op::HobDataType("targets", 0) == OF_PP_PAIR_SECOND(target_type))         \
+          && (user_op::HobDataType("input_lengths", 0) == OF_PP_PAIR_SECOND(idx_dtype)))    \
+      .SetInferTmpSizeFn([](user_op::InferContext* ctx) {                                   \
+        const Shape& log_probs_shape = ctx->InputShape("log_probs", 0);                     \
+        const int64_t max_target_length = ctx->Attr<int64_t>("max_target_length");          \
+        int64_t elem_cnt =                                                                  \
+            log_probs_shape.At(1) * log_probs_shape.At(0) * (2 * max_target_length + 1);    \
+        return elem_cnt * sizeof(OF_PP_PAIR_FIRST(dtype));                                  \
       });
 
 OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(REGISTER_CTC_LOSS_BACKWARD_KERNEL, DEVICE_TYPE_SEQ,
-                                 FLOATING_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ)
+                                 FLOATING_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ)
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/ctc_loss_kernel_util.cpp
+++ b/oneflow/user/kernels/ctc_loss_kernel_util.cpp
@@ -17,12 +17,12 @@ limitations under the License.
 
 namespace oneflow {
 
-template<typename IDX>
-int get_target_prime(const int* targets_ptr, const IDX* target_lengths_ptr,
-                     int64_t max_target_length, int64_t b, int64_t s, int blank,
-                     const int32_t targets_ndim) {
+template<typename TARGET, typename IDX>
+int64_t get_target_prime(const TARGET* targets_ptr, const IDX* target_lengths_ptr,
+                         int64_t max_target_length, int64_t b, int64_t s, int64_t blank,
+                         const int32_t targets_ndim) {
   if (s % 2 == 0) {
-    return blank;
+    return static_cast<int64_t>(blank);
   } else {
     int64_t idx = 0;
     if (targets_ndim == 1) {
@@ -35,36 +35,36 @@ int get_target_prime(const int* targets_ptr, const IDX* target_lengths_ptr,
   }
 }
 
-template<typename T, typename IDX>
-struct CtcLossKernelUtil<DeviceType::kCPU, T, IDX> final {
-  static void CtcLossForward(ep::Stream* stream, const T* log_probs_ptr, const int* targets_ptr,
+template<typename T, typename TARGET, typename IDX>
+struct CtcLossKernelUtil<DeviceType::kCPU, T, TARGET, IDX> final {
+  static void CtcLossForward(ep::Stream* stream, const T* log_probs_ptr, const TARGET* targets_ptr,
                              const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
                              T* alpha_ptr, T* loss_ptr,
                              NdIndexOffsetHelper<int64_t, 3>& input_helper,
                              NdIndexOffsetHelper<int64_t, 3>& alpha_helper,
                              const int64_t batch_size, const int64_t max_input_length,
-                             const int64_t max_target_length, const int blank,
+                             const int64_t max_target_length, const int64_t blank,
                              const int32_t targets_ndim);
 
   static void CtcLossBackward(ep::Stream* stream, const T* grad_out_ptr, const T* loss_ptr,
-                              const T* alpha_ptr, const T* log_probs_ptr, const int* targets_ptr,
+                              const T* alpha_ptr, const T* log_probs_ptr, const TARGET* targets_ptr,
                               const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
                               T* beta_ptr, T* grad_ptr,
                               NdIndexOffsetHelper<int64_t, 3>& input_helper,
                               NdIndexOffsetHelper<int64_t, 3>& beta_helper,
                               const int64_t batch_size, const int64_t max_input_length,
                               const int64_t max_target_length, const int64_t num_labels,
-                              const int blank, const bool zero_infinity,
+                              const int64_t blank, const bool zero_infinity,
                               const int32_t targets_ndim);
 };
 
-template<typename T, typename IDX>
-void CtcLossKernelUtil<DeviceType::kCPU, T, IDX>::CtcLossForward(
-    ep::Stream* stream, const T* log_probs_ptr, const int* targets_ptr,
+template<typename T, typename TARGET, typename IDX>
+void CtcLossKernelUtil<DeviceType::kCPU, T, TARGET, IDX>::CtcLossForward(
+    ep::Stream* stream, const T* log_probs_ptr, const TARGET* targets_ptr,
     const IDX* input_lengths_ptr, const IDX* target_lengths_ptr, T* alpha_ptr, T* loss_ptr,
     NdIndexOffsetHelper<int64_t, 3>& input_helper, NdIndexOffsetHelper<int64_t, 3>& alpha_helper,
     const int64_t batch_size, const int64_t max_input_length, const int64_t max_target_length,
-    const int blank, const int32_t targets_ndim) {
+    const int64_t blank, const int32_t targets_ndim) {
   constexpr T neginf = -std::numeric_limits<T>::infinity();
   FOR_RANGE(int64_t, b, 0, batch_size) {
     CHECK_GE(max_input_length, input_lengths_ptr[b]);
@@ -78,15 +78,15 @@ void CtcLossKernelUtil<DeviceType::kCPU, T, IDX>::CtcLossForward(
     for (IDX s = 0; s < 2 * target_length + 1; s++) { alpha_ptr[alpha_idx + s] = neginf; }
     alpha_ptr[alpha_idx] = log_probs_ptr[input_helper.NdIndexToOffset(0, b, blank)];
     if (target_length > 0) {
-      int target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b, 1, blank,
-                                    targets_ndim);
+      TARGET target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b, 1,
+                                       blank, targets_ndim);
       alpha_ptr[alpha_idx + 1] = log_probs_ptr[input_helper.NdIndexToOffset(0, b, target)];
     }
 
     for (IDX t = 1; t < input_length; t++) {
       for (IDX s = 0; s < 2 * target_length + 1; s++) {
-        int current_target_prime = get_target_prime(targets_ptr, target_lengths_ptr,
-                                                    max_target_length, b, s, blank, targets_ndim);
+        TARGET current_target_prime = get_target_prime(
+            targets_ptr, target_lengths_ptr, max_target_length, b, s, blank, targets_ndim);
         T la1 = alpha_ptr[alpha_helper.NdIndexToOffset(b, t - 1, s)];
         T la2, la3, lamax = la1;
         if (s > 0) {
@@ -129,14 +129,14 @@ void CtcLossKernelUtil<DeviceType::kCPU, T, IDX>::CtcLossForward(
   }
 }
 
-template<typename T, typename IDX>
-void CtcLossKernelUtil<DeviceType::kCPU, T, IDX>::CtcLossBackward(
+template<typename T, typename TARGET, typename IDX>
+void CtcLossKernelUtil<DeviceType::kCPU, T, TARGET, IDX>::CtcLossBackward(
     ep::Stream* stream, const T* grad_out_ptr, const T* loss_ptr, const T* alpha_ptr,
-    const T* log_probs_ptr, const int* targets_ptr, const IDX* input_lengths_ptr,
+    const T* log_probs_ptr, const TARGET* targets_ptr, const IDX* input_lengths_ptr,
     const IDX* target_lengths_ptr, T* beta_ptr, T* grad_ptr,
     NdIndexOffsetHelper<int64_t, 3>& input_helper, NdIndexOffsetHelper<int64_t, 3>& beta_helper,
     const int64_t batch_size, const int64_t max_input_length, const int64_t max_target_length,
-    const int64_t num_labels, const int blank, const bool zero_infinity,
+    const int64_t num_labels, const int64_t blank, const bool zero_infinity,
     const int32_t targets_ndim) {
   constexpr T neginf = -std::numeric_limits<T>::infinity();
   int64_t elem_cnt = max_input_length * batch_size * num_labels;
@@ -165,8 +165,8 @@ void CtcLossKernelUtil<DeviceType::kCPU, T, IDX>::CtcLossBackward(
           + beta_ptr[beta_helper.NdIndexToOffset(b, input_length - 1, 2 * target_length)];
 
       if (target_length > 0) {
-        int target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b,
-                                      2 * target_length - 1, blank, targets_ndim);
+        TARGET target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b,
+                                         2 * target_length - 1, blank, targets_ndim);
         beta_ptr[beta_helper.NdIndexToOffset(b, input_length - 1, 2 * target_length - 1)] =
             log_probs_ptr[input_helper.NdIndexToOffset(input_length - 1, b, target)];
         grad_ptr[input_helper.NdIndexToOffset(input_length - 1, b, target)] =
@@ -177,8 +177,8 @@ void CtcLossKernelUtil<DeviceType::kCPU, T, IDX>::CtcLossBackward(
 
     for (IDX t = input_length - 2; t >= 0; t--) {
       for (IDX s = 2 * target_length; s >= 0; s--) {
-        int current_target_prime = get_target_prime(targets_ptr, target_lengths_ptr,
-                                                    max_target_length, b, s, blank, targets_ndim);
+        TARGET current_target_prime = get_target_prime(
+            targets_ptr, target_lengths_ptr, max_target_length, b, s, blank, targets_ndim);
         T lb1 = beta_ptr[beta_helper.NdIndexToOffset(b, t + 1, s)];
         T lb2, lb3, lbmax = lb1;
 
@@ -237,12 +237,13 @@ void CtcLossKernelUtil<DeviceType::kCPU, T, IDX>::CtcLossBackward(
 }
 
 #define INSTANTIATE_CTC_LOSS_KERNEL_UTIL_CPU(device_type_v, log_probs_dtype_pair,          \
-                                             input_lengths_dtype_pair)                     \
+                                             targets_dtype_pair, input_lengths_dtype_pair) \
   template struct CtcLossKernelUtil<device_type_v, OF_PP_PAIR_FIRST(log_probs_dtype_pair), \
+                                    OF_PP_PAIR_FIRST(targets_dtype_pair),                  \
                                     OF_PP_PAIR_FIRST(input_lengths_dtype_pair)>;
 
 OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(INSTANTIATE_CTC_LOSS_KERNEL_UTIL_CPU, (DeviceType::kCPU),
-                                 FLOATING_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ)
+                                 FLOATING_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ)
 #undef INSTANTIATE_CTC_LOSS_KERNEL_UTIL_CPU
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/ctc_loss_kernel_util.cpp
+++ b/oneflow/user/kernels/ctc_loss_kernel_util.cpp
@@ -22,7 +22,7 @@ int64_t get_target_prime(const TARGET* targets_ptr, const IDX* target_lengths_pt
                          int64_t max_target_length, int64_t b, int64_t s, int64_t blank,
                          const int32_t targets_ndim) {
   if (s % 2 == 0) {
-    return static_cast<int64_t>(blank);
+    return blank;
   } else {
     int64_t idx = 0;
     if (targets_ndim == 1) {
@@ -31,7 +31,7 @@ int64_t get_target_prime(const TARGET* targets_ptr, const IDX* target_lengths_pt
       idx = b * max_target_length;
     }
     idx += s / 2;
-    return targets_ptr[idx];
+    return static_cast<int64_t>(targets_ptr[idx]);
   }
 }
 

--- a/oneflow/user/kernels/ctc_loss_kernel_util.cu
+++ b/oneflow/user/kernels/ctc_loss_kernel_util.cu
@@ -20,13 +20,14 @@ namespace oneflow {
 
 namespace {
 
-template<typename IDX>
-__device__ __inline__ static int get_target_prime(const int* targets_ptr,
-                                                  const IDX* target_lengths_ptr,
-                                                  int64_t max_target_length, int64_t b, int64_t s,
-                                                  int blank, const int32_t targets_ndim) {
+template<typename TARGET, typename IDX>
+__device__ __inline__ static int64_t get_target_prime(const TARGET* targets_ptr,
+                                                      const IDX* target_lengths_ptr,
+                                                      int64_t max_target_length, int64_t b,
+                                                      int64_t s, int64_t blank,
+                                                      const int32_t targets_ndim) {
   if (s % 2 == 0) {
-    return blank;
+    return static_cast<int64_t>(blank);
   } else {
     int64_t idx = 0;
     if (targets_ndim == 1) {
@@ -39,13 +40,13 @@ __device__ __inline__ static int get_target_prime(const int* targets_ptr,
   }
 }
 
-template<typename T, typename IDX>
-__global__ void CtcLossGpu(const T* log_probs_ptr, const int* targets_ptr,
+template<typename T, typename TARGET, typename IDX>
+__global__ void CtcLossGpu(const T* log_probs_ptr, const TARGET* targets_ptr,
                            const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
                            T* alpha_ptr, T* loss_ptr, NdIndexOffsetHelper<int64_t, 3> input_helper,
                            NdIndexOffsetHelper<int64_t, 3> alpha_helper, const int64_t batch_size,
                            const int64_t max_input_length, const int64_t max_target_length,
-                           const int blank, const int32_t targets_ndim) {
+                           const int64_t blank, const int32_t targets_ndim) {
   constexpr T neginf = -INFINITY;
   const int32_t bid = blockIdx.x;
   const int32_t tid = threadIdx.x;
@@ -66,8 +67,8 @@ __global__ void CtcLossGpu(const T* log_probs_ptr, const int* targets_ptr,
       alpha_ptr[alpha_helper.NdIndexToOffset(b, 0, 0)] =
           log_probs_ptr[input_helper.NdIndexToOffset(0, b, blank)];
       if (target_length > 0) {
-        int target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b, 1,
-                                      blank, targets_ndim);
+        TARGET target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b, 1,
+                                         blank, targets_ndim);
         alpha_ptr[alpha_helper.NdIndexToOffset(b, 0, 1)] =
             log_probs_ptr[input_helper.NdIndexToOffset(0, b, target)];
       }
@@ -75,8 +76,8 @@ __global__ void CtcLossGpu(const T* log_probs_ptr, const int* targets_ptr,
     __syncthreads();
     for (IDX t = 1; t < input_length; t++) {
       for (IDX s = tid; s < 2 * target_length + 1; s += blockDim.x) {
-        int current_target_prime = get_target_prime(targets_ptr, target_lengths_ptr,
-                                                    max_target_length, b, s, blank, targets_ndim);
+        TARGET current_target_prime = get_target_prime(
+            targets_ptr, target_lengths_ptr, max_target_length, b, s, blank, targets_ndim);
         T la1 = alpha_ptr[alpha_helper.NdIndexToOffset(b, t - 1, s)];
         T la2, la3, lamax = la1;
         if (s > 0) {
@@ -121,14 +122,14 @@ __global__ void CtcLossGpu(const T* log_probs_ptr, const int* targets_ptr,
   }
 }
 
-template<typename T, typename IDX>
+template<typename T, typename TARGET, typename IDX>
 __global__ void CtcLossGradGpu(
     const T* grad_out_ptr, const T* loss_ptr, const T* alpha_ptr, const T* log_probs_ptr,
-    const int* targets_ptr, const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
+    const TARGET* targets_ptr, const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
     T* beta_ptr, T* grad_ptr, NdIndexOffsetHelper<int64_t, 3> input_helper,
     NdIndexOffsetHelper<int64_t, 3> beta_helper, const int64_t batch_size,
     const int64_t max_input_length, const int64_t max_target_length, const int64_t num_labels,
-    const int blank, const bool zero_infinity, const int32_t targets_ndim) {
+    const int64_t blank, const bool zero_infinity, const int32_t targets_ndim) {
   constexpr T neginf = -INFINITY;
   const int32_t bid = blockIdx.x;
   const int32_t tid = threadIdx.x;
@@ -155,8 +156,8 @@ __global__ void CtcLossGradGpu(
         beta_ptr[beta_helper.NdIndexToOffset(b, input_length - 1, 2 * target_length)] =
             log_probs_ptr[input_helper.NdIndexToOffset(input_length - 1, b, blank)];
         if (target_length > 0) {
-          int target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b,
-                                        2 * target_length - 1, blank, targets_ndim);
+          TARGET target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b,
+                                           2 * target_length - 1, blank, targets_ndim);
           beta_ptr[beta_helper.NdIndexToOffset(b, input_length - 1, 2 * target_length - 1)] =
               log_probs_ptr[input_helper.NdIndexToOffset(input_length - 1, b, target)];
         }
@@ -165,8 +166,8 @@ __global__ void CtcLossGradGpu(
     }
     for (IDX t = input_length - 2; t >= 0; t--) {
       for (IDX s = tid; s < 2 * target_length + 1; s += blockDim.x) {
-        int current_target_prime = get_target_prime(targets_ptr, target_lengths_ptr,
-                                                    max_target_length, b, s, blank, targets_ndim);
+        TARGET current_target_prime = get_target_prime(
+            targets_ptr, target_lengths_ptr, max_target_length, b, s, blank, targets_ndim);
         T lb1 = beta_ptr[beta_helper.NdIndexToOffset(b, t + 1, s)];
         T lb2, lb3, lbmax = lb1;
         if (s < 2 * target_length) {
@@ -204,8 +205,8 @@ __global__ void CtcLossGradGpu(
           alpha_ptr[beta_helper.NdIndexToOffset(b, input_length - 1, 2 * target_length)]
           + beta_ptr[beta_helper.NdIndexToOffset(b, input_length - 1, 2 * target_length)];
       if (target_length > 0) {
-        int target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b,
-                                      2 * target_length - 1, blank, targets_ndim);
+        TARGET target = get_target_prime(targets_ptr, target_lengths_ptr, max_target_length, b,
+                                         2 * target_length - 1, blank, targets_ndim);
         grad_ptr[input_helper.NdIndexToOffset(input_length - 1, b, target)] =
             alpha_ptr[beta_helper.NdIndexToOffset(b, input_length - 1, 2 * target_length - 1)]
             + beta_ptr[beta_helper.NdIndexToOffset(b, input_length - 1, 2 * target_length - 1)];
@@ -214,8 +215,8 @@ __global__ void CtcLossGradGpu(
     __syncthreads();
     for (IDX t = tid; t < input_length; t += blockDim.x) {
       for (IDX s = 0; (t < input_length - 1) && (s < 2 * target_length + 1); s += 1) {
-        int current_target_prime = get_target_prime(targets_ptr, target_lengths_ptr,
-                                                    max_target_length, b, s, blank, targets_ndim);
+        TARGET current_target_prime = get_target_prime(
+            targets_ptr, target_lengths_ptr, max_target_length, b, s, blank, targets_ndim);
         int64_t idx_t_s = beta_helper.NdIndexToOffset(b, t, s);
         T log_alpha_beta = alpha_ptr[idx_t_s] + beta_ptr[idx_t_s];
         T& lcab = grad_ptr[input_helper.NdIndexToOffset(t, b, current_target_prime)];
@@ -237,48 +238,49 @@ __global__ void CtcLossGradGpu(
 
 }  // namespace
 
-template<typename T, typename IDX>
-struct CtcLossKernelUtil<DeviceType::kCUDA, T, IDX> {
-  static void CtcLossForward(ep::Stream* stream, const T* log_probs_ptr, const int* targets_ptr,
+template<typename T, typename TARGET, typename IDX>
+struct CtcLossKernelUtil<DeviceType::kCUDA, T, TARGET, IDX> {
+  static void CtcLossForward(ep::Stream* stream, const T* log_probs_ptr, const TARGET* targets_ptr,
                              const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
                              T* alpha_ptr, T* loss_ptr,
                              NdIndexOffsetHelper<int64_t, 3>& input_helper,
                              NdIndexOffsetHelper<int64_t, 3>& alpha_helper,
                              const int64_t batch_size, const int64_t max_input_length,
-                             const int64_t max_target_length, const int blank,
+                             const int64_t max_target_length, const int64_t blank,
                              const int32_t targets_ndim) {
     int32_t thread_num = batch_size * kCudaThreadsNumPerBlock;
-    RUN_CUDA_KERNEL((CtcLossGpu<T, IDX>), stream, thread_num, log_probs_ptr, targets_ptr,
+    RUN_CUDA_KERNEL((CtcLossGpu<T, TARGET, IDX>), stream, thread_num, log_probs_ptr, targets_ptr,
                     input_lengths_ptr, target_lengths_ptr, alpha_ptr, loss_ptr, input_helper,
                     alpha_helper, batch_size, max_input_length, max_target_length, blank,
                     targets_ndim);
   }
 
   static void CtcLossBackward(ep::Stream* stream, const T* grad_out_ptr, const T* loss_ptr,
-                              const T* alpha_ptr, const T* log_probs_ptr, const int* targets_ptr,
+                              const T* alpha_ptr, const T* log_probs_ptr, const TARGET* targets_ptr,
                               const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
                               T* beta_ptr, T* grad_ptr,
                               NdIndexOffsetHelper<int64_t, 3>& input_helper,
                               NdIndexOffsetHelper<int64_t, 3>& beta_helper,
                               const int64_t batch_size, const int64_t max_input_length,
                               const int64_t max_target_length, const int64_t num_labels,
-                              const int blank, const bool zero_infinity,
+                              const int64_t blank, const bool zero_infinity,
                               const int32_t targets_ndim) {
     int32_t thread_num = batch_size * kCudaThreadsNumPerBlock;
-    RUN_CUDA_KERNEL((CtcLossGradGpu<T, IDX>), stream, thread_num, grad_out_ptr, loss_ptr, alpha_ptr,
-                    log_probs_ptr, targets_ptr, input_lengths_ptr, target_lengths_ptr, beta_ptr,
-                    grad_ptr, input_helper, beta_helper, batch_size, max_input_length,
+    RUN_CUDA_KERNEL((CtcLossGradGpu<T, TARGET, IDX>), stream, thread_num, grad_out_ptr, loss_ptr,
+                    alpha_ptr, log_probs_ptr, targets_ptr, input_lengths_ptr, target_lengths_ptr,
+                    beta_ptr, grad_ptr, input_helper, beta_helper, batch_size, max_input_length,
                     max_target_length, num_labels, blank, zero_infinity, targets_ndim);
   }
 };
 
-#define INSTANTIATE_CTC_LOSS_KERNEL_UTIL_CUDA(device_type_v, log_probs_dtype_pair,         \
-                                              input_lengths_dtype_pair)                    \
-  template struct CtcLossKernelUtil<device_type_v, OF_PP_PAIR_FIRST(log_probs_dtype_pair), \
+#define INSTANTIATE_CTC_LOSS_KERNEL_UTIL_CUDA(device_type_v, log_probs_dtype_pair,          \
+                                              targets_dtype_pair, input_lengths_dtype_pair) \
+  template struct CtcLossKernelUtil<device_type_v, OF_PP_PAIR_FIRST(log_probs_dtype_pair),  \
+                                    OF_PP_PAIR_FIRST(targets_dtype_pair),                   \
                                     OF_PP_PAIR_FIRST(input_lengths_dtype_pair)>;
 
 OF_PP_SEQ_PRODUCT_FOR_EACH_TUPLE(INSTANTIATE_CTC_LOSS_KERNEL_UTIL_CUDA, (DeviceType::kCUDA),
-                                 FLOATING_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ)
+                                 FLOATING_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ, INDEX_DATA_TYPE_SEQ)
 #undef INSTANTIATE_CTC_LOSS_KERNEL_UTIL_CUDA
 
 }  // namespace oneflow

--- a/oneflow/user/kernels/ctc_loss_kernel_util.cu
+++ b/oneflow/user/kernels/ctc_loss_kernel_util.cu
@@ -27,7 +27,7 @@ __device__ __inline__ static int64_t get_target_prime(const TARGET* targets_ptr,
                                                       int64_t s, int64_t blank,
                                                       const int32_t targets_ndim) {
   if (s % 2 == 0) {
-    return static_cast<int64_t>(blank);
+    return blank;
   } else {
     int64_t idx = 0;
     if (targets_ndim == 1) {
@@ -36,7 +36,7 @@ __device__ __inline__ static int64_t get_target_prime(const TARGET* targets_ptr,
       idx = b * max_target_length;
     }
     idx += s / 2;
-    return targets_ptr[idx];
+    return static_cast<int64_t>(targets_ptr[idx]);
   }
 }
 

--- a/oneflow/user/kernels/ctc_loss_kernel_util.h
+++ b/oneflow/user/kernels/ctc_loss_kernel_util.h
@@ -21,26 +21,26 @@ limitations under the License.
 
 namespace oneflow {
 
-template<DeviceType device_type, typename T, typename IDX>
+template<DeviceType device_type, typename T, typename TARGET, typename IDX>
 struct CtcLossKernelUtil final {
-  static void CtcLossForward(ep::Stream* stream, const T* log_probs_ptr, const int* targets_ptr,
+  static void CtcLossForward(ep::Stream* stream, const T* log_probs_ptr, const TARGET* targets_ptr,
                              const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
                              T* alpha_ptr, T* loss_ptr,
                              NdIndexOffsetHelper<int64_t, 3>& input_helper,
                              NdIndexOffsetHelper<int64_t, 3>& alpha_helper,
                              const int64_t batch_size, const int64_t max_input_length,
-                             const int64_t max_target_length, const int blank,
+                             const int64_t max_target_length, const int64_t blank,
                              const int32_t targets_ndim);
 
   static void CtcLossBackward(ep::Stream* stream, const T* grad_out_ptr, const T* loss_ptr,
-                              const T* alpha_ptr, const T* log_probs_ptr, const int* targets_ptr,
+                              const T* alpha_ptr, const T* log_probs_ptr, const TARGET* targets_ptr,
                               const IDX* input_lengths_ptr, const IDX* target_lengths_ptr,
                               T* beta_ptr, T* grad_ptr,
                               NdIndexOffsetHelper<int64_t, 3>& input_helper,
                               NdIndexOffsetHelper<int64_t, 3>& beta_helper,
                               const int64_t batch_size, const int64_t max_input_length,
                               const int64_t max_target_length, const int64_t num_labels,
-                              const int blank, const bool zero_infinity,
+                              const int64_t blank, const bool zero_infinity,
                               const int32_t targets_ndim);
 };
 

--- a/oneflow/user/ops/ctc_loss_op.cpp
+++ b/oneflow/user/ops/ctc_loss_op.cpp
@@ -31,8 +31,8 @@ namespace oneflow {
   }
   CHECK_EQ_OR_RETURN(input_lengths.shape().At(0), batch_size);
   CHECK_EQ_OR_RETURN(target_lengths.shape().At(0), batch_size);
-  CHECK_GE_OR_RETURN(ctx->Attr<int32_t>("blank"), 0);
-  CHECK_LT_OR_RETURN(ctx->Attr<int32_t>("blank"), log_probs.shape().At(2));
+  CHECK_GE_OR_RETURN(ctx->Attr<int64_t>("blank"), 0);
+  CHECK_LT_OR_RETURN(ctx->Attr<int64_t>("blank"), log_probs.shape().At(2));
 
   ctx->SetOutputShape("loss", 0, Shape({batch_size}));
   ctx->SetOutputShape("alpha", 0,
@@ -75,8 +75,8 @@ namespace oneflow {
   }
   CHECK_EQ_OR_RETURN(input_lengths.shape().At(0), batch_size);
   CHECK_EQ_OR_RETURN(target_lengths.shape().At(0), batch_size);
-  CHECK_GE_OR_RETURN(ctx->Attr<int32_t>("blank"), 0);
-  CHECK_LT_OR_RETURN(ctx->Attr<int32_t>("blank"), log_probs.shape().At(2));
+  CHECK_GE_OR_RETURN(ctx->Attr<int64_t>("blank"), 0);
+  CHECK_LT_OR_RETURN(ctx->Attr<int64_t>("blank"), log_probs.shape().At(2));
 
   ctx->SetOutputShape("grad", 0, log_probs.shape());
   return Maybe<void>::Ok();

--- a/python/oneflow/test/modules/test_ctc_loss.py
+++ b/python/oneflow/test/modules/test_ctc_loss.py
@@ -180,6 +180,7 @@ def compare_with_np(
     device_type,
     device_num,
     data_type,
+    target_dtype,
     max_input_length,
     batch_size,
     num_classes,
@@ -188,13 +189,13 @@ def compare_with_np(
     reduction,
     zero_infinity,
 ):
-    assert data_type in ["float32", "double"]
+    assert data_type in [flow.float32, flow.double]
     assert device_type in ["cuda", "cpu"]
     assert reduction in ["none", "mean", "sum"]
     assert zero_infinity in [False, True]
     log_probs = np.random.random(
         size=(max_input_length, batch_size, num_classes)
-    ).astype(np.float32)
+    ).astype(flow.convert_oneflow_dtype_to_numpy_dtype(data_type))
     log_probs = log_softmax(log_probs, axis=2)
     targets = np.random.randint(
         1, high=num_classes, size=(batch_size, max_target_length), dtype=np.int32
@@ -239,13 +240,13 @@ def compare_with_np(
         blank=blank, reduction=reduction, zero_infinity=zero_infinity
     )
     log_probs = flow.tensor(
-        log_probs,
-        dtype=flow.float32,
-        requires_grad=True,
-        device=flow.device(device_type),
+        log_probs, dtype=data_type, requires_grad=True, device=flow.device(device_type),
     )
     targets = flow.tensor(
-        targets, dtype=flow.int32, requires_grad=False, device=flow.device(device_type)
+        targets,
+        dtype=target_dtype,
+        requires_grad=False,
+        device=flow.device(device_type),
     )
     input_lengths = flow.tensor(
         input_lengths,
@@ -271,7 +272,8 @@ def gen_arg_list():
     arg_dict = OrderedDict()
     arg_dict["device_type"] = ["cuda", "cpu"]
     arg_dict["device_num"] = [1]
-    arg_dict["data_type"] = ["float32"]
+    arg_dict["data_type"] = [flow.float32, flow.double]
+    arg_dict["target_dtype"] = [flow.float32, flow.double, flow.int32, flow.int64]
     arg_dict["max_input_length"] = [20]
     arg_dict["batch_size"] = [4]
     arg_dict["num_classes"] = [5]


### PR DESCRIPTION
修复 ctc loss 不支持 除int32类型之外的target的bug