### PR TITLE
perf(slice): only memset in S to P in slice kernel

### DIFF
--- a/oneflow/user/kernels/slice_kernel.cpp
+++ b/oneflow/user/kernels/slice_kernel.cpp
@@ -269,6 +269,9 @@ void WriteSlice(user_op::KernelComputeContext* ctx, const user_op::Tensor* src,
       SliceKernelUtil<device_type, T>::Forward(ctx->stream(), large_slice_param, src->dptr<T>(),
                                                dst->mut_dptr<T>());
     } else {
+      AutoMemset(ctx->stream(), dst->mut_dptr(), 0,
+                 dst->shape_view().elem_cnt() * GetSizeOfDataType(dst->data_type()),
+                 dst->mem_case());
       SliceKernelUtil<device_type, T>::Forward(ctx->stream(), large_slice_param, small_slice_param,
                                                src->dptr<T>(), dst->mut_dptr<T>());
     }
@@ -329,9 +332,6 @@ class SliceKernel final : public user_op::OpKernel, public user_op::CudaGraphSup
     const user_op::Tensor* x_tensor = ctx->Tensor4ArgNameAndIndex("x", 0);
     const SliceContext& slice_ctx =
         dynamic_cast<const OpKernelCacheWrapper<SliceContext>*>(cache)->Get();
-    AutoMemset(ctx->stream(), y_tensor->mut_dptr(), 0,
-               y_tensor->shape_view().elem_cnt() * GetSizeOfDataType(y_tensor->data_type()),
-               y_tensor->mem_case());
     WriteSlice<device_type, T>(ctx, x_tensor, y_tensor, slice_ctx, /*from_large_to_small=*/true);
   }
   bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }


### PR DESCRIPTION
slice kernel 中只在 S -> P 时做 memset，其他情况下 output 的数据会被一一覆盖，不需要 memset