### PR TITLE
allow override ONEFLOW_PYTHON_STACK_GETTER

### DIFF
--- a/oneflow/core/common/env_var/debug_mode.h
+++ b/oneflow/core/common/env_var/debug_mode.h
@@ -28,10 +28,8 @@ inline bool IsInDebugMode() { return EnvBool<ONEFLOW_DEBUG_MODE>() || EnvBool<ON
 DEFINE_ENV_BOOL(ENABLE_LOGICAL_CHAIN, false);
 inline bool EnableLogicalChain() { return EnvBool<ENABLE_LOGICAL_CHAIN>(); }
 
-DEFINE_ENV_BOOL(ONEFLOW_PYTHON_STACK_GETTER, false);
-
 inline bool IsPythonStackGetterEnabled() {
-  return IsInDebugMode() || EnvBool<ONEFLOW_PYTHON_STACK_GETTER>();
+  return ParseBooleanFromEnv("ONEFLOW_PYTHON_STACK_GETTER", IsInDebugMode());
 }
 
 }  // namespace oneflow


### PR DESCRIPTION
原来的逻辑为 ONEFLOW_DEBUG_MODE 和 ONEFLOW_PYTHON_STACK_GETTER 任一开启都会导致 IsPythonStackGetterEnabled 返回 true，更新后的逻辑为如果提供了 ONEFLOW_PYTHON_STACK_GETTER，则以此为准，同时以 ONEFLOW_DEBUG_MODE 作为默认值