### PR TITLE
remove redundant Device constructor in copy op

### DIFF
--- a/oneflow/user/ops/copy_op.cpp
+++ b/oneflow/user/ops/copy_op.cpp
@@ -36,8 +36,7 @@ Maybe<Symbol<Stream>> MakeCopyStream(const Symbol<Device>& in_device,
   if (in_device->type() != "cpu" && out_device->type() == "cpu") {
     return Stream::New(in_device, StreamType::kDevice2Host);
   } else if (in_device->type() == "cpu" && out_device->type() != "cpu") {
-    const auto device = JUST(Device::New(out_device->type(), out_device->device_id()));
-    return Stream::New(device, GetH2DStreamType());
+    return Stream::New(out_device, GetH2DStreamType());
   } else if (in_device->type() == "cpu" && out_device->type() == "cpu" && pin_memory) {
     // TODO:(zhaoluyang) Parsing pin-memory-device from python
     auto pin_device = JUST(Device::New("cuda"));


### PR DESCRIPTION
一个很小的改动，去掉多余的 `Device::New`