### PR TITLE
Save / Load cached plan

### DIFF
--- a/oneflow/core/framework/nn_graph.h
+++ b/oneflow/core/framework/nn_graph.h
@@ -39,7 +39,8 @@ class NNGraph final : public NNGraphIf {
         job_id_(job_id),
         session_ctx_(session_ctx),
         runtime_inited_(false),
-        is_closed_(false) {}
+        is_closed_(false),
+        try_cache_graph_(false) {}
   OF_DISALLOW_COPY_AND_MOVE(NNGraph);
   ~NNGraph();
 
@@ -72,6 +73,7 @@ class NNGraph final : public NNGraphIf {
   Maybe<std::vector<std::string>> GetAdditionalVarOpNames() const;
   Maybe<std::vector<std::shared_ptr<one::Tensor>>> GetAdditionalVarOpTensors() const;
   Maybe<void> CompileAndInitRuntime();
+  Maybe<void> CompleteJobAndCompliePlan();
   Maybe<void> Close();
 
  private:
@@ -108,6 +110,7 @@ class NNGraph final : public NNGraphIf {
   std::unique_ptr<Runtime> runtime_;
   bool runtime_inited_;
   bool is_closed_;
+  bool try_cache_graph_;
 };
 
 Maybe<void> RunLazyNNGraph(const one::TensorTuple& inputs, const one::TensorTuple& outputs,

--- a/oneflow/core/job/cache_graph.proto
+++ b/oneflow/core/job/cache_graph.proto
@@ -5,7 +5,6 @@ import "oneflow/core/job/job.proto";
 import "oneflow/core/job/plan.proto";
 
 message CacheGraph {
-  required string graph_name = 1;
-  required Job job = 2;
-  required Plan plan = 3;
+  required Job job = 1;
+  required Plan plan = 2;
 }

--- a/oneflow/core/job/cache_graph.proto
+++ b/oneflow/core/job/cache_graph.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+package oneflow;
+
+import "oneflow/core/job/job.proto";
+import "oneflow/core/job/plan.proto";
+
+message CacheGraph {
+  required string graph_name = 1;
+  required Job job = 2;
+  required Plan plan = 3;
+}

--- a/oneflow/core/job/job_conf.proto
+++ b/oneflow/core/job/job_conf.proto
@@ -223,6 +223,8 @@ message JobConfigProto {
     InitializerConf default_initializer_conf = 10;
     string default_initialize_with_snapshot_path = 11;
   }
+  
+  optional bool try_cache_graph = 100 [default = false];
 
   optional MemoryAllocationAlgorithmConf memory_allocation_algorithm_conf = 102;
 

--- a/python/oneflow/nn/graph/graph_config.py
+++ b/python/oneflow/nn/graph/graph_config.py
@@ -371,6 +371,12 @@ class GraphConfig(object):
         """
         self.proto.enable_fused_model_update_cast = mode
 
+    def try_cache_graph(self, mode: bool = True):
+        """
+        Try cache graph and skip Compiler when second run.
+        """
+        self.proto.try_cache_graph = mode
+
     def _generate_optimizer_and_variable_configs(
         self, opt_dict: OptDict = None, variables_conf: OrderedDict = None,
     ):


### PR DESCRIPTION
较早的 Cache Plan 的功能。 当时提到的需求，和现在的紧急需求有所不同。

### 本 PR 当时提到的需求：

- **尝试**进行 Graph 的缓存，编译 Graph 保存 cached plan，保存在临时的 log 目录下
- 等这个脚本执行结束，再次重新执行本脚本时，可以**尝试**加载缓存，因此必须要判断**缓存是否命中**， 如果不命中，则重新编译，并刷新 cache 保存

主要特点是： 重新执行的是一样的脚本，会重新触发  Graph 的 build 过程，与 eager 的交互， try cache 的逻辑，存在不命中的可能。


### 目前最新的需求

- 支持 Graph  的 Save 和 Load，Save 包含 Graph Struct （plan）和 Graph state （eager Variable）， load 直接加载启动 runtime，不会触发 build、job pass 和 compile
- Save 指定 key 和 路径， Load 也会指定 key 和 路径，不会出现不命中的问题。 Load 会跳过所有 build、job pass 和 compile 环节，直接启动 runtime。 且 Save 和 Load 的 脚本及逻辑由用户控制并区分， 且 Load 不会触发 Eager Module 和相关的交互（甚至可以没有 eager module） 

新的需求由 @strint  负责开发， @leaves-zwx  和 我随时讨论和联调。