### PR TITLE
dev add spectral_norm

### DIFF
--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -1993,6 +1993,10 @@
   signature: "Tensor (Tensor input, Tensor other, Int64 dim=None) => LinalgCross"
   bind_python: True
 
+- name: "multi_dot"
+  signature: "Tensor (TensorTuple tensors) => MultiDot"
+  bind_python: True
+
 - name: "dropout"
   signature: "Tensor (Tensor input, Float p=0.5, Bool training=True, Bool inplace=False, Generator generator=None, *, Tensor addend=None) => Dropout"
   bind_python: True

--- a/python/oneflow/linalg.py
+++ b/python/oneflow/linalg.py
@@ -41,3 +41,7 @@ def diagonal(self, input, offset=0, dim1=-2, dim2=-1):
 
 def cross(input, other, dim=-1):
     return flow._C.linalg_cross(input, other, dim=dim)
+
+
+def multi_dot(tensors):
+    return flow._C.multi_dot(tensors)

--- a/python/oneflow/nn/init.py
+++ b/python/oneflow/nn/init.py
@@ -202,6 +202,9 @@ def kaiming_uniform_(
     """
     if os.getenv("ONEFLOW_ENABLE_NHWC") == "1":
         data_format = "NHWC"
+    if 0 in tensor.shape:
+        warnings.warn("Initializing zero-element tensors is a no-op")
+        return tensor
     fan = calc_fan(tensor.shape, mode, get_data_format(data_format))
     gain = calculate_gain(nonlinearity, a)
     std = gain / math.sqrt(fan)
@@ -245,6 +248,9 @@ def kaiming_normal_(
     if os.getenv("ONEFLOW_ENABLE_NHWC") == "1":
         data_format = "NHWC"
     assert mode in ["fan_in", "fan_out"]
+    if 0 in tensor.shape:
+        warnings.warn("Initializing zero-element tensors is a no-op")
+        return tensor
     fan = calc_fan(tensor.shape, mode, get_data_format(data_format))
     gain = calculate_gain(nonlinearity, a)
     std = gain / math.sqrt(fan)

--- a/python/oneflow/nn/utils/__init__.py
+++ b/python/oneflow/nn/utils/__init__.py
@@ -16,3 +16,5 @@ limitations under the License.
 from oneflow.nn.utils.clip_grad import clip_grad_norm_, clip_grad_value_
 from oneflow.nn.utils.weight_norm import weight_norm
 from oneflow.nn.utils.weight_norm import remove_weight_norm
+from oneflow.nn.utils.spectral_norm import spectral_norm
+from oneflow.nn.utils.spectral_norm import remove_spectral_norm

--- a/python/oneflow/nn/utils/spectral_norm.py
+++ b/python/oneflow/nn/utils/spectral_norm.py
@@ -1,0 +1,245 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from typing import Any, Optional, TypeVar
+
+import oneflow as flow
+from oneflow.nn.functional import normalize
+from oneflow.nn.modules.module import Module
+from oneflow.framework.tensor import Tensor
+
+
+class SpectralNorm:
+    _version: int = 1
+    name: str
+    dim: int
+    n_power_iterations: int
+    eps: float
+
+    def __init__(
+        self,
+        name: str = "weight",
+        n_power_iterations: int = 1,
+        dim: int = 0,
+        eps: float = 1e-12,
+    ) -> None:
+        self.name = name
+        self.dim = dim
+        if n_power_iterations <= 0:
+            raise ValueError(
+                "Expected n_power_iterations to be positive, but "
+                "got n_power_iterations={}".format(n_power_iterations)
+            )
+        self.n_power_iterations = n_power_iterations
+        self.eps = eps
+
+    def reshape_weight_to_matrix(self, weight: Tensor) -> Tensor:
+        weight_mat = weight
+        if self.dim != 0:
+            # permute dim to front
+            weight_mat = weight_mat.permute(
+                self.dim, *[d for d in range(weight_mat.dim()) if d != self.dim]
+            )
+        height = weight_mat.size(0)
+        return weight_mat.reshape(height, -1)
+
+    def compute_weight(self, module: Module, do_power_iteration: bool) -> Tensor:
+        weight = getattr(module, self.name + "_orig")
+        u = getattr(module, self.name + "_u")
+        v = getattr(module, self.name + "_v")
+        weight_mat = self.reshape_weight_to_matrix(weight)
+
+        if do_power_iteration:
+            with flow.no_grad():
+                for _ in range(self.n_power_iterations):
+                    # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
+                    # are the first left and right singular vectors.
+                    # This power iteration produces approximations of `u` and `v`.
+                    v = normalize(flow.mv(weight_mat.t(), u), dim=0, eps=self.eps)
+                    u = normalize(flow.mv(weight_mat, v), dim=0, eps=self.eps)
+                if self.n_power_iterations > 0:
+                    # TODO(hujiakui): flow.contiguous_format needed
+                    # u = u.clone(memory_format=flow.contiguous_format)
+                    # v = v.clone(memory_format=flow.contiguous_format)
+                    u = u.clone()
+                    v = v.clone()
+
+        sigma = flow.dot(u, flow.mv(weight_mat, v))
+        weight = weight / sigma
+        return weight
+
+    def remove(self, module: Module) -> None:
+        with flow.no_grad():
+            weight = self.compute_weight(module, do_power_iteration=False)
+        delattr(module, self.name)
+        delattr(module, self.name + "_u")
+        delattr(module, self.name + "_v")
+        delattr(module, self.name + "_orig")
+        module.register_parameter(self.name, flow.nn.Parameter(weight.detach()))
+
+    def __call__(self, module: Module, inputs: Any) -> None:
+        setattr(
+            module,
+            self.name,
+            self.compute_weight(module, do_power_iteration=module.training),
+        )
+
+    def _solve_v_and_rescale(self, weight_mat, u, target_sigma):
+        # Tries to returns a vector `v` s.t. `u = normalize(W @ v)`
+        # (the invariant at top of this class) and `u @ W @ v = sigma`.
+        # This uses pinverse in case W^T W is not invertible.
+        v = flow.linalg.multi_dot(
+            [weight_mat.t().mm(weight_mat).pinverse(), weight_mat.t(), u.unsqueeze(1)]
+        ).squeeze(1)
+        return v.mul_(target_sigma / flow.dot(u, flow.mv(weight_mat, v)))
+
+    @staticmethod
+    def apply(
+        module: Module, name: str, n_power_iterations: int, dim: int, eps: float
+    ) -> "SpectralNorm":
+        for k, hook in module._forward_pre_hooks.items():
+            if isinstance(hook, SpectralNorm) and hook.name == name:
+                raise RuntimeError(
+                    "Cannot register two spectral_norm hooks on "
+                    "the same parameter {}".format(name)
+                )
+
+        fn = SpectralNorm(name, n_power_iterations, dim, eps)
+        weight = module._parameters[name]
+        if weight is None:
+            raise ValueError(
+                f"`SpectralNorm` cannot be applied as parameter `{name}` is None"
+            )
+
+        with flow.no_grad():
+            weight_mat = fn.reshape_weight_to_matrix(weight)
+
+            h, w = weight_mat.size()
+            # randomly initialize `u` and `v`
+            u = normalize(weight.new_empty(h).normal_(0, 1), dim=0, eps=fn.eps)
+            v = normalize(weight.new_empty(w).normal_(0, 1), dim=0, eps=fn.eps)
+
+        delattr(module, fn.name)
+        module.register_parameter(fn.name + "_orig", weight)
+        # We still need to assign weight back as fn.name because all sorts of
+        # things may assume that it exists, e.g., when initializing weights.
+        # However, we can't directly assign as it could be an nn.Parameter and
+        # gets added as a parameter. Instead, we register weight.data as a plain
+        # attribute.
+        setattr(module, fn.name, weight.data)
+        module.register_buffer(fn.name + "_u", u)
+        module.register_buffer(fn.name + "_v", v)
+
+        module.register_forward_pre_hook(fn)
+        return fn
+
+
+T_module = TypeVar("T_module", bound=Module)
+
+
+def spectral_norm(
+    module: T_module,
+    name: str = "weight",
+    n_power_iterations: int = 1,
+    eps: float = 1e-12,
+    dim: Optional[int] = None,
+) -> T_module:
+    r"""Applies spectral normalization to a parameter in the given module.
+
+    .. math::
+        \mathbf{W}_{SN} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})},
+        \sigma(\mathbf{W}) = \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
+
+    Spectral normalization stabilizes the training of discriminators (critics)
+    in Generative Adversarial Networks (GANs) by rescaling the weight tensor
+    with spectral norm :math:`\sigma` of the weight matrix calculated using
+    power iteration method. If the dimension of the weight tensor is greater
+    than 2, it is reshaped to 2D in power iteration method to get spectral
+    norm. This is implemented via a hook that calculates spectral norm and
+    rescales weight before every :meth:`~Module.forward` call.
+
+    See `Spectral Normalization for Generative Adversarial Networks`_ .
+
+    .. _`Spectral Normalization for Generative Adversarial Networks`: https://arxiv.org/abs/1802.05957
+
+    Args:
+        module (nn.Module): containing module
+        name (str, optional): name of weight parameter
+        n_power_iterations (int, optional): number of power iterations to
+            calculate spectral norm
+        eps (float, optional): epsilon for numerical stability in
+            calculating norms
+        dim (int, optional): dimension corresponding to number of outputs,
+            the default is ``0``, except for modules that are instances of
+            ConvTranspose{1,2,3}d, when it is ``1``
+
+    Returns:
+        The original module with the spectral norm hook
+
+    For Example::
+
+    .. code-block:: python
+
+        >>> import oneflow as flow
+        >>> m = spectral_norm(nn.Linear(20, 40))
+        >>> m
+        Linear(in_features=20, out_features=40, bias=True)
+        >>> m.weight_u.size()
+        oneflow.Size([40])
+
+    """
+    if dim is None:
+        if isinstance(
+            module,
+            (flow.nn.ConvTranspose1d, flow.nn.ConvTranspose2d, flow.nn.ConvTranspose3d),
+        ):
+            dim = 1
+        else:
+            dim = 0
+    SpectralNorm.apply(module, name, n_power_iterations, dim, eps)
+    return module
+
+
+def remove_spectral_norm(module: T_module, name: str = "weight") -> T_module:
+    r"""Removes the spectral normalization reparameterization from a module.
+
+    Args:
+        module (Module): containing module
+        name (str, optional): name of weight parameter
+
+    For Example:
+
+    .. code-block:: python
+
+        >>> import oneflow as flow
+        >>> m = spectral_norm(nn.Linear(40, 10))
+        >>> remove_spectral_norm(m)
+
+    """
+    for k, hook in module._forward_pre_hooks.items():
+        if isinstance(hook, SpectralNorm) and hook.name == name:
+            hook.remove(module)
+            del module._forward_pre_hooks[k]
+            break
+    else:
+        raise ValueError("spectral_norm of '{}' not found in {}".format(name, module))
+
+    return module
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod(raise_on_error=True)

--- a/python/oneflow/test/modules/test_dot.py
+++ b/python/oneflow/test/modules/test_dot.py
@@ -31,6 +31,21 @@ class TestDot(flow.unittest.TestCase):
         z = torch.dot(x, y)
         return z
 
+    @autotest(n=5, check_graph=False)
+    def test_dot_with_random_int_data(test_case):
+        k = np.random.randint(0, 100)
+        x = np.random.randint(low=0, high=100, size=k)
+        y = np.random.randint(low=0, high=100, size=k)
+        torch_x = torch.from_numpy(x).to(torch.int)
+        torch_y = torch.from_numpy(y).to(torch.int)
+        torch_output_numpy = torch.dot(torch_x, torch_y).numpy()
+        flow_x = flow.tensor(x).to(flow.int)
+        flow_y = flow.tensor(y).to(flow.int)
+        flow_output_numpy = flow.dot(flow_x, flow_y).numpy()
+        test_case.assertTrue(
+            np.allclose(flow_output_numpy, torch_output_numpy, 1e-05, 1e-05)
+        )
+
     @profile(torch.dot)
     def profile_dot(test_case):
         input1 = torch.ones(10000)

--- a/python/oneflow/test/modules/test_multi_dot.py
+++ b/python/oneflow/test/modules/test_multi_dot.py
@@ -1,0 +1,54 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from collections import OrderedDict
+
+import numpy as np
+from oneflow.test_utils.automated_test_util import *
+import oneflow as flow
+import oneflow.unittest
+
+
+class TestMultiDotModule(flow.unittest.TestCase):
+    @autotest()
+    def test_multi_dot_random_1d_tensors(test_case):
+        device = random_device()
+        k = random(10, 100)
+        x = random_tensor(ndim=1, dim0=k).to(device)
+        y = random_tensor(ndim=1, dim0=k).to(device)
+        return torch.linalg.multi_dot([x, y])
+
+    @autotest()
+    def test_multi_dot_random_first_2d_tensor(test_case):
+        device = random_device()
+        k = random(10, 100)
+        x = random_tensor(ndim=2, dim1=k).to(device)
+        y = random_tensor(ndim=random(1, 2), dim0=k).to(device)
+        return torch.linalg.multi_dot([x, y])
+
+    @autotest()
+    def test_multi_dot_random_multi_2d_tensors(test_case):
+        device = random_device()
+        k0 = random(10, 100)
+        k1 = random(10, 100)
+        x = random_tensor(ndim=2, dim1=k0).to(device)
+        y = random_tensor(ndim=2, dim0=k0, dim1=k1).to(device)
+        z = random_tensor(ndim=2, dim0=k1)
+        return torch.linalg.multi_dot([x, y, z])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/oneflow/test/modules/test_spectral_norm.py
+++ b/python/oneflow/test/modules/test_spectral_norm.py
@@ -1,0 +1,109 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from collections import OrderedDict
+
+import numpy as np
+import oneflow as flow
+import oneflow.nn as nn
+import oneflow.nn.functional as F
+import oneflow.unittest
+
+from oneflow.test_utils.test_util import GenArgList
+
+import torch as torch_original
+from oneflow.test_utils.automated_test_util import *
+
+
+def _test_spectral_norm(test_case, device):
+    input = flow.rand(3, 5).to(device)
+    m = nn.Linear(5, 7).to(device)
+    m = flow.nn.utils.spectral_norm(m)
+
+    test_case.assertEqual(m.weight_u.size(), flow.Size([m.weight.size(0)]))
+
+    test_case.assertTrue(hasattr(m, "weight_orig"))
+    test_case.assertTrue("weight_orig" in m._parameters)
+
+    test_case.assertTrue(hasattr(m, "weight_u"))
+    test_case.assertTrue("weight_u" in m._buffers)
+    test_case.assertTrue("weight_v" in m._buffers)
+
+    test_case.assertFalse("weight" in m._parameters)
+    test_case.assertFalse("weight" in m._buffers)
+
+    test_case.assertEqual(m.weight_orig.storage_offset(), m.weight.storage_offset())
+    test_case.assertEqual(m.weight_orig.size(), m.weight.size())
+    test_case.assertEqual(m.weight_orig.stride(), m.weight.stride())
+
+    m = flow.nn.utils.remove_spectral_norm(m)
+    test_case.assertFalse(hasattr(m, "weight_orig"))
+    test_case.assertFalse(hasattr(m, "weight_u"))
+
+    test_case.assertTrue(hasattr(m, "weight"))
+    test_case.assertTrue("weight" in m._parameters)
+
+    with test_case.assertRaisesRegex(RuntimeError, "register two spectral_norm hooks"):
+        m = flow.nn.utils.spectral_norm(m)
+        m = flow.nn.utils.spectral_norm(m)
+
+
+def _test_spectral_norm_dim(test_case, device):
+    input = flow.randn(2, 3, 10, 12).to(device)
+    m = nn.ConvTranspose2d(3, 4, (5, 6)).to(device)
+    m = flow.nn.utils.spectral_norm(m)
+    x = m(input)
+    test_case.assertEqual(m.weight_u.shape, m.weight_orig[0, :, 0, 0].shape)
+
+
+def _test_spectral_norm_forward(test_case, device):
+    k = np.random.randint(1, 100)
+    input = flow.randn(21, k).to(device)
+    m = nn.Linear(k, 10).to(device)
+    m = nn.utils.spectral_norm(m)
+
+    _weight, _bias, _u = m.weight_orig, m.bias, m.weight_u
+    _weight_mat = _weight.view(_weight.size(0), -1)
+    _v = flow.mv(_weight_mat.t(), _u)
+    _v = F.normalize(_v, dim=0, eps=1e-12)
+    _u = flow.mv(_weight_mat, _v)
+    _u = F.normalize(_u, dim=0, eps=1e-12)
+    _weight.data /= flow.dot(_u, flow.matmul(_weight_mat, _v))
+
+    out_hat = F.linear(input, _weight, _bias)
+    expect_out = m(input)
+    test_case.assertTrue(
+        np.allclose(expect_out.numpy(), out_hat.numpy(), rtol=1e-5, atol=1e-5)
+    )
+
+
+@flow.unittest.skip_unless_1n1d()
+class TestSpectralNorm(flow.unittest.TestCase):
+    @autotest()
+    def test_spectral_norm(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["test_fun"] = [
+            _test_spectral_norm,
+            _test_spectral_norm_dim,
+            _test_spectral_norm_forward,
+        ]
+        arg_dict["device"] = ["cpu", "cuda"]
+        for arg in GenArgList(arg_dict):
+            arg[0](test_case, *arg[1:])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@BBuf 修复了一些 spectral_norm 实现过程中遇到的bug

- [x] 修复 dot 在 cpu 下不支持 int32 与 int64 计算的 bug （因为matmul）
- [x] 增加 spectral_norm 的基本功能
- [x] 修复 kaiming_uniform_ 和 kaiming_normal_ 在输入0size tensor 的时候的除0 bug
- [x] 新增 oneflow.linalg.multi_dot()
- [ ] spectral_norm 的 load_state_dict 测试 load 与 hook
- [ ] spectral_norm  和 multi_dot 的文档