### PR TITLE
Update fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,9 +293,9 @@ set(ROBIN_HOOD_HASHING_URL
 use_mirror(VARIABLE ROBIN_HOOD_HASHING_URL URL ${ROBIN_HOOD_HASHING_URL})
 set(ROBIN_HOOD_HASHING_MD5 a78bd30a7582f25984f8592652836467)
 
-set(FMT_URL https://github.com/fmtlib/fmt/archive/e9ca7ea472a387639cef65a93037afcee26e4733.zip)
+set(FMT_URL https://github.com/fmtlib/fmt/archive/fc07217d85e6dcec52878807d6bbd89a9d9156a5.zip)
 use_mirror(VARIABLE FMT_URL URL ${FMT_URL})
-set(FMT_MD5 f126df4cffec775e118837db0c64b920)
+set(FMT_MD5 7d9bb2ececc9ede29cd35bdc42a7e22c)
 
 set(KINETO_URL
     https://github.com/pytorch/kineto/archive/ff8dba20499a660650632952be76450bd70a52a6.zip)


### PR DESCRIPTION
修复在Clang14下编译出现的下图中的问题：

![233](https://user-images.githubusercontent.com/16584240/200498115-9537b677-8237-40a9-baf0-678652218512.jpg)
