### PR TITLE
remove CHECK_JUST in TensorStorage destructor

### DIFF
--- a/oneflow/core/framework/tensor_impl.cpp
+++ b/oneflow/core/framework/tensor_impl.cpp
@@ -81,15 +81,25 @@ EagerLocalTensorImpl::~EagerLocalTensorImpl() {}
 Maybe<void> EagerLocalTensorImpl::UpdateTensorStorage() {
   const auto& eager_blob_object = eager_blob_object_;
   tensor_storage_ = std::make_shared<TensorStorage>(eager_blob_object->tensor_storage());
-  tensor_storage_->set_releaser_hook(
-      [eager_blob_object](const std::shared_ptr<vm::TensorStorage>&) {
-        CHECK_JUST(PhysicalRun([&](InstructionsBuilder* builder) -> Maybe<void> {
-          if (eager_blob_object->producer_stream().has_value()) {
-            JUST(builder->ReleaseTensor(eager_blob_object));
-          }
-          return Maybe<void>::Ok();
-        }));
-      });
+  tensor_storage_->set_releaser_hook([eager_blob_object](
+                                         const std::shared_ptr<vm::TensorStorage>&) {
+    auto ret = PhysicalRun([&](InstructionsBuilder* builder) -> Maybe<void> {
+      if (eager_blob_object->producer_stream().has_value()) {
+        JUST(builder->ReleaseTensor(eager_blob_object));
+      }
+      return Maybe<void>::Ok();
+    });
+    // We should not use CHECK_JUST here because it will throw an exception
+    // in destructor.
+    if (!ret.IsOk()) {
+      LOG(WARNING)
+          << "Release hook gets an error. Release hooks are executed in destructor, so the error "
+             "is possibly only a secondary error caused by another unrelated exception.";
+      LOG(WARNING) << "======= Error message begin =======";
+      LOG(WARNING) << ret.GetSerializedError();
+      LOG(WARNING) << "======= Error message end =======";
+    }
+  });
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
在 destructor 里调用 CHECK_JUST 等价于在 destructor 里抛异常，是 c++ 不允许的，实测会引起错误信息错乱