### PR TITLE
fix_inplace_copy_bug

### DIFF
--- a/oneflow/api/python/functional/tensor_api.cpp
+++ b/oneflow/api/python/functional/tensor_api.cpp
@@ -220,7 +220,9 @@ class AssignLocalTensorFunctor {
     // JUST(CheckInplaceValid(ref)); // align check to torch
     CHECK_OR_RETURN(ref->is_local() && value->is_local())
         << "Both ref and value must be local tensor.";
-    JUST(OpInterpUtil::Dispatch<TensorTuple>(*op_, {ref, value}));
+    std::shared_ptr<one::Tensor> src = value;
+    if (ref->dtype() != src->dtype()) { src = JUST(To(src, ref->dtype(), false)); }
+    JUST(OpInterpUtil::Dispatch<TensorTuple>(*op_, {ref, src}));
     return Maybe<void>::Ok();
   }
 

--- a/oneflow/user/ops/assign_op.cpp
+++ b/oneflow/user/ops/assign_op.cpp
@@ -68,7 +68,9 @@ Maybe<void> InputArgModifierFn(const user_op::GetInputArgModifier& GetInputArgMo
 Maybe<void> InferDataType_(user_op::InferContext* ctx) {
   const user_op::TensorDesc& ref_desc = ctx->InputTensorDesc("ref", 0);
   const user_op::TensorDesc& value_desc = ctx->InputTensorDesc("value", 0);
-  CHECK_OR_RETURN(ref_desc.data_type() == value_desc.data_type());
+  CHECK_OR_RETURN(ref_desc.data_type() == value_desc.data_type())
+      << Error::RuntimeError() << DataType_Name(ref_desc.data_type()) << " vs."
+      << DataType_Name(value_desc.data_type());
   if (ctx->has_input("condition", 0)) {
     const user_op::TensorDesc& condition = ctx->InputTensorDesc("condition", 0);
     CHECK_OR_RETURN(IsIndexDataType(condition.data_type()));

--- a/python/oneflow/test/modules/test_copy.py
+++ b/python/oneflow/test/modules/test_copy.py
@@ -62,6 +62,16 @@ class Test_Copy_module(flow.unittest.TestCase):
         x.copy_(a)
         test_case.assertTrue(np.array_equal(x.numpy(), a))
 
+    @flow.unittest.skip_unless_1n1d()
+    def test_tensor_inplace_copy_with_diff_dtype(test_case):
+        np_arr = np.random.randn(4, 12)
+        x = flow.tensor(np_arr)
+        y = flow.tensor(np_arr, dtype=flow.int)
+        y.copy_(x)
+        a = ori_torch.tensor(np_arr)
+        b = ori_torch.tensor(np_arr, dtype=ori_torch.int)
+        test_case.assertTrue(np.array_equal(y.numpy(), b.cpu().numpy()))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
修复（参考[pytorch 1.12.1](https://github.com/pytorch/pytorch/blob/v1.12.1/aten/src/ATen/native/cpu/CopyKernel.cpp#L102)）tesnor.copy_方法中当src于dst的dtype不同时报错的bug，这与文档不符

<img width="781" alt="image" src="https://user-images.githubusercontent.com/28134523/197510027-af29e51a-cae2-4e85-b917-418a83949406.png">
