### PR TITLE
refactor iterator when env use rdma

### DIFF
--- a/python/oneflow/utils/data/dataloader.py
+++ b/python/oneflow/utils/data/dataloader.py
@@ -337,7 +337,7 @@ class DataLoader(Generic[T_co]):
         if self.num_workers > 0:
             assert (
                 not flow.env.rdma_is_initialized()
-            ), "RDMA is initialized! DataLoader could not create multi-process worker any more. "
+            ), "RDMA is initialized before DataLoader __init__()."
             "Please make sure Dataloader is created before invoking oneflow.env.init_rdma() to avoid this error!"
             # NOTE: When num_workers > 0 and set env_use_rdma=True, it means RDMA will be initialized later,
             # and we need to start multi-processes DataLoader workers immediately by self._get_iterator()
@@ -911,6 +911,9 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         super(_MultiProcessingDataLoaderIter, self).__init__(loader)
         assert self._num_workers > 0
         assert self._prefetch_factor > 0
+        assert (
+                not flow.env.rdma_is_initialized()
+            ), "RDMA is initialized! DataLoader could not create multi-process worker any more. Please set DataLoader's env_use_rdma=True and make sure that Dataloader is created before invoking oneflow.env.init_rdma() to avoid this error!"
 
         if loader.multiprocessing_context is None:
             multiprocessing_context = multiprocessing

--- a/python/oneflow/utils/data/dataloader.py
+++ b/python/oneflow/utils/data/dataloader.py
@@ -913,7 +913,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         assert self._prefetch_factor > 0
         assert (
             not flow.env.rdma_is_initialized()
-        ), "RDMA is initialized! DataLoader could not create multi-process worker any more. Please set DataLoader's env_use_rdma=True and make sure that Dataloader is created before invoking oneflow.env.init_rdma() to avoid this error!"
+        ), "RDMA is initialized! DataLoader could not create multi-processes workers any more. Please set DataLoader's env_use_rdma=True and make sure that Dataloader is created before invoking oneflow.env.init_rdma() to avoid this error!"
 
         if loader.multiprocessing_context is None:
             multiprocessing_context = multiprocessing

--- a/python/oneflow/utils/data/dataloader.py
+++ b/python/oneflow/utils/data/dataloader.py
@@ -912,8 +912,8 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         assert self._num_workers > 0
         assert self._prefetch_factor > 0
         assert (
-                not flow.env.rdma_is_initialized()
-            ), "RDMA is initialized! DataLoader could not create multi-process worker any more. Please set DataLoader's env_use_rdma=True and make sure that Dataloader is created before invoking oneflow.env.init_rdma() to avoid this error!"
+            not flow.env.rdma_is_initialized()
+        ), "RDMA is initialized! DataLoader could not create multi-process worker any more. Please set DataLoader's env_use_rdma=True and make sure that Dataloader is created before invoking oneflow.env.init_rdma() to avoid this error!"
 
         if loader.multiprocessing_context is None:
             multiprocessing_context = multiprocessing

--- a/python/oneflow/utils/data/dataloader.py
+++ b/python/oneflow/utils/data/dataloader.py
@@ -335,15 +335,20 @@ class DataLoader(Generic[T_co]):
         )
 
         if self.num_workers > 0:
-            assert not flow.env.rdma_is_initialized(), "RDMA is initialized! DataLoader could not create multi-process worker any more. "
+            assert (
+                not flow.env.rdma_is_initialized()
+            ), "RDMA is initialized! DataLoader could not create multi-process worker any more. "
             "Please make sure Dataloader is created before invoking oneflow.env.init_rdma() to avoid this error!"
             # NOTE: When num_workers > 0 and set env_use_rdma=True, it means RDMA will be initialized later,
             # and we need to start multi-processes DataLoader workers immediately by self._get_iterator()
             # to avoid conflict between RDMA and workers(fork process). see: https://www.rdmamojo.com/2012/05/24/ibv_fork_init
-            self._iterator = self._get_iterator() if self.env_use_rdma or flow.env.rdma_is_initialized() else None
+            self._iterator = (
+                self._get_iterator()
+                if self.env_use_rdma or flow.env.rdma_is_initialized()
+                else None
+            )
         else:
             self._iterator = None
-
 
     def _get_iterator(self) -> "_BaseDataLoaderIter":
         if self.num_workers == 0:
@@ -386,7 +391,7 @@ class DataLoader(Generic[T_co]):
                 self._iterator = self._get_iterator()
             else:
                 self._iterator._reset(self)
-            
+
             return self._iterator
         else:
             return self._get_iterator()
@@ -903,7 +908,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
     #     down.
 
     def __init__(self, loader):
-        super(_MultiProcessingDataLoaderIter, self).__init__(loader)    
+        super(_MultiProcessingDataLoaderIter, self).__init__(loader)
         assert self._num_workers > 0
         assert self._prefetch_factor > 0
 


### PR DESCRIPTION
### 问题背景
之前为了解决dataloader中worker进程初始化时fork进程和RDMA冲突(segmentation fault)，在dataloader中使用了destory_rdma接口，但这个用法在lazy静态图下会有问题，具体见：
- https://github.com/Oneflow-Inc/OneTeam/issues/1794#issuecomment-1328744312
- https://github.com/Oneflow-Inc/OneTeam/issues/1463#issuecomment-1330246528

### 解决方案
此PR移除了dataloader中destory_rdma相关的改动，而采取之前的做法：如果确认需要在环境中使用RDMA，则需要保证RDMA init在DataLoader创建之后。由于先初始化DataLoader（初始化时即创建worker进程），后使用RDMA即可避免问题；同时此PR解耦了使用RDMA时必须传persistent_workers=True的限制性条件。

- [x] test case：基于 @xiezipeng-ML 提供的[libai的case](https://github.com/Oneflow-Inc/OneTeam/issues/1794#issuecomment-1328170592)基于27机器测试通过