### PR TITLE
Rename cast to global and cast from global

### DIFF
--- a/oneflow/core/framework/op_expr.cpp
+++ b/oneflow/core/framework/op_expr.cpp
@@ -586,8 +586,7 @@ LocalToGlobalOpExpr::LocalToGlobalOpExpr(const std::string& op_name) : CastGloba
   return std::shared_ptr<LocalToGlobalOpExpr>(new LocalToGlobalOpExpr(op_name));
 }
 
-GlobalToLocalOpExpr::GlobalToLocalOpExpr(const std::string& op_name)
-    : CastGlobalOpExpr(op_name) {}
+GlobalToLocalOpExpr::GlobalToLocalOpExpr(const std::string& op_name) : CastGlobalOpExpr(op_name) {}
 
 /* static */ Maybe<GlobalToLocalOpExpr> GlobalToLocalOpExpr::New(const std::string& op_name) {
   return std::shared_ptr<GlobalToLocalOpExpr>(new GlobalToLocalOpExpr(op_name));

--- a/oneflow/core/framework/op_expr.cpp
+++ b/oneflow/core/framework/op_expr.cpp
@@ -85,13 +85,13 @@ const std::string& GlobalToGlobalOpExpr::op_type_name() const {
   return kOpTypeName;
 }
 
-const std::string& CastToGlobalOpExpr::op_type_name() const {
-  static const std::string kOpTypeName = "cast_to_global";
+const std::string& LocalToGlobalOpExpr::op_type_name() const {
+  static const std::string kOpTypeName = "local_to_global";
   return kOpTypeName;
 }
 
-const std::string& CastFromGlobalOpExpr::op_type_name() const {
-  static const std::string kOpTypeName = "cast_from_global";
+const std::string& GlobalToLocalOpExpr::op_type_name() const {
+  static const std::string kOpTypeName = "global_to_local";
   return kOpTypeName;
 }
 
@@ -580,17 +580,17 @@ GlobalToGlobalOpExpr::GlobalToGlobalOpExpr(const Optional<Symbol<NdSbp>>& grad_n
 
 CastGlobalOpExpr::CastGlobalOpExpr(const std::string& op_name) : op_name_(op_name) {}
 
-CastToGlobalOpExpr::CastToGlobalOpExpr(const std::string& op_name) : CastGlobalOpExpr(op_name) {}
+LocalToGlobalOpExpr::LocalToGlobalOpExpr(const std::string& op_name) : CastGlobalOpExpr(op_name) {}
 
-/* static */ Maybe<CastToGlobalOpExpr> CastToGlobalOpExpr::New(const std::string& op_name) {
-  return std::shared_ptr<CastToGlobalOpExpr>(new CastToGlobalOpExpr(op_name));
+/* static */ Maybe<LocalToGlobalOpExpr> LocalToGlobalOpExpr::New(const std::string& op_name) {
+  return std::shared_ptr<LocalToGlobalOpExpr>(new LocalToGlobalOpExpr(op_name));
 }
 
-CastFromGlobalOpExpr::CastFromGlobalOpExpr(const std::string& op_name)
+GlobalToLocalOpExpr::GlobalToLocalOpExpr(const std::string& op_name)
     : CastGlobalOpExpr(op_name) {}
 
-/* static */ Maybe<CastFromGlobalOpExpr> CastFromGlobalOpExpr::New(const std::string& op_name) {
-  return std::shared_ptr<CastFromGlobalOpExpr>(new CastFromGlobalOpExpr(op_name));
+/* static */ Maybe<GlobalToLocalOpExpr> GlobalToLocalOpExpr::New(const std::string& op_name) {
+  return std::shared_ptr<GlobalToLocalOpExpr>(new GlobalToLocalOpExpr(op_name));
 }
 
 template<>
@@ -733,18 +733,18 @@ Maybe<OpExprGradClosure> GlobalToGlobalOpExpr::GetOrCreateOpGradClosure() const 
   return std::make_shared<OpExprGradClosure>(op_grad_func_);
 }
 
-Maybe<OpExprGradClosure> CastToGlobalOpExpr::GetOrCreateOpGradClosure() const {
+Maybe<OpExprGradClosure> LocalToGlobalOpExpr::GetOrCreateOpGradClosure() const {
   if (!op_grad_func_.get()) {
-    op_grad_func_.reset(NewObj<std::string, OpExprGradFunctionIf>("cast_to_global"));
+    op_grad_func_.reset(NewObj<std::string, OpExprGradFunctionIf>("local_to_global"));
     CHECK_NOTNULL_OR_RETURN(op_grad_func_.get());
     JUST(op_grad_func_->Init(*this));
   }
   return std::make_shared<OpExprGradClosure>(op_grad_func_);
 }
 
-Maybe<OpExprGradClosure> CastFromGlobalOpExpr::GetOrCreateOpGradClosure() const {
+Maybe<OpExprGradClosure> GlobalToLocalOpExpr::GetOrCreateOpGradClosure() const {
   if (!op_grad_func_.get()) {
-    op_grad_func_.reset(NewObj<std::string, OpExprGradFunctionIf>("cast_from_global"));
+    op_grad_func_.reset(NewObj<std::string, OpExprGradFunctionIf>("global_to_local"));
     CHECK_NOTNULL_OR_RETURN(op_grad_func_.get());
     JUST(op_grad_func_->Init(*this));
   }

--- a/oneflow/core/framework/op_expr.h
+++ b/oneflow/core/framework/op_expr.h
@@ -227,30 +227,30 @@ class CastGlobalOpExpr : public OpExpr {
   mutable std::shared_ptr<OpExprGradFunctionIf> op_grad_func_;
 };
 
-class CastToGlobalOpExpr final : public CastGlobalOpExpr {
+class LocalToGlobalOpExpr final : public CastGlobalOpExpr {
  public:
-  ~CastToGlobalOpExpr() = default;
+  ~LocalToGlobalOpExpr() = default;
 
-  static Maybe<CastToGlobalOpExpr> New(const std::string& op_name);
+  static Maybe<LocalToGlobalOpExpr> New(const std::string& op_name);
 
   const std::string& op_type_name() const override;
   Maybe<OpExprGradClosure> GetOrCreateOpGradClosure() const override;
 
  private:
-  CastToGlobalOpExpr(const std::string& op_name);
+  LocalToGlobalOpExpr(const std::string& op_name);
 };
 
-class CastFromGlobalOpExpr final : public CastGlobalOpExpr {
+class GlobalToLocalOpExpr final : public CastGlobalOpExpr {
  public:
-  ~CastFromGlobalOpExpr() = default;
+  ~GlobalToLocalOpExpr() = default;
 
-  static Maybe<CastFromGlobalOpExpr> New(const std::string& op_name);
+  static Maybe<GlobalToLocalOpExpr> New(const std::string& op_name);
 
   const std::string& op_type_name() const override;
   Maybe<OpExprGradClosure> GetOrCreateOpGradClosure() const override;
 
  private:
-  CastFromGlobalOpExpr(const std::string& op_name);
+  GlobalToLocalOpExpr(const std::string& op_name);
 };
 
 // NOTE(chengcheng): For Lazy nn.Graph Feed/Fetch EagerTensor to/from LazyTensor.

--- a/oneflow/core/framework/op_interpreter.h
+++ b/oneflow/core/framework/op_interpreter.h
@@ -81,8 +81,8 @@ class OpExprInterpreter {
   _macro(CastToLocalOp);             \
   _macro(CastFromLocalOp);           \
   _macro(GlobalToGlobalOp);          \
-  _macro(CastToGlobalOp);            \
-  _macro(CastFromGlobalOp);          \
+  _macro(LocalToGlobalOp);            \
+  _macro(GlobalToLocalOp);          \
   _macro(DistributeSplitOp);         \
   _macro(DistributeCloneOp);         \
   _macro(DistributeConcatOp);        \

--- a/oneflow/core/framework/op_interpreter.h
+++ b/oneflow/core/framework/op_interpreter.h
@@ -81,8 +81,8 @@ class OpExprInterpreter {
   _macro(CastToLocalOp);             \
   _macro(CastFromLocalOp);           \
   _macro(GlobalToGlobalOp);          \
-  _macro(LocalToGlobalOp);            \
-  _macro(GlobalToLocalOp);          \
+  _macro(LocalToGlobalOp);           \
+  _macro(GlobalToLocalOp);           \
   _macro(DistributeSplitOp);         \
   _macro(DistributeCloneOp);         \
   _macro(DistributeConcatOp);        \

--- a/oneflow/core/framework/op_interpreter/eager_global_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/eager_global_op_interpreter.cpp
@@ -249,13 +249,13 @@ Maybe<void> EagerGlobalInterpreter::ApplyImpl(const GlobalToGlobalOpExpr& op_exp
   return Maybe<void>::Ok();
 }
 
-Maybe<void> EagerGlobalInterpreter::ApplyImpl(const CastToGlobalOpExpr& op_expr,
+Maybe<void> EagerGlobalInterpreter::ApplyImpl(const LocalToGlobalOpExpr& op_expr,
                                               const TensorTuple& inputs, TensorTuple* outputs,
                                               const OpExprInterpContext& ctx) const {
   OF_UNIMPLEMENTED();
 }
 
-Maybe<void> EagerGlobalInterpreter::ApplyImpl(const CastFromGlobalOpExpr& op_expr,
+Maybe<void> EagerGlobalInterpreter::ApplyImpl(const GlobalToLocalOpExpr& op_expr,
                                               const TensorTuple& inputs, TensorTuple* outputs,
                                               const OpExprInterpContext& ctx) const {
   CHECK_EQ_OR_RETURN(inputs.size(), 1);

--- a/oneflow/core/framework/op_interpreter/eager_local_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/eager_local_op_interpreter.cpp
@@ -278,7 +278,7 @@ Maybe<void> EagerLocalInterpreter::ApplyImpl(const GlobalToGlobalOpExpr& op_expr
 
 namespace {
 
-Maybe<void> RawLocalToGlobal(const CastToGlobalOpExpr& op_expr, const TensorTuple& inputs,
+Maybe<void> RawLocalToGlobal(const LocalToGlobalOpExpr& op_expr, const TensorTuple& inputs,
                              TensorTuple* outputs, const OpExprInterpContext& ctx) {
   std::shared_ptr<LocalTensor> input_local_tensor;
   {
@@ -323,7 +323,7 @@ static constexpr auto* LocalToGlobal = DECORATE(&RawLocalToGlobal, NonRecursiveI
 
 }  // namespace
 
-Maybe<void> EagerLocalInterpreter::ApplyImpl(const CastToGlobalOpExpr& op_expr,
+Maybe<void> EagerLocalInterpreter::ApplyImpl(const LocalToGlobalOpExpr& op_expr,
                                              const TensorTuple& inputs, TensorTuple* outputs,
                                              const OpExprInterpContext& ctx) const {
   bool sync_data = JUST(ctx.attrs.GetAttr<bool>("sync_data"));
@@ -350,7 +350,7 @@ Maybe<void> EagerLocalInterpreter::ApplyImpl(const CastToGlobalOpExpr& op_expr,
   return Maybe<void>::Ok();
 }
 
-Maybe<void> EagerLocalInterpreter::ApplyImpl(const CastFromGlobalOpExpr& op_expr,
+Maybe<void> EagerLocalInterpreter::ApplyImpl(const GlobalToLocalOpExpr& op_expr,
                                              const TensorTuple& inputs, TensorTuple* outputs,
                                              const OpExprInterpContext& ctx) const {
   OF_UNIMPLEMENTED();

--- a/oneflow/core/framework/op_interpreter/op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/op_interpreter.cpp
@@ -60,8 +60,8 @@ Maybe<void> EagerInterpreter::Apply(const OpExpr& op_expr, const TensorTuple& in
   APPLY_IF(CastToLocalOp);
   APPLY_IF(CastFromLocalOp);
   APPLY_IF(GlobalToGlobalOp);
-  APPLY_IF(CastToGlobalOp);
-  APPLY_IF(CastFromGlobalOp);
+  APPLY_IF(LocalToGlobalOp);
+  APPLY_IF(GlobalToLocalOp);
   APPLY_IF(DistributeSplitOp);
   APPLY_IF(DistributeCloneOp);
   APPLY_IF(DistributeConcatOp);

--- a/oneflow/core/functional/impl/global_cast.cpp
+++ b/oneflow/core/functional/impl/global_cast.cpp
@@ -459,7 +459,7 @@ Maybe<Tensor> LocalToGlobal(const std::shared_ptr<Tensor>& x, Symbol<ParallelDes
 class LocalToGlobalFunctor {
  public:
   LocalToGlobalFunctor() {
-    op_ = CHECK_JUST(one::CastToGlobalOpExpr::New(*CHECK_JUST(UniqueStr("cast_to_global"))));
+    op_ = CHECK_JUST(one::LocalToGlobalOpExpr::New(*CHECK_JUST(UniqueStr("local_to_global"))));
   }
 
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
@@ -509,7 +509,7 @@ class ToGlobalFunctor {
  public:
   ToGlobalFunctor() {
     local_to_global_op_ =
-        CHECK_JUST(one::CastToGlobalOpExpr::New(*CHECK_JUST(UniqueStr("cast_to_global"))));
+        CHECK_JUST(one::LocalToGlobalOpExpr::New(*CHECK_JUST(UniqueStr("local_to_global"))));
   }
 
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
@@ -553,7 +553,7 @@ class ToGlobalFunctor {
 class GlobalToLocalFunctor {
  public:
   GlobalToLocalFunctor() {
-    op_ = CHECK_JUST(one::CastFromGlobalOpExpr::New(*CHECK_JUST(UniqueStr("global_to_local"))));
+    op_ = CHECK_JUST(one::GlobalToLocalOpExpr::New(*CHECK_JUST(UniqueStr("global_to_local"))));
   }
 
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, bool copy) const {


### PR DESCRIPTION
重命名cast_to_global/cast_from_global为local_to_global/global_to_local，避免语义不明确