### PR TITLE
ddp supports use_bucket=False

### DIFF
--- a/python/oneflow/nn/parallel/distributed.py
+++ b/python/oneflow/nn/parallel/distributed.py
@@ -35,12 +35,12 @@ def grad_setting_fn(module, param):
     return grad_setting
 
 
-def allreduce_fn(module, param):
+def allreduce_fn(module, param, use_bucket):
     ddp_state_for_reversed_params = module._ddp_state_for_reversed_params
-    buckets = module._buckets
-    bucket_tensors = module._bucket_tensors
 
-    def allreduce(grad):
+    def allreduce_with_bucket(grad):
+        buckets = module._buckets
+        bucket_tensors = module._bucket_tensors
         ddp_state_for_reversed_params[param][0] = True
         for index, bucket in enumerate(buckets):
             deleted = all(ddp_state_for_reversed_params[x][1] for x in bucket)
@@ -61,7 +61,22 @@ def allreduce_fn(module, param):
             else:
                 break
 
-    return allreduce
+    def allreduce_without_bucket(grad):
+        ddp_state_for_reversed_params[param][0] = True
+        for cur_param, (ready, deleted) in ddp_state_for_reversed_params.items():
+            if deleted:
+                continue
+            if ready:
+                ddp_state_for_reversed_params[cur_param][1] = True
+                # NOTE(jianhao)(higher-order-grad): local allreduce doesn't have gradient function, higher-order grad may be unsupported
+                if cur_param is param:
+                    flow._C.local_all_reduce(grad, True)
+                else:
+                    flow._C.local_all_reduce(cur_param.grad, True)
+            else:
+                break
+
+    return allreduce_with_bucket if use_bucket else allreduce_without_bucket
 
 
 def DistributedDataParallel(
@@ -69,14 +84,15 @@ def DistributedDataParallel(
     *,
     broadcast_buffers: bool = True,
     broadcast_parameters: bool = True,
-    bucket_size: int = 10
+    bucket_size: int = 10,
+    use_bucket: bool = True,
 ):
     assert all(x.dtype == flow.float32 for x in module.parameters())
-    if parse_boolean_from_env("ONEFLOW_DISABLE_VIEW", False):
+    if use_bucket and parse_boolean_from_env("ONEFLOW_DISABLE_VIEW", False):
         warnings.warn(
-            "because the environment variable 'ONEFLOW_DISABLE_VIEW' is set to true, so the view mechanism is disabled, and we will set bucket_size = 1"
+            "because the environment variable 'ONEFLOW_DISABLE_VIEW' is set to true, so the view mechanism is disabled, and we will set use_bucket=False"
         )
-        bucket_size = 1
+        use_bucket = False
     world_size = flow.env.get_world_size()
     if broadcast_parameters:
         with flow.no_grad():
@@ -87,47 +103,52 @@ def DistributedDataParallel(
                 # after flow._C.comm_broadcast
                 x.requires_grad_(requires_grad)
 
-    all_grad_size = sum([x.numel() for x in module.parameters()])
-    if all_grad_size > 0:
-        device = list(module.parameters())[0].device
-        assert all(x.device == device for x in module.parameters())
-    reversed_param_list = list(
-        reversed(list([param for param in module.parameters() if param.requires_grad]))
-    )
-    module._param_grad_offset_in_bucket = {}
-
-    def numel_in_bucket(tensor: flow.Tensor):
-        def align(x: int, unit_size: int):
-            return (x + (unit_size - 1)) // unit_size * unit_size
-
-        # tensor memory should be align to 512 bytes for cuda operations,
-        # 4 is the bytes of a float number
-        return align(tensor.numel(), flow._oneflow_internal.max_alignment_size() // 4)
-
-    offset_in_bucket = 0
-    with flow.no_grad():
-        for i, param in enumerate(reversed_param_list):
-            assert param.is_leaf
-            if i % bucket_size == 0:
-                offset_in_bucket = 0
-            module._param_grad_offset_in_bucket[param] = offset_in_bucket
-            offset_in_bucket += numel_in_bucket(param)
-
-    module._bucket_index = {
-        x: i // bucket_size for i, x in enumerate(reversed_param_list)
-    }
-    module._buckets = [
-        reversed_param_list[i : i + bucket_size]
-        for i in range(0, len(reversed_param_list), bucket_size)
-    ]
-
-    bucket_elems = 0
-    module._bucket_tensors = []
-    for b in module._buckets:
-        bucket_elems = sum([numel_in_bucket(x) for x in b])
-        module._bucket_tensors.append(
-            flow.zeros(bucket_elems, dtype=flow.float32, device=device)
+    if use_bucket:
+        all_grad_size = sum([x.numel() for x in module.parameters()])
+        if all_grad_size > 0:
+            device = list(module.parameters())[0].device
+            assert all(x.device == device for x in module.parameters())
+        reversed_param_list = list(
+            reversed(
+                list([param for param in module.parameters() if param.requires_grad])
+            )
         )
+        module._param_grad_offset_in_bucket = {}
+
+        def numel_in_bucket(tensor: flow.Tensor):
+            def align(x: int, unit_size: int):
+                return (x + (unit_size - 1)) // unit_size * unit_size
+
+            # tensor memory should be align to 512 bytes for cuda operations,
+            # 4 is the bytes of a float number
+            return align(
+                tensor.numel(), flow._oneflow_internal.max_alignment_size() // 4
+            )
+
+        offset_in_bucket = 0
+        with flow.no_grad():
+            for i, param in enumerate(reversed_param_list):
+                assert param.is_leaf
+                if i % bucket_size == 0:
+                    offset_in_bucket = 0
+                module._param_grad_offset_in_bucket[param] = offset_in_bucket
+                offset_in_bucket += numel_in_bucket(param)
+
+        module._bucket_index = {
+            x: i // bucket_size for i, x in enumerate(reversed_param_list)
+        }
+        module._buckets = [
+            reversed_param_list[i : i + bucket_size]
+            for i in range(0, len(reversed_param_list), bucket_size)
+        ]
+
+        bucket_elems = 0
+        module._bucket_tensors = []
+        for b in module._buckets:
+            bucket_elems = sum([numel_in_bucket(x) for x in b])
+            module._bucket_tensors.append(
+                flow.zeros(bucket_elems, dtype=flow.float32, device=device)
+            )
 
     ddp_state_for_reversed_params = OrderedDict(
         reversed([(x, [False, False]) for x in module.parameters() if x.requires_grad])
@@ -147,9 +168,12 @@ def DistributedDataParallel(
 
     for param in module.parameters():
         if param.requires_grad:
-            param.register_hook(grad_setting_fn(module, param))
+            if use_bucket:
+                param.register_hook(grad_setting_fn(module, param))
             param._register_post_grad_accumulation_hook(inplace_mul_and_return_none)
-            param._register_post_grad_accumulation_hook(allreduce_fn(module, param))
+            param._register_post_grad_accumulation_hook(
+                allreduce_fn(module, param, use_bucket)
+            )
 
     def post_forward_hook(module, input, output):
         ddp_state_for_reversed_params = module._ddp_state_for_reversed_params

--- a/python/oneflow/test/modules/test_ddp.py
+++ b/python/oneflow/test/modules/test_ddp.py
@@ -19,6 +19,7 @@ import oneflow as flow
 # Test import from oneflow.nn.parallel.distributed
 from oneflow.nn.parallel.distributed import DistributedDataParallel
 from oneflow.nn.parallel import DistributedDataParallel as ddp
+from oneflow.test_utils.test_util import GenCartesianProduct
 import oneflow.unittest
 
 import numpy as np
@@ -67,7 +68,7 @@ class TestDDP(flow.unittest.TestCase):
         for dev_type in test_device:
             test_case._test_ddp_basic(dev_type)
 
-    def _test_ddp_multiple_buckets(test_case, dev_type):
+    def _test_ddp_multiple_buckets(test_case, dev_type, use_bucket):
         class Mul(flow.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -91,7 +92,7 @@ class TestDDP(flow.unittest.TestCase):
 
         x = x.to(dev_type)
         m = Mul().to(dev_type)
-        m = ddp(m, bucket_size=3)
+        m = ddp(m, bucket_size=3, use_bucket=use_bucket)
 
         y = m(x)
         y.sum().backward()
@@ -105,8 +106,8 @@ class TestDDP(flow.unittest.TestCase):
             )
 
     def test_ddp_multiple_buckets(test_case):
-        for dev_type in test_device:
-            test_case._test_ddp_multiple_buckets(dev_type)
+        for dev_type, use_bucket in GenCartesianProduct((test_device, [True, False])):
+            test_case._test_ddp_multiple_buckets(dev_type, use_bucket)
 
     def _test_ddp_with_unused_param(test_case, dev_type):
         class Model(flow.nn.Module):


### PR DESCRIPTION
DDP 的 allreduce grouping，以及 contiguous params（https://github.com/Oneflow-Inc/oneflow/pull/9340 ）和 DTR 里的一些优化都会把 parameters 的 grad 放在一段连续的 buffer 上，但它们彼此没有相互感知，同时打开两个功能会导致其中一方的 buffer 得不到正确的 grad，出现正确性问题

完善的解决方式可能比较复杂，要仔细考虑下。现在先给 DDP 加一个关闭 allreduce grouping 的参数 use_bucket（False 表示关闭 allreduce grouping）