### PR TITLE
Graph global ops test merge

### DIFF
--- a/oneflow/core/ep/cuda/primitive/permute.cu
+++ b/oneflow/core/ep/cuda/primitive/permute.cu
@@ -281,10 +281,12 @@ void LaunchKernel(Stream* stream, const int64_t* src_dims, const void* src, cons
             cuda_stream, params, num_batches, rows, cols);
       }
     } else {
+      if (params.count == 0) { return; }
       PermuteKernel<num_dims, movement_size, IndexType>
           <<<BlocksNum4ThreadsNum(params.count), kCudaThreadsNumPerBlock, 0, cuda_stream>>>(params);
     }
   } else {
+    if (params.count == 0) { return; }
     PermuteKernel<num_dims, movement_size, IndexType>
         <<<BlocksNum4ThreadsNum(params.count), kCudaThreadsNumPerBlock, 0, cuda_stream>>>(params);
   }

--- a/oneflow/user/ops/affine_grid_op.cpp
+++ b/oneflow/user/ops/affine_grid_op.cpp
@@ -119,7 +119,7 @@ Maybe<void> CheckAttr_(const user_op::UserOpDefWrapper& def,
         JUST(GetPhysicalShape(logical_shape, nd_sbp, ctx->parallel_desc(), ctx->parallel_ctx()));
     N = physical_shape->At(0);
   }
-  CHECK_EQ_OR_RETURN(theta_shape.At(0), size.At(0))
+  CHECK_EQ_OR_RETURN(theta_shape.At(0), N)
       << "The dimension 0 size of theta shape should be " << N << ", but got " << theta_shape.At(0);
 
   grid->set_is_dynamic(theta.is_dynamic());

--- a/python/oneflow/test/modules/test_global_affine_grid.py
+++ b/python/oneflow/test/modules/test_global_affine_grid.py
@@ -22,7 +22,7 @@ import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
 
-@autotest(n=1, rtol=1e-03, atol=1e-04, check_graph=False)
+@autotest(n=1, rtol=1e-03, atol=1e-04, check_graph=True)
 def _test_affine_grid_2d_with_random_data(test_case, placement, sbp):
     N = random(1, 3).to(int).value() * 8
     C = random(1, 8).to(int).value()
@@ -38,7 +38,7 @@ def _test_affine_grid_2d_with_random_data(test_case, placement, sbp):
     return output
 
 
-@autotest(n=1, rtol=1e-03, atol=1e-04, check_graph=False)
+@autotest(n=1, rtol=1e-03, atol=1e-04, check_graph=True)
 def _test_affine_grid_3d_with_random_data(test_case, placement, sbp):
     N = random(1, 3).to(int) * 8
     C = random(1, 8).to(int)

--- a/python/oneflow/test/modules/test_global_avgpool.py
+++ b/python/oneflow/test/modules/test_global_avgpool.py
@@ -21,7 +21,7 @@ import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_avgpool1d_with_random_data(test_case, placement, sbp):
     m = torch.nn.AvgPool1d(
         kernel_size=random(4, 6),
@@ -39,7 +39,7 @@ def _test_avgpool1d_with_random_data(test_case, placement, sbp):
     return y
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_avgpool2d_with_random_data(test_case, placement, sbp):
     m = torch.nn.AvgPool2d(
         kernel_size=random(4, 6),
@@ -58,7 +58,7 @@ def _test_avgpool2d_with_random_data(test_case, placement, sbp):
     return y
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_avgpool3d_with_random_data(test_case, placement, sbp):
     m = torch.nn.AvgPool3d(
         kernel_size=random(4, 6),
@@ -77,7 +77,7 @@ def _test_avgpool3d_with_random_data(test_case, placement, sbp):
     return y
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_functional_avgpool1d_with_random_data(test_case, placement, sbp):
     ndim = 3
     dims = [random(1, 3) * 8 for _ in range(ndim)]
@@ -93,7 +93,7 @@ def _test_functional_avgpool1d_with_random_data(test_case, placement, sbp):
     return y
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_functional_avgpool2d_with_random_data(test_case, placement, sbp):
     ndim = 4
     dims = [random(1, 3) * 8 for _ in range(ndim)]
@@ -109,7 +109,7 @@ def _test_functional_avgpool2d_with_random_data(test_case, placement, sbp):
     return y
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_functional_avgpool3d_with_random_data(test_case, placement, sbp):
     ndim = 5
     dims = [random(1, 3) * 8 for _ in range(ndim)]

--- a/python/oneflow/test/modules/test_global_deconv2d.py
+++ b/python/oneflow/test/modules/test_global_deconv2d.py
@@ -21,7 +21,7 @@ import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
 
-@autotest(n=1, auto_backward=True, check_graph=False)
+@autotest(n=1, auto_backward=True, check_graph=True)
 def _test_deconv2d_impl(test_case, placement, input_sbp):
     ndim = 4
     in_channels = random(1, 5).to(int).value() * 8

--- a/python/oneflow/test/modules/test_global_grid_sample.py
+++ b/python/oneflow/test/modules/test_global_grid_sample.py
@@ -23,7 +23,7 @@ import oneflow as flow
 import oneflow.unittest
 
 
-@autotest(n=1, rtol=1e-03, atol=1e-04, check_graph=False)
+@autotest(n=1, rtol=1e-03, atol=1e-04, check_graph=True)
 def _test_flow_grid_sample_cudnn(test_case, placement, sbp):
     # cudnn only support 4D input, with mode = 'bilinear' && padding_mode = 'zeros' && align_corners
     N = random(1, 3).to(int) * 8
@@ -57,7 +57,7 @@ def _test_flow_grid_sample_cudnn(test_case, placement, sbp):
     auto_backward=False,
     rtol=1e-03,
     atol=1e-04,
-    check_graph=False,
+    check_graph=True,
     check_allclose=False,
 )
 def _test_flow_grid_sample_4d(test_case, placement, sbp):
@@ -85,7 +85,7 @@ def _test_flow_grid_sample_4d(test_case, placement, sbp):
     return output
 
 
-@autotest(n=1, auto_backward=False, rtol=1e-03, atol=1e-03, check_graph=False)
+@autotest(n=1, auto_backward=False, rtol=1e-03, atol=1e-03, check_graph=True)
 def _test_flow_grid_sample_5d(test_case, placement, sbp):
     N = random(1, 3).to(int) * 8
     C = random(1, 3).to(int) * 8

--- a/python/oneflow/test/modules/test_global_gru_cell.py
+++ b/python/oneflow/test/modules/test_global_gru_cell.py
@@ -23,63 +23,13 @@ from oneflow.test_utils.automated_test_util import *
 
 
 @autotest(n=1, check_graph=True)
-def _test_rnn_relu_cell(test_case, placement, sbp):
+def _test_gru_cell(test_case, placement, sbp):
     batch_size = random(2, 3) * 8
     time_steps = random(2, 3) * 8
     input_size = random(2, 3) * 8
     hidden_size = random(2, 3) * 8
     has_bias = random().to(bool)
-    m = torch.nn.RNNCell(
-        input_size=input_size,
-        hidden_size=hidden_size,
-        bias=has_bias,
-        nonlinearity="relu",
-    )
-
-    weight_sbp = random_sbp(placement, max_dim=2, except_partial_sum=True)
-    m.weight_ih = torch.nn.Parameter(
-        m.weight_ih.to_global(placement=placement, sbp=weight_sbp)
-    )
-    m.weight_hh = torch.nn.Parameter(
-        m.weight_hh.to_global(placement=placement, sbp=weight_sbp)
-    )
-    if m.bias_ih is not None:
-        # bias is 1-d tensor
-        bias_sbp = random_sbp(placement, max_dim=1, except_partial_sum=True)
-        m.bias_ih = torch.nn.Parameter(
-            m.bias_ih.to_global(placement=placement, sbp=bias_sbp)
-        )
-        m.bias_hh = torch.nn.Parameter(
-            m.bias_hh.to_global(placement=placement, sbp=bias_sbp)
-        )
-
-    input_sbp = random_sbp(placement, max_dim=3, valid_split_axis=1)
-    input = random_tensor(
-        ndim=3, dim0=time_steps, dim1=batch_size, dim2=input_size
-    ).to_global(placement=placement, sbp=input_sbp)
-    hx = random_tensor(
-        ndim=2, dim0=batch_size, dim1=hidden_size, requires_grad=False
-    ).to_global(placement=placement, sbp=sbp)
-
-    for i in range(time_steps.to(int).value()):
-        hx = m(input[i], hx)
-
-    return hx
-
-
-@autotest(n=1, check_graph=True)
-def _test_rnn_tanh_cell(test_case, placement, sbp):
-    batch_size = random(2, 3) * 8
-    time_steps = random(2, 3) * 8
-    input_size = random(2, 3) * 8
-    hidden_size = random(2, 3) * 8
-    has_bias = random().to(bool)
-    m = torch.nn.RNNCell(
-        input_size=input_size,
-        hidden_size=hidden_size,
-        bias=has_bias,
-        nonlinearity="tanh",
-    )
+    m = torch.nn.GRUCell(input_size=input_size, hidden_size=hidden_size, bias=has_bias,)
 
     weight_sbp = random_sbp(placement, max_dim=2, except_partial_sum=True)
     m.weight_ih = torch.nn.Parameter(
@@ -114,16 +64,10 @@ def _test_rnn_tanh_cell(test_case, placement, sbp):
 
 class TestRNNCellGlobal(flow.unittest.TestCase):
     @globaltest
-    def test_rnn_relu_cell(test_case):
+    def test_gru_cell(test_case):
         for placement in all_placement():
             for sbp in all_sbp(placement, max_dim=2):
-                _test_rnn_relu_cell(test_case, placement, sbp)
-
-    @globaltest
-    def test_rnn_tanh_cell(test_case):
-        for placement in all_placement():
-            for sbp in all_sbp(placement, max_dim=2):
-                _test_rnn_tanh_cell(test_case, placement, sbp)
+                _test_gru_cell(test_case, placement, sbp)
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_global_gru_cell.py
+++ b/python/oneflow/test/modules/test_global_gru_cell.py
@@ -20,6 +20,7 @@ import numpy as np
 import oneflow as flow
 import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
+import oneflow.framework.session_context as session_ctx
 
 
 @autotest(n=1, check_graph=True)

--- a/python/oneflow/test/modules/test_global_gru_cell.py
+++ b/python/oneflow/test/modules/test_global_gru_cell.py
@@ -69,6 +69,8 @@ class TestRNNCellGlobal(flow.unittest.TestCase):
             for sbp in all_sbp(placement, max_dim=2):
                 _test_gru_cell(test_case, placement, sbp)
 
+                session_ctx.GetDefaultSession().Reset()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/oneflow/test/modules/test_global_linear.py
+++ b/python/oneflow/test/modules/test_global_linear.py
@@ -26,17 +26,18 @@ import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
 
-@autotest(n=1, check_graph=False)
-def _test_linear_with_random_data(test_case, placement, weight_sbp, input_sbp):
+@autotest(n=1, check_graph=True)
+def _test_linear_with_random_data(test_case, placement, input_sbp):
     input_size = 8
     m = torch.nn.Linear(in_features=input_size, out_features=8, bias=random())
     m.train(random())
+    weight_sbp = random_sbp(placement, max_dim=2, except_partial_sum=True)
     m.weight = torch.nn.Parameter(
         m.weight.to_global(placement=placement, sbp=weight_sbp)
     )
     if m.bias is not None:
         # bias is 1-d tensor
-        bias_sbp = random_sbp(placement, max_dim=1)
+        bias_sbp = random_sbp(placement, max_dim=1, except_partial_sum=True)
         m.bias = torch.nn.Parameter(m.bias.to_global(placement=placement, sbp=bias_sbp))
     x = random_tensor(ndim=2, dim0=input_size, dim1=8).to_global(
         placement=placement, sbp=input_sbp
@@ -49,8 +50,8 @@ class TestLinearModule(flow.unittest.TestCase):
     @globaltest
     def test_linear_with_random_data(test_case):
         for placement in all_placement():
-            for sbp in all_sbp(placement, max_dim=2):
-                _test_linear_with_random_data(test_case, placement, sbp, sbp)
+            for input_sbp in all_sbp(placement, max_dim=2):
+                _test_linear_with_random_data(test_case, placement, input_sbp)
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_global_linear.py
+++ b/python/oneflow/test/modules/test_global_linear.py
@@ -26,7 +26,7 @@ import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
 
-@autotest(n=1, check_graph=True)
+@autotest(n=1, check_graph=False)
 def _test_linear_with_random_data(test_case, placement, input_sbp):
     input_size = 8
     m = torch.nn.Linear(in_features=input_size, out_features=8, bias=random())

--- a/python/oneflow/test/modules/test_global_lstm_cell.py
+++ b/python/oneflow/test/modules/test_global_lstm_cell.py
@@ -23,17 +23,15 @@ from oneflow.test_utils.automated_test_util import *
 
 
 @autotest(n=1, check_graph=True)
-def _test_rnn_relu_cell(test_case, placement, sbp):
+def _test_lstm_cell(test_case, placement, sbp):
     batch_size = random(2, 3) * 8
     time_steps = random(2, 3) * 8
     input_size = random(2, 3) * 8
     hidden_size = random(2, 3) * 8
     has_bias = random().to(bool)
-    m = torch.nn.RNNCell(
-        input_size=input_size,
-        hidden_size=hidden_size,
-        bias=has_bias,
-        nonlinearity="relu",
+    cx_requires_grad = random().to(bool)
+    m = torch.nn.LSTMCell(
+        input_size=input_size, hidden_size=hidden_size, bias=has_bias,
     )
 
     weight_sbp = random_sbp(placement, max_dim=2, except_partial_sum=True)
@@ -60,70 +58,23 @@ def _test_rnn_relu_cell(test_case, placement, sbp):
     hx = random_tensor(
         ndim=2, dim0=batch_size, dim1=hidden_size, requires_grad=False
     ).to_global(placement=placement, sbp=sbp)
-
-    for i in range(time_steps.to(int).value()):
-        hx = m(input[i], hx)
-
-    return hx
-
-
-@autotest(n=1, check_graph=True)
-def _test_rnn_tanh_cell(test_case, placement, sbp):
-    batch_size = random(2, 3) * 8
-    time_steps = random(2, 3) * 8
-    input_size = random(2, 3) * 8
-    hidden_size = random(2, 3) * 8
-    has_bias = random().to(bool)
-    m = torch.nn.RNNCell(
-        input_size=input_size,
-        hidden_size=hidden_size,
-        bias=has_bias,
-        nonlinearity="tanh",
-    )
-
-    weight_sbp = random_sbp(placement, max_dim=2, except_partial_sum=True)
-    m.weight_ih = torch.nn.Parameter(
-        m.weight_ih.to_global(placement=placement, sbp=weight_sbp)
-    )
-    m.weight_hh = torch.nn.Parameter(
-        m.weight_hh.to_global(placement=placement, sbp=weight_sbp)
-    )
-    if m.bias_ih is not None:
-        # bias is 1-d tensor
-        bias_sbp = random_sbp(placement, max_dim=1, except_partial_sum=True)
-        m.bias_ih = torch.nn.Parameter(
-            m.bias_ih.to_global(placement=placement, sbp=bias_sbp)
-        )
-        m.bias_hh = torch.nn.Parameter(
-            m.bias_hh.to_global(placement=placement, sbp=bias_sbp)
-        )
-
-    input_sbp = random_sbp(placement, max_dim=3, valid_split_axis=1)
-    input = random_tensor(
-        ndim=3, dim0=time_steps, dim1=batch_size, dim2=input_size
-    ).to_global(placement=placement, sbp=input_sbp)
-    hx = random_tensor(
-        ndim=2, dim0=batch_size, dim1=hidden_size, requires_grad=False
+    cx = random_tensor(
+        ndim=2, dim0=batch_size, dim1=hidden_size, requires_grad=cx_requires_grad
     ).to_global(placement=placement, sbp=sbp)
 
     for i in range(time_steps.to(int).value()):
-        hx = m(input[i], hx)
-
-    return hx
+        res = m(input[i], (hx, cx))
+        hx = res[0]
+        cx = res[1]
+    return res[0]
 
 
 class TestRNNCellGlobal(flow.unittest.TestCase):
     @globaltest
-    def test_rnn_relu_cell(test_case):
+    def test_lstm_cell(test_case):
         for placement in all_placement():
             for sbp in all_sbp(placement, max_dim=2):
-                _test_rnn_relu_cell(test_case, placement, sbp)
-
-    @globaltest
-    def test_rnn_tanh_cell(test_case):
-        for placement in all_placement():
-            for sbp in all_sbp(placement, max_dim=2):
-                _test_rnn_tanh_cell(test_case, placement, sbp)
+                _test_lstm_cell(test_case, placement, sbp)
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_global_lstm_cell.py
+++ b/python/oneflow/test/modules/test_global_lstm_cell.py
@@ -20,6 +20,7 @@ import numpy as np
 import oneflow as flow
 import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
+import oneflow.framework.session_context as session_ctx
 
 
 @autotest(n=1, check_graph=True)

--- a/python/oneflow/test/modules/test_global_lstm_cell.py
+++ b/python/oneflow/test/modules/test_global_lstm_cell.py
@@ -76,6 +76,8 @@ class TestRNNCellGlobal(flow.unittest.TestCase):
             for sbp in all_sbp(placement, max_dim=2):
                 _test_lstm_cell(test_case, placement, sbp)
 
+                session_ctx.GetDefaultSession().Reset()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/oneflow/test/modules/test_global_masked_select.py
+++ b/python/oneflow/test/modules/test_global_masked_select.py
@@ -20,8 +20,10 @@ import oneflow.unittest
 
 from oneflow.test_utils.automated_test_util import *
 
-
-@autotest(n=1, check_graph=False)
+# Not check graph because of one reason:
+# Reason 1, The implementation of the masked_select op calls argwhere with the lazy tensor as an argument, but lazy tensor can not be applied to argwhere.
+# Please refer to File "python/oneflow/nn/modules/masked_select.py", line 54, in masked_select_op.
+@autotest(n=1, check_graph="ValidatedFalse")
 def _test_masked_select(test_case, placement, sbp):
     k1 = random(1, 2).to(int).value() * 8
     k2 = random(1, 2).to(int).value() * 8
@@ -30,7 +32,10 @@ def _test_masked_select(test_case, placement, sbp):
     return torch.masked_select(input, mask)
 
 
-@autotest(n=1, check_graph=False)
+# Not check graph because of one reason:
+# Reason 1, The implementation of the masked_select op calls argwhere with the lazy tensor as an argument, but lazy tensor can not be applied to argwhere.
+# Please refer to File "python/oneflow/nn/modules/masked_select.py", line 54, in masked_select_op.
+@autotest(n=1, check_graph="ValidatedFalse")
 def _test_masked_select_broadcast(test_case, placement, input_sbp, mask_sbp):
     k1 = random(1, 2).to(int).value() * 8
     k2 = random(1, 2).to(int).value() * 8

--- a/python/oneflow/test/modules/test_global_nozero.py
+++ b/python/oneflow/test/modules/test_global_nozero.py
@@ -18,8 +18,10 @@ import oneflow as flow
 import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
-
-@autotest(n=1, auto_backward=False, check_graph=False)
+# Not check graph because of one reason:
+# Reason 1, lazy tensor cannot call numpy(), tensor.numpy() is not allowed to called in nn.Graph.build(*args) or called by lazy tensor.
+# Please refer to File "python/oneflow/nn/modules/nonzero.py", line 29, in nonzero_op.
+@autotest(n=1, auto_backward=False, check_graph="ValidatedFalse")
 def _test_nonzero(test_case, placement, sbp, ndim):
     shape = [8 for _ in range(ndim)]
     x = random_tensor(ndim, *shape).to_global(placement, sbp)

--- a/python/oneflow/test/modules/test_global_rnn_cell.py
+++ b/python/oneflow/test/modules/test_global_rnn_cell.py
@@ -20,6 +20,7 @@ import numpy as np
 import oneflow as flow
 import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
+import oneflow.framework.session_context as session_ctx
 
 
 @autotest(n=1, check_graph=False)

--- a/python/oneflow/test/modules/test_global_rnn_cell.py
+++ b/python/oneflow/test/modules/test_global_rnn_cell.py
@@ -119,11 +119,15 @@ class TestRNNCellGlobal(flow.unittest.TestCase):
             for sbp in all_sbp(placement, max_dim=2):
                 _test_rnn_relu_cell(test_case, placement, sbp)
 
+                session_ctx.GetDefaultSession().Reset()
+
     @globaltest
     def test_rnn_tanh_cell(test_case):
         for placement in all_placement():
             for sbp in all_sbp(placement, max_dim=2):
                 _test_rnn_tanh_cell(test_case, placement, sbp)
+
+                session_ctx.GetDefaultSession().Reset()
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_global_rnn_cell.py
+++ b/python/oneflow/test/modules/test_global_rnn_cell.py
@@ -22,7 +22,7 @@ import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
 
-@autotest(n=1, check_graph=True)
+@autotest(n=1, check_graph=False)
 def _test_rnn_relu_cell(test_case, placement, sbp):
     batch_size = random(2, 3) * 8
     time_steps = random(2, 3) * 8
@@ -67,7 +67,7 @@ def _test_rnn_relu_cell(test_case, placement, sbp):
     return hx
 
 
-@autotest(n=1, check_graph=True)
+@autotest(n=1, check_graph=False)
 def _test_rnn_tanh_cell(test_case, placement, sbp):
     batch_size = random(2, 3) * 8
     time_steps = random(2, 3) * 8

--- a/python/oneflow/test/modules/test_global_sub.py
+++ b/python/oneflow/test/modules/test_global_sub.py
@@ -25,7 +25,7 @@ import oneflow.unittest
 from oneflow.test_utils.automated_test_util import *
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_global_sub(test_case, placement, sbp):
     x = random_tensor(2, 8, 8).to_global(placement=placement, sbp=sbp)
     y = random_tensor(2, 8, 8).to_global(placement=placement, sbp=sbp)
@@ -36,7 +36,7 @@ def _test_global_sub(test_case, placement, sbp):
     return out1, out2, out3, out4
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_global_sub_with_0_size_data(test_case, placement, sbp):
     device = random_device()
     x = random_tensor(2, 0, 8).to_global(placement=placement, sbp=sbp)

--- a/python/oneflow/test/modules/test_global_unfold.py
+++ b/python/oneflow/test/modules/test_global_unfold.py
@@ -22,7 +22,7 @@ from oneflow.test_utils.automated_test_util import *
 from oneflow.nn.common_types import _size_2_t
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_unfold_with_random_data(test_case, placement, sbp):
     ndim = 4
     dims = [random(1, 4).to(int).value() * 8 for i in range(ndim)]

--- a/python/oneflow/test/modules/test_global_where.py
+++ b/python/oneflow/test/modules/test_global_where.py
@@ -22,7 +22,7 @@ import oneflow as flow
 import oneflow.unittest
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_global_where(test_case, placement, sbp):
     x = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     y = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
@@ -36,7 +36,7 @@ def _test_global_where(test_case, placement, sbp):
     return z
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_global_where_broadcast(test_case, placement, sbp):
     x = random_tensor(ndim=3, dim0=8, dim1=16, dim2=1).to_global(placement, sbp)
     y = random_tensor(ndim=3, dim0=8, dim1=16, dim2=8).to_global(placement, sbp)
@@ -50,7 +50,7 @@ def _test_global_where_broadcast(test_case, placement, sbp):
     return z
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_global_where_scalar(test_case, placement, sbp):
     x = random_tensor(ndim=0).to_global(placement, sbp)
     y = random_tensor(ndim=0).to_global(placement, sbp)
@@ -64,7 +64,10 @@ def _test_global_where_scalar(test_case, placement, sbp):
 
 # Close auto_backward because pytorch raise error:
 # PyTorch error: element 0 of tensors does not require grad and does not have a grad_fn
-@autotest(n=1, auto_backward=False, check_graph=False)
+# Not check graph because of one reason:
+# Reason 1, lazy tensor cannot call .numpy(), tensor.numpy() is not allowed to called in nn.Graph.build(*args) or called by lazy tensor.
+# Please refer to File "python/oneflow/nn/modules/nonzero.py", line 29, in nonzero_op. Because nonzero_op is called by where.
+@autotest(n=1, auto_backward=False, check_graph="ValidatedFalse")
 def _test_where_x_y_none(test_case, placement, sbp):
     condition = random_tensor(ndim=2, dim0=8, dim1=8, low=-1, high=1).to_global(
         placement, sbp
@@ -73,7 +76,7 @@ def _test_where_x_y_none(test_case, placement, sbp):
     return y[0], y[1]
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_global_where_tensor_with_0dim_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = random_tensor(ndim=0).to_global(placement, sbp)
@@ -81,7 +84,7 @@ def _test_global_where_tensor_with_0dim_data(test_case, placement, sbp):
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_flow_where_tensor_broadcast_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=3, dim0=8, dim1=16, dim2=8).to_global(placement, sbp)
     x = random_tensor(ndim=3, dim0=8, dim1=1, dim2=8).to_global(placement, sbp)
@@ -89,7 +92,7 @@ def _test_flow_where_tensor_broadcast_with_random_data(test_case, placement, sbp
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_flow_where_scalar_x_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = random().to(float)
@@ -101,7 +104,7 @@ def _test_flow_where_scalar_x_with_random_data(test_case, placement, sbp):
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_flow_where_scalar_x_broadcast_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=1, dim1=16).to_global(placement, sbp)
     x = random().to(float)
@@ -113,7 +116,7 @@ def _test_flow_where_scalar_x_broadcast_with_random_data(test_case, placement, s
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_scalar_x_int_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = random().to(int)
@@ -121,7 +124,7 @@ def _test_flow_where_scalar_x_int_with_random_data(test_case, placement, sbp):
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_flow_where_scalar_y_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = (
@@ -133,7 +136,7 @@ def _test_flow_where_scalar_y_with_random_data(test_case, placement, sbp):
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, check_graph=False)
+@autotest(n=1, check_graph=True)
 def _test_flow_where_scalar_y_broadcast_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=1, dim1=16).to_global(placement, sbp)
     x = (
@@ -145,7 +148,7 @@ def _test_flow_where_scalar_y_broadcast_with_random_data(test_case, placement, s
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_scalar_y_int_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = random_tensor(ndim=2, dim0=8, dim1=16, dtype=int).to_global(placement, sbp)
@@ -153,7 +156,7 @@ def _test_flow_where_scalar_y_int_with_random_data(test_case, placement, sbp):
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_tensor_bool_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp).to(torch.bool)
@@ -161,7 +164,7 @@ def _test_flow_where_tensor_bool_with_random_data(test_case, placement, sbp):
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_tensor_broadcast_bool_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = random_tensor(ndim=2, dim0=1, dim1=16).to_global(placement, sbp).to(torch.bool)
@@ -169,7 +172,7 @@ def _test_flow_where_tensor_broadcast_bool_with_random_data(test_case, placement
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_scalar_x_bool_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = random().to(bool)
@@ -181,7 +184,7 @@ def _test_flow_where_scalar_x_bool_with_random_data(test_case, placement, sbp):
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_scalar_x_broadcast_bool_with_random_data(
     test_case, placement, sbp
 ):
@@ -195,7 +198,7 @@ def _test_flow_where_scalar_x_broadcast_bool_with_random_data(
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_scalar_y_bool_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = (
@@ -207,7 +210,7 @@ def _test_flow_where_scalar_y_bool_with_random_data(test_case, placement, sbp):
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_scalar_y_broadcast_bool_with_random_data(
     test_case, placement, sbp
 ):
@@ -221,7 +224,7 @@ def _test_flow_where_scalar_y_broadcast_bool_with_random_data(
     return torch.where(cond > 0, x, y)
 
 
-@autotest(n=1, auto_backward=False, check_graph=False)
+@autotest(n=1, auto_backward=False, check_graph=True)
 def _test_flow_where_scalar_xy_bool_with_random_data(test_case, placement, sbp):
     cond = random_tensor(ndim=2, dim0=8, dim1=16).to_global(placement, sbp)
     x = random().to(bool)

--- a/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
+++ b/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
@@ -390,7 +390,7 @@ def get_functional_graph_res(
             return graph_functional_oneflow(*graph_args, **graph_kwargs)
 
     try:
-        # When the tensor on the cpu executes to the cpu in nn.Graph, a check error will be reported.
+        # When the tensor on the cpu executes to to the cpu in nn.Graph, a check error will be reported.
         if oneflow.__name__ == "to" or oneflow.__name__ == "_to":
             if isinstance(oneflow_res, flow.Tensor):
                 # The global tensor needs to obtain the device type through placement.type.

--- a/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
+++ b/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
@@ -390,7 +390,7 @@ def get_functional_graph_res(
             return graph_functional_oneflow(*graph_args, **graph_kwargs)
 
     try:
-        # When the tensor on the cpu executes to to the cpu in nn.Graph, a check error will be reported.
+        # In graph mode, when the tensor on the cpu executes the to("cpu") method, a check error will be reported.
         if oneflow.__name__ == "to" or oneflow.__name__ == "_to":
             if isinstance(oneflow_res, flow.Tensor):
                 # The global tensor needs to obtain the device type through placement.type.

--- a/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
+++ b/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
@@ -411,6 +411,9 @@ def get_functional_graph_res(
                         test_g_res = oneflow_res
             else:
                 pass
+        # nn.Graph donot deal with Module type. EX: m.to_global(placement, sbp).
+        elif oneflow.__name__ == "to_global":
+            test_g_res = oneflow_res
         elif oneflow.__name__ == "Parameter":
             # nn.Graph donot deal with Parameter creation.
             test_g_res = oneflow_res

--- a/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
+++ b/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
@@ -402,6 +402,7 @@ def get_functional_graph_res(
                         and oneflow_res.placement.type == oneflow_kwargs["device"]
                     ):
                         test_g_res = oneflow_res
+                # The tensor needs to obtain the device type through device.type.
                 else:
                     if (
                         oneflow_args and oneflow_res.device.type == oneflow_args[0]

--- a/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
+++ b/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
@@ -393,11 +393,22 @@ def get_functional_graph_res(
         # When the tensor on the cpu executes to to the cpu in nn.Graph, a check error will be reported.
         if oneflow.__name__ == "to" or oneflow.__name__ == "_to":
             if isinstance(oneflow_res, flow.Tensor):
-                if (oneflow_args and oneflow_res.device.type == oneflow_args[0]) or (
-                    oneflow_kwargs
-                    and oneflow_res.device.type == oneflow_kwargs["device"]
-                ):
-                    test_g_res = oneflow_res
+                if is_global():
+                    if (
+                        oneflow_args and oneflow_res.placement.type == oneflow_args[0]
+                    ) or (
+                        oneflow_kwargs
+                        and oneflow_res.placement.type == oneflow_kwargs["device"]
+                    ):
+                        test_g_res = oneflow_res
+                else:
+                    if (
+                        oneflow_args and oneflow_res.device.type == oneflow_args[0]
+                    ) or (
+                        oneflow_kwargs
+                        and oneflow_res.device.type == oneflow_kwargs["device"]
+                    ):
+                        test_g_res = oneflow_res
             else:
                 pass
         elif oneflow.__name__ == "Parameter":

--- a/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
+++ b/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
@@ -390,9 +390,10 @@ def get_functional_graph_res(
             return graph_functional_oneflow(*graph_args, **graph_kwargs)
 
     try:
-        # When the tensor on the cpu executes to to the cpu in nn.Graph, a check error will be reported.
+        # When the tensor on the cpu executes to the cpu in nn.Graph, a check error will be reported.
         if oneflow.__name__ == "to" or oneflow.__name__ == "_to":
             if isinstance(oneflow_res, flow.Tensor):
+                # The global tensor needs to obtain the device type through placement.type.
                 if is_global():
                     if (
                         oneflow_args and oneflow_res.placement.type == oneflow_args[0]


### PR DESCRIPTION
## This PR is done:

合并了之前的几个遗留的 graph global test 的 PR：

1. https://github.com/Oneflow-Inc/oneflow/pull/8660
2. https://github.com/Oneflow-Inc/oneflow/pull/8679
3. https://github.com/Oneflow-Inc/oneflow/pull/8690
4. https://github.com/Oneflow-Inc/oneflow/pull/8700
5. https://github.com/Oneflow-Inc/oneflow/pull/8726

依次做了下面的改动：

- [x] 完善 graph global autotest，既某些 case 调用 to() 时，需要通过 placement.type 获得设备类型。
- [x] 打开 where op .etc 的 graph global test。
- [x] 修复多卡 Global 环境下，affine op 的 check 错误。
- [x] 在 global 单侧代码中，存在 m.to_global(placement, sbp) 的情况(m 是 nn.module)，Graph 不能处理这种 Module type。所以在 autotest 中特化：

```python
elif oneflow.__name__ == "to_global":
    test_g_res = oneflow_res
```

- [x]  打开一些 check_graph 开关为 "ValidatedFalse"。
- [x] weight 一类的 op 不测试 sbp 为 partial_sum 的情况，并打开相关 op 的 Graph global test。
- [x] 重构 rnn_cell op 的测试脚本。
- [x] Fix: https://github.com/Oneflow-Inc/OneTeam/issues/1571