### PR TITLE
DenseElementsAttrToTensor reuse managed tensor

### DIFF
--- a/oneflow/ir/include/OneFlow/OneFlowSupport.h
+++ b/oneflow/ir/include/OneFlow/OneFlowSupport.h
@@ -49,6 +49,9 @@ mlir::DenseElementsAttr TensorToDenseElementsAttr(
 std::shared_ptr<::oneflow::one::Tensor> DenseElementsAttrToTensor(
     const mlir::Attribute& attr, const mlir::Attribute& device_tag,
     const mlir::Attribute& device_name);
+void DenseElementsAttrToTensor(const mlir::Attribute& attr, const mlir::Attribute& device_tag,
+                               const mlir::Attribute& device_name,
+                               std::shared_ptr<::oneflow::one::Tensor>& tensor);
 
 FailureOr<::oneflow::DataType> FromMLIRTypeToOFDataType(Type mlir_type);
 FailureOr<::oneflow::DataType> FromMLIRDataTypeToOFDataType(::mlir::oneflow::DataType data_type);

--- a/oneflow/ir/lib/OneFlow/OneFlowSupport.cpp
+++ b/oneflow/ir/lib/OneFlow/OneFlowSupport.cpp
@@ -29,9 +29,11 @@ limitations under the License.
 #include "oneflow/core/framework/user_op_registry_manager.h"
 #include "oneflow/core/kernel/kernel_util.h"
 #include "oneflow/core/memory/memory_case_util.h"
+#include "oneflow/core/common/data_type.h"
 
 #include <iostream>
 #include <vector>
+
 namespace mlir {
 
 namespace oneflow {
@@ -119,6 +121,53 @@ std::shared_ptr<::oneflow::one::Tensor> __DenseElementsAttrToTensor(
   return tensor;
 }
 
+template<typename T>
+void __DenseElementsAttrToTensor(const mlir::DenseElementsAttr dense_attr,
+                                 const mlir::Attribute& device_tag_attr,
+                                 const mlir::Attribute& device_name_attr,
+                                 const ::oneflow::DataType& dtype,
+                                 std::shared_ptr<::oneflow::one::Tensor>& tensor) {
+  const auto dense_type = dense_attr.getType().cast<mlir::RankedTensorType>();
+  std::vector<int64_t> shape = dense_type.getShape().vec();
+  int ndim = shape.size();
+  CHECK_EQ(tensor->shape()->size(), ndim);
+  for (int i = 0; i < ndim; ++i) { CHECK_EQ(tensor->shape()->at(i), shape[i]); }
+
+  const auto device = MakeDevice(device_tag_attr, device_name_attr);
+  CHECK(CHECK_JUST(tensor->device()) == device);
+
+  std::vector<T> data;
+  std::vector<::oneflow::float16> fp16_data;
+  void* dptr = nullptr;
+  const size_t tensor_size =
+      tensor->shape()->elem_cnt() * ::oneflow::GetSizeOfDataType(tensor->dtype()->data_type());
+
+  CHECK_EQ(::oneflow::GetDataType<T>::value, dtype);
+  if (tensor->dtype()->data_type() == ::oneflow::DataType::kFloat16) {
+    for (const T elem : dense_attr.getValues<T>()) {
+      fp16_data.push_back(static_cast<::oneflow::float16>(elem));
+    }
+    CHECK_EQ(fp16_data.size() * sizeof(::oneflow::float16), tensor_size);
+    dptr = fp16_data.data();
+  } else if (tensor->dtype()->data_type() == dtype) {
+    for (const T elem : dense_attr.getValues<T>()) { data.push_back(elem); }
+    CHECK_EQ(data.size() * sizeof(T), tensor_size);
+    dptr = data.data();
+  } else {
+    UNIMPLEMENTED();
+  }
+
+  const auto& callback =
+      [=](::oneflow::ep::Stream* stream,
+          const std::shared_ptr<::oneflow::vm::EagerBlobObject>& eager_blob_object) {
+        OF_CUDA_CHECK(
+            cudaStreamSynchronize(stream->As<::oneflow::ep::CudaStream>()->cuda_stream()));
+        ::oneflow::AutoMemcpy(stream, eager_blob_object->mut_dptr(), dptr, tensor_size,
+                              eager_blob_object->mem_case(), ::oneflow::memory::MakeHostMemCase());
+      };
+  ::oneflow::one::SyncAccessTensorWithTimeOut(tensor, callback, "mut").GetOrThrow();
+}
+
 }  // namespace
 
 mlir::DenseElementsAttr TensorToDenseElementsAttr(
@@ -151,6 +200,24 @@ std::shared_ptr<::oneflow::one::Tensor> DenseElementsAttrToTensor(
       << "Converting mlir::DenseElementsAttr to oneflow::Tensor only support float32 and int64 now."
       << "\n";
   exit(EXIT_FAILURE);
+}
+
+void DenseElementsAttrToTensor(const mlir::Attribute& dense_attr,
+                               const mlir::Attribute& device_tag_attr,
+                               const mlir::Attribute& device_name_attr,
+                               std::shared_ptr<::oneflow::one::Tensor>& tensor) {
+  ::oneflow::LazyMode::Guard guard{false};
+  const auto dense_attr_ = dense_attr.cast<mlir::DenseElementsAttr>();
+  const auto dense_element_type = dense_attr_.getElementType();
+  if (dense_element_type.isF32()) {
+    __DenseElementsAttrToTensor<float>(dense_attr_, device_tag_attr, device_name_attr,
+                                       ::oneflow::DataType::kFloat, tensor);
+  } else {
+    llvm::errs() << "Converting mlir::DenseElementsAttr to oneflow::Tensor only support float32 "
+                    "and int64 now."
+                 << "\n";
+    exit(EXIT_FAILURE);
+  }
 }
 
 FailureOr<::oneflow::DataType> FromMLIRTypeToOFDataType(Type mlir_type) {

--- a/oneflow/ir/lib/OneFlow/OneFlowSupport.cpp
+++ b/oneflow/ir/lib/OneFlow/OneFlowSupport.cpp
@@ -160,8 +160,6 @@ void __DenseElementsAttrToTensor(const mlir::DenseElementsAttr dense_attr,
   const auto& callback =
       [=](::oneflow::ep::Stream* stream,
           const std::shared_ptr<::oneflow::vm::EagerBlobObject>& eager_blob_object) {
-        OF_CUDA_CHECK(
-            cudaStreamSynchronize(stream->As<::oneflow::ep::CudaStream>()->cuda_stream()));
         ::oneflow::AutoMemcpy(stream, eager_blob_object->mut_dptr(), dptr, tensor_size,
                               eager_blob_object->mem_case(), ::oneflow::memory::MakeHostMemCase());
       };

--- a/oneflow/ir/lib/OneFlow/Passes.cpp
+++ b/oneflow/ir/lib/OneFlow/Passes.cpp
@@ -570,13 +570,21 @@ struct ReplaceVariableIrPattern : public ::mlir::RewritePattern {
                                      ConvertToString(op.data_typeAttr().getValue())));
       return ::mlir::failure();
     }
-    CHECK_JUST(::oneflow::Singleton<::oneflow::VariableTensorMgr>::Get()->Set(
-        tensor_name,  // tensor_name can't be replaced by op.op_nameAttr().str() directly when
-                      // compiling with gcc and I has no idea why.
-                      // But it works when compiling with clang.
-                      // Maybe temporary objects would be released earlier when using gcc.
-        support::DenseElementsAttrToTensor(tensor_attr, op.device_tagAttr(), op.device_nameAttr()),
-        CHECK_JUST(::oneflow::DType::Get(data_type.getValue()))));
+    auto var_tensor = CHECK_JUST(
+        ::oneflow::Singleton<::oneflow::VariableTensorMgr>::Get()->Get(op.op_name().str()));
+    if (var_tensor) {
+      support::DenseElementsAttrToTensor(tensor_attr, op.device_tagAttr(), op.device_nameAttr(),
+                                         var_tensor);
+    } else {
+      CHECK_JUST(::oneflow::Singleton<::oneflow::VariableTensorMgr>::Get()->Set(
+          tensor_name,  // tensor_name can't be replaced by op.op_nameAttr().str() directly when
+                        // compiling with gcc and I has no idea why.
+                        // But it works when compiling with clang.
+                        // Maybe temporary objects would be released earlier when using gcc.
+          support::DenseElementsAttrToTensor(tensor_attr, op.device_tagAttr(),
+                                             op.device_nameAttr()),
+          CHECK_JUST(::oneflow::DType::Get(data_type.getValue()))));
+    }
     // replaceOp may deallocate `op0` (and also `op`), so we should not use `op` after this call.
     rewriter.replaceOp(op0, op_new->getResults());
     return ::mlir::success();


### PR DESCRIPTION
ReplaceVariableIrPattern 加了1个判断，在把 variable_ir 转回 variable 时，会在 VariableTensorMgr 中找是否已经存在对应的 variable tensor，如果不存在，则代表是 FuseConv2DBatchNormPattern 新创建出来的 variable，否则是已经存在的 variable，对于已经存在 variable，则直接复用它的 variable tensor，把 variable_ir 的 dense attr 写回去。

sd2 中测试 7437 MB  -> 6643 MB

------

目前该方法会有一些副作用，会直接影响 graph 外的 eager variable tensor。不过目前该 pass 有一个潜在的约束就是不会修改 variable 的数据。(有该约束在，其实把 dense attr 写回 tensor 也不是必须的，不过 @jackalcooper 说为了防止未来的修改破坏该约束，还是以 dense attr 的数据为准，这可能是被 mlir 修改过的)

