### PR TITLE
fix event_recorder.cpp clang-format

### DIFF
--- a/oneflow/core/profiler/event_recorder.cpp
+++ b/oneflow/core/profiler/event_recorder.cpp
@@ -52,7 +52,7 @@ Maybe<EventRecorder> EventRecorder::CreateKernelEventRecorder(
       }
       return std::make_shared<EventRecorder>(event);
     }
-#else   // WITH_CUDA
+#else
     if (pmgr->use_cpu_) {
       return std::make_shared<EventRecorder>(KernelEvent::Create(name, description_getter()));
     }


### PR DESCRIPTION
这行注释的clang-format在ci里面和开发环境里面可能有不一致的行为，暂时删除