### PR TITLE
fix equal

### DIFF
--- a/python/oneflow/nn/modules/equal.py
+++ b/python/oneflow/nn/modules/equal.py
@@ -17,8 +17,12 @@ import oneflow as flow
 
 
 def equal_op(a, b):
-    res = flow._C.equal(a, b)
-    return res.all().item()
+    # True if two tensors have the same size and elements, False otherwise.
+    if a.shape == b.shape and a.numel() == b.numel():
+        res = flow._C.equal(a, b)
+        return res.all().item()
+    else:
+        return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] fix flow.equal接受的input tensor和other tensor，shape不同时报错的bug
- [x] 基于stable diffusion测试通过

## Bug复现
### stable diffusion

跑oneflow版的stable diffusion时，设置prompt的token数量大于77即可复现，报错：
```shell
Traceback (most recent call last):
  File "oneflow_stable.py", line 21, in <module>
    images = pipe(prompt).images
  File "/home/zhaoluyang/Oneflow/oneflow/python/oneflow/autograd/autograd_mode.py", line 154, in wrapper
    return func(*args, **kwargs)
  File "/home/zhaoluyang/Oneflow/diffusers/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_oneflow.py", line 606, in __call__
    text_embeddings = self._encode_prompt(
  File "/home/zhaoluyang/Oneflow/diffusers/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_oneflow.py", line 364, in _encode_prompt
    if not torch.equal(text_input_ids, untruncated_ids):
  File "/home/zhaoluyang/Oneflow/oneflow/python/oneflow/nn/modules/equal.py", line 20, in equal_op
    res = flow._C.equal(a, b)
RuntimeError: The size of tensor a (77) must match the size of tensor b (92) at non-singleton dimension 1
Segmentation fault (core dumped)
```


### 最小复现脚本
对于以下test case：
```python
import oneflow as torch
import numpy as np

a = np.array([1, 2, 3, 4, 5])
b = np.array([1, 2 ,3])

out = torch.equal(torch.tensor(a), torch.tensor(b))
print("out >>>>>>>>>>>> ", out)
```
由于a和b的shape、以及tensor的element count不同，pytorch会直接输出False，而oneflow会bug：
```shell
Traceback (most recent call last):
  File "test_equal.py", line 7, in <module>
    out = torch.equal(torch.tensor(a), torch.tensor(b))
  File "/home/zhaoluyang/Oneflow/oneflow/python/oneflow/nn/modules/equal.py", line 20, in equal_op
    res = flow._C.equal(a, b)
RuntimeError: The size of tensor a (5) must match the size of tensor b (3) at non-singleton dimension 0
terminate called without an active exception
```


本pr在equal.py中fix了此问题