### PR TITLE
fix bug of matmul dim check in `oneflow.bmm`

### DIFF
--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -331,8 +331,8 @@ class BatchMatMulFunctor {
         << "-dimensional tensor for argument #2";
     CHECK_EQ_OR_RETURN(a_shape->At(0), b_shape->At(0))
         << Error::RuntimeError() << "Batch dim not match, please check input!";
-    int64_t matmul_dim_a = transpose_a ? a_shape->At(1) : a_shape->At(2);
-    int64_t matmul_dim_b = transpose_b ? b_shape->At(2) : a_shape->At(1);
+    const int64_t matmul_dim_a = transpose_a ? a_shape->At(1) : a_shape->At(2);
+    const int64_t matmul_dim_b = transpose_b ? b_shape->At(2) : a_shape->At(1);
     CHECK_EQ_OR_RETURN(matmul_dim_a, matmul_dim_b)
         << Error::RuntimeError() << "Matmul dim not match, got " << matmul_dim_a << " of mat1 and "
         << matmul_dim_b << " of mat2, please check input!";

--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -331,8 +331,11 @@ class BatchMatMulFunctor {
         << "-dimensional tensor for argument #2";
     CHECK_EQ_OR_RETURN(a_shape->At(0), b_shape->At(0))
         << Error::RuntimeError() << "Batch dim not match, please check input!";
-    CHECK_EQ_OR_RETURN(a_shape->At(2), b_shape->At(1))
-        << Error::RuntimeError() << "Matmul dim not match, please check input!";
+    int64_t matmul_dim_a = transpose_a ? a_shape->At(1) : a_shape->At(2);
+    int64_t matmul_dim_b = transpose_b ? b_shape->At(2) : a_shape->At(1);
+    CHECK_EQ_OR_RETURN(matmul_dim_a, matmul_dim_b)
+        << Error::RuntimeError() << "Matmul dim not match, got " << matmul_dim_a << " of mat1 and "
+        << matmul_dim_b << " of mat2, please check input!";
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("transpose_a", "transpose_b", "alpha");
     attrs.SetAllAttrs(transpose_a, transpose_b, alpha);
     return OpInterpUtil::Dispatch<Tensor>(*batch_matmul_op_, {a, b}, attrs);

--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -332,7 +332,7 @@ class BatchMatMulFunctor {
     CHECK_EQ_OR_RETURN(a_shape->At(0), b_shape->At(0))
         << Error::RuntimeError() << "Batch dim not match, please check input!";
     const int64_t matmul_dim_a = transpose_a ? a_shape->At(1) : a_shape->At(2);
-    const int64_t matmul_dim_b = transpose_b ? b_shape->At(2) : a_shape->At(1);
+    const int64_t matmul_dim_b = transpose_b ? b_shape->At(2) : b_shape->At(1);
     CHECK_EQ_OR_RETURN(matmul_dim_a, matmul_dim_b)
         << Error::RuntimeError() << "Matmul dim not match, got " << matmul_dim_a << " of mat1 and "
         << matmul_dim_b << " of mat2, please check input!";


### PR DESCRIPTION
原来的代码中，对进行矩阵乘法的 dim 进行检查的时候没考虑 transpose 的问题，这个 PR 修复了这个问题。

修复后的表现及报错信息：

```python
In [1]: import oneflow as flow

In [2]: x = flow.randn(2, 3, 2)

In [3]: flow.bmm(x, x)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Input In [3], in <cell line: 1>()
----> 1 flow.bmm(x, x)

RuntimeError: Matmul dim not match, got 2 of mat1 and 3 of mat2, please check input!

In [4]: flow.bmm(x, x, transpose_b=True)
Out[4]:
tensor([[[ 1.9190, -1.2085,  1.0687],
         [-1.2085,  0.8370, -1.0026],
         [ 1.0687, -1.0026,  2.0245]],

        [[ 0.7823,  0.6783,  1.3357],
         [ 0.6783,  2.5911,  0.9357],
         [ 1.3357,  0.9357,  2.3053]]], dtype=oneflow.float32)

In [5]: flow.bmm(x, x, transpose_a=True)
Out[5]:
tensor([[[ 3.8497,  0.0716],
         [ 0.0716,  0.9308]],

        [[ 2.1972, -0.9827],
         [-0.9827,  3.4816]]], dtype=oneflow.float32)

In [6]: flow.bmm(x, x, transpose_a=True, transpose_b=True)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Input In [6], in <cell line: 1>()
----> 1 flow.bmm(x, x, transpose_a=True, transpose_b=True)

RuntimeError: Matmul dim not match, got 3 of mat1 and 2 of mat2, please check input!
```