### PR TITLE
Disable CUDA virtual arch compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,14 +320,6 @@ if(BUILD_CUDA)
       # NVIDIA H100
       list(APPEND CMAKE_CUDA_ARCHITECTURES 90-real)
     endif()
-
-    if(CUDA_VERSION VERSION_GREATER_EQUAL "11.0")
-      list(APPEND CMAKE_CUDA_ARCHITECTURES 80-virtual)
-    elseif(CUDA_VERSION VERSION_GREATER_EQUAL "10.0")
-      list(APPEND CMAKE_CUDA_ARCHITECTURES 75-virtual)
-    else()
-      list(APPEND CMAKE_CUDA_ARCHITECTURES 70-virtual)
-    endif()
   endif()
 
   enable_language(CUDA)


### PR DESCRIPTION
禁用 virtual 架构的编译
ptx jit 目前来看至少需要半个小时以上的时间，缺乏实际意义，应该尽早出错并提示用户更换版本
后续在程序启动时检查是否兼容并给出友好的提示