### PR TITLE
Fix type error for entering a single tensor using concat op

### DIFF
--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -531,7 +531,6 @@ class ConcatFunctor {
       JUST(tensor_processor.PromoteInputsToCommonDtype(true)
                .AddInputs(partial_inputs, inputs.at(i)->dtype())
                .Apply());
-
       TensorTuple input_tuple = JUST(tensor_processor.GetInputs());
       outputs.emplace_back(
           JUST(OpInterpUtil::Dispatch<Tensor>(*ops_[size - 1], input_tuple, attrs)));

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -528,7 +528,10 @@ class ConcatFunctor {
       TensorTuple partial_inputs(size);
       TensorProcessor tensor_processor;
       for (int j = 0; j < size; ++j) { partial_inputs[j] = inputs[i + j]; }
-      JUST(tensor_processor.PromoteInputsToCommonDtype(true).AddInputs(partial_inputs).Apply());
+      JUST(tensor_processor.PromoteInputsToCommonDtype(true)
+               .AddInputs(partial_inputs, inputs.at(i)->dtype())
+               .Apply());
+
       TensorTuple input_tuple = JUST(tensor_processor.GetInputs());
       outputs.emplace_back(
           JUST(OpInterpUtil::Dispatch<Tensor>(*ops_[size - 1], input_tuple, attrs)));

--- a/oneflow/core/functional/tensor_processor.cpp
+++ b/oneflow/core/functional/tensor_processor.cpp
@@ -37,13 +37,10 @@ Symbol<DType> ComputeCommonDType(const TensorTuple& tensor_tuple) {
 }
 
 bool CheckHasDifferentInputDType(const TensorTuple& tensor_tuple) {
-  Symbol<DType> common_dtype = DType::InvalidDataType();
+  if (tensor_tuple.size() == 0) { return false; }
+  Symbol<DType> common_dtype = tensor_tuple.at(0)->dtype();
   for (auto& tensor_ptr : tensor_tuple) {
-    if (common_dtype == DType::InvalidDataType()) {
-      common_dtype = tensor_ptr->dtype();  // Initialize the common_dtype_
-    } else {
-      return true;
-    }
+    if (common_dtype != tensor_ptr->dtype()) { return true; }
   }
   return false;
 }

--- a/oneflow/core/functional/tensor_processor.cpp
+++ b/oneflow/core/functional/tensor_processor.cpp
@@ -113,7 +113,7 @@ Maybe<void> TensorProcessor::Apply() {
       JUST(CastToSameType(tensor_tuple_, common_dtype_));
     } else {
       if (tensor_tuple_.size() == 1 && !tensor_tuple_[0]->dtype()->is_floating_point()) {
-        Symbol<DType> cast_dtype = inputs_lowest_dtype_vec_[0]->InvalidDataType()
+        Symbol<DType> cast_dtype = (inputs_lowest_dtype_vec_[0] == DType::InvalidDataType())
                                        ? DType::Float()
                                        : inputs_lowest_dtype_vec_[0];
         JUST(CastToSameType(tensor_tuple_, cast_dtype));

--- a/oneflow/core/functional/tensor_processor.cpp
+++ b/oneflow/core/functional/tensor_processor.cpp
@@ -37,8 +37,8 @@ Symbol<DType> ComputeCommonDType(const TensorTuple& tensor_tuple) {
 }
 
 bool CheckHasDifferentInputDType(const TensorTuple& tensor_tuple) {
-  if (tensor_tuple.size() == 0) { return false; }
-  Symbol<DType> common_dtype = tensor_tuple.at(0)->dtype();
+  if (tensor_tuple.size() <= 1) { return false; }
+  Symbol<DType> common_dtype = tensor_tuple[0]->dtype();
   for (auto& tensor_ptr : tensor_tuple) {
     if (common_dtype != tensor_ptr->dtype()) { return true; }
   }

--- a/python/oneflow/test/modules/test_concat.py
+++ b/python/oneflow/test/modules/test_concat.py
@@ -162,7 +162,6 @@ def _test_concat_single_input_type(test_case, device):
     flow_cat_list = flow.cat(flow_list)
     test_case.assertTrue(flow_cat_list.dtype is oneflow.int64)
 
-
 @flow.unittest.skip_unless_1n1d()
 class TestModule(flow.unittest.TestCase):
     def test_concat(test_case):

--- a/python/oneflow/test/modules/test_concat.py
+++ b/python/oneflow/test/modules/test_concat.py
@@ -153,6 +153,16 @@ def _test_concat_grad_and_no_grad(test_case, device):
     )
 
 
+def _test_concat_single_input_type(test_case, device):
+    torch_list = [torch.Tensor([1, 1, 9, 1])]
+    torch_list = [t.to(dtype=torch.int64, device=device) for t in torch_list]
+
+    flow_list = [flow.Tensor([1, 1, 9, 1])]
+    flow_list = [t.to(dtype=flow.int64, device=device) for t in flow_list]
+    flow_cat_list = flow.cat(flow_list)
+    test_case.assertTrue(flow_cat_list.dtype is oneflow.int64)
+
+
 @flow.unittest.skip_unless_1n1d()
 class TestModule(flow.unittest.TestCase):
     def test_concat(test_case):
@@ -164,6 +174,7 @@ class TestModule(flow.unittest.TestCase):
             _test_concat_with_three_tensor,
             _test_concat_with_three_tensor_backward,
             _test_concat_grad_and_no_grad,
+            _test_concat_single_input_type,
         ]
         arg_dict["device"] = ["cpu", "cuda"]
         for arg in GenArgList(arg_dict):

--- a/python/oneflow/test/modules/test_concat.py
+++ b/python/oneflow/test/modules/test_concat.py
@@ -162,6 +162,7 @@ def _test_concat_single_input_type(test_case, device):
     flow_cat_list = flow.cat(flow_list)
     test_case.assertTrue(flow_cat_list.dtype is oneflow.int64)
 
+
 @flow.unittest.skip_unless_1n1d()
 class TestModule(flow.unittest.TestCase):
     def test_concat(test_case):


### PR DESCRIPTION
- fix https://github.com/Oneflow-Inc/oneflow/issues/9305
- 修改 `CheckHasDifferentInputDType()`存在的 bug