### PR TITLE
HobEnvBool

### DIFF
--- a/oneflow/core/framework/user_op_hob.h
+++ b/oneflow/core/framework/user_op_hob.h
@@ -78,6 +78,15 @@ ALWAYS_INLINE inline auto HobDeviceSubTag() {
   });
 }
 
+ALWAYS_INLINE inline auto HobEnvBool(const std::string& env_var, bool default_value) {
+  std::ostringstream string_stream;
+  string_stream << "environment variable \'" << env_var << "\'";
+  return hob::make_custom(string_stream.str(),
+                          [env_var, default_value](const KernelRegContext& ctx) -> bool {
+                            return ParseBooleanFromEnv(env_var, default_value);
+                          });
+}
+
 }  // namespace user_op
 
 }  // namespace oneflow

--- a/oneflow/core/job_rewriter/cutlass_conv_tuning_warmup_pass.cpp
+++ b/oneflow/core/job_rewriter/cutlass_conv_tuning_warmup_pass.cpp
@@ -39,10 +39,14 @@ class CutlassConvTuningWarmupPass final : public JobPass {
 };
 
 Maybe<void> CutlassConvTuningWarmupPass::Apply(Job* job, JobPassCtx* ctx) const {
-  if (!ParseBooleanFromEnv("ONEFLOW_KERENL_CONV_ENABLE_CUTLASS_IMPL", false)) {
+  // Compatible with typo `KERENL`
+  if (!ParseBooleanFromEnv("ONEFLOW_KERNEL_CONV_ENABLE_CUTLASS_IMPL",
+                           ParseBooleanFromEnv("ONEFLOW_KERENL_CONV_ENABLE_CUTLASS_IMPL", false))) {
     return Maybe<void>::Ok();
   }
-  if (!ParseBooleanFromEnv("ONEFLOW_KERENL_CONV_CUTLASS_IMPL_ENABLE_TUNING_WARMUP", false)) {
+  if (!ParseBooleanFromEnv(
+          "ONEFLOW_KERNEL_CONV_CUTLASS_IMPL_ENABLE_TUNING_WARMUP",
+          ParseBooleanFromEnv("ONEFLOW_KERENL_CONV_CUTLASS_IMPL_ENABLE_TUNING_WARMUP", false))) {
     return Maybe<void>::Ok();
   }
   const OpGraph op_graph(*job);

--- a/oneflow/user/kernels/conv_cutlass_kernels.cu
+++ b/oneflow/user/kernels/conv_cutlass_kernels.cu
@@ -153,8 +153,11 @@ REGISTER_USER_KERNEL("conv2d")
                      && (user_op::HobAttr<std::string>("data_format") == "channels_last")
                      && (user_op::HobAttr<int32_t>("groups") == 1)
                      && (user_op::HobDataType("in", 0) == DataType::kFloat16)
-                     && (user_op::HobTrue()
-                         == ParseBooleanFromEnv("ONEFLOW_KERENL_CONV_ENABLE_CUTLASS_IMPL", false)))
+                     && (user_op::HobEnvBool(
+                             // Compatible with typo `KERENL`
+                             "ONEFLOW_KERNEL_CONV_ENABLE_CUTLASS_IMPL",
+                             ParseBooleanFromEnv("ONEFLOW_KERENL_CONV_ENABLE_CUTLASS_IMPL", false))
+                         == true))
     .SetInferTmpSizeFn([](user_op::InferContext* ctx) -> size_t {
       // use static workspace size
       return 128 * 1024 * 1024;

--- a/oneflow/user/kernels/conv_cutlass_kernels.cu
+++ b/oneflow/user/kernels/conv_cutlass_kernels.cu
@@ -149,15 +149,14 @@ class Conv2dCutlassKernel final : public user_op::OpKernel, public user_op::Cuda
 
 REGISTER_USER_KERNEL("conv2d")
     .SetCreateFn<Conv2dCutlassKernel>()
-    .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kCUDA)
-                     && (user_op::HobAttr<std::string>("data_format") == "channels_last")
-                     && (user_op::HobAttr<int32_t>("groups") == 1)
-                     && (user_op::HobDataType("in", 0) == DataType::kFloat16)
-                     && (user_op::HobEnvBool(
-                             // Compatible with typo `KERENL`
-                             "ONEFLOW_KERNEL_CONV_ENABLE_CUTLASS_IMPL",
-                             ParseBooleanFromEnv("ONEFLOW_KERENL_CONV_ENABLE_CUTLASS_IMPL", false))
-                         == true))
+    .SetIsMatchedHob(
+        (user_op::HobDeviceType() == DeviceType::kCUDA)
+        && (user_op::HobAttr<std::string>("data_format") == "channels_last")
+        && (user_op::HobAttr<int32_t>("groups") == 1)
+        && (user_op::HobDataType("in", 0) == DataType::kFloat16)
+        // Compatible with typo `KERENL`
+        && ((user_op::HobEnvBool("ONEFLOW_KERNEL_CONV_ENABLE_CUTLASS_IMPL", false) == true)
+            || (user_op::HobEnvBool("ONEFLOW_KERENL_CONV_ENABLE_CUTLASS_IMPL", false) == true)))
     .SetInferTmpSizeFn([](user_op::InferContext* ctx) -> size_t {
       // use static workspace size
       return 128 * 1024 * 1024;

--- a/oneflow/user/kernels/fused_glu_kernel.cu
+++ b/oneflow/user/kernels/fused_glu_kernel.cu
@@ -285,7 +285,7 @@ bool TryDispatchDualGemmImpl(ep::CudaStream* stream, const std::string& activati
                              int32_t n, int32_t k, const T* x, const T* w, const T* v, const T* b,
                              const T* c, T* wx, int32_t wx_stride, T* vx, int32_t vx_stride, T* y) {
 #ifdef WITH_CUTLASS
-  const bool enabled = ParseBooleanFromEnv("ONEFLOW_KERNEL_GLU_ENABLE_DUAL_GEMM_IMPL", false);
+  const bool enabled = ParseBooleanFromEnv("ONEFLOW_KERNEL_GLU_ENABLE_DUAL_GEMM_IMPL", true);
   if (enabled) {
     return TryDispatchDualGemmImplArchTag<T>(stream, activation, m, n, k, x, w, v, b, c, wx,
                                              wx_stride, vx, vx_stride, y);

--- a/oneflow/user/kernels/fused_multi_head_attention_inference_kernel.cu
+++ b/oneflow/user/kernels/fused_multi_head_attention_inference_kernel.cu
@@ -255,8 +255,11 @@ class FusedMultiHeadAttentionInferenceKernel final : public user_op::OpKernel,
 
     auto* cuda_stream = ctx->stream()->As<ep::CudaStream>();
 
+    // Compatible with typo `KERENL`
     const bool enable_trt_flash_attn =
-        ParseBooleanFromEnv("ONEFLOW_KERENL_FMHA_ENABLE_TRT_FLASH_ATTN_IMPL", false)
+        ParseBooleanFromEnv(
+            "ONEFLOW_KERNEL_FMHA_ENABLE_TRT_FLASH_ATTN_IMPL",
+            ParseBooleanFromEnv("ONEFLOW_KERENL_FMHA_ENABLE_TRT_FLASH_ATTN_IMPL", true))
         && ParseBooleanFromEnv("ONEFLOW_MATMUL_ALLOW_HALF_PRECISION_ACCUMULATION", false);
     const int arch = cuda_stream->cuda_arch() / 10;
     const bool inputs_contiguous =


### PR DESCRIPTION
* 添加 HobEnvBool， 支持在Kernel创建的时候而不是在注册的时候解析环境变量
* 修复了 KERENL typo， 但是依然兼容原来错误的拼写
* ONEFLOW_KERNEL_FMHA_ENABLE_TRT_FLASH_ATTN_IMPL/ONEFLOW_KERNEL_GLU_ENABLE_DUAL_GEMM_IMPL 默认值修改为 true