### PR TITLE
clear instruction list to fix item segfault

### DIFF
--- a/oneflow/core/vm/virtual_machine.cpp
+++ b/oneflow/core/vm/virtual_machine.cpp
@@ -237,6 +237,7 @@ Maybe<void> VirtualMachine::Receive(vm::InstructionList* instruction_list) {
       JUST(instruction->Prepare());
       instruction->Compute();
     }
+    instruction_list->Clear();
   } else if (unlikely(disable_vm_threads_)) {
     JUST(RunInCurrentThread(instruction_list));
   } else {


### PR DESCRIPTION
Fixes https://github.com/Oneflow-Inc/OneTeam/issues/1798 

原因是 https://github.com/Oneflow-Inc/oneflow/pull/9394/files#diff-82bd41862a7126a5f7c02115d013754c9fbf5fbd2ce8886e8202e5cb40192804R794 这里有一个 static 的 instruction_list，在子进程下 vm::Run 没有把 instruction_list 清空，所以里面的指令被重复运行，此时指令内的数据已经失效了