### PR TITLE
Fix stack getter segfault caused by is_shutting_down and gil

### DIFF
--- a/python/oneflow/__init__.py
+++ b/python/oneflow/__init__.py
@@ -298,8 +298,8 @@ hook = ExitHook()
 
 
 def atexit_hook(hook):
-    oneflow.framework.session_context.TryCloseDefaultSession()
     __oneflow_global_unique_env.switch_to_shutting_down(hook.is_normal_exit())
+    oneflow.framework.session_context.TryCloseDefaultSession()
 
 
 atexit.register(atexit_hook, hook)


### PR DESCRIPTION
Fixes https://github.com/Oneflow-Inc/OneTeam/issues/1861 ，在 TryCloseDefaultSession 之前设置 is_shutting_down 为 true（https://github.com/Oneflow-Inc/oneflow/pull/9502 这个 PR 在 TryCloseDefaultSession 里引入了 Sync 操作），并把 python c 对象的指针保存在 PyFrame 对象里，GetCurrentFrame 里不再需要重复获取，修复因为没有拿到 gil 锁导致的 segfault