### PR TITLE
add DataParallel API

### DIFF
--- a/python/oneflow/cuda/__init__.py
+++ b/python/oneflow/cuda/__init__.py
@@ -194,3 +194,28 @@ def empty_cache() -> None:
 
 
 from .random import *  # noqa: F403
+
+
+class device(object):
+    r"""Context-manager that changes the selected device.
+
+    Args:
+        device (flow.device or int): device index to select. It's a no-op if
+            this argument is a negative integer or ``None``.
+    """
+
+    def __init__(self, device: Any):
+        self.idx = _get_device_index(device, optional=True)
+        self.prev_idx = -1
+
+    def __enter__(self):
+        if self.idx == -1:
+            return
+        self.prev_idx = current_device()
+        if self.prev_idx != self.idx:
+            set_device(self.idx)
+
+    def __exit__(self, type: Any, value: Any, traceback: Any):
+        if self.prev_idx != self.idx:
+            set_device(self.prev_idx)
+        return False

--- a/python/oneflow/cuda/_utils.py
+++ b/python/oneflow/cuda/_utils.py
@@ -69,3 +69,35 @@ def _get_device_index(
                 "or an integer, but got:{}".format(device)
             )
     return device_idx
+
+
+def _get_all_device_indices():
+    # all device index
+    return _get_device_attr(lambda m: list(range(m.device_count())))
+
+
+def _get_device_attr(get_member):
+    device_type = _get_available_device_type()
+    if device_type and device_type.lower() == "cuda":
+        return get_member(flow.cuda)
+    # add more available device types here
+    return None
+
+
+def _get_available_device_type():
+    if flow.cuda.is_available():
+        return "cuda"
+    # add more available device types here
+    return None
+
+
+def _get_devices_properties(device_ids):
+    # all device properties
+    return [_get_device_attr(lambda m: m.get_device_properties(i)) for i in device_ids]
+
+
+def _handle_complex(tensor):
+    """
+    Complex checking is not supported by oneflow, we add this for future usage.
+    """
+    return tensor

--- a/python/oneflow/nn/modules/module.py
+++ b/python/oneflow/nn/modules/module.py
@@ -1390,3 +1390,17 @@ class Module(object):
                 main_str += "\n  " + "\n  ".join(lines) + "\n"
         main_str += ")"
         return main_str
+
+    def _replicate_for_data_parallel(self):
+        # use this model for DP mode
+        replica = self.__new__(type(self))
+        replica.__dict__ = self.__dict__.copy()
+
+        # replicas do not have parameters themselves, the replicas reference the original
+        # module.
+        replica._parameters = OrderedDict()
+        replica._buffers = replica._buffers.copy()
+        replica._modules = replica._modules.copy()
+        replica._is_replica = True  # type: ignore[assignment]
+
+        return replica

--- a/python/oneflow/nn/parallel/_functions.py
+++ b/python/oneflow/nn/parallel/_functions.py
@@ -1,0 +1,140 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import warnings
+
+import oneflow as flow
+from . import comm
+from oneflow.autograd import Function
+from oneflow.cuda._utils import _get_device_index
+from typing import List, Optional
+
+
+class Broadcast(Function):
+    @staticmethod
+    def forward(ctx, target_gpus, *inputs):
+        assert all(
+            i.device.type != "cpu" for i in inputs
+        ), "Broadcast function not implemented for CPU tensors"
+        # convert tensor to list
+        target_gpus = [t.item() for t in list(target_gpus)]
+        target_gpus = [_get_device_index(x, True) for x in target_gpus]
+        ctx.target_gpus = target_gpus
+        if len(inputs) == 0:
+            return tuple()
+        ctx.needs_input_grad = (False, True)
+        ctx.num_inputs = len(inputs)
+        ctx.input_device = inputs[0].get_device()
+        outputs = comm.broadcast_coalesced(inputs, ctx.target_gpus)
+        non_differentiables = []
+        for idx, input_requires_grad in enumerate(ctx.needs_input_grad[1:]):
+            if not input_requires_grad:
+                for output in outputs:
+                    non_differentiables.append(output[idx])
+        ctx.mark_non_differentiable(*non_differentiables)
+        return tuple([t for tensors in outputs for t in tensors])
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        return (None, ) + ReduceAddCoalesced.apply(
+            flow.tensor(ctx.input_device), flow.tensor(ctx.num_inputs), *grad_outputs
+        )
+
+
+class ReduceAddCoalesced(Function):
+    @staticmethod
+    def forward(ctx, destination, num_inputs, *grads):
+        destination = destination.item()
+        num_inputs = num_inputs.item()
+        ctx.target_gpus = [grads[i].get_device() for i in range(0, len(grads), num_inputs)]
+        grads_ = [grads[i : i + num_inputs] for i in range(0, len(grads), num_inputs)]
+        return comm.reduce_add_coalesced(grads_, destination)
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        return (None, None, ) + Broadcast.apply(flow.tensor(ctx.target_gpus), *grad_outputs)
+
+
+class Gather(Function):
+    @staticmethod
+    def forward(ctx, target_device, dim, *inputs):
+        assert all(
+            i.device.type != "cpu" for i in inputs
+        ), "Gather function not implemented for CPU tensors"
+        # using -1 represents 'cpu' device
+        target_device = target_device.item()
+        target_device = _get_device_index(target_device, True)
+        ctx.target_device = target_device
+        ctx.dim = dim.item()
+        ctx.input_gpus = tuple(i.get_device() for i in inputs)
+        if all(t.dim() == 0 for t in inputs) and dim.item() == 0:
+            inputs = tuple(t.view(1) for t in inputs)
+            warnings.warn(
+                "Was asked to gather along dimension 0, but all "
+                "input tensors were scalars; will instead unsqueeze "
+                "and return a vector."
+            )
+            ctx.unsqueezed_scalar = True
+        else:
+            ctx.unsqueezed_scalar = False
+        ctx.input_sizes = tuple(i.size(dim.item()) for i in inputs)
+        return comm.gather(inputs, dim.item(), target_device)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        scattered_grads = Scatter.apply(
+            flow.tensor(ctx.input_gpus), flow.tensor(ctx.input_sizes), flow.tensor(ctx.dim), grad_output
+        )
+        if ctx.unsqueezed_scalar:
+            scattered_grads = tuple(g[0] for g in scattered_grads)
+        return (None, None) + scattered_grads
+
+
+class Scatter(Function):
+    @staticmethod
+    def forward(ctx, target_gpus, chunk_sizes, dim, input):
+        target_gpus = [t.item() for t in list(target_gpus)]
+        target_gpus = [_get_device_index(x, True) for x in target_gpus]
+        ctx.target_gpus_len = len(target_gpus)
+        # use flow.tensor(-1) represent None
+        if chunk_sizes.nelement() == 1 and chunk_sizes.item() == -1:
+            chunk_sizes = None
+        else:
+            chunk_sizes = [t.item() for t in list(chunk_sizes)]
+        ctx.dim = dim.item()
+        ctx.input_device = input.get_device() if input.device.type != "cpu" else -1
+        streams = None
+        outputs = comm.scatter(input, target_gpus, chunk_sizes, ctx.dim, streams)
+        return outputs
+
+    @staticmethod
+    def backward(ctx, *grad_output):
+        return None, None, None, Gather.apply(flow.tensor(ctx.input_device), flow.tensor(ctx.dim), *grad_output)
+
+
+# background streams used for copying
+# _streams: Optional[List[Optional[torch.cuda.Stream]]] = None
+
+
+# def _get_stream(device: int):
+#     """Gets a background stream for copying between CPU and GPU"""
+#     global _streams
+#     if device == -1:
+#         return None
+#     if _streams is None:
+#         _streams = [None] * torch.cuda.device_count()
+#     if _streams[device] is None:
+#         _streams[device] = torch.cuda.Stream(device)
+#     return _streams[device]

--- a/python/oneflow/nn/parallel/comm.py
+++ b/python/oneflow/nn/parallel/comm.py
@@ -1,0 +1,566 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import warnings
+import oneflow as flow
+from collections import defaultdict
+from oneflow.cuda._utils import _get_device_index, _handle_complex
+from oneflow._utils import (
+    _flatten_dense_tensors,
+    _unflatten_dense_tensors,
+    _take_tensors,
+    _reorder_tensors_as,
+)
+from typing import List
+
+
+def broadcast(tensor, devices=None, *, out=None):
+    r"""Broadcasts a tensor to specified GPU devices.
+
+    Args:
+        tensor (Tensor): tensor to broadcast. Can be on CPU or GPU.
+        devices (Iterable[flow.device, str or int], optional): an iterable of
+          GPU devices, among which to broadcast.
+        out (Sequence[Tensor], optional, keyword-only): the GPU tensors to
+          store output results.
+
+    .. note::
+        Exactly one of :attr:`devices` and :attr:`out` must be specified.
+
+    Returns:
+        - If :attr:`devices` is specified,
+            a tuple containing copies of :attr:`tensor`, placed on
+            :attr:`devices`.
+        - If :attr:`out` is specified,
+            a tuple containing :attr:`out` tensors, each containing a copy of
+            :attr:`tensor`.
+    """
+    tensor = _handle_complex(tensor)
+    if not ((devices is None) ^ (out is None)):
+        raise RuntimeError(r"Exactly one of 'devices' and 'out'")
+    if devices is not None:
+        devices = [_get_device_index(d) for d in devices]
+        return _comm_broadcast(tensor, devices)
+    else:
+        return _comm_broadcast_out(tensor, out)
+
+
+def broadcast_coalesced(tensors, devices, buffer_size=10485760):
+    """Broadcasts a sequence tensors to the specified GPUs.
+    Small tensors are first coalesced into a buffer to reduce the number
+    of synchronizations.
+
+    Args:
+        tensors (sequence): tensors to broadcast. Must be on the same device,
+          either CPU or GPU.
+        devices (Iterable[torch.device, str or int]): an iterable of GPU
+          devices, among which to broadcast.
+        buffer_size (int): maximum size of the buffer used for coalescing
+
+    Returns:
+        A tuple containing copies of :attr:`tensor`, placed on :attr:`devices`.
+    """
+    devices = [_get_device_index(d) for d in devices]
+    tensors = [_handle_complex(t) for t in tensors]
+    return _comm_broadcast_coalesced(tensors, devices, buffer_size)
+
+
+def reduce_add(inputs, destination=None):
+    """Sums tensors from multiple GPUs.
+
+    All inputs should have matching shapes, dtype, and layout. The output tensor
+    will be of the same shape, dtype, and layout.
+
+    Args:
+        inputs (Iterable[Tensor]): an iterable of tensors to add.
+        destination (int, optional): a device on which the output will be
+            placed (default: current device).
+
+    Returns:
+        A tensor containing an elementwise sum of all inputs, placed on the
+        :attr:`destination` device.
+    """
+    destination = _get_device_index(destination, optional=True)
+    input_size = inputs[0].size()
+    root_index = None  # index of input tensor that already is on the correct device
+    for i, inp in enumerate(inputs):
+        assert inp.device.type != "cpu", "reduce_add expects all inputs to be on GPUs"
+        if inp.get_device() == destination:
+            root_index = i
+        if inp.size() != input_size:
+            got = "x".join(str(x) for x in inp.size())
+            expected = "x".join(str(x) for x in input_size)
+            raise ValueError(
+                "input {} has invalid size: got {}, but expected "
+                "{}".format(i, got, expected)
+            )
+    if root_index is None:
+        raise RuntimeError(
+            "reduce_add expects destination to be on the same GPU with one of the tensors"
+        )
+
+    if len(inputs) == 1:
+        return inputs[0]
+
+    # if nccl.is_available(inputs):
+    #     result = torch.empty_like(inputs[root_index])
+    #     nccl.reduce(inputs, output=result, root=root_index)
+    # else:
+    destination_device = flow.device(inputs[root_index].device.type, destination)
+    nonroot = [t for i, t in enumerate(inputs) if i != root_index]
+    # make a new tensor w/o clone
+    result = inputs[root_index] + nonroot[0].to(device=destination_device)
+    for other in nonroot[1:]:
+        result.add_(other.to(device=destination_device))
+    return result
+
+
+def reduce_add_coalesced(inputs, destination=None, buffer_size=10485760):
+    """Sums tensors from multiple GPUs.
+
+    Small tensors are first coalesced into a buffer to reduce the number
+    of synchronizations.
+
+    Args:
+        inputs (Iterable[Iterable[Tensor]]): iterable of iterables that
+            contain tensors from a single device.
+        destination (int, optional): a device on which the output will be
+            placed (default: current device).
+        buffer_size (int): maximum size of the buffer used for coalescing
+
+    Returns:
+        A tuple of tensors containing an elementwise sum of each group of
+        inputs, placed on the ``destination`` device.
+    """
+    # TODO: When `len(inputs) == 1` and all inputs are on `destination`, just
+    #       return `inputs`.
+    dense_tensors: List[List] = [[] for _ in inputs]  # shape (num_gpus, num_tensors)
+    output = []
+    ref_order = []
+
+    for tensor_at_gpus in zip(*inputs):
+        for coll, t in zip(dense_tensors, tensor_at_gpus):
+            coll.append(t)
+        ref_order.append(dense_tensors[0][-1])
+    itrs = [_take_tensors(tensors, buffer_size) for tensors in dense_tensors]
+    # now the dense ones, which have consistent sizes
+    for chunks in zip(*itrs):
+        flat_tensors = [
+            _flatten_dense_tensors(chunk) for chunk in chunks
+        ]  # (num_gpus,)
+        flat_result = reduce_add(flat_tensors, destination)
+        for t in _unflatten_dense_tensors(flat_result, chunks[0]):
+            # The unflattened tensors do not share storage, and we don't expose
+            # base flat tensor anyways, so give them different version counters.
+            # See NOTE [ Version Counter in comm.*_coalesced ]
+            output.append(t.data)
+    return tuple(_reorder_tensors_as(output, ref_order))
+
+
+def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=None):
+    """Scatters tensor across multiple GPUs.
+
+    Args:
+        tensor (Tensor): tensor to scatter. Can be on CPU or GPU.
+        devices (Iterable[torch.device, str or int], optional): an iterable of
+          GPU devices, among which to scatter.
+        chunk_sizes (Iterable[int], optional): sizes of chunks to be placed on
+          each device. It should match :attr:`devices` in length and sums to
+          ``tensor.size(dim)``. If not specified, :attr:`tensor` will be divided
+          into equal chunks.
+        dim (int, optional): A dimension along which to chunk :attr:`tensor`.
+          Default: ``0``.
+        streams (Iterable[Stream], optional): an iterable of Streams, among
+          which to execute the scatter. If not specified, the default stream will
+          be utilized.
+        out (Sequence[Tensor], optional, keyword-only): the GPU tensors to
+          store output results. Sizes of these tensors must match that of
+          :attr:`tensor`, except for :attr:`dim`, where the total size must
+          sum to ``tensor.size(dim)``.
+
+    .. note::
+        Exactly one of :attr:`devices` and :attr:`out` must be specified. When
+        :attr:`out` is specified, :attr:`chunk_sizes` must not be specified and
+        will be inferred from sizes of :attr:`out`.
+
+    Returns:
+        - If :attr:`devices` is specified,
+            a tuple containing chunks of :attr:`tensor`, placed on
+            :attr:`devices`.
+        - If :attr:`out` is specified,
+            a tuple containing :attr:`out` tensors, each containing a chunk of
+            :attr:`tensor`.
+    """
+    tensor = _handle_complex(tensor)
+    if out is None:
+        devices = [_get_device_index(d) for d in devices]
+        return tuple(_comm_scatter(tensor, devices, chunk_sizes, dim, streams))
+    else:
+        if devices is not None:
+            raise RuntimeError(
+                r"'devices' must not be specified when 'out' is specified, but \
+                got devices={}".format(
+                    devices
+                )
+            )
+        if chunk_sizes is not None:
+            raise RuntimeError(
+                r"'chunk_sizes' must not be specified when 'out' is specified, \
+                but got chunk_sizes={}".format(
+                    chunk_sizes
+                )
+            )
+        return tuple(_comm_scatter_out(tensor, out, dim, streams))
+
+
+def gather(tensors, dim=0, destination=None, *, out=None):
+    r"""Gathers tensors from multiple GPU devices.
+
+    Args:
+        tensors (Iterable[Tensor]): an iterable of tensors to gather.
+          Tensor sizes in all dimensions other than :attr:`dim` have to match.
+        dim (int, optional): a dimension along which the tensors will be
+          concatenated. Default: ``0``.
+        destination (torch.device, str, or int, optional): the output device.
+          Can be CPU or CUDA. Default: the current CUDA device.
+        out (Tensor, optional, keyword-only): the tensor to store gather result.
+          Its sizes must match those of :attr:`tensors`, except for :attr:`dim`,
+          where the size must equal ``sum(tensor.size(dim) for tensor in tensors)``.
+          Can be on CPU or CUDA.
+
+    .. note::
+        :attr:`destination` must not be specified when :attr:`out` is specified.
+
+    Returns:
+        - If :attr:`destination` is specified,
+            a tensor located on :attr:`destination` device, that is a result of
+            concatenating :attr:`tensors` along :attr:`dim`.
+        - If :attr:`out` is specified,
+            the :attr:`out` tensor, now containing results of concatenating
+            :attr:`tensors` along :attr:`dim`.
+    """
+    tensors = [_handle_complex(t) for t in tensors]
+    if out is None:
+        if destination == -1:
+            warnings.warn(
+                "Using -1 to represent CPU tensor is deprecated. Please use a "
+                'device object or string instead, e.g., "cpu".'
+            )
+        destination = _get_device_index(destination, allow_cpu=True, optional=True)
+        return _comm_gather(tensors, dim, destination)
+    else:
+        if destination is not None:
+            raise RuntimeError(
+                "'destination' must not be specified when 'out' is specified, but "
+                "got destination={}".format(destination)
+            )
+        return _comm_gather_out(tensors, out, dim)
+
+
+def _comm_scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None):
+    """
+    Scatters tensor across multiple GPUs.
+
+    Args:
+        tensor (Tensor): tensor to scatter. Can be on CPU or GPU.
+        devices (Iterable[flow.device, str or int], optional): an iterable of
+          GPU devices, among which to scatter.
+        chunk_sizes (Iterable[int], optional): sizes of chunks to be placed on
+          each device. It should match :attr:`devices` in length and sums to
+          ``flow.size(dim)``. If not specified, :attr:`tensor` will be divided
+          into equal chunks.
+        dim (int, optional): A dimension along which to chunk :attr:`tensor`.
+          Default: ``0``.
+        streams (Iterable[Stream], optional): an iterable of Streams, among
+          which to execute the scatter. If not specified, the default stream will
+          be utilized.
+    """
+    if len(devices) < 1:
+        raise RuntimeError(r"Expected at least one device to scatter to")
+    if chunk_sizes is not None:
+        if len(chunk_sizes) != len(devices):
+            raise RuntimeError(r"Expected devices and chunk_sizes to be of same length")
+    out_tensors = (
+        flow.split(tensor, chunk_sizes, dim=dim)
+        if chunk_sizes
+        else flow.chunk(tensor, len(devices), dim=dim)
+    )
+    tensor_index = -1 if tensor.device.type == "cpu" else tensor.get_device()
+    out_tensors = list(out_tensors)
+    for index in range(len(out_tensors)):
+        device_index = devices[index]
+        if device_index != tensor_index:
+            out_tensors[index] = out_tensors[index].cuda(device_index)
+    return out_tensors
+
+
+def _comm_scatter_out(tensor, out_tensors, dim, streams):
+    """
+    Scatters tensor across multiple GPUs.
+
+    Args:
+        tensor (Tensor): tensor to scatter. Can be on CPU or GPU.
+        out_tensor (Sequence[Tensor], optional, keyword-only): the GPU tensors to
+          store output results. Sizes of these tensors must match that of
+          :attr:`flow`, except for :attr:`dim`, where the total size must
+          sum to ``flow.size(dim)``.
+        dim (int, optional): A dimension along which to chunk :attr:`tensor`.
+          Default: ``0``.
+        streams (Iterable[Stream], optional): an iterable of Streams, among
+          which to execute the scatter. If not specified, the default stream will
+          be utilized.
+    """
+    if len(out_tensors) < 1:
+        raise RuntimeError(r"Expected at least one output tensor to scatter to")
+
+    chunk_sizes = []
+    total_size = 0
+    for index in range(len(out_tensors)):
+        total_size += out_tensors[index].size(dim)
+        chunk_sizes.append(out_tensors[index].size(dim))
+        out_tensors_size = list(out_tensors[index].size())
+        out_tensors_size[dim] = tensor.size(dim)
+        if not out_tensors[index].is_cuda:
+            raise RuntimeError(
+                r"Expected all output tensors to be CUDA tensors, but output tensor at index {}".format(
+                    index
+                )
+            )
+        if out_tensors[index].dim() != tensor.dim():
+            raise RuntimeError("Output tensor at index 0 has incorrect shape")
+        if list(tensor.size()) != out_tensors_size:
+            raise RuntimeError(
+                r"Output tensor at index 0 has incorrect shape".format(index)
+            )
+    if total_size != tensor.size(dim):
+        raise RuntimeError(
+            r"Total size for output tensors along scatter dim does not match"
+        )
+
+    chunks = flow.split(tensor, chunk_sizes, dim=dim)
+    for index in range(len(out_tensors)):
+        out_tensors[index].copy_(chunks[index])
+    return out_tensors
+
+
+def _comm_broadcast(tensor, devices):
+    """
+    Broadcast tensor to specified GPU devices.
+
+    Args:
+        tensor(Tensor):tensor to broadcast.
+        devices(List):the index of GPU devices.
+
+    Return:
+        A list containing copies of :attr:`tensor`, placed on :attr:`devices`.
+    """
+    if tensor.device.type == "cpu":
+        tensor = tensor.cuda()
+    diff_device_dst_tensors = list()
+    for index in devices:
+        assert index >= 0, "Expected non-negative device index, but got ".format(index)
+        if index != tensor.get_device():
+            diff_device_dst_tensors.append(
+                flow.empty(
+                    tensor.size(), dtype=tensor.dtype, device=flow.device("cuda", index)
+                )
+            )
+    _boradcast_out_impl(tensor, diff_device_dst_tensors)
+    dst_tensors = list()
+    i = 0
+    for index in devices:
+        if index != tensor.get_device():
+            dst_tensors.append(diff_device_dst_tensors[i])
+            i += 1
+        else:
+            dst_tensors.append(tensor)
+    return dst_tensors
+
+
+def _comm_broadcast_out(tensor, out_tensor):
+    """
+    Broadcast tensor to specified out_tensor.
+
+    Args:
+        tensor(Tensor):tensor to broadcast.
+        out_tensor(List):a list contains output tensor.
+    """
+    for index in range(len(out_tensor)):
+        if not out_tensor[index].is_cuda:
+            raise RuntimeError(
+                r"Expected all output tensors to be CUDA tensors, but output tensor at index {}".format(
+                    index
+                )
+            )
+        if out_tensor[index].size() != tensor.size():
+            raise RuntimeError(
+                r"Expected all output tensors to have same shape as the source at index {}".format(
+                    index
+                )
+            )
+    return _boradcast_out_impl(tensor, out_tensor)
+
+
+def _boradcast_out_impl(tensor, out_tensor):
+    """
+    Copy source tensor to output tensor.
+    Args:
+        tensor(Tensor):the source tensor to broadcast.
+        out_tensor(List):the list of containing copies of source tensor.
+    Returns:
+        A list containing tensor, every element is the same as source tensor.
+    """
+    for index in range(len(out_tensor)):
+        out_tensor[index].copy_(tensor)
+    return out_tensor
+
+
+def _comm_broadcast_coalesced(tensors, devices, buffer_size=10485760):
+    """Broadcasts a sequence tensors to the specified GPUs.
+    Small tensors are first coalesced into a buffer to reduce the number
+    of synchronizations.
+
+    Args:
+        tensors (List): tensors to broadcast. Must be on the same device GPU.
+        devices (List[int]): an list of GPU devices, among which to broadcast.
+        buffer_size (int): maximum size of the buffer used for coalescing
+
+    Returns:
+        A tuple containing copies of :attr:`tensor`, placed on :attr:`devices`.
+    """
+    # check elements of tensors should be same device
+    if not all(param.get_device() == devices[0] for param in tensors):
+        raise RuntimeError(r"Must be on the same device GPU")
+    tensorlist2d = [[] for _ in range(len(devices))]
+    tensorlist2d[0] = tensors
+    for data in tensors:
+        results = _comm_broadcast(tensor=data, devices=devices)
+        for i, device_tensor in enumerate(results):
+            if i == 0:
+                continue
+            tensorlist2d[i].append(device_tensor)
+    return tuple(tensorlist2d)
+
+
+def _comm_gather(tensors, dim=0, destination=None):
+    r"""
+    Args:
+        tensors (List): an list of tensors to gather.
+          Tensor sizes in all dimensions other than :attr:`dim` have to match.
+        dim (int, optional): a dimension along which the tensors will be
+          concatenated. Default: ``0``.
+        destination (torch.device, str, or int, optional): the output device.
+          Can be CPU or CUDA. Default: the current CUDA device.
+    """
+    pass
+
+
+def _comm_gather_out(tensors, out, dim):
+    r"""
+    Args:
+        tensors (List): an list of tensors to gather.
+          Tensor sizes in all dimensions other than :attr:`dim` have to match.
+        out (Tensor): the tensor to store gather result.
+          Its sizes must match those of :attr:`tensors`, except for :attr:`dim`,
+          where the size must equal ``sum(tensor.size(dim) for tensor in tensors)``.
+          Can be on CPU or CUDA.
+        dim (int, optional): a dimension along which the tensors will be
+          concatenated. Default: ``0``.
+    """
+    if len(tensors) < 1:
+        raise RuntimeError(r"Expected at least one tensor to gather from")
+    expected_size = list(tensors[0].size())
+    total_size = 0
+    for index in range(len(tensors)):
+        if not tensors[index].is_cuda:
+            raise RuntimeError(r"Expected all input tensors to be CUDA tensors, ")
+        if tensors[index].ndim != len(expected_size):
+            raise RuntimeError(
+                r"Expected all input tensors to have the same number of dimensions"
+            )
+        expected_size[dim] = tensors[index].size(dim)
+        for dimension in range(len(expected_size)):
+            if expected_size[dimension] != tensors[index].size(dimension):
+                raise RuntimeError(
+                    r"Input tensor at index {} has invalid shape".format(dimension)
+                )
+
+        total_size += tensors[index].size(dim)
+    expected_size[dim] = total_size
+    if expected_size != list(out.size()):
+        raise RuntimeError(r"Out tensor shape don't match")
+
+    return _comm_gather_out_impl(tensors, out, dim)
+
+
+def _comm_gather(tensors, dim, destination):
+    r"""
+    Args:
+        tensors (List): an list of tensors to gather.
+          Tensor sizes in all dimensions other than :attr:`dim` have to match.
+        dim (int, optional): a dimension along which the tensors will be
+          concatenated. Default: ``0``.
+        destination (int): the output device.
+          Can be CPU or CUDA. Default: the current CUDA device.
+    """
+    if len(tensors) < 1:
+        raise RuntimeError(r"Expected at least one tensor to gather from")
+    expected_size = list(tensors[0].size())
+    total_size = 0
+    for index in range(len(tensors)):
+        if not tensors[index].is_cuda:
+            raise RuntimeError(r"Expected all input tensors to be CUDA tensors, ")
+        if tensors[index].ndim != len(expected_size):
+            raise RuntimeError(
+                r"Expected all input tensors to have the same number of dimensions"
+            )
+        expected_size[dim] = tensors[index].size(dim)
+        for dimension in range(len(expected_size)):
+            if expected_size[dimension] != tensors[index].size(dimension):
+                raise RuntimeError(
+                    r"Input tensor at index {} has invalid shape".format(index)
+                )
+
+        total_size += tensors[index].size(dim)
+    expected_size[dim] = total_size
+    device = (
+        flow.device("cuda", destination) if destination != -1 else flow.device("cpu")
+    )
+    result = flow.empty(expected_size, device=device)
+    return _comm_gather_out_impl(tensors, result, dim)
+
+
+def _comm_gather_out_impl(tensors, out_tensor, dim):
+    r"""
+    Args:
+        tensors (List): an list of tensors to gather.
+          Tensor sizes in all dimensions other than :attr:`dim` have to match.
+        out (Tensor): the tensor to store gather result.
+          Its sizes must match those of :attr:`tensors`, except for :attr:`dim`,
+          where the size must equal ``sum(tensor.size(dim) for tensor in tensors)``.
+          Can be on CPU or CUDA.
+        dim (int, optional): a dimension along which the tensors will be
+          concatenated. Default: ``0``.
+    """
+    # chunk_sizes = list()
+    # for t in tensors:
+    #     chunk_sizes.append(t.size(dim))
+    # chunks = flow.split(out_tensor, chunk_sizes, dim = dim)
+    # for index in range(len(chunks)):
+    #     chunks[index].copy_(tensors[index])
+    tensors = [t.cpu() for t in tensors]
+    tmp = flow.cat(tensors, dim=dim)
+    out_tensor.copy_(tmp)
+    return out_tensor

--- a/python/oneflow/nn/parallel/data_parallel.py
+++ b/python/oneflow/nn/parallel/data_parallel.py
@@ -1,0 +1,263 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import operator
+import oneflow as flow
+import warnings
+from itertools import chain
+from ..modules import Module
+from .scatter_gather import scatter_kwargs, gather
+from .replicate import replicate
+from .parallel_apply import parallel_apply
+from oneflow.cuda._utils import (
+    _get_all_device_indices,
+    _get_available_device_type,
+    _get_device_index,
+    _get_devices_properties,
+)
+
+__all__ = ["DataParallel", "data_parallel"]
+
+
+def _check_balance(device_ids):
+    imbalance_warn = """
+    There is an imbalance between your GPUs. You may want to exclude GPU {} which
+    has less than 75% of the memory or cores of GPU {}. You can do so by setting
+    the device_ids argument to DataParallel, or by setting the CUDA_VISIBLE_DEVICES
+    environment variable."""
+    device_ids = [_get_device_index(x, True) for x in device_ids]
+    dev_props = _get_devices_properties(device_ids)
+
+    def warn_imbalance(get_prop):
+        values = [get_prop(props) for props in dev_props]
+        min_pos, min_val = min(enumerate(values), key=operator.itemgetter(1))
+        max_pos, max_val = max(enumerate(values), key=operator.itemgetter(1))
+        if min_val / max_val < 0.75:
+            warnings.warn(
+                imbalance_warn.format(device_ids[min_pos], device_ids[max_pos])
+            )
+            return True
+        return False
+
+    if warn_imbalance(lambda props: props.total_memory):
+        return
+    if warn_imbalance(lambda props: props.multi_processor_count):
+        return
+
+
+class DataParallel(Module):
+    r"""Implements data parallelism at the module level.
+
+    This container parallelizes the application of the given :attr:`module` by
+    splitting the input across the specified devices by chunking in the batch
+    dimension (other objects will be copied once per device). In the forward
+    pass, the module is replicated on each device, and each replica handles a
+    portion of the input. During the backwards pass, gradients from each replica
+    are summed into the original module.
+
+    The batch size should be larger than the number of GPUs used.
+
+    .. warning::
+        It is recommended to use :class:`~torch.nn.parallel.DistributedDataParallel`,
+        instead of this class, to do multi-GPU training, even if there is only a single
+        node. See: :ref:`cuda-nn-ddp-instead` and :ref:`ddp`.
+
+    Arbitrary positional and keyword inputs are allowed to be passed into
+    DataParallel but some types are specially handled. tensors will be
+    **scattered** on dim specified (default 0). tuple, list and dict types will
+    be shallow copied. The other types will be shared among different threads
+    and can be corrupted if written to in the model's forward pass.
+
+    The parallelized :attr:`module` must have its parameters and buffers on
+    ``device_ids[0]`` before running this :class:`~torch.nn.DataParallel`
+    module.
+
+    .. warning::
+        In each forward, :attr:`module` is **replicated** on each device, so any
+        updates to the running module in ``forward`` will be lost. For example,
+        if :attr:`module` has a counter attribute that is incremented in each
+        ``forward``, it will always stay at the initial value because the update
+        is done on the replicas which are destroyed after ``forward``. However,
+        :class:`~torch.nn.DataParallel` guarantees that the replica on
+        ``device[0]`` will have its parameters and buffers sharing storage with
+        the base parallelized :attr:`module`. So **in-place** updates to the
+        parameters or buffers on ``device[0]`` will be recorded. E.g.,
+        :class:`~torch.nn.BatchNorm2d` and :func:`~torch.nn.utils.spectral_norm`
+        rely on this behavior to update the buffers.
+
+    .. warning::
+        Forward and backward hooks defined on :attr:`module` and its submodules
+        will be invoked ``len(device_ids)`` times, each with inputs located on
+        a particular device. Particularly, the hooks are only guaranteed to be
+        executed in correct order with respect to operations on corresponding
+        devices. For example, it is not guaranteed that hooks set via
+        :meth:`~torch.nn.Module.register_forward_pre_hook` be executed before
+        `all` ``len(device_ids)`` :meth:`~torch.nn.Module.forward` calls, but
+        that each such hook be executed before the corresponding
+        :meth:`~torch.nn.Module.forward` call of that device.
+
+    .. warning::
+        When :attr:`module` returns a scalar (i.e., 0-dimensional tensor) in
+        :func:`forward`, this wrapper will return a vector of length equal to
+        number of devices used in data parallelism, containing the result from
+        each device.
+
+    .. note::
+        There is a subtlety in using the
+        ``pack sequence -> recurrent network -> unpack sequence`` pattern in a
+        :class:`~torch.nn.Module` wrapped in :class:`~torch.nn.DataParallel`.
+        See :ref:`pack-rnn-unpack-with-data-parallelism` section in FAQ for
+        details.
+
+
+    Args:
+        module (Module): module to be parallelized
+        device_ids (list of int or torch.device): CUDA devices (default: all devices)
+        output_device (int or torch.device): device location of output (default: device_ids[0])
+
+    Attributes:
+        module (Module): the module to be parallelized
+
+    Example::
+
+        >>> # xdoctest: +SKIP
+        >>> net = torch.nn.DataParallel(model, device_ids=[0, 1, 2])
+        >>> output = net(input_var)  # input_var can be on any device, including CPU
+    """
+
+    # TODO: update notes/cuda.rst when this class handles 8+ GPUs well
+
+    def __init__(self, module, device_ids=None, output_device=None, dim=0):
+        super(DataParallel, self).__init__()
+        device_type = _get_available_device_type()
+        if device_type is None:
+            self.module = module
+            self.device_ids = []
+            return
+
+        if device_ids is None:
+            device_ids = _get_all_device_indices()
+
+        if output_device is None:
+            output_device = device_ids[0]
+
+        self.dim = dim
+        self.module = module
+        self.device_ids = [_get_device_index(x, True) for x in device_ids]
+        self.output_device = _get_device_index(output_device, True)
+        self.src_device_obj = flow.device(device_type, self.device_ids[0])
+
+        _check_balance(self.device_ids)
+
+        if len(self.device_ids) == 1:
+            self.module.to(self.src_device_obj)
+
+    def forward(self, *inputs, **kwargs):
+        if not self.device_ids:
+            return self.module(*inputs, **kwargs)
+
+        for t in chain(self.module.parameters(), self.module.buffers()):
+            if t.device != self.src_device_obj:
+                raise RuntimeError(
+                    "module must have its parameters and buffers "
+                    "on device {} (device_ids[0]) but found one of "
+                    "them on device: {}".format(self.src_device_obj, t.device)
+                )
+
+        inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
+        # for forward function without any inputs, empty list and dict will be created
+        # so the module can be executed on one device which is the first one in device_ids
+        if not inputs and not kwargs:
+            inputs = ((),)
+            kwargs = ({},)
+
+        if len(self.device_ids) == 1:
+            return self.module(*inputs[0], **kwargs[0])
+        replicas = self.replicate(self.module, self.device_ids[: len(inputs)])
+        with flow.no_grad():
+            for replica in replicas:
+                for param in replica.parameters():
+                    param.requires_grad_(True)
+        outputs = self.parallel_apply(replicas, inputs, kwargs)
+        return self.gather(outputs, self.output_device)
+
+    def replicate(self, module, device_ids):
+        return replicate(module, device_ids, not flow.is_grad_enabled())
+
+    def scatter(self, inputs, kwargs, device_ids):
+        return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
+
+    def parallel_apply(self, replicas, inputs, kwargs):
+        return parallel_apply(
+            replicas, inputs, kwargs, self.device_ids[: len(replicas)]
+        )
+
+    def gather(self, outputs, output_device):
+        return gather(outputs, output_device, dim=self.dim)
+
+
+def data_parallel(
+    module, inputs, device_ids=None, output_device=None, dim=0, module_kwargs=None
+):
+    r"""Evaluates module(input) in parallel across the GPUs given in device_ids.
+
+    This is the functional version of the DataParallel module.
+
+    Args:
+        module (Module): the module to evaluate in parallel
+        inputs (Tensor): inputs to the module
+        device_ids (list of int or torch.device): GPU ids on which to replicate module
+        output_device (list of int or torch.device): GPU location of the output  Use -1 to indicate the CPU.
+            (default: device_ids[0])
+    Returns:
+        a Tensor containing the result of module(input) located on
+        output_device
+    """
+    if not isinstance(inputs, tuple):
+        inputs = (inputs,) if inputs is not None else ()
+
+    device_type = _get_available_device_type()
+
+    if device_ids is None:
+        device_ids = _get_all_device_indices()
+
+    if output_device is None:
+        output_device = device_ids[0]
+
+    device_ids = [_get_device_index(x, True) for x in device_ids]
+    output_device = _get_device_index(output_device, True)
+    src_device_obj = torch.device(device_type, device_ids[0])
+
+    for t in chain(module.parameters(), module.buffers()):
+        if t.device != src_device_obj:
+            raise RuntimeError(
+                "module must have its parameters and buffers "
+                "on device {} (device_ids[0]) but found one of "
+                "them on device: {}".format(src_device_obj, t.device)
+            )
+
+    inputs, module_kwargs = scatter_kwargs(inputs, module_kwargs, device_ids, dim)
+    # for module without any inputs, empty list and dict will be created
+    # so the module can be executed on one device which is the first one in device_ids
+    if not inputs and not module_kwargs:
+        inputs = ((),)
+        module_kwargs = ({},)
+
+    if len(device_ids) == 1:
+        return module(*inputs[0], **module_kwargs[0])
+    used_device_ids = device_ids[: len(inputs)]
+    replicas = replicate(module, used_device_ids)
+    outputs = parallel_apply(replicas, inputs, module_kwargs, used_device_ids)
+    return gather(outputs, output_device, dim)

--- a/python/oneflow/nn/parallel/parallel_apply.py
+++ b/python/oneflow/nn/parallel/parallel_apply.py
@@ -1,0 +1,116 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import threading
+import oneflow as flow
+from oneflow.cuda._utils import _get_device_index
+from oneflow.cuda.amp import autocast
+from oneflow._utils import ExceptionWrapper
+
+
+def get_a_var(obj):
+    if isinstance(obj, flow.Tensor):
+        return obj
+
+    if isinstance(obj, list) or isinstance(obj, tuple):
+        for result in map(get_a_var, obj):
+            if isinstance(result, flow.Tensor):
+                return result
+    if isinstance(obj, dict):
+        for result in map(get_a_var, obj.items()):
+            if isinstance(result, flow.Tensor):
+                return result
+    return None
+
+
+def parallel_apply(modules, inputs, kwargs_tup=None, devices=None):
+    r"""Applies each `module` in :attr:`modules` in parallel on arguments
+    contained in :attr:`inputs` (positional) and :attr:`kwargs_tup` (keyword)
+    on each of :attr:`devices`.
+
+    Args:
+        modules (Module): modules to be parallelized
+        inputs (tensor): inputs to the modules
+        devices (list of int or flow.device): CUDA devices
+
+    :attr:`modules`, :attr:`inputs`, :attr:`kwargs_tup` (if given), and
+    :attr:`devices` (if given) should all have same length. Moreover, each
+    element of :attr:`inputs` can either be a single object as the only argument
+    to a module, or a collection of positional arguments.
+    """
+    assert len(modules) == len(inputs)
+    if kwargs_tup is not None:
+        assert len(modules) == len(kwargs_tup)
+    else:
+        kwargs_tup = ({},) * len(modules)
+    if devices is not None:
+        assert len(modules) == len(devices)
+    else:
+        devices = [None] * len(modules)
+    devices = [_get_device_index(x, True) for x in devices]
+    # oneflow not support flow.cuda.current_stream flow.cuda.current_stream(x)
+    streams = [None for x in devices]
+    lock = threading.Lock()
+    results = {}
+    grad_enabled, autocast_enabled = flow.is_grad_enabled(), flow.is_autocast_enabled()
+    print(grad_enabled, autocast_enabled)
+
+    def _worker(i, module, input, kwargs, device=None, stream=None):
+        flow.set_grad_enabled(grad_enabled)
+        if device is None:
+            device = get_a_var(input).get_device()
+        if stream is None:
+            # oneflow not support flow.cuda.current_stream
+            # stream = flow.cuda.current_stream(device)
+            stream = None
+        try:
+            # flow.cuda.stream(stream)
+            # with flow.cuda.device(device), autocast(enabled=autocast_enabled):
+            # this also avoids accidental slicing of `input` if it is a Tensor
+            if not isinstance(input, (list, tuple)):
+                input = (input,)
+            output = module(*input, **kwargs)
+            with lock:
+                results[i] = output
+        except Exception:
+            with lock:
+                results[i] = ExceptionWrapper(
+                    where="in replica {} on device {}".format(i, device)
+                )
+
+    if len(modules) > 1:
+        threads = [
+            threading.Thread(
+                target=_worker, args=(i, module, input, kwargs, device, stream)
+            )
+            for i, (module, input, kwargs, device, stream) in enumerate(
+                zip(modules, inputs, kwargs_tup, devices, streams)
+            )
+        ]
+
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+    else:
+        _worker(0, modules[0], inputs[0], kwargs_tup[0], devices[0], streams[0])
+
+    outputs = []
+    for i in range(len(inputs)):
+        output = results[i]
+        if isinstance(output, ExceptionWrapper):
+            output.reraise()
+        outputs.append(output)
+    return outputs

--- a/python/oneflow/nn/parallel/replicate.py
+++ b/python/oneflow/nn/parallel/replicate.py
@@ -1,0 +1,190 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from . import comm
+import oneflow as flow
+from oneflow.cuda._utils import _get_device_index
+
+from collections import OrderedDict
+
+# oneflow.jit is developing https://github.com/Oneflow-Inc/oneflow/pull/6674#issue-1042112252
+def _is_script_module(module):
+    return False
+
+
+def _is_script_method(module):
+    # oneflow not support jit
+    return False
+
+
+# def _init_script_module():
+#     import torch.jit
+#     return torch.jit.ScriptModule()
+
+
+# def _is_jit_enabled():
+#     import torch.jit
+#     return torch.jit._state._enabled
+
+
+# Check if we can safely replicate the module.
+# there are two types of module:
+# 1. python modules
+# 2. ScriptModule
+#
+# currently a module cannot be replicated properly if the descendants of
+# any ScriptModule contains python module (type 1 above)
+def _replicatable_module(module, memo=None):
+
+    # module.modules() contains module itself as the first element
+    def descendant_modules(module):
+        gen = module.modules()
+        next(gen)
+        return gen
+
+    if memo is None:
+        memo = set()
+
+    # memoize visited modules
+    memo.add(module)
+    if _is_script_module(module):
+        memo.update(descendant_modules(module))
+        return all(
+            _is_script_module(descendant) for descendant in descendant_modules(module)
+        )
+
+    for child in module.children():
+        # since any unreplicatable module will cause the check to return
+        # False early, visited modules here can be safely ignored.
+        if child in memo:
+            continue
+        if not _replicatable_module(child, memo):
+            return False
+
+    return True
+
+
+def _broadcast_coalesced_reshape(tensors, devices, detach=False):
+    from ._functions import Broadcast
+
+    if detach:
+        return comm.broadcast_coalesced(tensors, devices)
+    else:
+        # Use the autograd function to broadcast if not detach
+        if len(tensors) > 0:
+            # convert list to tensor
+            tensor_copies = Broadcast.apply(flow.tensor(devices), *tensors)
+            return [
+                tensor_copies[i : i + len(tensors)]
+                for i in range(0, len(tensor_copies), len(tensors))
+            ]
+        else:
+            return []
+
+
+def replicate(network, devices, detach=False):
+    if not _replicatable_module(network):
+        raise RuntimeError(
+            "Cannot replicate network where python modules are "
+            "childrens of ScriptModule"
+        )
+
+    if not devices:
+        return []
+
+    devices = [_get_device_index(x, True) for x in devices]
+    num_replicas = len(devices)
+
+    params = list(network.parameters())
+    param_indices = {param: idx for idx, param in enumerate(params)}
+    param_copies = _broadcast_coalesced_reshape(params, devices, detach)
+
+    buffers = list(network.buffers())
+    buffers_rg = []
+    buffers_not_rg = []
+    for buf in buffers:
+        if buf.requires_grad and not detach:
+            buffers_rg.append(buf)
+        else:
+            buffers_not_rg.append(buf)
+
+    buffer_indices_rg = {buf: idx for idx, buf in enumerate(buffers_rg)}
+    buffer_indices_not_rg = {buf: idx for idx, buf in enumerate(buffers_not_rg)}
+
+    buffer_copies_rg = _broadcast_coalesced_reshape(buffers_rg, devices, detach=detach)
+    buffer_copies_not_rg = _broadcast_coalesced_reshape(
+        buffers_not_rg, devices, detach=True
+    )
+
+    modules = list(network.modules())
+    module_copies = [[] for device in devices]
+    module_indices = {}
+
+    for i, module in enumerate(modules):
+        module_indices[module] = i
+        for j in range(num_replicas):
+            replica = module._replicate_for_data_parallel()
+            # This is a temporary fix for DDP. DDP needs to access the
+            # replicated model parameters. It used to do so through
+            # `mode.parameters()`. The fix added in #33907 for DP stops the
+            # `parameters()` API from exposing the replicated parameters.
+            # Hence, we add a `_former_parameters` dict here to support DDP.
+            replica._former_parameters = OrderedDict()
+
+            module_copies[j].append(replica)
+
+    for i, module in enumerate(modules):
+        for key, child in module._modules.items():
+            if child is None:
+                for j in range(num_replicas):
+                    replica = module_copies[j][i]
+                    replica._modules[key] = None
+            else:
+                module_idx = module_indices[child]
+                for j in range(num_replicas):
+                    replica = module_copies[j][i]
+                    setattr(replica, key, module_copies[j][module_idx])
+        for key, param in module._parameters.items():
+            if param is None:
+                for j in range(num_replicas):
+                    replica = module_copies[j][i]
+                    replica._parameters[key] = None
+            else:
+                param_idx = param_indices[param]
+                for j in range(num_replicas):
+                    replica = module_copies[j][i]
+                    param = param_copies[j][param_idx]
+                    # parameters in replicas are no longer leaves,
+                    # so setattr them as non-parameter attributes
+                    setattr(replica, key, param)
+                    # expose the parameter for DDP
+                    replica._former_parameters[key] = param
+        for key, buf in module._buffers.items():
+            if buf is None:
+                for j in range(num_replicas):
+                    replica = module_copies[j][i]
+                    replica._buffers[key] = None
+            else:
+                if buf.requires_grad and not detach:
+                    buffer_copies = buffer_copies_rg
+                    buffer_idx = buffer_indices_rg[buf]
+                else:
+                    buffer_copies = buffer_copies_not_rg
+                    buffer_idx = buffer_indices_not_rg[buf]
+                for j in range(num_replicas):
+                    replica = module_copies[j][i]
+                    setattr(replica, key, buffer_copies[j][buffer_idx])
+
+    return [module_copies[j][0] for j in range(num_replicas)]

--- a/python/oneflow/nn/parallel/scatter_gather.py
+++ b/python/oneflow/nn/parallel/scatter_gather.py
@@ -1,0 +1,111 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import oneflow as flow
+from ._functions import Scatter, Gather
+import warnings
+
+__all__ = ["scatter", "scatter_kwargs", "gather"]
+
+
+def is_namedtuple(obj):
+    # Check if type was created from collections.namedtuple or a typing.NamedTuple.
+    warnings.warn("is_namedtuple is deprecated, please use the python checks instead")
+    return _is_namedtuple(obj)
+
+
+def _is_namedtuple(obj):
+    # Check if type was created from collections.namedtuple or a typing.NamedTuple.
+    return (
+        isinstance(obj, tuple) and hasattr(obj, "_asdict") and hasattr(obj, "_fields")
+    )
+
+
+def scatter(inputs, target_gpus, dim=0):
+    r"""
+    Slices tensors into approximately equal chunks and
+    distributes them across given GPUs. Duplicates
+    references to objects that are not tensors.
+    """
+
+    def scatter_map(obj):
+        if isinstance(obj, flow.Tensor):
+            # Gather.forward need flow.Tensor format, use -1 represent None
+            return Scatter.apply(
+                flow.tensor(target_gpus), flow.tensor(-1), flow.tensor(dim), obj
+            )
+        if _is_namedtuple(obj):
+            return [type(obj)(*args) for args in zip(*map(scatter_map, obj))]
+        if isinstance(obj, tuple) and len(obj) > 0:
+            return list(zip(*map(scatter_map, obj)))
+        if isinstance(obj, list) and len(obj) > 0:
+            return [list(i) for i in zip(*map(scatter_map, obj))]
+        if isinstance(obj, dict) and len(obj) > 0:
+            return [type(obj)(i) for i in zip(*map(scatter_map, obj.items()))]
+        return [obj for targets in target_gpus]
+
+    # After scatter_map is called, a scatter_map cell will exist. This cell
+    # has a reference to the actual function scatter_map, which has references
+    # to a closure that has a reference to the scatter_map cell (because the
+    # fn is recursive). To avoid this reference cycle, we set the function to
+    # None, clearing the cell
+    try:
+        res = scatter_map(inputs)
+    finally:
+        scatter_map = None
+    return res
+
+
+def scatter_kwargs(inputs, kwargs, target_gpus, dim=0):
+    r"""Scatter with support for kwargs dictionary"""
+    inputs = scatter(inputs, target_gpus, dim) if inputs else []
+    kwargs = scatter(kwargs, target_gpus, dim) if kwargs else []
+    if len(inputs) < len(kwargs):
+        inputs.extend(() for _ in range(len(kwargs) - len(inputs)))
+    elif len(kwargs) < len(inputs):
+        kwargs.extend({} for _ in range(len(inputs) - len(kwargs)))
+    inputs = tuple(inputs)
+    kwargs = tuple(kwargs)
+    return inputs, kwargs
+
+
+def gather(outputs, target_device, dim=0):
+    r"""
+    Gathers tensors from different GPUs on a specified device.
+    Use 'cpu' for CPU to avoid a deprecation warning.
+    """
+
+    def gather_map(outputs):
+        out = outputs[0]
+        if isinstance(out, flow.Tensor):
+            # Gather.forward need flow.Tensor format
+            return Gather.apply(flow.tensor(target_device), flow.tensor(dim), *outputs)
+        if out is None:
+            return None
+        if isinstance(out, dict):
+            if not all(len(out) == len(d) for d in outputs):
+                raise ValueError("All dicts must have the same number of keys")
+            return type(out)((k, gather_map([d[k] for d in outputs])) for k in out)
+        if _is_namedtuple(out):
+            return type(out)._make(map(gather_map, zip(*outputs)))
+        return type(out)(map(gather_map, zip(*outputs)))
+
+    # Recursive function calls like this create reference cycles.
+    # Setting the function to None clears the refcycle.
+    try:
+        res = gather_map(outputs)
+    finally:
+        gather_map = None
+    return res

--- a/python/oneflow/test/modules/test_dp.py
+++ b/python/oneflow/test/modules/test_dp.py
@@ -1,0 +1,372 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+import itertools
+import numpy as np
+from itertools import repeat
+
+import oneflow as flow
+import oneflow.nn as nn
+from oneflow.nn.parallel import comm
+import oneflow.unittest
+from oneflow.test_utils.automated_test_util import *
+
+TEST_CUDA = flow.cuda.is_available()
+TEST_MULTIGPU = TEST_CUDA and flow.cuda.device_count() >= 2
+"""
+This test unit is referenced from pytorch.
+/pytorch/test/test_cuda.py
+"""
+
+
+@flow.unittest.skip_unless_1n1d()
+class TestDp(flow.unittest.TestCase):
+    def _test_scatter(self, input, chunk_sizes=None, dim=0):
+        if not TEST_MULTIGPU:
+            raise unittest.SkipTest("only one GPU detected")
+        if chunk_sizes is None:
+            ref_chunk_sizes = tuple(repeat(input.size(dim) // 2, 2))
+        else:
+            ref_chunk_sizes = chunk_sizes
+
+        # test regular
+        result = comm.scatter(input, (0, 1), chunk_sizes, dim)
+        self.assertEqual(len(result), 2)
+        chunk_start = 0
+        for i, r in enumerate(result):
+            chunk_end = chunk_start + ref_chunk_sizes[i]
+            index = [slice(None, None) for _ in range(input.dim())]
+            index[dim] = slice(chunk_start, chunk_end)
+            self.assertTrue(
+                flow.allclose(r.cpu(), input[tuple(index)].cpu(), atol=0, rtol=0)
+            )
+            # self.assertEqual(r, input[tuple(index)], atol=0, rtol=0)
+            chunk_start = chunk_end
+            # if r.device == input.device:
+            #     self.assertEqual(r.data_ptr(), input.data_ptr())  # for target @ same device, a view should be returned
+
+        # test out
+        out = [flow.empty_like(t) for t in result]
+        result = comm.scatter(input, dim=dim, out=out)
+        self.assertEqual(len(result), 2)
+        chunk_start = 0
+        for i, r in enumerate(result):
+            self.assertIs(r, out[i])
+            chunk_end = chunk_start + ref_chunk_sizes[i]
+            index = [slice(None, None) for _ in range(input.dim())]
+            index[dim] = slice(chunk_start, chunk_end)
+            self.assertTrue(
+                flow.allclose(r.cpu(), input[tuple(index)].cpu(), atol=0, rtol=0)
+            )
+            # self.assertEqual(r, input[tuple(index)], atol=0, rtol=0)
+            chunk_start = chunk_end
+
+        # test error msg
+        if chunk_sizes is not None:
+            with self.assertRaisesRegex(
+                RuntimeError, r"Expected devices and chunk_sizes to be of same length"
+            ):
+                comm.scatter(
+                    input,
+                    [0 for _ in range(len(chunk_sizes) + 1)],
+                    dim=dim,
+                    chunk_sizes=chunk_sizes,
+                )
+        with self.assertRaisesRegex(RuntimeError, r"'devices' must not be specified"):
+            comm.scatter(input, (0, 1), dim=dim, out=out)
+        with self.assertRaisesRegex(
+            RuntimeError, r"Expected at least one device to scatter to"
+        ):
+            comm.scatter(input, (), dim=dim)
+        with self.assertRaisesRegex(
+            RuntimeError, r"Expected at least one output tensor to scatter to"
+        ):
+            comm.scatter(input, dim=dim, out=[])
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Expected all output tensors to be CUDA tensors, but output tensor at index 0",
+        ):
+            comm.scatter(input, dim=dim, out=([out[0].cpu()] + out[1:]))
+        with self.assertRaisesRegex(
+            RuntimeError, r"Output tensor at index 0 has incorrect shape"
+        ):
+            comm.scatter(input, dim=dim, out=([out[0].unsqueeze(0)] + out[1:]))
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Total size for output tensors along scatter dim does not match",
+        ):
+            index = [slice(None, None) for _ in range(input.dim())]
+            index[dim] = slice(1, None)
+            comm.scatter(input, dim=dim, out=([out[0][tuple(index)]] + out[1:]))
+
+    def test_scatter_cpu(self):
+        self._test_scatter(flow.randn(4, 4), dim=0)
+
+    def test_scatter_cpu_dim(self):
+        self._test_scatter(flow.randn(4, 4), dim=1)
+
+    def test_scatter_cpu_neg_dim(self):
+        self._test_scatter(flow.randn(4, 4), dim=-2)
+
+    def test_scatter_cpu_sizes(self):
+        self._test_scatter(flow.randn(6, 4), chunk_sizes=(2, 4))
+
+    def test_scatter_gpu(self):
+        self._test_scatter(flow.randn(4, 4).cuda(), dim=0)
+
+    def test_scatter_gpu_dim(self):
+        self._test_scatter(flow.randn(4, 4).cuda(), dim=1)
+
+    def test_scatter_gpu_neg_dim(self):
+        self._test_scatter(flow.randn(4, 4).cuda(), dim=-2)
+
+    def test_scatter_gpu_sizes(self):
+        self._test_scatter(flow.randn(6, 4).cuda(), chunk_sizes=(2, 4))
+
+    def _test_broadcast(self, input):
+        if not TEST_MULTIGPU:
+            raise unittest.SkipTest("only one GPU detected")
+        # test regular
+        results = comm.broadcast(input, (0, 1))
+        for i, t in enumerate(results):
+            self.assertEqual(t.get_device(), i)
+            self.assertTrue(flow.allclose(t.cpu(), input.cpu(), atol=0, rtol=0))
+            if (
+                input.is_cuda and input.get_device() == i
+            ):  # test not copying on same device
+                self.assertEqual(id(t), id(input))
+                # self.assertEqual(t.data_ptr(), input.data_ptr())
+        # test out=
+        for inplace in [True, False]:
+            if inplace:
+                outputs = [
+                    flow.empty_like(input, device=flow.device("cuda", 0)),
+                    flow.empty_like(input, device=flow.device("cuda", 1)),
+                ]
+            else:
+                outputs = [
+                    input.cuda(0),
+                    flow.empty_like(input, device=flow.device("cuda", 1)),
+                ]
+            results = comm.broadcast(input, out=outputs)
+            for r, o in zip(results, outputs):
+                self.assertIs(r, o)
+            for i, t in enumerate(results):
+                self.assertEqual(t.get_device(), i)
+                self.assertTrue(flow.allclose(t.cpu(), input.cpu(), atol=0, rtol=0))
+                # self.assertEqual(t, input)
+        # test error msg
+        with self.assertRaisesRegex(
+            RuntimeError, r"Exactly one of 'devices' and 'out'"
+        ):
+            comm.broadcast(input, (0, 1), out=outputs)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Expected all output tensors to be CUDA tensors, but output tensor at index 1",
+        ):
+            comm.broadcast(input, out=[input.cuda(0), input.cpu()])
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Expected all output tensors to have same shape as the source at index 1",
+        ):
+            comm.broadcast(input, out=[input.cuda(0), input.cuda(1).unsqueeze(0)])
+
+    def test_broadcast_cpu(self):
+        self._test_broadcast(flow.randn(5, 5))
+
+    def test_broadcast_gpu(self):
+        self._test_broadcast(flow.randn(5, 5).cuda())
+
+    def _test_broadcast_coalesced(self, tensors, buffer_size):
+        b_tensors = [comm.broadcast(t, (0, 1)) for t in tensors]
+        for (_, bt), t in zip(b_tensors, tensors):
+            self.assertEqual(bt.get_device(), 1)
+            self.assertTrue(flow.allclose(bt.cpu(), t.cpu(), atol=0, rtol=0))
+            # self.assertEqual(bt, t)
+            self.assertIsInstance(bt, type(t))
+
+        bc_tensors = comm.broadcast_coalesced(tensors, (0, 1), buffer_size=buffer_size)
+        bc_tensors_t = list(zip(*bc_tensors))
+        for x, y in zip(bc_tensors_t, b_tensors):
+            for tensor_x, tensor_y in zip(x, y):
+                self.assertTrue(flow.allclose(tensor_x, tensor_y, atol=0, rtol=0))
+        # self.assertEqual(b_tensors, bc_tensors_t)
+        for (_, bt), (_, bct) in zip(b_tensors, bc_tensors_t):
+            self.assertEqual(bt.get_device(), bct.get_device())
+            self.assertIsInstance(bct, type(bt))
+
+        # check that tensors on device[0] are returned as-is
+        for out_tensors in (b_tensors, bc_tensors_t):
+            for inp_t, (out_t, _) in zip(tensors, out_tensors):
+                self.assertIs(inp_t, out_t)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    # Note: fails sometimes on the CI, passes on dual gfx906
+    def test_broadcast_coalesced(self):
+        numel = 5
+        num_bytes = numel * 8
+        tensors = [
+            flow.randn(numel).long().cuda(),
+            flow.randn(numel).cuda(),
+            flow.randn(numel).long().cuda(),
+            flow.randn(numel).long().cuda(),
+            flow.randn(numel * 2).int().cuda(),  # int is 2x shorter
+            flow.randn(numel).cuda(),
+        ]
+        self._test_broadcast_coalesced(tensors, num_bytes * 5 // 2)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    def test_broadcast_coalesced_empty_tensors(self):
+        tensors = [
+            flow.tensor([]).byte().cuda(),
+            flow.randn(5).cuda(),
+            flow.randn(5).double().cuda(),
+        ]
+        self._test_broadcast_coalesced(tensors, 256)
+
+    def _test_gather(self, dim):
+        if not TEST_MULTIGPU:
+            raise unittest.SkipTest("only one GPU detected")
+        x = flow.randn(2, 5, device=flow.device("cuda", 0))
+        y = flow.randn(2, 5, device=flow.device("cuda", 1))
+        expected_size = list(x.size())
+        expected_size[dim] += y.size(dim)
+        expected_size = flow.Size(expected_size)
+
+        destinations = [None, flow.device("cuda:0"), flow.device("cpu")]
+        if flow.cuda.device_count() > 2:
+            destinations.append(flow.device("cuda:2"))
+        # with flow.cuda.device(flow.device('cuda', 1)):
+        for destination in destinations:
+            if destination is None:
+                expected_device = flow.device("cuda", 1)
+            else:
+                expected_device = destination
+            for use_out in [True, False]:
+                if use_out:
+                    out = flow.empty(expected_size, device=expected_device)
+                    result = comm.gather((x, y), dim, out=out)
+                    self.assertIs(out, result)
+                else:
+                    result = comm.gather((x, y), dim, destination=expected_device)
+
+                self.assertEqual(result.device, expected_device)
+                self.assertEqual(result.size(), expected_size)
+
+                index = [slice(None, None), slice(None, None)]
+                index[dim] = slice(0, x.size(dim))
+                self.assertTrue(
+                    flow.allclose(result[tuple(index)].cpu(), x.cpu(), atol=0, rtol=0)
+                )
+                # self.assertEqual(result[tuple(index)], x)
+                index[dim] = slice(x.size(dim), x.size(dim) + y.size(dim))
+                self.assertTrue(
+                    flow.allclose(result[tuple(index)].cpu(), y.cpu(), atol=0, rtol=0)
+                )
+                # self.assertEqual(result[tuple(index)], y)
+
+        # test error msg
+        with self.assertRaisesRegex(
+            RuntimeError, r"'destination' must not be specified"
+        ):
+            comm.gather(
+                (x, y),
+                dim,
+                destination="cpu",
+                out=torch.empty(expected_size, device="cpu"),
+            )
+        with self.assertRaisesRegex(
+            RuntimeError, r"Expected at least one tensor to gather from"
+        ):
+            comm.gather(())
+        with self.assertRaisesRegex(
+            RuntimeError, r"Expected all input tensors to be CUDA tensors, "
+        ):
+            comm.gather((x.cpu(), y))
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Expected all input tensors to have the same number of dimensions",
+        ):
+            comm.gather((x, y.unsqueeze(0)))
+        with self.assertRaisesRegex(
+            RuntimeError, r"Input tensor at index 1 has invalid shape"
+        ):
+            if dim in [0, -2]:
+                comm.gather((x, y[:, 1:]), dim=dim)
+            elif dim in [1, -1]:
+                comm.gather((x, y[1:, :]), dim=dim)
+
+    def test_gather(self):
+        self._test_gather(0)
+
+    def test_gather_dim(self):
+        self._test_gather(1)
+
+    def test_gather_neg_dim(self):
+        self._test_gather(-1)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    def test_reduce_add(self):
+        x = flow.randn(5, 5)
+        y = flow.randn(5, 5)
+        x_cuda = x.cuda(0)
+        y_cuda = y.cuda(1)
+        result = comm.reduce_add((x_cuda, y_cuda))
+        self.assertEqual(result.get_device(), 0)
+        self.assertTrue(flow.allclose(result.cpu(), x + y, atol=0, rtol=0))
+
+    def _test_reduce_add_coalesced(self, tensors, buffer_size):
+        dup_tensors = [tensors, [t.cuda(1) for t in tensors]]
+
+        r_tensors = [comm.reduce_add(t) for t in zip(*dup_tensors)]
+        for r, t in zip(r_tensors, tensors):
+            self.assertEqual(r.device, t.device)
+            self.assertEqual(r.dtype, t.dtype)
+            self.assertTrue(flow.allclose(r, t * 2, atol=0, rtol=0))
+
+        rc_tensors = comm.reduce_add_coalesced(dup_tensors, buffer_size=buffer_size)
+
+        for r, rc in zip(r_tensors, rc_tensors):
+            self.assertEqual(r.device, rc.device)
+            self.assertEqual(r.dtype, rc.dtype)
+            self.assertTrue(flow.allclose(r, rc, atol=0, rtol=0))
+
+        # Since we have both cuda:0 and cuda:1 inputs, the outputs must be new.
+        # We can check that they have different version counters.
+        # NOTE [ Version Counter in comm.*_coalesced ]
+        # versions = [t._version for t in rc_tensors]
+        # for old_version, t in zip(versions, rc_tensors):
+        #     self.assertEqual(t._version, old_version)
+        #     t.zero_()
+        #     self.assertEqual(t._version, old_version + 1)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    def test_reduce_add_coalesced_dense_only(self):
+        numel = 5
+        num_bytes = numel * 8
+        tensors = [
+            flow.randn(numel).long().cuda(),
+            flow.randn(numel).cuda(),
+            flow.randn(numel).long().cuda(),
+            flow.randn(numel).long().cuda(),
+            flow.randn(numel * 2).int().cuda(),  # int is 2x shorter
+            flow.randn(numel).cuda(),
+        ]
+        self._test_reduce_add_coalesced(tensors, num_bytes * 5 // 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
该 PR 主要是用于提供 DataParallel 的相关接口，目前实现了基本前向传播的功能，但是反向传播过程存在问题，一时排查不出什么问题，所以先提了 PR 看看谁是否有相关经验可以提供解决思路。

新增的一些东西主要如下：
1.  增加了 `with torch.cuda.device()` 的用法匹配 torch 
2.  新增了一些 `oneflow.cuda._utils.py`中的设备相关的接口函数，目前这些函数的目录位置还未与 torch 匹配，后续会更改
3.  新增  `oneflow/python/oneflow/nn/parallel` 目录下的文件，主要是服务 `DataParallel` 的接口
4.  新增 一个测试文件 `oneflow/python/oneflow/test/modules/test_dp.py` ，主要用于测试一些接口函数的实现正确性
5.  实现过程仿照了 torch 的实现，相关引用链接和文档后续会添加完善

目前存在的问题主要是数据并行的网络模型计算得到对应的损失值，通过 `loss.backward()` 进行梯度反向回传时，检查网络参数的梯度全为 None。具体描述请见，https://github.com/Oneflow-Inc/OneCloud/issues/185#issuecomment-1413249234