### PR TITLE
add a new OP: oneflow.nn.functional.depend

### DIFF
--- a/oneflow/core/autograd/gradient_funcs/depand.cpp
+++ b/oneflow/core/autograd/gradient_funcs/depand.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/framework/op_expr_grad_function.h"
+#include "oneflow/core/functional/functional.h"
+
+namespace oneflow {
+namespace one {
+
+struct DependCaptureState : public AutoGradCaptureState {
+  bool in_requires_grad;
+  bool depend_tensor_requires_grad;
+  Shape depend_tensor_shape;
+};
+
+class Depend : public OpExprGradFunction<DependCaptureState> {
+ public:
+  Maybe<void> Init(const OpExpr& op) override { return Maybe<void>::Ok(); }
+
+  Maybe<void> Capture(DependCaptureState* ctx, const TensorTuple& inputs,
+                      const TensorTuple& outputs, const AttrMap& attrs) const override {
+    CHECK_EQ_OR_RETURN(inputs.size(), 2);   // NOLINT(maybe-need-error-msg)
+    CHECK_EQ_OR_RETURN(outputs.size(), 1);  // NOLINT(maybe-need-error-msg)
+    ctx->in_requires_grad = inputs.at(0)->requires_grad();
+    ctx->depend_tensor_requires_grad = inputs.at(1)->requires_grad();
+    if (ctx->depend_tensor_requires_grad) { ctx->depend_tensor_shape = *(inputs.at(1)->shape()); }
+    return Maybe<void>::Ok();
+  }
+
+  Maybe<void> Apply(const DependCaptureState* ctx, const TensorTuple& out_grads,
+                    TensorTuple* in_grads) const override {
+    CHECK_EQ_OR_RETURN(out_grads.size(), 1);  // NOLINT(maybe-need-error-msg)
+    in_grads->resize(2);
+    if (ctx->in_requires_grad) { in_grads->at(0) = out_grads.at(0); }
+    if (ctx->depend_tensor_requires_grad) {
+      in_grads->at(1) =
+          JUST(functional::Constant(ctx->depend_tensor_shape, Scalar(0), out_grads.at(0)->dtype(),
+                                    JUST(out_grads.at(0)->device())));
+    }
+    return Maybe<void>::Ok();
+  }
+};
+
+REGISTER_OP_EXPR_GRAD_FUNCTION("depend", Depend);
+
+}  // namespace one
+}  // namespace oneflow

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -2749,6 +2749,10 @@
   signature: "Tensor (Tensor input) => IsFinite"
   bind_python: True
 
+- name: "depend"
+  signature: "Tensor (Tensor input, Tensor depend_tensor) => Depend"
+  bind_python: True
+
 - name: "roc_auc_score"
   signature: "Tensor (Tensor label, Tensor pred) => RocAucScore"
   bind_python: True

--- a/oneflow/core/functional/impl/util_ops_functor.cpp
+++ b/oneflow/core/functional/impl/util_ops_functor.cpp
@@ -60,6 +60,19 @@ class IsFiniteFunctor final : public UtilOpsFunctor {
   }
 };
 
+class DependFunctor {
+ public:
+  DependFunctor() {
+    op_ = CHECK_JUST(one::OpBuilder("depend").Input("in").Input("depend_tensor").Output("out").Build());
+  }
+  Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& in, const std::shared_ptr<one::Tensor>& depend_tensor) const {
+    return OpInterpUtil::Dispatch<Tensor>(*op_, {in, depend_tensor});
+  }
+
+ private:
+  std::shared_ptr<OpExpr> op_;
+};
+
 }  // namespace impl
 
 using namespace impl;
@@ -67,6 +80,7 @@ using namespace impl;
 ONEFLOW_FUNCTION_LIBRARY(m) { m.add_functor<IsNanFunctor>("IsNan"); };
 ONEFLOW_FUNCTION_LIBRARY(m) { m.add_functor<IsInfFunctor>("IsInf"); };
 ONEFLOW_FUNCTION_LIBRARY(m) { m.add_functor<IsFiniteFunctor>("IsFinite"); };
+ONEFLOW_FUNCTION_LIBRARY(m) { m.add_functor<DependFunctor>("Depend"); };
 
 }  // namespace functional
 }  // namespace one

--- a/oneflow/core/job/job_build_and_infer_ctx.cpp
+++ b/oneflow/core/job/job_build_and_infer_ctx.cpp
@@ -1005,6 +1005,9 @@ Maybe<void> LazyJobBuildAndInferCtx::Complete() {
     // pinned identity can be pruned since GenerateOptimizerOpConfs pass has
     // already construct a complete computational graph
     JUST(DoPass("PrunePinnedIdentityOpPass"));
+    // prune depend OP and and add ctrl_in_op to op_conf accordingly
+    // to express the same semantics and avoid performance loss
+    JUST(DoPass("PruneDependOpPass"));
     JUST(DoPass("ReplaceEmbeddingOps"));
     JUST(DoPass("SequentialOneEmbeddingOpsPass"));
     JUST(DoPass("FuseEmbeddingShuffleInteractionPass"));

--- a/oneflow/core/job/job_conf.proto
+++ b/oneflow/core/job/job_conf.proto
@@ -266,6 +266,7 @@ message JobConfigProto {
   optional bool prune_parallel_cast_ops = 509 [default = true];
   optional bool prune_cast_to_static_shape_ops = 510 [default = true];
   optional bool prune_amp_white_identity_ops = 511 [default = true];
+  optional bool prune_depend_ops = 512 [default = true];
 
   optional bool cudnn_conv_enable_pseudo_half = 600 [default = true];
   optional bool enable_auto_mixed_precision = 602 [default = false];

--- a/oneflow/core/job/job_desc.h
+++ b/oneflow/core/job/job_desc.h
@@ -62,6 +62,7 @@ class JobDesc final {
   bool prune_parallel_cast_ops() const { return job_conf_.prune_parallel_cast_ops(); }
   bool prune_cast_to_static_shape_ops() const { return job_conf_.prune_cast_to_static_shape_ops(); }
   bool prune_amp_white_identity_ops() const { return job_conf_.prune_amp_white_identity_ops(); }
+  bool prune_depend_ops() const { return job_conf_.prune_depend_ops(); }
   bool enable_auto_parallel() const { return job_conf_.enable_auto_parallel(); }
   int64_t cudnn_buf_limit_mbyte() const { return job_conf_.cudnn_buf_limit_mbyte(); }
 

--- a/oneflow/core/job_rewriter/prune_depend_op_pass.cpp
+++ b/oneflow/core/job_rewriter/prune_depend_op_pass.cpp
@@ -1,0 +1,226 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <glog/logging.h>
+#include <string>
+#include <vector>
+#include "oneflow/core/framework/framework.h"
+#include "oneflow/core/graph/node.h"
+#include "oneflow/core/graph/op_graph.h"
+#include "oneflow/core/job_rewriter/job_pass.h"
+
+namespace oneflow {
+
+namespace {
+
+struct RelativeNodes {
+  const OpNode* input = nullptr;
+  const OpNode* output = nullptr;
+  std::vector<const OpNode*> depends = {};
+};
+
+bool IsDependyOp(const OperatorConf& op) {
+  return op.has_user_conf() && (op.user_conf().op_type_name() == "depend");
+}
+
+bool NeedDoPass(const Job& job) {
+  return std::any_of(job.net().op().cbegin(), job.net().op().cend(), IsDependyOp);
+}
+
+const OpNode* GetNodeFromEdgeByTensorName(const OpNode* op_node,
+                                          const std::string target_tensor_name) {
+  CHECK(IsDependyOp(op_node->op().op_conf()));
+  for (const OpEdge* in_edge : op_node->in_edges()) {
+    const OpNode* in_op_node = in_edge->src_node();
+    const std::string& in_op_node_name = in_op_node->op().op_name();
+    const HashMap<LogicalBlobId, std::vector<std::string>>& lbi2ibns = in_edge->lbi2ibns();
+
+    for (const auto& item : lbi2ibns) {
+      const std::string& lbi_op_name = item.first.op_name();
+      for (const std::string& tensor_name : item.second) {
+        if (in_op_node_name == lbi_op_name && tensor_name == target_tensor_name) {
+          return in_op_node;
+        }
+      }
+    }
+  }
+  return nullptr;
+}
+
+const OpNode* GetNodeFromInputEdge(const OpNode* op_node) {
+  return GetNodeFromEdgeByTensorName(op_node, "in_0");
+}
+
+const OpNode* GetNodeFromDependEdge(const OpNode* op_node) {
+  return GetNodeFromEdgeByTensorName(op_node, "depend_tensor_0");
+}
+
+const OpNode* GetValidInputNode(const OpNode* op_node, HashSet<const OpNode*>& del_nodes) {
+  CHECK(IsDependyOp(op_node->op().op_conf()));
+  const OpNode* input_op_node = GetNodeFromInputEdge(op_node);
+  if (del_nodes.find(input_op_node) == del_nodes.end()) { return input_op_node; }
+  return nullptr;
+}
+
+void GetRelativeNodesHelper(const OpNode* op_node, const HashSet<const OpNode*>& del_nodes,
+                            const OpNode* input_node, std::vector<const OpNode*> depend_nodes,
+                            std::vector<RelativeNodes>& ret) {
+  CHECK(IsDependyOp(op_node->op().op_conf()));
+  for (const OpEdge* out_edge : op_node->out_edges()) {
+    const OpNode* out_op_node = out_edge->dst_node();
+    if (del_nodes.find(out_op_node) == del_nodes.end()) {
+      // "out_op_node" is one of valid output nodes
+
+      // in this case, record the nodes as result
+      const OpNode* depend_node = GetNodeFromDependEdge(op_node);
+      depend_nodes.emplace_back(depend_node);
+      ret.push_back({input_node, out_op_node, depend_nodes});
+    } else if (op_node == GetNodeFromDependEdge(out_op_node)) {
+      // "out_op_node" is ALSO a depend OP Node, and "op_node" is an in-control OP
+
+      // in this case, two precursor node of op_node be interpreted as in-control OP
+      // the input_node should not NOT be the precursor of the target output node
+      // thus, put input_node into "depend_nodes", and set "input_node" as NULL in
+      // subsequent processing
+      if (input_node) depend_nodes.push_back(input_node);
+      input_node = nullptr;
+      // continue recursion until the target output node is found
+      GetRelativeNodesHelper(out_op_node, del_nodes, input_node, depend_nodes, ret);
+    } else {
+      // "out_op_node" is ALSO a depend OP Node, and "op_node" is an input OP
+
+      // in this case, "input_node" should be the real precursor of the target output node
+      // thus, append in-ctrl op-node conneted to "op_node" input_node into "depend_nodes",
+      // and remain "input_node as" in subsequent processing
+      const OpNode* depend_node = GetNodeFromDependEdge(op_node);
+      depend_nodes.emplace_back(depend_node);
+      // continue recursion until the target output node is found
+      GetRelativeNodesHelper(out_op_node, del_nodes, input_node, depend_nodes, ret);
+    }
+  }
+}
+
+const std::vector<RelativeNodes> GetRelativeNodes(const OpNode* op_node,
+                                                  const HashSet<const OpNode*>& del_nodes,
+                                                  const OpNode* input_node) {
+  std::vector<RelativeNodes> ret;
+  GetRelativeNodesHelper(op_node, del_nodes, input_node, {}, ret);
+  return ret;
+}
+
+class PruneDependOpPass final : public JobPass {
+ public:
+  PruneDependOpPass() = default;
+  ~PruneDependOpPass() override = default;
+
+  Maybe<void> Apply(Job* job, JobPassCtx* ctx) const override;
+};
+
+Maybe<void> PruneDependOpPass::Apply(Job* job, JobPassCtx* ctx) const {
+  if (!ctx->job_desc().prune_depend_ops()) { return Maybe<void>::Ok(); }
+  if (!NeedDoPass(*job)) { return Maybe<void>::Ok(); }
+  const OpGraph op_graph(*job);
+
+  HashSet<std::string> ctrl_in_op_names;
+  op_graph.ForEachNode([&](const OpNode* op_node) {
+    for (const std::string& ctrl_in_op_name : op_node->op().op_conf().ctrl_in_op_name()) {
+      ctrl_in_op_names.insert(ctrl_in_op_name);
+    }
+  });
+
+  HashSet<const OpNode*> del_nodes;
+  op_graph.ForEachNode([&](const OpNode* op_node) {
+    const std::string& op_name = op_node->op().op_name();
+    const OperatorConf& op_conf = op_node->op().op_conf();
+    // not depend op
+    if (!IsDependyOp(op_conf)) { return; }
+    // has ctrl in
+    if (!op_conf.ctrl_in_op_name().empty()) { return; }
+    // is ctrl in of another op
+    if (ctrl_in_op_names.find(op_name) != ctrl_in_op_names.end()) { return; }
+
+    del_nodes.insert(op_node);
+  });
+
+  HashMap<std::string, OperatorConf> to_update_op_confs;
+  std::vector<std::string> del_op_names;
+  del_op_names.reserve(del_nodes.size());
+  for (const OpNode* op_node : del_nodes) {
+    del_op_names.emplace_back(op_node->op().op_name());
+    // valid input node is node which is bind to 'in' edger of depend OP, and not in del_nodes
+    const OpNode* valid_input_node = GetValidInputNode(op_node, del_nodes);
+    // GetRelativeNodes() considers the chain of multiple depend OP Nodes and processes them
+    // from the beginning, so skip the intermediate nodes whose valid_input_node is NULL
+    if (valid_input_node == nullptr) { continue; }
+    const std::vector<RelativeNodes> relatives =
+        GetRelativeNodes(op_node, del_nodes, valid_input_node);
+    const auto& old_lbi = op_node->op().BnInOp2Lbi(op_node->op().SoleObn());
+
+    // adjust op_conf of nodes connected to depend OP Nodes
+    for (const RelativeNodes& item : relatives) {
+      const OpNode* input_node = item.input;
+      const OpNode* output_node = item.output;
+      const std::vector<const OpNode*>& depend_nodes = item.depends;
+      // in some cases (e.g. the second branch in GetRelativeNodesHelper()), input nodes should
+      // be interpreted as control nodes for those case, accordingly their input_node is NULL
+      // and the ibn modifications should be skip
+      if (input_node) {
+        const auto& new_lbi = input_node->op().BnInOp2Lbi(input_node->op().SoleObn());
+        const Operator& op = output_node->op();
+        for (const std::string& ibn : op.input_bns()) {
+          if (op.BnInOp2Lbi(ibn) == old_lbi) {
+            auto iter = to_update_op_confs.find(op.op_name());
+            if (iter == to_update_op_confs.end()) {
+              iter = to_update_op_confs.emplace(op.op_name(), op.op_conf()).first;
+            }
+            OperatorConf& op_conf = iter->second;
+            const auto& old_val =
+                ReplaceInputLbnInOpCustomizedConf(&op_conf, ibn, GenLogicalBlobName(new_lbi));
+            CHECK_EQ_OR_RETURN(GenLogicalBlobName(old_lbi), old_val);
+          }
+        }
+      }
+      // add ctrl_in_op
+      const Operator& out_op = output_node->op();
+      auto out_iter = to_update_op_confs.find(out_op.op_name());
+      if (out_iter == to_update_op_confs.end()) {
+        out_iter = to_update_op_confs.emplace(out_op.op_name(), out_op.op_conf()).first;
+      }
+      OperatorConf& out_op_conf = out_iter->second;
+      for (const OpNode* node : depend_nodes) {
+        CHECK(output_node != node);  // self-loop found
+        const auto& existed_ctrl_in_op_names = op_node->op().op_conf().ctrl_in_op_name();
+        const std::string& new_ctrl_in_op_name = node->op().op_name();
+        auto existed_it = std::find(existed_ctrl_in_op_names.begin(),
+                                    existed_ctrl_in_op_names.end(), new_ctrl_in_op_name);
+        if (existed_it == existed_ctrl_in_op_names.end()) {  // avoid adding duplicate control nodes
+          out_op_conf.add_ctrl_in_op_name(new_ctrl_in_op_name);
+        }
+      }
+    }
+  }
+
+  JobBuilder job_builder(job);
+  for (const auto& pair : to_update_op_confs) { job_builder.MutOpsOnlyOnce({pair.second}); }
+  job_builder.DelOps(del_op_names);
+
+  return Maybe<void>::Ok();
+}
+
+}  // namespace
+
+REGISTER_JOB_PASS("PruneDependOpPass", PruneDependOpPass);
+
+}  // namespace oneflow

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -5403,8 +5403,8 @@ def OneFlow_GroupedMatmulBiasOp : OneFlow_BaseOp<"grouped_matmul_bias", [NoSideE
 #endif // GET_ONEFLOW_MATMUL_OP_DEFINITIONS
 
 // Group: MISC
-// CategoricalOrdinalEncode, add_n, arange, bincount, coin_flip, concat, tensor_constant, constant, dropout, elementwise_maximum_backward, elementwise_minimum_backward, empty, eye, grid_sample_grad, multi_count_not_finite, multi_square_sum, nll, nll_grad, pow_x_grad, pow_y_grad, prelu_grad, randperm, recv, send, split_like, ssp_variable_proxy, tf_prelu_grad, uniform, uniform_int, unique, unique_with_counts, xdivy_x_grad, xdivy_y_grad, stack, stack_grad, fill_, fill_tensor_, exponential, multinomial_with_replacement, fused_weighted_sum
-// Total: 40
+// CategoricalOrdinalEncode, add_n, arange, bincount, coin_flip, concat, tensor_constant, constant, dropout, elementwise_maximum_backward, elementwise_minimum_backward, empty, eye, grid_sample_grad, multi_count_not_finite, multi_square_sum, nll, nll_grad, pow_x_grad, pow_y_grad, prelu_grad, randperm, recv, send, split_like, ssp_variable_proxy, tf_prelu_grad, uniform, uniform_int, unique, unique_with_counts, xdivy_x_grad, xdivy_y_grad, stack, stack_grad, fill_, fill_tensor_, exponential, multinomial_with_replacement, fused_weighted_sum, depend
+// Total: 41
 
 #ifdef GET_ONEFLOW_MISC_OP_DEFINITIONS
 
@@ -6149,6 +6149,20 @@ def OneFlow_FusedWeightedSumOp : OneFlow_BaseOp<"fused_weighted_sum", [NoSideEff
     DefaultValuedAttr<F32Attr, "1.0">:$alpha
   );
   let has_check_fn = 1;
+  let has_logical_tensor_desc_infer_fn = 1;
+  let has_physical_tensor_desc_infer_fn = 1;
+  let has_get_sbp_fn = 1;
+  let has_data_type_infer_fn = 1;
+}
+
+def OneFlow_DependOp : OneFlow_BaseOp<"depend", [NoSideEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+  let input = (ins
+    OneFlow_Tensor:$in,
+    OneFlow_Tensor:$depend_tensor
+  );
+  let output = (outs
+    OneFlow_Tensor:$out
+  );
   let has_logical_tensor_desc_infer_fn = 1;
   let has_physical_tensor_desc_infer_fn = 1;
   let has_get_sbp_fn = 1;

--- a/oneflow/user/kernels/copy_data_content_kernel.cpp
+++ b/oneflow/user/kernels/copy_data_content_kernel.cpp
@@ -84,6 +84,7 @@ REGISTER_COPY_DATA_CONTENT_KERNEL("parallel_cast");
 REGISTER_COPY_DATA_CONTENT_KERNEL("hierarchical_parallel_cast");
 REGISTER_COPY_DATA_CONTENT_KERNEL("hierarchical_parallel_cast_like");
 REGISTER_COPY_DATA_CONTENT_KERNEL("pinned_identity");
+REGISTER_COPY_DATA_CONTENT_KERNEL("depend");
 
 }  // namespace
 

--- a/oneflow/user/ops/depend_op.cpp
+++ b/oneflow/user/ops/depend_op.cpp
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/framework/framework.h"
+#include "oneflow/core/framework/op_generated.h"
+
+namespace oneflow {
+
+/* static */ Maybe<void> DependOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
+  ctx->SetOutputShape("out", 0, ctx->InputShape("in", 0));
+  ctx->SetOutputIsDynamic("out", 0, ctx->InputIsDynamic("in", 0));
+  return Maybe<void>::Ok();
+}
+
+/*static*/ Maybe<void> DependOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
+  return InferLogicalTensorDesc(ctx);
+}
+
+/* static */ Maybe<void> DependOp::GetSbp(user_op::SbpContext* ctx) {
+  const user_op::TensorDesc& in_tensor = ctx->LogicalTensorDesc4InputArgNameAndIndex("in", 0);
+  FOR_RANGE(int64_t, i, 0, in_tensor.shape().NumAxes()) {
+    ctx->NewBuilder()
+        .Split(user_op::OpArg("in", 0), i)
+        .Broadcast(user_op::OpArg("depend_tensor", 0))
+        .Split(user_op::OpArg("out", 0), i)
+        .Build();
+  }
+  ctx->NewBuilder()
+      .PartialSum(user_op::OpArg("in", 0))
+      .Broadcast(user_op::OpArg("depend_tensor", 0))
+      .PartialSum(user_op::OpArg("out", 0))
+      .Build();
+  return Maybe<void>::Ok();
+}
+
+/* static */ Maybe<void> DependOp::InferDataType(user_op::InferContext* ctx) {
+  ctx->SetOutputDType("out", 0, ctx->InputDType("in", 0));
+  return Maybe<void>::Ok();
+}
+
+}  // namespace oneflow

--- a/python/oneflow/framework/function_util.py
+++ b/python/oneflow/framework/function_util.py
@@ -532,6 +532,17 @@ def set_prune_amp_white_identity_ops(func_desc, value=True):
     func_desc.job_config_proto.prune_amp_white_identity_ops = value
 
 
+@oneflow_function_config("prune_depend_ops")
+def set_prune_depend_ops(func_desc, value=True):
+    """Whether prune depend operations or not.
+
+    Args:
+        func_desc ([type]): [description]
+        value (bool, optional): [description]. Defaults to True.
+    """
+    func_desc.job_config_proto.prune_depend_ops = value
+
+
 @oneflow_function_config("non_distributed_optimizer_group_size_mbyte")
 def set_non_distributed_optimizer_group_size_mbyte(func_desc, value):
     print(

--- a/python/oneflow/nn/functional/__init__.py
+++ b/python/oneflow/nn/functional/__init__.py
@@ -88,3 +88,4 @@ from oneflow._C import fold
 from .functional_deform_conv import deform_conv2d
 from oneflow._C import kl_div_loss as kl_div
 from oneflow._C import gumbel_softmax
+from .functional_depend import depend

--- a/python/oneflow/nn/functional/functional_depend.py
+++ b/python/oneflow/nn/functional/functional_depend.py
@@ -1,0 +1,72 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+from oneflow.framework.tensor import Tensor
+import oneflow as flow
+
+def depend(
+    input: Tensor,
+    depend_tesor: Tensor,
+) -> Tensor:
+    r"""
+    Add control dependency to guarantee OP A is executed before OP B.
+    Used to prevent OPs from being rearranged or eliminated during graph compilation.
+
+    Args:
+        input (Tensor): a tensor intended to input OP B
+        depend_tesor (Tensor): one of the output tensors of OP A
+
+    Returns:
+        Tensor: the identity of "input" tensor
+
+    Examples:
+        >>> import oneflow as flow
+        >>> import oneflow.nn as nn
+        >>> import oneflow.nn.functional as F
+        >>> class Model(nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.OP_A = nn.Linear(128, 128)
+        ...         self.OP_B = nn.Linear(128, 128)
+        ...
+        ...     def forward(self, x):
+        ...         x1 = self.OP_A(x)
+        ...         x = F.depend(x, x1)
+        ...         return self.OP_B(x)
+        ...
+        >>> model = Model()
+        >>> class Graph(nn.Graph):
+        ...     def __init__(self) -> None:
+        ...         super().__init__()
+        ...         self.model = model
+        ...
+        ...     def build(self, x):
+        ...         return self.model(x)
+        ...
+        >>> graph = Graph()
+        >>> x = flow.randn([1, 128], dtype=flow.float32)
+        >>> y = graph(x)
+    """
+    # avoid performance loss in eager mode
+    if not input.is_lazy:
+        return input
+ 
+    # avoid self-loop
+    if input is depend_tesor:
+         raise RuntimeError("\"input\" and \"depend_tesor\" can NOT be the same tensor.")
+
+    return flow._C.depend(input, depend_tesor)

--- a/python/oneflow/nn/functional/functional_depend.py
+++ b/python/oneflow/nn/functional/functional_depend.py
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
 from oneflow.framework.tensor import Tensor
 import oneflow as flow
 
+
 def depend(
-    input: Tensor,
-    depend_tesor: Tensor,
+        input: Tensor,
+        depend_tesor: Tensor,
 ) -> Tensor:
     r"""
     Add control dependency to guarantee OP A is executed before OP B.
@@ -64,9 +64,9 @@ def depend(
     # avoid performance loss in eager mode
     if not input.is_lazy:
         return input
- 
+
     # avoid self-loop
     if input is depend_tesor:
-         raise RuntimeError("\"input\" and \"depend_tesor\" can NOT be the same tensor.")
+        raise RuntimeError("\"input\" and \"depend_tesor\" can NOT be the same tensor.")
 
     return flow._C.depend(input, depend_tesor)


### PR DESCRIPTION
增加一个Python OP，用于防止指定OP在静态图优化时被重排序。
该OP存在于其他具有静态图特性的框架，例如：
Mindspore（https://www.mindspore.cn/docs/zh-CN/r1.9/api_python/ops/mindspore.ops.Depend.html）
Tensorflow （https://www.tensorflow.org/api_docs/python/tf/control_dependencies）

**特性：**
（1）为避免Eager Mode下的性能损失，Python接口判别在Eager Mode还是在Grpah Mode下运行，Eager Mode直接返回；
（2）避免self-loop导致的死锁；
（3）Kernel直接复用已有代码；
（4）为避免Grpah Mode下的性能损失，增加可配置开关的Pass，用于消除多添加的OP，并相应的添加底层的控制边;
（5）Pass考虑了多个depend OP连锁的情况，以及可能重复添加控制边的情况。