### PR TITLE
Compile mode rank per process

### DIFF
--- a/oneflow/core/common/async_deallocate_context.cpp
+++ b/oneflow/core/common/async_deallocate_context.cpp
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/common/async_deallocate_context.h"
+#include "oneflow/core/thread/thread_pool.h"
+
+namespace oneflow {
+
+AsyncDeallocateContext::AsyncDeallocateContext() : thread_pool_(std::make_unique<ThreadPool>(1)) {}
+
+AsyncDeallocateContext::~AsyncDeallocateContext() {}
+
+void AsyncDeallocateContext::LazyDeallocate(std::function<void()> LazyDeallocator) {
+  thread_pool_->AddWork(LazyDeallocator);
+}
+
+}  // namespace oneflow

--- a/oneflow/core/common/async_deallocate_context.h
+++ b/oneflow/core/common/async_deallocate_context.h
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_COMMON_ASYNC_DEALLOCATE_CONTEXT_H_
+#define ONEFLOW_CORE_COMMON_ASYNC_DEALLOCATE_CONTEXT_H_
+
+#include "oneflow/core/common/deallocate_context.h"
+
+namespace oneflow {
+
+class ThreadPool;
+
+class AsyncDeallocateContext final : public DeallocateContext {
+ public:
+  AsyncDeallocateContext();
+  ~AsyncDeallocateContext() override;
+
+  void LazyDeallocate(std::function<void()> LazyDeallocator) override;
+
+ private:
+  std::shared_ptr<ThreadPool> thread_pool_;
+};
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_COMMON_ASYNC_DEALLOCATE_CONTEXT_H_

--- a/oneflow/core/common/balanced_splitter.cpp
+++ b/oneflow/core/common/balanced_splitter.cpp
@@ -21,7 +21,10 @@ BalancedSplitter::BalancedSplitter(int64_t total_num, int64_t split_num) {
   base_part_size_ = total_num / split_num;
   base_begin_idx_ = total_num % split_num;
   split_num_ = split_num;
+  CHECK_EQ(this->total_num(), total_num);
 }
+
+int64_t BalancedSplitter::total_num() const { return At(split_num_ - 1).end(); }
 
 Range BalancedSplitter::At(int64_t idx) const {
   CHECK_LT(idx, split_num_);
@@ -44,6 +47,29 @@ Range BalancedSplitter::At(int64_t first_idx, int64_t last_idx) const {
   Range first_range = At(first_idx);
   Range last_range = At(last_idx);
   return Range(first_range.begin(), last_range.end());
+}
+
+int64_t BalancedSplitter::RecursiveBinarySearchIndex(int64_t value) const {
+  CHECK_GE(value, 0);
+  CHECK_LT(value, total_num());
+  return RecursiveBinarySearchIndex(value, 0, split_num_);
+}
+
+int64_t BalancedSplitter::RecursiveBinarySearchIndex(int64_t value, int begin_idx,
+                                                     int end_idx) const {
+  CHECK_LT(begin_idx, end_idx);
+  if (begin_idx + 1 == end_idx) {
+    Range ret = At(begin_idx);
+    CHECK_GE(value, ret.begin());
+    CHECK_LT(value, ret.end());
+    return begin_idx;
+  }
+  int middle_idx = (begin_idx + end_idx) / 2;
+  if (value >= At(middle_idx).begin()) {
+    return RecursiveBinarySearchIndex(value, middle_idx, end_idx);
+  } else {
+    return RecursiveBinarySearchIndex(value, begin_idx, middle_idx);
+  }
 }
 
 }  // namespace oneflow

--- a/oneflow/core/common/balanced_splitter.h
+++ b/oneflow/core/common/balanced_splitter.h
@@ -42,7 +42,13 @@ class BalancedSplitter final {
   Range At(int64_t idx) const;
   Range At(int64_t first_idx, int64_t last_idx) const;
 
+  int64_t RecursiveBinarySearchIndex(int64_t value) const;
+  int64_t total_num() const;
+
  private:
+  // search in [begin_idx, end_idx)
+  int64_t RecursiveBinarySearchIndex(int64_t value, int begin_idx, int end_idx) const;
+
   int64_t base_part_size_;
   int64_t base_begin_idx_;
   int64_t split_num_;

--- a/oneflow/core/common/balanced_splitter_test.cpp
+++ b/oneflow/core/common/balanced_splitter_test.cpp
@@ -35,4 +35,17 @@ TEST(BalancedSplitter, split_2_to_3_part) {
   ASSERT_TRUE(splitter.At(2) == Range(2, 2));
 }
 
+TEST(BalancedSplitter, RecursiveBinarySearchIndex) {
+  const size_t total_num = 937;
+  const size_t split_num = 11;
+  BalancedSplitter bs(total_num, split_num);
+  ASSERT_TRUE(bs.total_num() == total_num);
+  for (size_t i = 0; i < split_num; ++i) {
+    Range range = bs.At(i);
+    for (size_t value = range.begin(); value < range.end(); ++value) {
+      ASSERT_TRUE(bs.RecursiveBinarySearchIndex(value) == i);
+    }
+  }
+}
+
 }  // namespace oneflow

--- a/oneflow/core/common/deallocate_context.h
+++ b/oneflow/core/common/deallocate_context.h
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_COMMON_DEALLOCATE_CONTEXT_H_
+#define ONEFLOW_CORE_COMMON_DEALLOCATE_CONTEXT_H_
+
+#include <functional>
+#include <memory>
+
+namespace oneflow {
+
+class DeallocateContext {
+ public:
+  DeallocateContext() = default;
+  virtual ~DeallocateContext() = default;
+
+  template<typename T>
+  void Deallocate(std::shared_ptr<T>&& ptr) {
+    std::shared_ptr<T> data = ptr;
+    ptr.reset();
+    LazyDeallocate([data] { const_cast<std::shared_ptr<T>*>(&data)->reset(); });
+    data.reset();
+  }
+
+  virtual void LazyDeallocate(std::function<void()> LazyDeallocator) = 0;
+};
+
+class NaiveDeallocateContext final : public DeallocateContext {
+ public:
+  NaiveDeallocateContext() = default;
+  ~NaiveDeallocateContext() = default;
+
+  void LazyDeallocate(std::function<void()> LazyDeallocator) { LazyDeallocator(); }
+};
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_COMMON_DEALLOCATE_CONTEXT_H_

--- a/oneflow/core/common/env_var/lazy.h
+++ b/oneflow/core/common/env_var/lazy.h
@@ -22,6 +22,7 @@ limitations under the License.
 namespace oneflow {
 
 DEFINE_THREAD_LOCAL_ENV_STRING(ONEFLOW_LAZY_COMPILE_MODE, "naive");
+DEFINE_THREAD_LOCAL_ENV_INTEGER(ONEFLOW_LAZY_COMPILE_RPC_THREAD_NUM, 16);
 
 }  // namespace oneflow
 

--- a/oneflow/core/common/id_pairs.h
+++ b/oneflow/core/common/id_pairs.h
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_COMMON_ID_PAIRS_H_
+#define ONEFLOW_CORE_COMMON_ID_PAIRS_H_
+
+#include "oneflow/core/common/id_pairs.pb.h"
+#include <unordered_set>
+#include <utility>
+
+namespace oneflow {
+
+void InitIdPairs(const std::unordered_set<std::pair<int64_t, int64_t>>& pairs, IdPairs* proto) {
+  for (const auto& pair : pairs) {
+    auto* proto_pair = proto->mutable_int64_pair()->Add();
+    proto_pair->set_first(pair.first);
+    proto_pair->set_second(pair.second);
+  }
+}
+
+void MergeIdPairs(const IdPairs& id_pairs, std::unordered_set<std::pair<int64_t, int64_t>>* pairs) {
+  for (const auto& pair : id_pairs.int64_pair()) {
+    pairs->emplace(std::make_pair(pair.first(), pair.second()));
+  }
+}
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_COMMON_ID_PAIRS_H_

--- a/oneflow/core/common/id_pairs.proto
+++ b/oneflow/core/common/id_pairs.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+package oneflow;
+
+message Int64Pair {
+  required int64 first = 1;
+  required int64 second = 2;
+}
+
+message IdPairs {
+  repeated Int64Pair int64_pair = 1;
+}

--- a/oneflow/core/framework/instructions_builder.cpp
+++ b/oneflow/core/framework/instructions_builder.cpp
@@ -201,7 +201,7 @@ Maybe<void> InstructionsBuilder::SoftSyncNNGraphBuffers(
 namespace {
 
 int64_t NewSymbolId() {
-  static std::atomic<int64_t> cnt(0);
+  static std::atomic<int64_t> cnt(1);
   return cnt.fetch_add(1, std::memory_order_relaxed);
 }
 
@@ -217,10 +217,6 @@ Maybe<ParallelDesc> InstructionsBuilder::GetParallelDescSymbol(const ParallelCon
 
 Maybe<Scope> InstructionsBuilder::GetScopeSymbol(const ScopeProto& scope_proto) {
   return Singleton<symbol::Storage<Scope>>::Get()->FindOrCreate(scope_proto, &NewSymbolId);
-}
-
-Maybe<OperatorConfSymbol> InstructionsBuilder::GetOpConfSymbol(const OperatorConf& op_conf) {
-  return Singleton<symbol::Storage<OperatorConfSymbol>>::Get()->FindOrCreate(op_conf, &NewSymbolId);
 }
 
 Maybe<Scope> InstructionsBuilder::BuildInitialScope(

--- a/oneflow/core/framework/nn_graph.cpp
+++ b/oneflow/core/framework/nn_graph.cpp
@@ -509,10 +509,12 @@ Maybe<void> NNGraph::MasterAndWorkerRanksCompile() {
       Merge(ForEachPulledFromWorkersToMaster(std::string(__FUNCTION__) + "_reachable_cb_pairs",
                                              id_pairs, MergePairs));
     }
-    // TODO(chengcheng): test collective boxing for multi-job.
-    PlanUtil::GenCollectiveBoxingPlan(&job_, &plan_, [&] {
-      return std::make_unique<RankPlanTaskGraph>(plan_, reachable_cb_pairs);
-    });
+    if (GlobalProcessCtx::IsThisProcessMaster()) {
+      // TODO(chengcheng): test collective boxing for multi-job.
+      PlanUtil::GenCollectiveBoxingPlan(&job_, &plan_, [&] {
+        return std::make_unique<RankPlanTaskGraph>(plan_, reachable_cb_pairs);
+      });
+    }
     Merge(BroadcastFromMasterToWorkers(std::string(__FUNCTION__) + "_collective_boxing_plan",
                                        plan_.collective_boxing_plan(),
                                        plan_.mutable_collective_boxing_plan()));

--- a/oneflow/core/framework/nn_graph.h
+++ b/oneflow/core/framework/nn_graph.h
@@ -78,6 +78,7 @@ class NNGraph final : public NNGraphIf {
   Maybe<void> NaiveCompile();
   template<void (*Loop)(size_t num, const std::function<void(size_t i)>& Callback)>
   Maybe<void> MasterRankCompile();
+  Maybe<void> MasterAndWorkerRanksCompile();
   Maybe<void> RegisterFreeEagerTensorsToVariableOpNames();
   Maybe<void> RegisterNewVariableOpInJobPass();
   Maybe<void> DeleteOutdatedVariableInVariableTensorMgr();

--- a/oneflow/core/framework/symbol_storage_util.cpp
+++ b/oneflow/core/framework/symbol_storage_util.cpp
@@ -27,7 +27,5 @@ COMMAND(
     Singleton<symbol::Storage<ParallelDesc>>::SetAllocated(new symbol::Storage<ParallelDesc>()));
 COMMAND(Singleton<symbol::Storage<Scope>>::SetAllocated(new symbol::Storage<Scope>()));
 COMMAND(Singleton<symbol::Storage<JobDesc>>::SetAllocated(new symbol::Storage<JobDesc>()));
-COMMAND(Singleton<symbol::Storage<OperatorConfSymbol>>::SetAllocated(
-    new symbol::Storage<OperatorConfSymbol>()));
 
 }  // namespace oneflow

--- a/oneflow/core/graph/boxing_task_graph.proto
+++ b/oneflow/core/graph/boxing_task_graph.proto
@@ -13,7 +13,7 @@ import "oneflow/core/graph/task_edge.proto";
 import "oneflow/core/operator/op_conf.proto";
 import "oneflow/core/register/tensor_slice_view.proto";
 
-message ComputeTasks {
+message ComputeTasksProto {
   map<int64, TaskProto> parallel_id2task = 2;
 }
 
@@ -89,8 +89,13 @@ message TransportTaskProto {
   }
 }
 
+message TaskIdsProto {
+  repeated int64 task_id = 1;
+}
+
 message BoxingTaskGraphProto {
-  map<string, ComputeTasks> op_name2compute_tasks = 1;
+  map<string, ComputeTasksProto> boxing_related_op_name2compute_tasks = 1;
   repeated TransportTaskProto transport_task = 2;
   repeated TaskEdgeProto task_edge = 3;
+  map<string, TaskIdsProto> boxing_unrelated_op_name2task_ids = 4;
 }

--- a/oneflow/core/graph/compute_task_node.h
+++ b/oneflow/core/graph/compute_task_node.h
@@ -73,6 +73,9 @@ class CompTaskNode : public TaskNode, public FakeConsumedRegstProvider {
     static ExecNode::InferBlobDescsMethod VisitRankPerThread() {
       return &ExecNode::InferBlobDescsByNdSbp;
     }
+    static ExecNode::InferBlobDescsMethod VisitRankPerProcess() {
+      return &ExecNode::InferBlobDescsByNdSbp;
+    }
   };
 
   ParallelContext parallel_ctx_;

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -964,11 +964,12 @@ void BoxingTaskGraph::ToProto(const std::function<bool(TaskNode*)>& Pick,
     ForEachNode([&](TaskNode* task_node) {
       if (Pick(task_node)) { sources.insert(task_node); }
     });
+    HashSet<TaskNode*> ret_sources{sources.begin(), sources.end()};
     for (auto* source : sources) {
       // The consumed task_ids must be generated from out_nodes.
-      source->ForEachNodeOnOutEdge([&](TaskNode* out_node) { sources.insert(out_node); });
+      source->ForEachNodeOnOutEdge([&](TaskNode* out_node) { ret_sources.insert(out_node); });
     }
-    return std::list<TaskNode*>{sources.begin(), sources.end()};
+    return std::list<TaskNode*>{ret_sources.begin(), ret_sources.end()};
   }();
   const auto& TransportTaskNodeToProto = [&](TransportTaskNode* task_node) {
     task_node->ToTransportTaskProtoIf(proto->mutable_transport_task()->Add());
@@ -1183,11 +1184,12 @@ struct UpdateTaskIndex final : public CompileModeVisitor<UpdateTaskIndex> {
     UNIMPLEMENTED_THEN_RETURN() << "'naive' compile mode doesn't support update task index";
   }
   static Maybe<void> VisitRankPerIter(TaskGraph*) {
-    UNIMPLEMENTED_THEN_RETURN() << "'rank_per_iter' compile mode doesn't support update task index";
+    // Do nothing.
+    return Maybe<void>::Ok();
   }
   static Maybe<void> VisitRankPerThread(TaskGraph*) {
-    UNIMPLEMENTED_THEN_RETURN()
-        << "'rank_per_thread' compile mode doesn't support update task index";
+    // Do nothing.
+    return Maybe<void>::Ok();
   }
   static Maybe<void> VisitRankPerProcess(TaskGraph* task_graph) {
     auto* task_id_generator = Singleton<IDMgr>::Get()->GetTaskIdGenerator();

--- a/oneflow/core/graph/task_graph.h
+++ b/oneflow/core/graph/task_graph.h
@@ -146,9 +146,10 @@ class BoxingTaskGraph final : public TaskGraph {
   OF_DISALLOW_COPY_AND_MOVE(BoxingTaskGraph);
   ~BoxingTaskGraph() = default;
 
-  static Maybe<BoxingTaskGraph> New() {
+  static Maybe<BoxingTaskGraph> New(
+      const std::function<void(size_t, const std::function<void(size_t i)>&)>& Loop) {
     std::shared_ptr<BoxingTaskGraph> graph(new BoxingTaskGraph());
-    JUST(graph->Init());
+    JUST(graph->Init(Loop));
     return graph;
   }
 
@@ -160,9 +161,13 @@ class BoxingTaskGraph final : public TaskGraph {
 
  private:
   BoxingTaskGraph() = default;
-  Maybe<void> Init();
+  Maybe<void> Init(const std::function<void(size_t, const std::function<void(size_t i)>&)>& Loop);
 
-  HashMap<const OpNode*, std::vector<CompTaskNode*>> op_node2sorted_comp_tasks_;
+  void CreateOpNode2TaskIds(
+      const std::function<void(size_t, const std::function<void(size_t i)>&)>& Loop);
+
+  HashMap<const OpNode*, std::vector<CompTaskNode*>> boxing_related_op_node2sorted_comp_tasks_;
+  HashMap<const OpNode*, std::vector<TaskId>> boxing_unrelated_op_node2sorted_task_ids_;
 };
 
 class TaskGraphRebuildCtx;

--- a/oneflow/core/graph/task_graph.h
+++ b/oneflow/core/graph/task_graph.h
@@ -153,6 +153,9 @@ class BoxingTaskGraph final : public TaskGraph {
   }
 
   void ToProto(const std::function<bool(TaskNode*)>& Pick, BoxingTaskGraphProto* proto) const;
+  void ToProto(BoxingTaskGraphProto* proto, const std::function<bool(TaskNode*)>& Pick) const {
+    return ToProto(Pick, proto);
+  }
   static bool SelectTaskNodeByRank(TaskNode*, int64_t rank);
 
  private:

--- a/oneflow/core/graph/task_id_generator.h
+++ b/oneflow/core/graph/task_id_generator.h
@@ -29,6 +29,7 @@ class TaskIdGenerator final {
   ~TaskIdGenerator() = default;
 
   TaskId Generate(const StreamId& stream_id);
+  void UpdateCounterBiggerThan(const TaskId& task_id);
 
  private:
   std::mutex mutex_;
@@ -39,6 +40,12 @@ inline TaskId TaskIdGenerator::Generate(const StreamId& stream_id) {
   std::unique_lock<std::mutex> lock(mutex_);
   task_index_t task_index = stream_id2task_index_counter_[stream_id]++;
   return TaskId{stream_id, task_index};
+}
+
+inline void TaskIdGenerator::UpdateCounterBiggerThan(const TaskId& task_id) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  auto* ptr = &stream_id2task_index_counter_[task_id.stream_id()];
+  *ptr = std::max<task_index_t>(task_id.task_index() + 1, *ptr);
 }
 
 }  // namespace oneflow

--- a/oneflow/core/graph/task_node.cpp
+++ b/oneflow/core/graph/task_node.cpp
@@ -375,6 +375,13 @@ void TaskNode::UpdateTaskId() {
   task_id_ = EncodeTaskIdToInt64(*new_task_id_);
 }
 
+void TaskNode::update_new_task_id(const TaskId& task_id) {
+  CHECK(static_cast<bool>(new_task_id_));
+  CHECK(new_task_id_->stream_id() == task_id.stream_id());
+  *new_task_id_ = task_id;
+  task_id_ = EncodeTaskIdToInt64(*new_task_id_);
+}
+
 void TaskNode::EraseConsumedRegstsByName(const std::string& name) {
   if (consumed_regsts_.find(name) != consumed_regsts_.end()) {
     for (auto& regst : consumed_regsts_[name]) { regst->DeleteConsumer(this); }

--- a/oneflow/core/graph/task_node.h
+++ b/oneflow/core/graph/task_node.h
@@ -120,6 +120,10 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
   TaskEdge* SoleOutDataEdge() const;
   size_t in_data_edges_size() const;
   size_t out_data_edges_size() const;
+  const TaskId& new_task_id() const {
+    CHECK(has_new_task_id());
+    return *new_task_id_;
+  }
 
  protected:
   std::shared_ptr<RegstDesc> ProduceRegst(const std::string& name, bool enable_reuse_mem);

--- a/oneflow/core/graph/task_node.h
+++ b/oneflow/core/graph/task_node.h
@@ -124,6 +124,7 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
     CHECK(has_new_task_id());
     return *new_task_id_;
   }
+  void update_new_task_id(const TaskId& task_id);
 
  protected:
   std::shared_ptr<RegstDesc> ProduceRegst(const std::string& name, bool enable_reuse_mem);

--- a/oneflow/core/graph/task_stream_index_manager.h
+++ b/oneflow/core/graph/task_stream_index_manager.h
@@ -21,22 +21,55 @@ limitations under the License.
 
 namespace oneflow {
 
-class TaskStreamIndexManager final {
+class TaskStreamIndexManager {
  public:
   using stream_index_t = StreamId::stream_index_t;
 
   OF_DISALLOW_COPY_AND_MOVE(TaskStreamIndexManager);
   TaskStreamIndexManager() = default;
-  ~TaskStreamIndexManager() = default;
+  virtual ~TaskStreamIndexManager() = default;
 
-  StreamIndexGenerator* GetGenerator(const DeviceId& device_id);
-  stream_index_t GetTaskStreamIndex(TaskType task_type, const DeviceId& device_id);
-  stream_index_t GetComputeTaskStreamIndex(const DeviceId& device_id);
-  stream_index_t GetNamedTaskStreamIndex(const DeviceId& device_id, const std::string& name);
+  virtual StreamIndexGenerator* GetGenerator(const DeviceId& device_id);
+  virtual stream_index_t GetTaskStreamIndex(TaskType task_type, const DeviceId& device_id);
+  virtual stream_index_t GetComputeTaskStreamIndex(const DeviceId& device_id);
+  virtual stream_index_t GetNamedTaskStreamIndex(const DeviceId& device_id,
+                                                 const std::string& name);
 
  private:
   HashMap<DeviceId, std::unique_ptr<StreamIndexGenerator>> generators_;
   std::mutex mtx_;
+};
+
+class MasterTaskStreamIndexManager final : public TaskStreamIndexManager {
+ public:
+  using stream_index_t = StreamId::stream_index_t;
+
+  OF_DISALLOW_COPY_AND_MOVE(MasterTaskStreamIndexManager);
+  MasterTaskStreamIndexManager() = default;
+  ~MasterTaskStreamIndexManager() = default;
+};
+
+class WorkerTaskStreamIndexManager final : public TaskStreamIndexManager {
+ public:
+  using stream_index_t = StreamId::stream_index_t;
+
+  OF_DISALLOW_COPY_AND_MOVE(WorkerTaskStreamIndexManager);
+  WorkerTaskStreamIndexManager() = default;
+  ~WorkerTaskStreamIndexManager() = default;
+
+  StreamIndexGenerator* GetGenerator(const DeviceId& device_id) override {
+    UNIMPLEMENTED() << "TaskStreamIndexManager on worker process is disabled.";
+  }
+  stream_index_t GetTaskStreamIndex(TaskType task_type, const DeviceId& device_id) override {
+    UNIMPLEMENTED() << "TaskStreamIndexManager on worker process is disabled.";
+  }
+  stream_index_t GetComputeTaskStreamIndex(const DeviceId& device_id) override {
+    UNIMPLEMENTED() << "TaskStreamIndexManager on worker process is disabled.";
+  }
+  stream_index_t GetNamedTaskStreamIndex(const DeviceId& device_id,
+                                         const std::string& name) override {
+    UNIMPLEMENTED() << "TaskStreamIndexManager on worker process is disabled.";
+  }
 };
 
 class TaskStreamIndexGetterRegistry final {

--- a/oneflow/core/job/compile_mode.cpp
+++ b/oneflow/core/job/compile_mode.cpp
@@ -27,6 +27,7 @@ struct CompileModeName final : public CompileModeVisitor<CompileModeName> {
   static std::string VisitNaive() { return "naive"; }
   static std::string VisitRankPerIter() { return "rank_per_iter"; }
   static std::string VisitRankPerThread() { return "rank_per_thread"; }
+  static std::string VisitRankPerProcess() { return "rank_per_process"; }
 };
 
 std::unordered_map<std::string, CompileMode> Name2CompileMode() {

--- a/oneflow/core/job/compile_mode.h
+++ b/oneflow/core/job/compile_mode.h
@@ -21,11 +21,12 @@ limitations under the License.
 namespace oneflow {
 
 enum class CompileMode {
-  kInvalid = 0,
+  kInvalid = 0,  // make sure kInvalid is the first CompileMode
   kNaive,
   kRankPerIter,
   kRankPerThread,
-  kEnd,
+  kRankPerProcess,
+  kEnd,  // make sure kEnd is the last CompileMode
 };
 
 template<typename DerivedT>
@@ -39,6 +40,8 @@ struct CompileModeVisitor {
         return DerivedT::VisitRankPerIter(std::forward<Args>(args)...);
       case CompileMode::kRankPerThread:
         return DerivedT::VisitRankPerThread(std::forward<Args>(args)...);
+      case CompileMode::kRankPerProcess:
+        return DerivedT::VisitRankPerProcess(std::forward<Args>(args)...);
       case CompileMode::kEnd: LOG(FATAL) << "invalid compile mode";
     }
     LOG(FATAL) << "invalid compile mode";

--- a/oneflow/core/job/env_global_objects_scope.cpp
+++ b/oneflow/core/job/env_global_objects_scope.cpp
@@ -102,7 +102,6 @@ void ClearAllSymbol() {
   Singleton<symbol::Storage<Scope>>::Get()->ClearAll();
   Singleton<symbol::Storage<JobDesc>>::Get()->ClearAll();
   Singleton<symbol::Storage<ParallelDesc>>::Get()->ClearAll();
-  Singleton<symbol::Storage<OperatorConfSymbol>>::Get()->ClearAll();
 }
 
 #if defined(WITH_RDMA) && defined(OF_PLATFORM_POSIX)

--- a/oneflow/core/job/id_manager.cpp
+++ b/oneflow/core/job/id_manager.cpp
@@ -14,13 +14,48 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "oneflow/core/job/id_manager.h"
+#include "oneflow/core/rpc/include/global_process_ctx.h"
 
 namespace oneflow {
+
+namespace {
+
+constexpr static int kRankLimitShift = 16;
+
+struct Int64 {
+  int64_t first : kRankLimitShift;
+  int64_t second : (sizeof(int64_t) * 8 - kRankLimitShift);
+};
+static_assert(sizeof(Int64) == sizeof(int64_t), "");
+
+}  // namespace
 
 IDMgr::IDMgr() {
   regst_desc_id_count_ = 0;
   mem_block_id_count_ = 0;
   chunk_id_count_ = 0;
+  CHECK_LE(GlobalProcessCtx::WorldSize(), (static_cast<int64_t>(1) << kRankLimitShift));
+}
+
+int64_t IDMgr::NewRegstDescId() {
+  Int64 x;
+  x.first = GlobalProcessCtx::Rank();
+  x.second = regst_desc_id_count_++;
+  return *reinterpret_cast<int64_t*>(&x);
+}
+
+int64_t IDMgr::NewMemBlockId() {
+  Int64 x;
+  x.first = GlobalProcessCtx::Rank();
+  x.second = mem_block_id_count_++;
+  return *reinterpret_cast<int64_t*>(&x);
+}
+
+int64_t IDMgr::NewChunkId() {
+  Int64 x;
+  x.first = GlobalProcessCtx::Rank();
+  x.second = chunk_id_count_++;
+  return *reinterpret_cast<int64_t*>(&x);
 }
 
 }  // namespace oneflow

--- a/oneflow/core/job/id_manager.cpp
+++ b/oneflow/core/job/id_manager.cpp
@@ -41,21 +41,24 @@ int64_t IDMgr::NewRegstDescId() {
   Int64 x;
   x.first = GlobalProcessCtx::Rank();
   x.second = regst_desc_id_count_++;
-  return *reinterpret_cast<int64_t*>(&x);
+  const auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<int64_t*>(&x);
+  return *ptr;
 }
 
 int64_t IDMgr::NewMemBlockId() {
   Int64 x;
   x.first = GlobalProcessCtx::Rank();
   x.second = mem_block_id_count_++;
-  return *reinterpret_cast<int64_t*>(&x);
+  const auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<int64_t*>(&x);
+  return *ptr;
 }
 
 int64_t IDMgr::NewChunkId() {
   Int64 x;
   x.first = GlobalProcessCtx::Rank();
   x.second = chunk_id_count_++;
-  return *reinterpret_cast<int64_t*>(&x);
+  const auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<int64_t*>(&x);
+  return *ptr;
 }
 
 }  // namespace oneflow

--- a/oneflow/core/job/id_manager.cpp
+++ b/oneflow/core/job/id_manager.cpp
@@ -21,12 +21,14 @@ namespace oneflow {
 namespace {
 
 constexpr static int kRankLimitShift = 16;
+constexpr static int kIdLimitShift = (sizeof(int64_t) * 8 - kRankLimitShift);
+static_assert(kIdLimitShift > 0, "");
 
-struct Int64 {
-  int64_t first : kRankLimitShift;
-  int64_t second : (sizeof(int64_t) * 8 - kRankLimitShift);
-};
-static_assert(sizeof(Int64) == sizeof(int64_t), "");
+int64_t AddCurrentRankOffset(int64_t x) {
+  CHECK_GE(x, 0);
+  CHECK_LT(x, (static_cast<int64_t>(1) << kIdLimitShift));
+  return (static_cast<int64_t>(GlobalProcessCtx::Rank()) << kIdLimitShift) + x;
+}
 
 }  // namespace
 
@@ -37,28 +39,10 @@ IDMgr::IDMgr() {
   CHECK_LE(GlobalProcessCtx::WorldSize(), (static_cast<int64_t>(1) << kRankLimitShift));
 }
 
-int64_t IDMgr::NewRegstDescId() {
-  Int64 x;
-  x.first = GlobalProcessCtx::Rank();
-  x.second = regst_desc_id_count_++;
-  const auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<int64_t*>(&x);
-  return *ptr;
-}
+int64_t IDMgr::NewRegstDescId() { return AddCurrentRankOffset(regst_desc_id_count_++); }
 
-int64_t IDMgr::NewMemBlockId() {
-  Int64 x;
-  x.first = GlobalProcessCtx::Rank();
-  x.second = mem_block_id_count_++;
-  const auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<int64_t*>(&x);
-  return *ptr;
-}
+int64_t IDMgr::NewMemBlockId() { return AddCurrentRankOffset(mem_block_id_count_++); }
 
-int64_t IDMgr::NewChunkId() {
-  Int64 x;
-  x.first = GlobalProcessCtx::Rank();
-  x.second = chunk_id_count_++;
-  const auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<int64_t*>(&x);
-  return *ptr;
-}
+int64_t IDMgr::NewChunkId() { return AddCurrentRankOffset(chunk_id_count_++); }
 
 }  // namespace oneflow

--- a/oneflow/core/job/id_manager.h
+++ b/oneflow/core/job/id_manager.h
@@ -29,9 +29,9 @@ class IDMgr final {
   OF_DISALLOW_COPY_AND_MOVE(IDMgr);
   ~IDMgr() = default;
 
-  int64_t NewRegstDescId() { return regst_desc_id_count_++; }
-  int64_t NewMemBlockId() { return mem_block_id_count_++; }
-  int64_t NewChunkId() { return chunk_id_count_++; }
+  int64_t NewRegstDescId();
+  int64_t NewMemBlockId();
+  int64_t NewChunkId();
 
   TaskIdGenerator* GetTaskIdGenerator() { return &task_id_gen_; }
 

--- a/oneflow/core/job/intra_job_mem_sharing_util.cpp
+++ b/oneflow/core/job/intra_job_mem_sharing_util.cpp
@@ -267,7 +267,10 @@ void GenMemChainTasksAndRegsts(
   HashMap<int64_t, TaskProto*> task_id2proto;
   for (int64_t i = 0; i < plan->task_size(); ++i) {
     TaskProto* task = plan->mutable_task(i);
-    CHECK(task_id2proto.emplace(task->task_id(), task).second);
+    CHECK(task_id2proto.emplace(task->task_id(), task).second)
+        << "\n-------------old-------------\n"
+        << task_id2proto.at(task->task_id())->DebugString() << "\n-------------new-------------\n"
+        << task->DebugString();
   }
   for (auto& pair : *mem_chain2sorted_tasks) {
     std::vector<TaskProto*>* sorted_tasks = &(pair.second);

--- a/oneflow/core/job/job.proto
+++ b/oneflow/core/job/job.proto
@@ -10,6 +10,7 @@ import "oneflow/core/register/blob_desc.proto";
 import "oneflow/core/operator/op_conf.proto";
 import "oneflow/core/job/sbp_parallel.proto";
 import "oneflow/core/job/module_conf.proto";
+import "oneflow/core/job/scope.proto";
 
 message JobParallelViewConf {
   map<string, SbpSignature> op_name2sbp_signature_conf = 1;

--- a/oneflow/core/job/plan_util.cpp
+++ b/oneflow/core/job/plan_util.cpp
@@ -722,7 +722,8 @@ void GetDeviceDesc(const TaskProto* task_proto, boxing::collective::DeviceDesc* 
 }  // namespace
 
 void PlanUtil::GenCollectiveBoxingPlan(
-    Job* job, Plan* plan, const std::function<std::unique_ptr<PlanTaskGraph>()>& GetPlanTaskGraph) {
+    DeallocateContext* deallocate_ctx, Job* job, Plan* plan,
+    const std::function<std::unique_ptr<PlanTaskGraph>()>& GetPlanTaskGraph) {
   using namespace boxing::collective;
 
   RequestSet* request_set = &(*plan->mutable_collective_boxing_plan()
@@ -826,6 +827,7 @@ void PlanUtil::GenCollectiveBoxingPlan(
     all_visited.insert(visited.begin(), visited.end());
     ++dependency_depth;
   }
+  deallocate_ctx->Deallocate(std::shared_ptr<PlanTaskGraph>(std::move(plan_task_graph_ptr)));
 }
 
 void PlanUtil::GenRegisterHint(Plan* plan) {

--- a/oneflow/core/job/plan_util.h
+++ b/oneflow/core/job/plan_util.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <functional>
 #include "oneflow/core/common/protobuf.h"
 #include "oneflow/core/common/util.h"
+#include "oneflow/core/common/deallocate_context.h"
 #include "oneflow/core/job/plan.pb.h"
 #include "oneflow/core/job/job.pb.h"
 #include "oneflow/core/graph/stream_id.h"
@@ -39,8 +40,14 @@ struct PlanUtil {
   static void SetForceInplaceMemBlock(Plan* plan);
   static void DumpCtrlRegstInfoToPlan(Plan* plan);
   static void GenCollectiveBoxingPlan(
-      Job* job, Plan* plan,
+      DeallocateContext* deallocate_ctx, Job* job, Plan* plan,
       const std::function<std::unique_ptr<PlanTaskGraph>()>& GetPlanTaskGraph);
+  static void GenCollectiveBoxingPlan(
+      Job* job, Plan* plan,
+      const std::function<std::unique_ptr<PlanTaskGraph>()>& GetPlanTaskGraph) {
+    NaiveDeallocateContext deallocate_ctx;
+    return GenCollectiveBoxingPlan(&deallocate_ctx, job, plan, GetPlanTaskGraph);
+  }
   static void GenRegisterHint(Plan* plan);
   static void GenLightPlan(Plan* plan, const std::string& plan_name);
   static void PlanMemoryLog(Plan* plan, const std::string& plan_name);

--- a/oneflow/core/job/rank_compiler.cpp
+++ b/oneflow/core/job/rank_compiler.cpp
@@ -50,8 +50,8 @@ void CreateOpAttributeRef(Plan* plan, int64_t job_id, TaskProto* task_proto) {
 
 }  // namespace
 
-Maybe<void> RankCompiler::Compile(const HashSet<std::string>& var_op_names, Job* job,
-                                  Plan* plan) const {
+Maybe<void> RankCompiler::Compile(const HashSet<std::string>& var_op_names, Job* job, Plan* plan,
+                                  DeallocateContext* deallocate_ctx) const {
   // build task_gph.
   // TODO(levi): we can rewrite this part of code in visitor pattern.
   auto task_gph =
@@ -117,8 +117,7 @@ Maybe<void> RankCompiler::Compile(const HashSet<std::string>& var_op_names, Job*
     }
     plan->mutable_task()->Add(std::move(task_proto));
   });
-  // NOTE(levi): release task_gph here to decrise memory peak.
-  task_gph.reset();
+  deallocate_ctx->Deallocate(std::move(task_gph));
 
   // post-process for plan and delete Singleton<OpGraph>.
   auto* job_id2job_conf = plan->mutable_job_confs()->mutable_job_id2job_conf();

--- a/oneflow/core/job/rank_compiler.h
+++ b/oneflow/core/job/rank_compiler.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define ONEFLOW_CORE_JOB_RANK_COMPILER_H_
 
 #include "oneflow/core/common/protobuf.h"
+#include "oneflow/core/common/deallocate_context.h"
 #include "oneflow/core/graph/task_graph.h"
 #include "oneflow/core/graph/boxing_task_graph.pb.h"
 #include "oneflow/core/job/plan.pb.h"
@@ -31,7 +32,12 @@ class RankCompiler final {
       : boxing_task_graph_proto_(boxing_task_graph_proto), rank_(rank) {}
   ~RankCompiler() = default;
 
-  Maybe<void> Compile(const HashSet<std::string>& var_op_names, Job*, Plan*) const;
+  Maybe<void> Compile(const HashSet<std::string>& var_op_names, Job*, Plan*,
+                      DeallocateContext* deallocate_ctx) const;
+  Maybe<void> Compile(const HashSet<std::string>& var_op_names, Job* job, Plan* plan) const {
+    NaiveDeallocateContext deallocate_ctx{};
+    return Compile(var_op_names, job, plan, &deallocate_ctx);
+  }
 
   Maybe<void> WithSingletonOpGraph(const Job* job, const std::function<Maybe<void>()>& Callback);
 

--- a/oneflow/core/job/session_global_objects_scope.cpp
+++ b/oneflow/core/job/session_global_objects_scope.cpp
@@ -49,14 +49,16 @@ Maybe<void> SessionGlobalObjectsScope::Init(const ConfigProto& config_proto) {
   Singleton<ResourceDesc, ForSession>::New(config_proto.resource(),
                                            GlobalProcessCtx::NumOfProcessPerNode());
   Singleton<IDMgr>::New();
-  Singleton<TaskStreamIndexManager>::New();
   if (GlobalProcessCtx::IsThisProcessMaster()) {
+    Singleton<TaskStreamIndexManager>::SetAllocated(new MasterTaskStreamIndexManager());
     Singleton<JobName2JobId>::New();
     Singleton<CriticalSectionDesc>::New();
     Singleton<InterUserJobInfo>::New();
     Singleton<LazyJobBuildAndInferCtxMgr>::New();
     Singleton<JobSetCompileCtx>::New();
     Singleton<RuntimeBufferManagersScope>::New();
+  } else {
+    Singleton<TaskStreamIndexManager>::SetAllocated(new WorkerTaskStreamIndexManager());
   }
 
   {

--- a/oneflow/core/operator/op_attribute.proto
+++ b/oneflow/core/operator/op_attribute.proto
@@ -28,7 +28,6 @@ message OpAttribute {
   optional SbpSignature sbp_signature = 104;
   optional LocalSignature local_signature = 105;
   optional BlobDescSignature logical_blob_desc_signature = 106;
-  optional ParallelSignature parallel_signature = 108;
   optional ParallelConfSignature parallel_conf_signature = 109;
   optional NdSbpSignature nd_sbp_signature = 110;
 }

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -394,6 +394,7 @@ message OperatorConf {
   optional string device_tag = 4 [default = "invalid_device"];
   repeated string ctrl_in_op_name = 7;
   optional int64 scope_symbol_id = 8;
+  optional string calculation_pass_name = 1000 [default = "forward_pass"];
   optional string stream_name_hint = 9;
   optional string pass_tag = 10;
   optional string loc = 11 [default = ""];

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -1329,35 +1329,6 @@ Maybe<void> Operator::ToOpAttribute(OpAttribute* op_attribute) const {
       if (!has_same_parallel_conf_as_op) { (*map)[pair.first] = pair.second->parallel_conf(); }
     }
   }
-  if (op_parallel_desc_ && bn2parallel_desc_) {
-    if (op_conf().scope_symbol_id() != 0) {
-      const auto& scope_storage = *Singleton<symbol::Storage<Scope>>::Get();
-      const auto& scope = JUST(scope_storage.MaybeGet(op_conf().scope_symbol_id()));
-      int64_t parallel_desc_symbol_id = JUST(scope.GetParallelDescSymbolId(op_conf()));
-      auto* parallel_signature = op_attribute->mutable_parallel_signature();
-      parallel_signature->set_op_parallel_desc_symbol_id(parallel_desc_symbol_id);
-      auto* symbol_map = parallel_signature->mutable_bn_in_op2parallel_desc_symbol_id();
-      for (const auto& pair : *bn2parallel_desc_) {
-        if (*pair.second == *op_parallel_desc_) {
-          (*symbol_map)[pair.first] = parallel_desc_symbol_id;
-        } else {
-          ParallelConf parallel_conf = pair.second->parallel_conf();
-          const auto MakeParallelDescSymbol = [&parallel_conf]() -> Maybe<int64_t> {
-            int64_t symbol_id = 0;
-            const auto BuildInstruction =
-                [&symbol_id, &parallel_conf](InstructionsBuilder* builder) -> Maybe<void> {
-              symbol_id = JUST(JUST(builder->GetParallelDescSymbol(parallel_conf))->symbol_id());
-              return Maybe<void>::Ok();
-            };
-            JUST(PhysicalRun(BuildInstruction));
-            return symbol_id;
-          };
-          (*symbol_map)[pair.first] = JUST(MakeParallelDescSymbol());
-        }
-      }
-      for (const auto& tbn : tmp_bns()) { (*symbol_map)[tbn] = parallel_desc_symbol_id; }
-    }
-  }
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/register/register_desc.h
+++ b/oneflow/core/register/register_desc.h
@@ -118,8 +118,8 @@ class RegstDesc final {
   bool enable_reuse_mem_;
   int32_t mem_block_id_;
   int64_t mem_block_offset_;
-  int32_t hint_inplace_consumed_regst_desc_id_;
-  int32_t force_inplace_consumed_regst_desc_id_;
+  int64_t hint_inplace_consumed_regst_desc_id_;
+  int64_t force_inplace_consumed_regst_desc_id_;
 
   std::shared_ptr<Shape> data_regst_time_shape_;
 };

--- a/oneflow/core/thread/thread_manager.h
+++ b/oneflow/core/thread/thread_manager.h
@@ -73,6 +73,17 @@ void MultiThreadLoop(size_t num, const DoEachT& DoEach) {
   bc.WaitForeverUntilCntEqualZero();
 }
 
+template<typename DoEachT>
+void FixedMultiThreadLoop(size_t fixed_thread_num, size_t total_num, const DoEachT& DoEach) {
+  CHECK_GT(fixed_thread_num, 0);
+  fixed_thread_num = std::min(fixed_thread_num, total_num);
+  BalancedSplitter bs(total_num, fixed_thread_num);
+  MultiThreadLoop(fixed_thread_num, [&](size_t i) {
+    Range range = bs.At(i);
+    for (int j = range.begin(); j < range.end(); ++j) { DoEach(j); }
+  });
+}
+
 }  // namespace oneflow
 
 #endif  // ONEFLOW_CORE_THREAD_THREAD_MANAGER_H_

--- a/oneflow/core/vm/symbol_storage.cpp
+++ b/oneflow/core/vm/symbol_storage.cpp
@@ -43,12 +43,6 @@ Maybe<Scope> NewSymbol<Scope>(int64_t symbol_id,
   return Scope::New(symbol_id, data);
 }
 
-template<>
-Maybe<OperatorConfSymbol> NewSymbol<OperatorConfSymbol>(
-    int64_t symbol_id, const typename ConstructArgType4Symbol<OperatorConfSymbol>::type& data) {
-  return std::make_shared<OperatorConfSymbol>(symbol_id, data);
-}
-
 }  // namespace detail
 
 }  // namespace symbol

--- a/oneflow/core/vm/symbol_storage.h
+++ b/oneflow/core/vm/symbol_storage.h
@@ -23,7 +23,6 @@ limitations under the License.
 
 namespace oneflow {
 
-class OperatorConfSymbol;
 class OperatorConf;
 
 class ParallelDesc;
@@ -40,11 +39,6 @@ namespace symbol {
 template<typename T>
 struct ConstructArgType4Symbol final {
   using type = T;
-};
-
-template<>
-struct ConstructArgType4Symbol<OperatorConfSymbol> final {
-  using type = OperatorConf;
 };
 
 template<>
@@ -68,10 +62,6 @@ template<typename T>
 Maybe<T> NewSymbol(int64_t symbol_id, const typename ConstructArgType4Symbol<T>::type& data) {
   return std::make_shared<T>(data);
 }
-
-template<>
-Maybe<OperatorConfSymbol> NewSymbol<OperatorConfSymbol>(
-    int64_t symbol_id, const typename ConstructArgType4Symbol<OperatorConfSymbol>::type& data);
 
 template<>
 Maybe<ParallelDesc> NewSymbol<ParallelDesc>(


### PR DESCRIPTION
多进程分离编译。

核心思路：1）分发job而不是分发plan；2）在master上为每个task分配好task_id，然后分发给各个worker，worker进程在编译的时候直接使用这些task_id；3）regst_desc_id/mem_block_id/chunk_id在分配时分按照rank分段，保证不同rank上的plan肯定不会发生id冲突。