### PR TITLE
[draft] to_global only sync with group

### DIFF
--- a/oneflow/core/framework/consistency_check.cpp
+++ b/oneflow/core/framework/consistency_check.cpp
@@ -190,7 +190,9 @@ namespace {
 Maybe<void> MetaInfoConsistencyCheckUtil(const Symbol<ParallelDesc>& placement,
                                          const Optional<Symbol<NdSbp>>& nd_sbp,
                                          const Optional<Symbol<NdSbp>>& grad_nd_sbp) {
-  const auto& rank_group = JUST(RankGroupScope::CurrentRankGroup());
+  const auto& rank_group = JUST(RankGroup::New(placement));
+  if (!rank_group->ContainingCurrentRank()) return Maybe<void>::Ok();
+
   const auto& transport_token =
       JUST(TransportToken::NewTransportToken(kTransportTokenTypeCheckRankGroupConsistency));
   const auto& ctx = std::make_shared<CheckMetaInfoConsistencyAsyncTransportCtx>(

--- a/oneflow/core/framework/sync_symbol_parallel_desc.cpp
+++ b/oneflow/core/framework/sync_symbol_parallel_desc.cpp
@@ -99,7 +99,8 @@ Maybe<void> SyncSymbolParallelDesc(uint64_t symbol_id, Symbol<ParallelDesc> para
         *Cb = [recv_buffer] {};
         return Maybe<void>::Ok();
       });
-  const auto& rank_group = JUST(RankGroupScope::CurrentRankGroup());
+  const auto& rank_group = JUST(RankGroup::New(parallel_desc));
+  if (!rank_group->ContainingCurrentRank()) return Maybe<void>::Ok();
   JUST(TransportUtil::SendToNextRankInRing(rank_group, transport_token, &ctx));
   JUST(TransportUtil::ReceiveFromPrevRankInRing(rank_group, transport_token, &ctx));
   JUST_MSG(ctx.WaitDone(), kAsymmetricCodeErrorMsg);

--- a/oneflow/core/functional/impl/global_cast.cpp
+++ b/oneflow/core/functional/impl/global_cast.cpp
@@ -341,12 +341,13 @@ Maybe<void> GetLogicalShapeAndDataType(Shape* logical_shape, DataType* /* in and
       JUST(ShapeAndDataTypeConsistencyCheck(parallel_desc, *logical_shape, *dtype));
     }
   }
-  if (JUST(RankGroup::New(parallel_desc)) != JUST(RankGroupScope::CurrentRankGroup())) {
-    const auto& flat_shape_dtype =
-        JUST(BroadcastShapeAndDtype(*logical_shape, *dtype, parallel_desc));
-    *logical_shape = *JUST(flat_shape_dtype->ToShape());
-    *dtype = flat_shape_dtype->dtype();
-  }
+  // TODO: move global to global(e.g. from [0,1] to [2,3])
+  // if (JUST(RankGroup::New(parallel_desc)) != JUST(RankGroupScope::CurrentRankGroup())) {
+  //   const auto& flat_shape_dtype =
+  //       JUST(BroadcastShapeAndDtype(*logical_shape, *dtype, parallel_desc));
+  //   *logical_shape = *JUST(flat_shape_dtype->ToShape());
+  //   *dtype = flat_shape_dtype->dtype();
+  // }
   return Maybe<void>::Ok();
 }
 


### PR DESCRIPTION
Remove the global  sync to simply implement scheme 1 in issue https://github.com/Oneflow-Inc/oneflow/issues/9741
1. make to_global be aware of the placements and only sync between placements needed