### PR TITLE
support bool for `oneflow.nn.functional.pad`

### DIFF
--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -2381,7 +2381,7 @@ class ConstantPadFunctor {
     if (IsFloatingDataType(input->dtype()->data_type())
         || input->dtype()->data_type() == DataType::kFloat16) {
       attrs.SetAllAttrs(pad, value.As<double>(), static_cast<int64_t>(0), pad_before, pad_after);
-    } else if (IsIntegralDataType(input->dtype()->data_type())) {
+    } else if (IsIntegralDataType(input->dtype()->data_type()) || input->dtype()->data_type() == DataType::kBool) {
       attrs.SetAllAttrs(pad, static_cast<double>(0), value.As<int64_t>(), pad_before, pad_after);
     } else {
       UNIMPLEMENTED_THEN_RETURN() << "Data type should be floating or integral type.";

--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -2381,10 +2381,15 @@ class ConstantPadFunctor {
     if (IsFloatingDataType(input->dtype()->data_type())
         || input->dtype()->data_type() == DataType::kFloat16) {
       attrs.SetAllAttrs(pad, value.As<double>(), static_cast<int64_t>(0), pad_before, pad_after);
-    } else if (IsIntegralDataType(input->dtype()->data_type()) || input->dtype()->data_type() == DataType::kBool) {
+    } else if (IsIntegralDataType(input->dtype()->data_type())) {
+      attrs.SetAllAttrs(pad, static_cast<double>(0), value.As<int64_t>(), pad_before, pad_after);
+    } else if (input->dtype() == DType::Bool()) {
+      int64_t bool_value = value.As<int64_t>();
+      CHECK_OR_RETURN(bool_value == 1 || bool_value == 0)
+          << "value must be 1/0 or True/False for bool Tensor";
       attrs.SetAllAttrs(pad, static_cast<double>(0), value.As<int64_t>(), pad_before, pad_after);
     } else {
-      UNIMPLEMENTED_THEN_RETURN() << "Data type should be floating or integral type.";
+      UNIMPLEMENTED_THEN_RETURN() << "Data type should be floating, bool or integral type.";
     }
     return OpInterpUtil::Dispatch<Tensor>(*constant_pad_, {input}, attrs);
   }

--- a/oneflow/user/kernels/pad_kernel.cpp
+++ b/oneflow/user/kernels/pad_kernel.cpp
@@ -54,7 +54,7 @@ class PadKernel final : public OpKernel, public CudaGraphSupport {
     }
 
     Scalar value;
-    if (IsIntegralDataType(x->data_type())) {
+    if (IsIntegralDataType(x->data_type()) || x->data_type() == kBool) {
       value = Scalar(ctx->Attr<int64_t>("integral_constant_value"));
     } else {
       value = Scalar(ctx->Attr<double>("floating_constant_value"));

--- a/python/oneflow/test/modules/test_constant_pad.py
+++ b/python/oneflow/test/modules/test_constant_pad.py
@@ -20,6 +20,7 @@ from collections import OrderedDict
 import numpy as np
 
 
+from random import choice
 from oneflow.test_utils.automated_test_util import *
 from oneflow.nn.common_types import _size_2_t, _size_4_t, _size_6_t
 import oneflow as flow
@@ -40,6 +41,20 @@ class TestConstantPad1d(flow.unittest.TestCase):
         y = m(x)
         return y
 
+    @autotest(n=10, rtol=0.001, atol=0.001, auto_backward=False)
+    def test_constantpad1d_with_random_int_data(test_case):
+        dtype = choice([int, bool])
+        m = torch.nn.ConstantPad1d(
+            padding=random(1, 6).to(_size_2_t), value=random().to(dtype)
+        )
+        m.train(random())
+        device = random_device()
+        m.to(device)
+        x = random_tensor(ndim=3, dim1=random(1, 6), dim2=random(1, 6), dtype=int).to(device)
+        if dtype is bool:
+            x = x.bool()
+        y = m(x)
+        return y
 
 @flow.unittest.skip_unless_1n1d()
 class TestConstantPad2d(flow.unittest.TestCase):
@@ -57,6 +72,22 @@ class TestConstantPad2d(flow.unittest.TestCase):
         y = m(x)
         return y
 
+    @autotest(n=10, rtol=0.001, atol=0.001, auto_backward=False)
+    def test_constantpad2d_with_random_int_data(test_case):
+        dtype = choice([int, bool])
+        m = torch.nn.ConstantPad2d(
+            padding=random(1, 6).to(_size_4_t), value=random().to(dtype)
+        )
+        m.train(random())
+        device = random_device()
+        m.to(device)
+        x = random_tensor(
+            ndim=4, dim1=random(1, 6), dim2=random(1, 6), dim3=random(1, 6)
+        ).to(device)
+        if dtype is bool:
+            x = x.bool()
+        y = m(x)
+        return y
 
 @flow.unittest.skip_unless_1n1d()
 class TestConstantPad3d(flow.unittest.TestCase):
@@ -77,6 +108,27 @@ class TestConstantPad3d(flow.unittest.TestCase):
         ).to(device)
         y = m(x)
         return y
+    
+    @autotest(n=10, rtol=0.001, atol=0.001, auto_backward=False)
+    def test_constantpad3d_with_random_data(test_case):
+        dtype = choice([bool, int])
+        m = torch.nn.ConstantPad3d(
+            padding=random(1, 6).to(_size_6_t), value=random().to(dtype)
+        )
+        m.train(random())
+        device = random_device()
+        m.to(device)
+        x = random_tensor(
+            ndim=5,
+            dim1=random(1, 6),
+            dim2=random(1, 6),
+            dim3=random(1, 6),
+            dim4=random(1, 6),
+        ).to(device)
+        if dtype is bool:
+            x = x.bool()
+        y = m(x)
+        return y
 
 
 @flow.unittest.skip_unless_1n1d()
@@ -93,6 +145,24 @@ class TestFunctionalConstantPad2d(flow.unittest.TestCase):
             dim2=random(2, 6),
             dim3=random(2, 6),
         ).to(device)
+        y = torch.nn.functional.pad(x, pad=padding, mode="constant", value=value)
+        return y
+
+    @autotest(n=10, rtol=0.001, atol=0.001, check_graph=True, auto_backward=False)
+    def test_functional_constantpad2d_int_data(test_case):
+        dtype = choice([bool, int])
+        device = random_device()
+        padding = random(-1, 6).to(_size_4_t)
+        value = random().to(dtype)
+        x = random_tensor(
+            ndim=4,
+            dim0=random(1, 6),
+            dim1=random(1, 6),
+            dim2=random(2, 6),
+            dim3=random(2, 6),
+        ).to(device)
+        if dtype is bool:
+            x = x.bool()
         y = torch.nn.functional.pad(x, pad=padding, mode="constant", value=value)
         return y
 

--- a/python/oneflow/test/modules/test_constant_pad.py
+++ b/python/oneflow/test/modules/test_constant_pad.py
@@ -45,17 +45,18 @@ class TestConstantPad1d(flow.unittest.TestCase):
     def test_constantpad1d_with_random_int_data(test_case):
         dtype = choice([int, bool])
         value = random(0, 2).to(bool) if dtype is bool else random().to(int)
-        m = torch.nn.ConstantPad1d(
-            padding=random(1, 6).to(_size_2_t), value=value
-        )
+        m = torch.nn.ConstantPad1d(padding=random(1, 6).to(_size_2_t), value=value)
         m.train(random())
         device = random_device()
         m.to(device)
-        x = random_tensor(ndim=3, dim1=random(1, 6), dim2=random(1, 6), dtype=int).to(device)
+        x = random_tensor(ndim=3, dim1=random(1, 6), dim2=random(1, 6), dtype=int).to(
+            device
+        )
         if dtype is bool:
             x = x.bool()
         y = m(x)
         return y
+
 
 @flow.unittest.skip_unless_1n1d()
 class TestConstantPad2d(flow.unittest.TestCase):
@@ -77,9 +78,7 @@ class TestConstantPad2d(flow.unittest.TestCase):
     def test_constantpad2d_with_random_int_data(test_case):
         dtype = choice([int, bool])
         value = random(0, 2).to(bool) if dtype is bool else random().to(int)
-        m = torch.nn.ConstantPad2d(
-            padding=random(1, 6).to(_size_4_t), value=value,
-        )
+        m = torch.nn.ConstantPad2d(padding=random(1, 6).to(_size_4_t), value=value,)
         m.train(random())
         device = random_device()
         m.to(device)
@@ -90,6 +89,7 @@ class TestConstantPad2d(flow.unittest.TestCase):
             x = x.bool()
         y = m(x)
         return y
+
 
 @flow.unittest.skip_unless_1n1d()
 class TestConstantPad3d(flow.unittest.TestCase):
@@ -110,14 +110,12 @@ class TestConstantPad3d(flow.unittest.TestCase):
         ).to(device)
         y = m(x)
         return y
-    
+
     @autotest(n=10, rtol=0.001, atol=0.001, auto_backward=False)
     def test_constantpad3d_with_random_data(test_case):
         dtype = choice([bool, int])
         value = random(0, 2).to(bool) if dtype is bool else random().to(int)
-        m = torch.nn.ConstantPad3d(
-            padding=random(1, 6).to(_size_6_t), value=value,
-        )
+        m = torch.nn.ConstantPad3d(padding=random(1, 6).to(_size_6_t), value=value,)
         m.train(random())
         device = random_device()
         m.to(device)

--- a/python/oneflow/test/modules/test_constant_pad.py
+++ b/python/oneflow/test/modules/test_constant_pad.py
@@ -44,8 +44,9 @@ class TestConstantPad1d(flow.unittest.TestCase):
     @autotest(n=10, rtol=0.001, atol=0.001, auto_backward=False)
     def test_constantpad1d_with_random_int_data(test_case):
         dtype = choice([int, bool])
+        value = random(0, 2).to(bool) if dtype is bool else random().to(int)
         m = torch.nn.ConstantPad1d(
-            padding=random(1, 6).to(_size_2_t), value=random().to(dtype)
+            padding=random(1, 6).to(_size_2_t), value=value
         )
         m.train(random())
         device = random_device()
@@ -75,8 +76,9 @@ class TestConstantPad2d(flow.unittest.TestCase):
     @autotest(n=10, rtol=0.001, atol=0.001, auto_backward=False)
     def test_constantpad2d_with_random_int_data(test_case):
         dtype = choice([int, bool])
+        value = random(0, 2).to(bool) if dtype is bool else random().to(int)
         m = torch.nn.ConstantPad2d(
-            padding=random(1, 6).to(_size_4_t), value=random().to(dtype)
+            padding=random(1, 6).to(_size_4_t), value=value,
         )
         m.train(random())
         device = random_device()
@@ -112,8 +114,9 @@ class TestConstantPad3d(flow.unittest.TestCase):
     @autotest(n=10, rtol=0.001, atol=0.001, auto_backward=False)
     def test_constantpad3d_with_random_data(test_case):
         dtype = choice([bool, int])
+        value = random(0, 2).to(bool) if dtype is bool else random().to(int)
         m = torch.nn.ConstantPad3d(
-            padding=random(1, 6).to(_size_6_t), value=random().to(dtype)
+            padding=random(1, 6).to(_size_6_t), value=value,
         )
         m.train(random())
         device = random_device()
@@ -153,7 +156,7 @@ class TestFunctionalConstantPad2d(flow.unittest.TestCase):
         dtype = choice([bool, int])
         device = random_device()
         padding = random(-1, 6).to(_size_4_t)
-        value = random().to(dtype)
+        value = random(0, 2).to(bool) if dtype is bool else random().to(int)
         x = random_tensor(
             ndim=4,
             dim0=random(1, 6),


### PR DESCRIPTION
背景是 multihead attention 里面需要对 bool tensor 做 pad，torch 支持而 oneflow 不支持
- 增加了 pad 对 bool Tensor 的支持，在 kernel 和 functor 中增加了对应的条件判断
- 增加了 int 和 bool 的单测