### PR TITLE
fix autotest fake program 0 input

### DIFF
--- a/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
+++ b/python/oneflow/test_utils/automated_test_util/torch_flow_dual_object.py
@@ -1361,6 +1361,7 @@ def random_tensor(
         .value()
         .requires_grad_(requires_grad and dtype != int)
     )
+    extra_input_tensor.append(pytorch_tensor)
     if is_global():
         flow_tensor = flow.tensor(
             pytorch_tensor.detach().cpu().numpy(),


### PR DESCRIPTION
之前自动测试失败时autotest产生的fake program的输入有些时候总是没有捕获到，我在调试升级torch 1.13.0的时候发现原因是因为我当时少加了一句代码导致的，这个pr修复之后就可以拿到非常完整的复现程序以及输入数据了。