### PR TITLE
Allocate in instruction computation

### DIFF
--- a/oneflow/api/python/functional/tensor_api.cpp
+++ b/oneflow/api/python/functional/tensor_api.cpp
@@ -291,10 +291,10 @@ class LocalTensorSharedNumpyDataFunctor {
     };
 
     const auto array_size_in_bytes = PyArray_NBYTES(array);
-    auto tensor_data = std::make_shared<vm::TensorStorage>();
+    auto tensor_data = std::make_shared<vm::OutsideVmTensorStorage>();
     tensor_data->set_blob_dptr(
         std::unique_ptr<char, std::function<void(char*)>>(static_cast<char*>(data_ptr), Free),
-        array_size_in_bytes, /*is_allocated_in_vm*/ false);
+        array_size_in_bytes);
 
     // Build TensorStorage: decrease ndarray reference count before releasing
     auto tensor_storage = std::make_shared<TensorStorage>(tensor_data);

--- a/oneflow/core/eager/eager_blob_object.cpp
+++ b/oneflow/core/eager/eager_blob_object.cpp
@@ -35,7 +35,6 @@ EagerBlobObject::EagerBlobObject(
       data_type_(data_type),
       storage_offset_(0),
       tensor_storage_(tensor_storage),
-      is_non_pod_object_placement_newed_(false),
       pin_memory_(false),
       compute_local_dep_object_(dep_object),
       static_local_tensor_meta_(static_local_tensor_meta),
@@ -106,7 +105,7 @@ Maybe<void> EagerBlobObject::TryAllocateBlobBodyMemory(vm::Allocator* allocator)
       allocator->Deallocate(dptr, required_body_bytes);
     };
     tensor_storage_->set_blob_dptr(std::unique_ptr<char, std::function<void(char*)>>(dptr, Free),
-                                   required_body_bytes, /*is_allocated_in_vm*/ true);
+                                   required_body_bytes);
     InitNonPODTypeEagerBlobObjectIfNeed(tensor_storage_->non_pod_allocator(), this);
   }
   return Maybe<void>::Ok();

--- a/oneflow/core/framework/instructions_builder.cpp
+++ b/oneflow/core/framework/instructions_builder.cpp
@@ -383,10 +383,10 @@ Maybe<void> InstructionsBuilder::Call(
     const std::shared_ptr<const one::GlobalTensorInferResult>& global_tensor_infer_result,
     const one::OpExprInterpContext& ctx, Symbol<Stream> stream) {
   stream = JUST(StreamGuard::TryConvertStream(stream));
-  //  Symbol<Stream> allocator_stream = JUST(GetAllocatorStream(stream));
-  //  if (stream != allocator_stream) {
-  //    JUST(AllocateTensors(output_eager_blob_objects, allocator_stream));
-  //  }
+  Symbol<Stream> allocator_stream = JUST(GetAllocatorStream(stream));
+  if (stream != allocator_stream) {
+    JUST(AllocateTensors(output_eager_blob_objects, allocator_stream));
+  }
   JUST(SoftSyncStream(output_eager_blob_objects, stream));
   JUST(SoftSyncStream(input_eager_blob_objects, stream));
   for (const auto& output : output_eager_blob_objects) {

--- a/oneflow/core/framework/instructions_builder.h
+++ b/oneflow/core/framework/instructions_builder.h
@@ -138,6 +138,8 @@ class InstructionsBuilder : public std::enable_shared_from_this<InstructionsBuil
       const one::OpExprInterpContext& ctx, Symbol<Stream> stream);
 
  private:
+  Maybe<void> AllocateTensors(const vm::EagerBlobObjectList& eager_blob_objects,
+                              Symbol<Stream> stream);
   Maybe<void> SoftSyncStream(const vm::EagerBlobObjectList& eager_blob_objects,
                              Symbol<Stream> stream);
   Maybe<void> SoftSyncStreamBetween(

--- a/oneflow/core/framework/stream.cpp
+++ b/oneflow/core/framework/stream.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "oneflow/core/common/singleton.h"
 #include "oneflow/core/job/parallel_desc.h"
 #include "oneflow/core/framework/stream_mgr.h"
+#include "oneflow/core/vm/stream_get_allocator_stream_type.h"
 
 namespace oneflow {
 
@@ -58,6 +59,13 @@ Maybe<Symbol<Stream>> RawGetDefaultStreamByPlacement(Symbol<ParallelDesc> parall
   return RawGetDefaultStreamByDevice(JUST(GetTensorDevice(parallel_desc)));
 }
 
+Maybe<Symbol<Stream>> RawGetAllocatorStream(Symbol<Stream> stream) {
+  if (stream->device()->enum_type() == DeviceType::kCPU) { return stream; }
+  StreamType allocator_stream_type = JUST(GetAllocatorStreamType::Visit(stream->stream_type()));
+  if (allocator_stream_type == stream->stream_type()) { return stream; }
+  return Stream::New(stream->device(), allocator_stream_type, stream->thread_uid());
+}
+
 }  // namespace
 
 int64_t Stream::kDefaultStreamThreadUid = 0;
@@ -67,5 +75,7 @@ decltype(GetDefaultStreamByDevice) GetDefaultStreamByDevice =
 
 decltype(GetDefaultStreamByPlacement) GetDefaultStreamByPlacement =
     DECORATE(&RawGetDefaultStreamByPlacement, ThreadLocal);
+
+decltype(GetAllocatorStream) GetAllocatorStream = DECORATE(&RawGetAllocatorStream, ThreadLocal);
 
 }  // namespace oneflow

--- a/oneflow/core/framework/stream.h
+++ b/oneflow/core/framework/stream.h
@@ -68,6 +68,8 @@ extern Maybe<Symbol<Stream>> (*GetDefaultStreamByDevice)(Symbol<Device>);
 class ParallelDesc;
 extern Maybe<Symbol<Stream>> (*GetDefaultStreamByPlacement)(Symbol<ParallelDesc>);
 
+extern Maybe<Symbol<Stream>> (*GetAllocatorStream)(Symbol<Stream>);
+
 }  // namespace oneflow
 
 namespace std {

--- a/oneflow/core/framework/tensor_impl.cpp
+++ b/oneflow/core/framework/tensor_impl.cpp
@@ -117,7 +117,7 @@ Maybe<void> EagerLocalTensorImpl::InitEagerBlobObject(
   } else {
     const auto& eager_blob_object = std::make_shared<vm::EagerBlobObject>(
         mem_case, local_tensor_meta, mut_local_tensor_meta, local_tensor_meta->dtype(),
-        std::make_shared<vm::TensorStorage>(), dep_object);
+        std::make_shared<vm::InsideVmTensorStorage>(), dep_object);
     JUST(set_eager_blob_object(eager_blob_object));
   }
   return Maybe<void>::Ok();

--- a/oneflow/core/framework/tensor_storage.cpp
+++ b/oneflow/core/framework/tensor_storage.cpp
@@ -22,7 +22,7 @@ namespace oneflow {
 namespace one {
 
 TensorStorage::TensorStorage(const std::shared_ptr<const ParallelDesc>& parallel_desc)
-    : storage_(std::make_shared<vm::TensorStorage>()) {}
+    : storage_(std::make_shared<vm::InsideVmTensorStorage>()) {}
 
 TensorStorage::TensorStorage(const std::shared_ptr<vm::TensorStorage>& tensor_storage)
     : storage_(tensor_storage) {}

--- a/oneflow/core/vm/access_blob_arg_cb_instruction_policy.h
+++ b/oneflow/core/vm/access_blob_arg_cb_instruction_policy.h
@@ -68,10 +68,6 @@ class AccessBlobArgCbInstructionPolicy final : public InstructionPolicy {
     if (modifier_ == "mut2") { DoEach(CHECK_JUST(eager_blob_object_->compute_local_dep_object())); }
   }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {
-    DoEach(eager_blob_object_.get());
-  }
-
   std::string DebugName(const Instruction& instruction) const override {
     return "AccessBlobByCallback";
   }

--- a/oneflow/core/vm/allocate_tensor_instruction_policy.cpp
+++ b/oneflow/core/vm/allocate_tensor_instruction_policy.cpp
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/vm/allocate_tensor_instruction_policy.h"
+
+namespace oneflow {
+namespace vm {
+
+AllocateTensorInstructionPolicy::AllocateTensorInstructionPolicy(
+    const EagerBlobObjectList& eager_blob_objects, vm::Stream* vm_stream)
+    : eager_blob_objects_(eager_blob_objects) {
+  stream_sequential_dependence_ = vm_stream->schedule_local_dep_object().get();
+}
+
+std::string AllocateTensorInstructionPolicy::DebugName(const vm::Instruction& instruction) const {
+  return "AllocateTensor";
+}
+
+void AllocateTensorInstructionPolicy::Compute(Instruction* instruction) {
+  Allocator* allocator = instruction->mut_stream()->mut_stream_policy()->mut_allocator();
+  for (const auto& eagerblob_object : eager_blob_objects_) {
+    CHECK_JUST(eagerblob_object->TryAllocateBlobBodyMemory(allocator));
+  }
+}
+
+}  // namespace vm
+}  // namespace oneflow

--- a/oneflow/core/vm/allocate_tensor_instruction_policy.h
+++ b/oneflow/core/vm/allocate_tensor_instruction_policy.h
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_VM_ALLOCATE_INSTRUCTION_POLICY_H_
+#define ONEFLOW_CORE_VM_ALLOCATE_INSTRUCTION_POLICY_H_
+
+#include <memory>
+#include "oneflow/core/eager/eager_blob_object.h"
+#include "oneflow/core/vm/instruction_policy.h"
+#include "oneflow/core/vm/stream.h"
+
+namespace oneflow {
+
+namespace vm {
+
+class AllocateTensorInstructionPolicy final : public InstructionPolicy {
+ public:
+  AllocateTensorInstructionPolicy(const EagerBlobObjectList& eager_blob_objects,
+                                  vm::Stream* vm_stream);
+  AllocateTensorInstructionPolicy(const AllocateTensorInstructionPolicy&) = delete;
+  AllocateTensorInstructionPolicy(AllocateTensorInstructionPolicy&&) = delete;
+
+  ~AllocateTensorInstructionPolicy() override = default;
+
+  const DependenceVector& input_dependences() const override {
+    static thread_local DependenceVector input_dependences{};
+    return input_dependences;
+  }
+  const DependenceVector& output_dependences() const override { return output_dependences_; }
+
+  InstructionFuseType fuse_type() const override { return kEnableInstructionFuseAtAnyPosition; }
+
+  std::string DebugName(const vm::Instruction& instruction) const override;
+
+ private:
+  Maybe<void> Prepare(Instruction* instruction) override { return Maybe<void>::Ok(); }
+  void Compute(Instruction* instruction) override;
+
+  EagerBlobObjectList eager_blob_objects_;
+  DependenceVector output_dependences_;
+};
+
+}  // namespace vm
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_VM_ALLOCATE_INSTRUCTION_POLICY_H_

--- a/oneflow/core/vm/allocator.h
+++ b/oneflow/core/vm/allocator.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <cstddef>
 #include "oneflow/core/common/maybe.h"
+#include "glog/logging.h"
 
 namespace oneflow {
 namespace vm {
@@ -32,6 +33,22 @@ class Allocator {
 
  protected:
   Allocator() = default;
+};
+
+class UnimplementedAllocator final : public Allocator {
+ public:
+  explicit UnimplementedAllocator(const std::string& debug_str) : debug_str_(debug_str) {}
+  virtual ~UnimplementedAllocator() = default;
+
+  Maybe<void> Allocate(char** mem_ptr, std::size_t size) override {
+    UNIMPLEMENTED_THEN_RETURN() << debug_str_;
+  }
+
+  void Deallocate(char* mem_ptr, std::size_t size) override { LOG(FATAL) << debug_str_; }
+  void DeviceReset() override { LOG(FATAL) << debug_str_; }
+
+ private:
+  std::string debug_str_;
 };
 
 }  // namespace vm

--- a/oneflow/core/vm/barrier_instruction_policy.h
+++ b/oneflow/core/vm/barrier_instruction_policy.h
@@ -36,8 +36,6 @@ class BarrierInstructionPolicy final : public InstructionPolicy {
     return dependences;
   }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {}
-
   bool IsBarrier() const override { return true; }
 
   std::string DebugName(const vm::Instruction& instruction) const override { return "Barrier"; }

--- a/oneflow/core/vm/critical_section_instruction_policy.h
+++ b/oneflow/core/vm/critical_section_instruction_policy.h
@@ -100,10 +100,6 @@ class CriticalSectionBeginInstructionPolicy
   void FinishInvalidInterfaceEventRecords();
   void Finish();
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {
-    for (const auto& eager_blob_object : *eager_blob_objects_) { DoEach(eager_blob_object.get()); }
-  }
-
  protected:
   std::shared_ptr<NNGraphIf> nn_graph_;
   EagerBlobObjectListPtr eager_blob_objects_;
@@ -286,10 +282,6 @@ class CriticalSectionEndInstructionPolicy : public InstructionPolicy {
   void ForEachDependence(const std::function<void(vm::Dependence* compute)>&) const;
 
   void ForEachMutDependence(const std::function<void(vm::Dependence* compute)>&) const;
-
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {
-    DoEach(eager_blob_object_.get());
-  }
 
  private:
   std::shared_ptr<EagerBlobObject> eager_blob_object_;

--- a/oneflow/core/vm/ep_record_event_instruction_policy.h
+++ b/oneflow/core/vm/ep_record_event_instruction_policy.h
@@ -64,7 +64,6 @@ class EpRecordEventInstructionPolicy final : public InstructionPolicy {
       for (const auto& dep : compute_local_dep_objects_) { DoEach(dep.get()); }
     }
   }
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {}
   InstructionFuseType fuse_type() const override { return kEnableInstructionFuseAsTailOnly; }
 
   void InitInstructionStatus(Instruction* instruction) override {

--- a/oneflow/core/vm/ep_stream_policy_base.cpp
+++ b/oneflow/core/vm/ep_stream_policy_base.cpp
@@ -52,7 +52,6 @@ void EpStreamPolicyBase::Run(Instruction* instruction) const {
   auto* ep_device = ep_stream_policy_base->GetOrCreateEpDevice();
   ep_device->SetAsActiveDevice();
   instruction->Compute();
-  ep_stream_policy_base->stream()->Sync();
   char* data_ptr = instruction->mut_status_buffer()->mut_buffer();
   EpOptionalEventRecordStatusQuerier::MutCast(data_ptr)->SetLaunched(
       stream->mut_stream_policy()->stream());

--- a/oneflow/core/vm/ep_stream_policy_base.cpp
+++ b/oneflow/core/vm/ep_stream_policy_base.cpp
@@ -52,6 +52,7 @@ void EpStreamPolicyBase::Run(Instruction* instruction) const {
   auto* ep_device = ep_stream_policy_base->GetOrCreateEpDevice();
   ep_device->SetAsActiveDevice();
   instruction->Compute();
+  ep_stream_policy_base->stream()->Sync();
   char* data_ptr = instruction->mut_status_buffer()->mut_buffer();
   EpOptionalEventRecordStatusQuerier::MutCast(data_ptr)->SetLaunched(
       stream->mut_stream_policy()->stream());

--- a/oneflow/core/vm/ep_stream_policy_base.h
+++ b/oneflow/core/vm/ep_stream_policy_base.h
@@ -28,8 +28,7 @@ namespace vm {
 
 class EpStreamPolicyBase : public StreamPolicy {
  public:
-  EpStreamPolicyBase(Symbol<Device> device,
-                     std::unique_ptr<BinAllocator<ThreadSafeLock>>&& backend_allocator)
+  EpStreamPolicyBase(Symbol<Device> device, std::unique_ptr<vm::Allocator>&& backend_allocator)
       : device_(device),
         ep_event_provier_(),
         ep_stream_(nullptr),
@@ -89,7 +88,7 @@ class EpStreamPolicyBase : public StreamPolicy {
   std::unique_ptr<EpEventProvider> ep_event_provier_;
   mutable std::shared_ptr<ep::Device> ep_device_;
   mutable ep::Stream* ep_stream_;
-  std::unique_ptr<BinAllocator<ThreadSafeLock>> ep_allocator_;
+  std::unique_ptr<vm::Allocator> ep_allocator_;
 };
 
 }  // namespace vm

--- a/oneflow/core/vm/event_recorded_ep_stream_policy.cpp
+++ b/oneflow/core/vm/event_recorded_ep_stream_policy.cpp
@@ -24,24 +24,9 @@ limitations under the License.
 namespace oneflow {
 namespace vm {
 
-namespace {
-
-std::unique_ptr<BinAllocator<ThreadSafeLock>> CreateEpBackendDeviceAllocator(
-    Symbol<Device> device) {
-  DeviceType device_type = device->enum_type();
-  size_t device_index = device->device_id();
-  auto ep_device =
-      Singleton<ep::DeviceManagerRegistry>::Get()->GetDevice(device_type, device_index);
-  auto ep_backend_allocator =
-      std::make_unique<EpBackendAllocator>(ep_device, ep::AllocationOptions{});
-  return std::make_unique<BinAllocator<ThreadSafeLock>>(ep::kMaxAlignmentRequirement,
-                                                        std::move(ep_backend_allocator));
-}
-
-}  // namespace
-
-EventRecordedEpStreamPolicy::EventRecordedEpStreamPolicy(Symbol<Device> device)
-    : EpStreamPolicyBase(device, CreateEpBackendDeviceAllocator(device)) {}
+EventRecordedEpStreamPolicy::EventRecordedEpStreamPolicy(Symbol<Device> device,
+                                                         std::unique_ptr<vm::Allocator>&& allocator)
+    : EpStreamPolicyBase(device, std::move(allocator)) {}
 
 void EventRecordedEpStreamPolicy::InitInstructionStatus(
     const Stream& stream, InstructionStatusBuffer* status_buffer) const {

--- a/oneflow/core/vm/event_recorded_ep_stream_policy.h
+++ b/oneflow/core/vm/event_recorded_ep_stream_policy.h
@@ -23,7 +23,7 @@ namespace vm {
 
 class EventRecordedEpStreamPolicy final : public EpStreamPolicyBase {
  public:
-  EventRecordedEpStreamPolicy(Symbol<Device> device);
+  EventRecordedEpStreamPolicy(Symbol<Device> device, std::unique_ptr<vm::Allocator>&& allocator);
   ~EventRecordedEpStreamPolicy() override = default;
 
   void InitInstructionStatus(const Stream& stream,

--- a/oneflow/core/vm/fuse_instruction_policy.h
+++ b/oneflow/core/vm/fuse_instruction_policy.h
@@ -62,7 +62,6 @@ class FuseInstructionPolicy final : public InstructionPolicy {
   const DependenceVector& output_dependences() const override { return output_dependences_; }
 
   InstructionList* mut_instruction_list() { return &instruction_list_; }
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {}
 
  private:
   Maybe<void> Prepare(Instruction* instruction) override {

--- a/oneflow/core/vm/global_sync_instruction_policy.h
+++ b/oneflow/core/vm/global_sync_instruction_policy.h
@@ -35,8 +35,6 @@ class GlobalSyncInstructionPolicy final : public InstructionPolicy {
     return dependences;
   }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {}
-
   bool IsBarrier() const override { return true; }
 
   std::string DebugName(const vm::Instruction& instruction) const override { return "GlobalSync"; }

--- a/oneflow/core/vm/instruction_policy.cpp
+++ b/oneflow/core/vm/instruction_policy.cpp
@@ -31,18 +31,5 @@ void InstructionPolicy::DeleteInstructionStatus(Instruction* instruction) {
                                                        instruction->mut_status_buffer());
 }
 
-namespace {
-
-void InitOrCheckMemPtrForAllocationCompuationPipelining(EagerBlobObject* eager_blob_object) {
-  eager_blob_object->InitOrCheckMemPtrForAllocationComputationPipelining();
-}
-
-}  // namespace
-
-void InstructionPolicy::InitOrCheckInputBlobsMemPtrForAllocationCompuationPipelining(
-    Instruction* instruction) {
-  ForEachInputEagerBlobObjects(&InitOrCheckMemPtrForAllocationCompuationPipelining);
-}
-
 }  // namespace vm
 }  // namespace oneflow

--- a/oneflow/core/vm/instruction_policy.h
+++ b/oneflow/core/vm/instruction_policy.h
@@ -43,7 +43,6 @@ class InstructionPolicy {
   virtual const DependenceVector& input_dependences() const = 0;
   virtual const DependenceVector& output_dependences() const = 0;
   virtual Dependence* stream_sequential_dependence() const { return stream_sequential_dependence_; }
-  virtual void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const = 0;
 
   virtual bool IsBarrier() const { return false; }
   virtual InstructionFuseType fuse_type() const { return kDisableInstructionFuse; }
@@ -51,7 +50,6 @@ class InstructionPolicy {
 
   Maybe<void> PrepareIf(Instruction* instruction) {
     OF_PROFILER_RANGE_GUARD(std::string("Prepare:") + DebugName(*instruction));
-    InitOrCheckInputBlobsMemPtrForAllocationCompuationPipelining(instruction);
     return Prepare(instruction);
   }
 
@@ -75,7 +73,6 @@ class InstructionPolicy {
   virtual void Compute(Instruction* instruction) = 0;
   virtual void InitInstructionStatus(Instruction* instruction);
   virtual void DeleteInstructionStatus(Instruction* instruction);
-  void InitOrCheckInputBlobsMemPtrForAllocationCompuationPipelining(Instruction* instruction);
 };
 
 }  // namespace vm

--- a/oneflow/core/vm/lazy_job_instruction_policy.h
+++ b/oneflow/core/vm/lazy_job_instruction_policy.h
@@ -81,10 +81,6 @@ class LaunchLazyJobInstructionPolicy final : public InstructionPolicy {  // NOLI
 
   void ForEachMut2Dependence(const std::function<void(Dependence* compute)>&) const {}
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {
-    for (const auto& eager_blob_object : *param_blob_objects_) { DoEach(eager_blob_object.get()); }
-  }
-
   std::string DebugName(const Instruction&) const override { return "LaunchLazyJob"; }
   Maybe<void> Prepare(Instruction* instruction) override { return Maybe<void>::Ok(); }
   void Compute(Instruction* instruction) override {

--- a/oneflow/core/vm/op_call_instruction_policy.h
+++ b/oneflow/core/vm/op_call_instruction_policy.h
@@ -57,8 +57,6 @@ class OpCallInstructionPolicy final : public InstructionPolicy {
     return dev_vm_dep_object_consume_mode_;
   }
 
-  bool is_all_outputs_pod() const { return is_all_outputs_pod_; }
-
   one::StatefulOpKernel* mut_opkernel() { return opkernel_.get(); }
 
   template<typename DoEachT>
@@ -91,10 +89,6 @@ class OpCallInstructionPolicy final : public InstructionPolicy {
 
   Stream* vm_stream() const { return vm_stream_; }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {
-    for (const auto& eager_blob_object : call_ctx_.inputs()) { DoEach(eager_blob_object.get()); }
-  }
-
   InstructionFuseType fuse_type() const override { return kEnableInstructionFuseAtAnyPosition; }
 
   std::string DebugName(const vm::Instruction& instruction) const override;
@@ -121,7 +115,6 @@ class OpCallInstructionPolicy final : public InstructionPolicy {
   const one::DevVmDepObjectConsumeMode dev_vm_dep_object_consume_mode_;
   DependenceVector input_dependences_;
   DependenceVector output_dependences_;
-  bool is_all_outputs_pod_;
 };
 
 }  // namespace vm

--- a/oneflow/core/vm/release_tensor_instruction_policy.h
+++ b/oneflow/core/vm/release_tensor_instruction_policy.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "oneflow/core/framework/device.h"
 #include "oneflow/core/framework/stream.h"
 #include "oneflow/core/vm/stream.h"
+#include "oneflow/core/framework/stream_need_soft_sync.h"
 
 namespace oneflow {
 
@@ -64,10 +65,6 @@ class ReleaseTensorInstructionPolicy : public InstructionPolicy {
     return stream_sequential_dependence_;
   }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {
-    DoEach(eager_blob_object_.get());
-  }
-
  protected:
   void Release(const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object) const {
     CHECK_JUST(eager_blob_object->DeallocateBlobDataPtr());
@@ -88,6 +85,10 @@ class ReleaseTensorInstructionPolicy : public InstructionPolicy {
 class FastReleaseTensorInstructionPolicy final : public ReleaseTensorInstructionPolicy {
  public:
   using ReleaseTensorInstructionPolicy::ReleaseTensorInstructionPolicy;
+
+  bool Prescheduleable(const vm::Stream* src, const vm::Stream* dst) const override {
+    return false;
+  }
 
  private:
   std::string DebugName(const vm::Instruction& instruction) const override {
@@ -121,64 +122,74 @@ class SlowReleaseTensorInstructionPolicy final : public ReleaseTensorInstruction
 
   Maybe<void> Prepare(vm::Instruction* instruction) override { return Maybe<void>::Ok(); }
 
-  void Compute(vm::Instruction* instruction) override {
-    DataType data_type = eager_blob_object()->data_type();
-    CHECK(!IsPODDataType(data_type));
-    Release(eager_blob_object());
-  }
+  void Compute(vm::Instruction* instruction) override { Release(eager_blob_object()); }
 };
 
 struct MakeReleaseTensorInstructionPolicy
     : public StreamTypeVisitor<MakeReleaseTensorInstructionPolicy> {
   static Maybe<vm::InstructionPolicy> VisitCompute(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
-    return Make(data_type, eager_blob_object, stream);
+    return Make(eager_blob_object, stream);
   }
   static Maybe<vm::InstructionPolicy> VisitHost2Device(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
-    return Make(data_type, eager_blob_object, stream);
+    return Make(eager_blob_object, stream);
   }
   static Maybe<vm::InstructionPolicy> VisitDevice2Host(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
-    return Make(data_type, eager_blob_object, stream);
+    return Make(eager_blob_object, stream);
   }
   static Maybe<vm::InstructionPolicy> VisitCcl(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
-    return Make(data_type, eager_blob_object, stream);
+    return Make(eager_blob_object, stream);
   }
   static Maybe<vm::InstructionPolicy> VisitBarrier(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
     UNIMPLEMENTED_THEN_RETURN() << "ReleaseTensor instruction not supported in Barrier stream";
   }
   static Maybe<vm::InstructionPolicy> VisitCriticalSection(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
     UNIMPLEMENTED_THEN_RETURN()
         << "ReleaseTensor instruction not supported in CriticalSection stream";
   }
   static Maybe<vm::InstructionPolicy> VisitLazyJobLauncher(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
     UNIMPLEMENTED_THEN_RETURN()
         << "ReleaseTensor instruction not supported in LaunchLazyJob stream";
   }
   static Maybe<vm::InstructionPolicy> VisitPinnedCompute(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
-    return VisitCompute(data_type, eager_blob_object, stream);
+    return VisitCompute(eager_blob_object, stream);
   }
 
  private:
   static Maybe<vm::InstructionPolicy> Make(
-      DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
+      const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
     return std::shared_ptr<vm::InstructionPolicy>(
         new vm::SlowReleaseTensorInstructionPolicy(eager_blob_object, stream));
+    DataType data_type = eager_blob_object->data_type();
+    if (!IsPODDataType(data_type)) {
+      return std::shared_ptr<vm::InstructionPolicy>(
+          new vm::SlowReleaseTensorInstructionPolicy(eager_blob_object, stream));
+    }
+    Symbol<oneflow::Stream> last_used_stream = JUST(eager_blob_object->last_used_stream());
+    DeviceType device_type = last_used_stream->device()->enum_type();
+    if (NeedSoftSync::Visit(last_used_stream->stream_type(), device_type)) {
+      return std::shared_ptr<vm::InstructionPolicy>(
+          new vm::SlowReleaseTensorInstructionPolicy(eager_blob_object, stream));
+    } else {
+      return std::shared_ptr<vm::InstructionPolicy>(
+          new vm::FastReleaseTensorInstructionPolicy(eager_blob_object, stream));
+    }
   }
 };
 

--- a/oneflow/core/vm/release_tensor_instruction_policy.h
+++ b/oneflow/core/vm/release_tensor_instruction_policy.h
@@ -177,13 +177,8 @@ struct MakeReleaseTensorInstructionPolicy
   static Maybe<vm::InstructionPolicy> Make(
       DataType data_type, const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
-    if (IsPODDataType(data_type)) {
-      return std::shared_ptr<vm::InstructionPolicy>(
-          new vm::FastReleaseTensorInstructionPolicy(eager_blob_object, stream));
-    } else {
-      return std::shared_ptr<vm::InstructionPolicy>(
-          new vm::SlowReleaseTensorInstructionPolicy(eager_blob_object, stream));
-    }
+    return std::shared_ptr<vm::InstructionPolicy>(
+        new vm::SlowReleaseTensorInstructionPolicy(eager_blob_object, stream));
   }
 };
 

--- a/oneflow/core/vm/release_tensor_instruction_policy.h
+++ b/oneflow/core/vm/release_tensor_instruction_policy.h
@@ -174,8 +174,6 @@ struct MakeReleaseTensorInstructionPolicy
   static Maybe<vm::InstructionPolicy> Make(
       const std::shared_ptr<vm::EagerBlobObject>& eager_blob_object,
       const Optional<vm::Stream*>& stream) {
-    return std::shared_ptr<vm::InstructionPolicy>(
-        new vm::SlowReleaseTensorInstructionPolicy(eager_blob_object, stream));
     DataType data_type = eager_blob_object->data_type();
     if (!IsPODDataType(data_type)) {
       return std::shared_ptr<vm::InstructionPolicy>(

--- a/oneflow/core/vm/stream.cpp
+++ b/oneflow/core/vm/stream.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 #include "oneflow/core/common/util.h"
 #include "oneflow/core/common/cpp_attribute.h"
 #include "oneflow/core/framework/device.h"
-#include "oneflow/core/vm/stream_get_stream_policy.h"
+#include "oneflow/core/vm/stream_create_stream_policy.h"
 #include "oneflow/core/framework/stream_on_independent_thread.h"
 
 namespace oneflow {

--- a/oneflow/core/vm/stream_create_stream_policy.h
+++ b/oneflow/core/vm/stream_create_stream_policy.h
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#ifndef ONEFLOW_CORE_VM_STREAM_GET_STREAM_POLICY_H_
-#define ONEFLOW_CORE_VM_STREAM_GET_STREAM_POLICY_H_
+#ifndef ONEFLOW_CORE_VM_STREAM_CREATE_STREAM_POLICY_H_
+#define ONEFLOW_CORE_VM_STREAM_CREATE_STREAM_POLICY_H_
 
 #include "oneflow/core/common/symbol.h"
 #include "oneflow/core/common/stream_type.h"
@@ -35,13 +35,19 @@ struct CreateStreamPolicy final : public StreamTypeVisitor<CreateStreamPolicy> {
     return std::shared_ptr<vm::StreamPolicy>(new vm::EpStreamPolicy(device));
   }
   static Maybe<vm::StreamPolicy> VisitHost2Device(Symbol<Device> device) {
-    return std::shared_ptr<vm::StreamPolicy>(new vm::EventRecordedEpStreamPolicy(device));
+    auto allocator =
+        std::make_unique<vm::UnimplementedAllocator>("allocator is not supported on h2d stream.");
+    return std::shared_ptr<vm::StreamPolicy>(
+        new vm::EventRecordedEpStreamPolicy(device, std::move(allocator)));
   }
   static Maybe<vm::StreamPolicy> VisitDevice2Host(Symbol<Device> device) {
     return std::shared_ptr<vm::StreamPolicy>(new vm::EpD2HStreamPolicy(device));
   }
   static Maybe<vm::StreamPolicy> VisitCcl(Symbol<Device> device) {
-    return std::shared_ptr<vm::StreamPolicy>(new vm::EventRecordedEpStreamPolicy(device));
+    auto allocator =
+        std::make_unique<vm::UnimplementedAllocator>("allocator is not supported on ccl stream.");
+    return std::shared_ptr<vm::StreamPolicy>(
+        new vm::EventRecordedEpStreamPolicy(device, std::move(allocator)));
   }
   static Maybe<vm::StreamPolicy> VisitBarrier(Symbol<Device> device) {
     return std::shared_ptr<vm::StreamPolicy>(new vm::ControlStreamPolicy());
@@ -59,4 +65,4 @@ struct CreateStreamPolicy final : public StreamTypeVisitor<CreateStreamPolicy> {
 
 }  // namespace oneflow
 
-#endif  // ONEFLOW_CORE_VM_STREAM_GET_STREAM_POLICY_H_
+#endif  // ONEFLOW_CORE_VM_STREAM_CREATE_STREAM_POLICY_H_

--- a/oneflow/core/vm/stream_get_allocator_stream_type.h
+++ b/oneflow/core/vm/stream_get_allocator_stream_type.h
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_VM_STREAM_GET_ALLOCATOR_STREAM_TYPE_H_
+#define ONEFLOW_CORE_VM_STREAM_GET_ALLOCATOR_STREAM_TYPE_H_
+
+#include "oneflow/core/common/stream_type.h"
+
+namespace oneflow {
+
+struct GetAllocatorStreamType final : public StreamTypeVisitor<GetAllocatorStreamType> {
+  static Maybe<StreamType> VisitCompute() { return StreamType::kCompute; }
+  static Maybe<StreamType> VisitHost2Device() { return StreamType::kCompute; }
+  static Maybe<StreamType> VisitCcl() { return StreamType::kCompute; }
+  static Maybe<StreamType> VisitPinnedCompute() { return StreamType::kPinnedCompute; }
+  static Maybe<StreamType> VisitDevice2Host() { return StreamType::kDevice2Host; }
+  static Maybe<StreamType> VisitBarrier() {
+    UNIMPLEMENTED_THEN_RETURN() << "no allocator supported on 'barrier' stream_type.";
+  }
+  static Maybe<StreamType> VisitCriticalSection() {
+    UNIMPLEMENTED_THEN_RETURN() << "no allocator supported on 'critical_section' stream_type.";
+  }
+  static Maybe<StreamType> VisitLazyJobLauncher() {
+    UNIMPLEMENTED_THEN_RETURN() << "no allocator supported on 'lazy_job_launcher' stream_type.";
+  }
+};
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_VM_STREAM_GET_ALLOCATOR_STREAM_TYPE_H_

--- a/oneflow/core/vm/stream_record_event_instruction_policy.h
+++ b/oneflow/core/vm/stream_record_event_instruction_policy.h
@@ -44,8 +44,6 @@ class StreamRecordEventInstructionPolicy final : public vm::InstructionPolicy {
   const DependenceVector& input_dependences() const override { return input_dependences_; }
   const DependenceVector& output_dependences() const override { return output_dependences_; }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {}
-
   std::shared_ptr<EpEvent>& mut_ep_event() { return ep_event_; }
 
  private:

--- a/oneflow/core/vm/stream_wait_event_instruction_policy.h
+++ b/oneflow/core/vm/stream_wait_event_instruction_policy.h
@@ -46,8 +46,6 @@ class StreamWaitEventInstructionPolicy final : public vm::InstructionPolicy {
   const DependenceVector& input_dependences() const override { return input_dependences_; }
   const DependenceVector& output_dependences() const override { return output_dependences_; }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {}
-
  private:
   small_vector<intrusive::shared_ptr<LocalDepObject>, kOpArgsReservedSize> dependences_;
   DependenceVector input_dependences_;

--- a/oneflow/core/vm/stream_wait_instruction_policy.h
+++ b/oneflow/core/vm/stream_wait_instruction_policy.h
@@ -47,8 +47,6 @@ class StreamWaitInstructionPolicy final : public vm::InstructionPolicy {
   const DependenceVector& input_dependences() const override { return input_dependences_; }
   const DependenceVector& output_dependences() const override { return output_dependences_; }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {}
-
  private:
   vm::Stream* mut_from_vm_stream() { return from_vm_stream_; }
   std::shared_ptr<EpEvent>& mut_ep_event() { return ep_event_; }

--- a/oneflow/core/vm/touch_tensors_instruction_policy.h
+++ b/oneflow/core/vm/touch_tensors_instruction_policy.h
@@ -40,9 +40,6 @@ class TouchTensorsInstructionPolicy final : public InstructionPolicy {
     return empty;
   }
 
-  void ForEachInputEagerBlobObjects(void (*DoEach)(EagerBlobObject*)) const override {
-    for (const auto& eager_blob_object : eager_blob_objects_) { DoEach(eager_blob_object.get()); }
-  }
   std::string DebugName(const vm::Instruction& instruction) const override {
     return "TouchTensors";
   }

--- a/oneflow/core/vm/virtual_machine_engine.h
+++ b/oneflow/core/vm/virtual_machine_engine.h
@@ -93,9 +93,6 @@ class VirtualMachineEngine final : public intrusive::Base {
   void MoveToGarbageListAndNotifyGC(const ScheduleCtx& schedule_ctx);
 
  private:
-  template<typename DoEachStreamT>
-  void ForEachStreamOnDevice(Symbol<Device> device, const DoEachStreamT& DoEachStream);
-
   ReadyInstructionList* mut_ready_instruction_list() { return &ready_instruction_list_; }
 
   void ReleaseFinishedInstructions(const ScheduleCtx& schedule_ctx);

--- a/oneflow/core/vm/virtual_machine_engine.h
+++ b/oneflow/core/vm/virtual_machine_engine.h
@@ -115,13 +115,10 @@ class VirtualMachineEngine final : public intrusive::Base {
   DependenceAccess* AccessDependence(OperandAccessType access_type, Dependence* dependence,
                                      Instruction* instrution);
   void ConsumeDependences(Instruction* instruction);
-  template<void (VirtualMachineEngine::*OOMHandler)(vm::Stream*, const ScheduleCtx&)>
   void DispatchInstruction(Instruction* instruction, const ScheduleCtx& schedule_ctx);
 
   bool EdgeDispatchable(const Instruction* src, const Instruction* dst) const;
   bool Dispatchable(Instruction* instruction) const;
-  void BusyWaitInstructionsDoneThenShrink(vm::Stream* stream, const ScheduleCtx& schedule_ctx);
-  void AbortOnOOM(vm::Stream* stream, const ScheduleCtx& schedule_ctx);
 
   void TryDispatchReadyInstructions();
 


### PR DESCRIPTION
解决多stream下比pytorch多耗内存的问题。
oneflow比pytorch多耗内存的根源有两个：
1. 内存分配的时机过早。之前是在scheduler线程里通过调用InstructionPolicy::Prepare分配内存，本pr里将内存分配时机放在worker线程里在InstructionPolicy::Compute一开始的时候。
2. 每个stream一个allocator，内存分配器之间并不互通。解决办法是只让kCompute stream持有allocator，其他stream的op如果需要内存，就需要在kCompute stream上首先通过新设计的AllocatorTensors指令分配内存，然后再执行其他stream的op。