### PR TITLE
add build config for RTX 40xx GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,8 @@ if(BUILD_CUDA)
     endif()
 
     if(CUDA_VERSION VERSION_GREATER_EQUAL "11.8")
+      # GeForce RTX 40xx
+      list(APPEND CMAKE_CUDA_ARCHITECTURES 89-real)
       # NVIDIA H100
       list(APPEND CMAKE_CUDA_ARCHITECTURES 90-real)
     endif()


### PR DESCRIPTION
RT.
Tested on Ubuntu 20.04, CUDA 11.8, RTX 4090 with Driver version 520.61.05.