### PR TITLE
hot fix for fused_get_boundding_boxes_coord

### DIFF
--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -2880,7 +2880,7 @@ def OneFlow_FusedFastGeluMulGradOp : OneFlow_BaseOp<"fused_fast_gelu_mul_grad", 
   let has_data_type_infer_fn = 1;
 }
 
-def OneFlow_FusedGetBounddingBoxesCoordOp : OneFlow_BaseOp<"fused_get_boundding_boxes_coord", [SupportNonContiguous, NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+def OneFlow_FusedGetBounddingBoxesCoordOp : OneFlow_BaseOp<"fused_get_boundding_boxes_coord", [NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
     OneFlow_Tensor:$x1,
     OneFlow_Tensor:$y1,

--- a/oneflow/user/ops/fused_get_boundding_boxes_coord_op.cpp
+++ b/oneflow/user/ops/fused_get_boundding_boxes_coord_op.cpp
@@ -26,43 +26,34 @@ Maybe<void> FusedGetBounddingBoxesCoordOp::InferLogicalTensorDesc(user_op::Infer
   user_op::TensorDesc* b1_x1 = ctx->MutOutputTensorDesc("b1_x1", 0);
   b1_x1->set_is_dynamic(x1.is_dynamic());
   b1_x1->set_shape(x1_shape);
-  // For one-yolov5, we can directly set output stride to (1, 1), beause input shape must be (n, 1).
-  ctx->SetOutputStride("b1_x1", 0, x1_stride);
 
   user_op::TensorDesc* b1_x2 = ctx->MutOutputTensorDesc("b1_x2", 0);
   b1_x2->set_is_dynamic(x1.is_dynamic());
   b1_x2->set_shape(x1_shape);
-  ctx->SetOutputStride("b1_x2", 0, x1_stride);
 
   user_op::TensorDesc* b1_y1 = ctx->MutOutputTensorDesc("b1_y1", 0);
   b1_y1->set_is_dynamic(x1.is_dynamic());
   b1_y1->set_shape(x1_shape);
-  ctx->SetOutputStride("b1_y1", 0, x1_stride);
 
   user_op::TensorDesc* b1_y2 = ctx->MutOutputTensorDesc("b1_y2", 0);
   b1_y2->set_is_dynamic(x1.is_dynamic());
   b1_y2->set_shape(x1_shape);
-  ctx->SetOutputStride("b1_y2", 0, x1_stride);
 
   user_op::TensorDesc* b2_x1 = ctx->MutOutputTensorDesc("b2_x1", 0);
   b2_x1->set_is_dynamic(x1.is_dynamic());
   b2_x1->set_shape(x1_shape);
-  ctx->SetOutputStride("b2_x1", 0, x1_stride);
 
   user_op::TensorDesc* b2_x2 = ctx->MutOutputTensorDesc("b2_x2", 0);
   b2_x2->set_is_dynamic(x1.is_dynamic());
   b2_x2->set_shape(x1_shape);
-  ctx->SetOutputStride("b2_x2", 0, x1_stride);
 
   user_op::TensorDesc* b2_y1 = ctx->MutOutputTensorDesc("b2_y1", 0);
   b2_y1->set_is_dynamic(x1.is_dynamic());
   b2_y1->set_shape(x1_shape);
-  ctx->SetOutputStride("b2_y1", 0, x1_stride);
 
   user_op::TensorDesc* b2_y2 = ctx->MutOutputTensorDesc("b2_y2", 0);
   b2_y2->set_is_dynamic(x1.is_dynamic());
   b2_y2->set_shape(x1_shape);
-  ctx->SetOutputStride("b2_y2", 0, x1_stride);
 
   return Maybe<void>::Ok();
 }

--- a/oneflow/user/ops/fused_get_boundding_boxes_coord_op.cpp
+++ b/oneflow/user/ops/fused_get_boundding_boxes_coord_op.cpp
@@ -20,7 +20,6 @@ namespace oneflow {
 
 Maybe<void> FusedGetBounddingBoxesCoordOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   const user_op::TensorDesc& x1 = ctx->InputTensorDesc("x1", 0);
-  Stride x1_stride = Stride(1, 1);
   Shape x1_shape = x1.shape();
 
   user_op::TensorDesc* b1_x1 = ctx->MutOutputTensorDesc("b1_x1", 0);


### PR DESCRIPTION
紧急修复因为 fused_get_boundding_boxes_coord 设置为支持 contiguous 导致yolov5的某些网络loss nan问题。