### PR TITLE
fuse get bounding boxes coord and to_contiguous kernel（only used in yolox algorithm）

### DIFF
--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -2880,7 +2880,7 @@ def OneFlow_FusedFastGeluMulGradOp : OneFlow_BaseOp<"fused_fast_gelu_mul_grad", 
   let has_data_type_infer_fn = 1;
 }
 
-def OneFlow_FusedGetBounddingBoxesCoordOp : OneFlow_BaseOp<"fused_get_boundding_boxes_coord", [NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+def OneFlow_FusedGetBounddingBoxesCoordOp : OneFlow_BaseOp<"fused_get_boundding_boxes_coord", [SupportNonContiguous, NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
     OneFlow_Tensor:$x1,
     OneFlow_Tensor:$y1,

--- a/oneflow/user/ops/fused_get_boundding_boxes_coord_op.cpp
+++ b/oneflow/user/ops/fused_get_boundding_boxes_coord_op.cpp
@@ -21,45 +21,46 @@ namespace oneflow {
 Maybe<void> FusedGetBounddingBoxesCoordOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const user_op::TensorDesc& x1 = ctx->InputTensorDesc("x1", 0);
   Stride x1_stride = Stride(1, 1);
+  Shape x1_shape = x1.shape();
 
   user_op::TensorDesc* b1_x1 = ctx->MutOutputTensorDesc("b1_x1", 0);
   b1_x1->set_is_dynamic(x1.is_dynamic());
-  b1_x1->set_shape(x1.shape());
+  b1_x1->set_shape(x1_shape);
   ctx->SetOutputStride("b1_x1", 0, x1_stride);
 
   user_op::TensorDesc* b1_x2 = ctx->MutOutputTensorDesc("b1_x2", 0);
   b1_x2->set_is_dynamic(x1.is_dynamic());
-  b1_x2->set_shape(x1.shape());
+  b1_x2->set_shape(x1_shape);
   ctx->SetOutputStride("b1_x2", 0, x1_stride);
 
   user_op::TensorDesc* b1_y1 = ctx->MutOutputTensorDesc("b1_y1", 0);
   b1_y1->set_is_dynamic(x1.is_dynamic());
-  b1_y1->set_shape(x1.shape());
+  b1_y1->set_shape(x1_shape);
   ctx->SetOutputStride("b1_y1", 0, x1_stride);
 
   user_op::TensorDesc* b1_y2 = ctx->MutOutputTensorDesc("b1_y2", 0);
   b1_y2->set_is_dynamic(x1.is_dynamic());
-  b1_y2->set_shape(x1.shape());
+  b1_y2->set_shape(x1_shape);
   ctx->SetOutputStride("b1_y2", 0, x1_stride);
 
   user_op::TensorDesc* b2_x1 = ctx->MutOutputTensorDesc("b2_x1", 0);
   b2_x1->set_is_dynamic(x1.is_dynamic());
-  b2_x1->set_shape(x1.shape());
+  b2_x1->set_shape(x1_shape);
   ctx->SetOutputStride("b2_x1", 0, x1_stride);
 
   user_op::TensorDesc* b2_x2 = ctx->MutOutputTensorDesc("b2_x2", 0);
   b2_x2->set_is_dynamic(x1.is_dynamic());
-  b2_x2->set_shape(x1.shape());
+  b2_x2->set_shape(x1_shape);
   ctx->SetOutputStride("b2_x2", 0, x1_stride);
 
   user_op::TensorDesc* b2_y1 = ctx->MutOutputTensorDesc("b2_y1", 0);
   b2_y1->set_is_dynamic(x1.is_dynamic());
-  b2_y1->set_shape(x1.shape());
+  b2_y1->set_shape(x1_shape);
   ctx->SetOutputStride("b2_y1", 0, x1_stride);
 
   user_op::TensorDesc* b2_y2 = ctx->MutOutputTensorDesc("b2_y2", 0);
   b2_y2->set_is_dynamic(x1.is_dynamic());
-  b2_y2->set_shape(x1.shape());
+  b2_y2->set_shape(x1_shape);
   ctx->SetOutputStride("b2_y2", 0, x1_stride);
 
   return Maybe<void>::Ok();

--- a/oneflow/user/ops/fused_get_boundding_boxes_coord_op.cpp
+++ b/oneflow/user/ops/fused_get_boundding_boxes_coord_op.cpp
@@ -20,38 +20,47 @@ namespace oneflow {
 
 Maybe<void> FusedGetBounddingBoxesCoordOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const user_op::TensorDesc& x1 = ctx->InputTensorDesc("x1", 0);
+  Stride x1_stride = Stride(1, 1);
 
   user_op::TensorDesc* b1_x1 = ctx->MutOutputTensorDesc("b1_x1", 0);
   b1_x1->set_is_dynamic(x1.is_dynamic());
   b1_x1->set_shape(x1.shape());
+  ctx->SetOutputStride("b1_x1", 0, x1_stride);
 
   user_op::TensorDesc* b1_x2 = ctx->MutOutputTensorDesc("b1_x2", 0);
   b1_x2->set_is_dynamic(x1.is_dynamic());
   b1_x2->set_shape(x1.shape());
+  ctx->SetOutputStride("b1_x2", 0, x1_stride);
 
   user_op::TensorDesc* b1_y1 = ctx->MutOutputTensorDesc("b1_y1", 0);
   b1_y1->set_is_dynamic(x1.is_dynamic());
   b1_y1->set_shape(x1.shape());
+  ctx->SetOutputStride("b1_y1", 0, x1_stride);
 
   user_op::TensorDesc* b1_y2 = ctx->MutOutputTensorDesc("b1_y2", 0);
   b1_y2->set_is_dynamic(x1.is_dynamic());
   b1_y2->set_shape(x1.shape());
+  ctx->SetOutputStride("b1_y2", 0, x1_stride);
 
   user_op::TensorDesc* b2_x1 = ctx->MutOutputTensorDesc("b2_x1", 0);
   b2_x1->set_is_dynamic(x1.is_dynamic());
   b2_x1->set_shape(x1.shape());
+  ctx->SetOutputStride("b2_x1", 0, x1_stride);
 
   user_op::TensorDesc* b2_x2 = ctx->MutOutputTensorDesc("b2_x2", 0);
   b2_x2->set_is_dynamic(x1.is_dynamic());
   b2_x2->set_shape(x1.shape());
+  ctx->SetOutputStride("b2_x2", 0, x1_stride);
 
   user_op::TensorDesc* b2_y1 = ctx->MutOutputTensorDesc("b2_y1", 0);
   b2_y1->set_is_dynamic(x1.is_dynamic());
   b2_y1->set_shape(x1.shape());
+  ctx->SetOutputStride("b2_y1", 0, x1_stride);
 
   user_op::TensorDesc* b2_y2 = ctx->MutOutputTensorDesc("b2_y2", 0);
   b2_y2->set_is_dynamic(x1.is_dynamic());
   b2_y2->set_shape(x1.shape());
+  ctx->SetOutputStride("b2_y2", 0, x1_stride);
 
   return Maybe<void>::Ok();
 }


### PR DESCRIPTION
此pr去掉了fused_get_bounnding_boxes_coord kernel必须依赖的8个to contiguous操作，减少调度开销并直接避免使用as_strided造成网络不收敛的情况。从nsys可以看到多余的8个to contiguous已经被消除了

![图片](https://user-images.githubusercontent.com/35585791/203239492-868f512e-1b44-4021-8bc1-8aa24d63b658.png)
