### PR TITLE
Fix scalar type

### DIFF
--- a/oneflow/core/functional/impl/math_functor.cpp
+++ b/oneflow/core/functional/impl/math_functor.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 #include "oneflow/core/common/container_util.h"
 #include "oneflow/core/common/scalar.h"
 #include "oneflow/core/common/optional.h"
-#include "oneflow/core/framework/dtype.h"
 #include "oneflow/core/framework/mutable_attr_map.h"
 #include "oneflow/core/framework/op_builder.h"
 #include "oneflow/core/framework/op_expr.h"

--- a/oneflow/core/functional/impl/math_functor.cpp
+++ b/oneflow/core/functional/impl/math_functor.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include "oneflow/core/common/container_util.h"
 #include "oneflow/core/common/scalar.h"
 #include "oneflow/core/common/optional.h"
+#include "oneflow/core/framework/dtype.h"
 #include "oneflow/core/framework/mutable_attr_map.h"
 #include "oneflow/core/framework/op_builder.h"
 #include "oneflow/core/framework/op_expr.h"
@@ -100,9 +101,13 @@ class ScalarMathBaseFunctor {
       attrs.SetAllAttrs(NullOpt, false, scalar.As<int64_t>(), true);
       // Promote type to Int64 when tensor is Bool type but scalar is int type.
       // Promote type to Float32 when op is scalar_div.
+      // Promote type to Float16 when tensor is Float16.
       if (DType::priority_order[x->dtype()->data_type()]
           == DType::priority_order[DType::Bool()->data_type()]) {
         lowest_dtype = DType::Int64();
+      } else if (DType::priority_order[x->dtype()->data_type()]
+          == DType::priority_order[DType::Float16()->data_type()]) {
+        lowest_dtype = DType::Float16();
       } else if (op_->op_type_name() == "scalar_div") {
         lowest_dtype = DType::Float();
       } else {


### PR DESCRIPTION
@BBuf @wyg1997 

fix之前 https://github.com/Oneflow-Inc/oneflow/pull/9360 的bug, 没有考虑到 float16

修复后：

```shell
Python 3.7.10 (default, Feb 26 2021, 18:47:35) 
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import oneflow
>>> a = oneflow.arange(20)
>>> a / 20
tensor([0.0000, 0.0500, 0.1000, 0.1500, 0.2000, 0.2500, 0.3000, 0.3500, 0.4000, 0.4500, 0.5000, 0.5500, 0.6000, 0.6500, 0.7000, 0.7500, 0.8000, 0.8500, 0.9000, 0.9500],
       dtype=oneflow.float32)
>>> a // 20
tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=oneflow.int64)
>>> b = a.to(oneflow.float16)
>>> b / 20
tensor([0.0000, 0.0500, 0.1000, 0.1500, 0.2000, 0.2500, 0.3000, 0.3501, 0.3999, 0.4500, 0.5000, 0.5498, 0.6001, 0.6499, 0.7002, 0.7500, 0.7998, 0.8501, 0.8999, 0.9502],
       dtype=oneflow.float16)
>>> b // 20
tensor([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], dtype=oneflow.float16)
```

- [ ] 添加 Tensor.copy()