### PR TITLE
enable cuda graph support for Conv2dCutlassKernel

### DIFF
--- a/oneflow/user/kernels/arange_kernel.cpp
+++ b/oneflow/user/kernels/arange_kernel.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "oneflow/user/kernels/arange_kernel_util.h"
 #include "oneflow/core/common/data_type.h"
 #include "oneflow/core/job/nd_sbp_util.h"
+#include "oneflow/core/kernel/cuda_graph_support.h"
 
 namespace oneflow {
 namespace user_op {
@@ -33,7 +34,7 @@ class ArangeOpKernelCache final : public user_op::OpKernelCache {
   const int32_t upper_;
 };
 template<DeviceType device_type, typename T>
-class ArangeKernel final : public OpKernel {
+class ArangeKernel final : public OpKernel, public CudaGraphSupport {
  public:
   ArangeKernel() = default;
   ~ArangeKernel() = default;

--- a/oneflow/user/kernels/clip_by_value_kernel.cpp
+++ b/oneflow/user/kernels/clip_by_value_kernel.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #include "oneflow/user/kernels/clip_by_value_kernel.h"
 #include "oneflow/core/framework/framework.h"
+#include "oneflow/core/kernel/cuda_graph_support.h"
 #ifdef WITH_CUDA
 #include <cuda_fp16.h>
 #endif
@@ -84,7 +85,7 @@ struct ClipKernelUtil<DeviceType::kCPU, T> {
 };
 
 template<DeviceType device_type, typename T>
-class ClipByScalarKernel final : public user_op::OpKernel {
+class ClipByScalarKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   ClipByScalarKernel() = default;
   ~ClipByScalarKernel() = default;
@@ -106,7 +107,7 @@ class ClipByScalarKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class ClipByScalarMinKernel final : public user_op::OpKernel {
+class ClipByScalarMinKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   ClipByScalarMinKernel() = default;
   ~ClipByScalarMinKernel() = default;
@@ -125,7 +126,7 @@ class ClipByScalarMinKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class ClipByScalarMaxKernel final : public user_op::OpKernel {
+class ClipByScalarMaxKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   ClipByScalarMaxKernel() = default;
   ~ClipByScalarMaxKernel() = default;
@@ -144,7 +145,7 @@ class ClipByScalarMaxKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class ClipByScalarGradKernel final : public user_op::OpKernel {
+class ClipByScalarGradKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   ClipByScalarGradKernel() = default;
   ~ClipByScalarGradKernel() = default;
@@ -167,7 +168,7 @@ class ClipByScalarGradKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class ClipByScalarMinGradKernel final : public user_op::OpKernel {
+class ClipByScalarMinGradKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   ClipByScalarMinGradKernel() = default;
   ~ClipByScalarMinGradKernel() = default;
@@ -187,7 +188,7 @@ class ClipByScalarMinGradKernel final : public user_op::OpKernel {
 };
 
 template<DeviceType device_type, typename T>
-class ClipByScalarMaxGradKernel final : public user_op::OpKernel {
+class ClipByScalarMaxGradKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   ClipByScalarMaxGradKernel() = default;
   ~ClipByScalarMaxGradKernel() = default;

--- a/oneflow/user/kernels/concat_kernel.cpp
+++ b/oneflow/user/kernels/concat_kernel.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<ep::primitive::CopyNd> NewCopyNdPrimitive(Context* ctx) {
   return ep::primitive::NewPrimitive<ep::primitive::CopyNdFactory>(ctx->device_type(), 2);
 }
 
-class ConcatKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport  {
+class ConcatKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   ConcatKernel() = default;
   ~ConcatKernel() = default;

--- a/oneflow/user/kernels/concat_kernel.cpp
+++ b/oneflow/user/kernels/concat_kernel.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/core/ep/include/primitive/copy_nd.h"
+#include "oneflow/core/kernel/cuda_graph_support.h"
 
 namespace oneflow {
 
@@ -25,7 +26,7 @@ std::unique_ptr<ep::primitive::CopyNd> NewCopyNdPrimitive(Context* ctx) {
   return ep::primitive::NewPrimitive<ep::primitive::CopyNdFactory>(ctx->device_type(), 2);
 }
 
-class ConcatKernel final : public user_op::OpKernel {
+class ConcatKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport  {
  public:
   ConcatKernel() = default;
   ~ConcatKernel() = default;

--- a/oneflow/user/kernels/conv_cutlass_kernels.cu
+++ b/oneflow/user/kernels/conv_cutlass_kernels.cu
@@ -30,7 +30,7 @@ namespace oneflow {
 
 namespace {
 
-class Conv2dCutlassKernel final : public user_op::OpKernel {
+class Conv2dCutlassKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   Conv2dCutlassKernel() = default;
   ~Conv2dCutlassKernel() override = default;

--- a/oneflow/user/kernels/cutlass_conv_tuner.cpp
+++ b/oneflow/user/kernels/cutlass_conv_tuner.cpp
@@ -208,10 +208,12 @@ const cutlass::library::Operation* CutlassConvTuner::Impl::FindConv2dOperation(
         GetTensorSize(functional_key.element_B, functional_key.layout_B,
                       configuraion.problem_size.filter_extent(), configuraion.stride_b);
     OF_CUDA_CHECK(cudaMalloc(&benchmark_arguments.B, b_size));
-    const size_t c_size =
-        GetTensorSize(functional_key.element_C, functional_key.layout_C,
-                      configuraion.problem_size.output_extent(), configuraion.stride_c);
-    OF_CUDA_CHECK(cudaMalloc(&benchmark_arguments.C, c_size));
+    if (benchmark_arguments.C != nullptr) {
+      const size_t c_size =
+          GetTensorSize(functional_key.element_C, functional_key.layout_C,
+                        configuraion.problem_size.output_extent(), configuraion.stride_c);
+      OF_CUDA_CHECK(cudaMalloc(&benchmark_arguments.C, c_size));
+    }
 
     const size_t d_size = GetTensorSize(
         functional_key.element_C, functional_key.layout_C,

--- a/oneflow/user/kernels/scalar_math_kernels.cpp
+++ b/oneflow/user/kernels/scalar_math_kernels.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/core/ep/include/primitive/broadcast_elementwise_binary.h"
 #include "oneflow/core/common/scalar.h"
+#include "oneflow/core/kernel/cuda_graph_support.h"
 
 namespace oneflow {
 
@@ -68,7 +69,7 @@ auto BroadcastElementwiseAttrBinaryPrimitiveExists() {
 }  // namespace
 
 template<ep::primitive::BinaryOp op>
-class ScalarMathKernel final : public user_op::OpKernel {
+class ScalarMathKernel final : public user_op::OpKernel, public user_op::CudaGraphSupport {
  public:
   ScalarMathKernel() = default;
   ~ScalarMathKernel() = default;


### PR DESCRIPTION
启用cuda graph的情况下，tuning部分的代码不能执行在计算stream上，同时，tensor 也无法保证可用，所以重新分配