### PR TITLE
Supplement ND SBP signatures for reshape op

### DIFF
--- a/oneflow/core/framework/user_op_registry.cpp
+++ b/oneflow/core/framework/user_op_registry.cpp
@@ -218,6 +218,11 @@ OpRegistry& OpRegistry::SetGetNdSbpSignatureListFn(GetNdSbpSignatureListFn get_n
   return *this;
 }
 
+OpRegistry& OpRegistry::SetEnumerateNdSbpSignaturesFn(EnumerateNdSbpSignaturesFn fn) {
+  result_.enumerate_nd_sbp_signatures_fn = std::move(fn);
+  return *this;
+}
+
 OpRegistry& OpRegistry::SetDumpNdSbpSignatureForOpConfFn(
     Operator::DumpNdSbpSignatureForOpConfFn fn) {
   result_.dump_nd_sbp_signature_for_op_conf_fn = std::move(fn);

--- a/oneflow/core/framework/user_op_registry.h
+++ b/oneflow/core/framework/user_op_registry.h
@@ -64,6 +64,7 @@ using NdSbpInferFn = std::function<Maybe<void>(InferNdSbpFnContext*)>;
 using ComputeComplexityFn = std::function<Maybe<double>(ComputeComplexityFnContext*)>;
 // TODO: set up another context
 using GetNdSbpSignatureListFn = std::function<Maybe<void>(GetNdSbpSignatureListContext*)>;
+using EnumerateNdSbpSignaturesFn = std::function<Maybe<void>(GetNdSbpSignatureListContext*)>;
 
 struct OpRegistryResult {
   OpRegistryResult()
@@ -94,6 +95,7 @@ struct OpRegistryResult {
   NdSbpInferFn nd_sbp_infer_fn;
   ComputeComplexityFn compute_complexity_fn;
   GetNdSbpSignatureListFn get_nd_sbp_list_fn;
+  EnumerateNdSbpSignaturesFn enumerate_nd_sbp_signatures_fn;
   Operator::DumpNdSbpSignatureForOpConfFn dump_nd_sbp_signature_for_op_conf_fn;
 };
 
@@ -143,6 +145,7 @@ class OpRegistry final {
   OpRegistry& SetDeviceAndStreamInferFn(DeviceAndStreamInferFn fn);
   OpRegistry& SetComputeComplexityFn(ComputeComplexityFn fn);
   OpRegistry& SetGetNdSbpSignatureListFn(GetNdSbpSignatureListFn fn);
+  OpRegistry& SetEnumerateNdSbpSignaturesFn(EnumerateNdSbpSignaturesFn fn);
   OpRegistry& SetDumpNdSbpSignatureForOpConfFn(Operator::DumpNdSbpSignatureForOpConfFn fn);
 
   Maybe<OpRegistry&> Finish();

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -506,6 +506,12 @@ Maybe<void> Operator::GetSbpSignaturesIf(
   return Maybe<void>::Ok();
 }
 
+Maybe<void> Operator::EnumerateNdSbpSignatures(
+    const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
+    const ParallelDesc& parallel_desc, std::vector<NdSbpSignature>* nd_sbp_sig_list) const {
+  return Maybe<void>::Ok();
+}
+
 Maybe<void> Operator::GetNdSbpSignatureList(
     const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
     const ParallelDesc& parallel_desc, std::vector<NdSbpSignature>* nd_sbp_sig_list) const {
@@ -536,6 +542,7 @@ Maybe<void> Operator::GetNdSbpSignatureList(
   CHECK_OR_RETURN(nd_sbp_sig_list->empty());
   DfsGetNdSbpSignature(nd_sbp_sig, 0, sbp_dimension, *parallel_desc.hierarchy(),
                        hierarchy_value2sbp_sig_list, nd_sbp_sig_list);
+  EnumerateNdSbpSignatures(LogicalBlobDesc4Ibn, parallel_desc, nd_sbp_sig_list);
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/operator/operator.h
+++ b/oneflow/core/operator/operator.h
@@ -176,6 +176,9 @@ class Operator {
   virtual Maybe<void> GetNdSbpSignatureList(
       const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
       const ParallelDesc& parallel_desc, std::vector<NdSbpSignature>* nd_sbp_sig_list) const;
+  virtual Maybe<void> EnumerateNdSbpSignatures(
+      const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
+      const ParallelDesc& parallel_desc, std::vector<NdSbpSignature>* nd_sbp_sig_list) const;
   virtual Maybe<double> GetComputeComplexity(
       NdSbpSignature* sbp_signature,
       std::function<const BlobDesc&(const std::string& bn)> logical_blob_desc4bn,

--- a/oneflow/core/operator/user_op.cpp
+++ b/oneflow/core/operator/user_op.cpp
@@ -992,6 +992,18 @@ Maybe<void> UserOp::InferNdSbpSignature(
   return Maybe<void>::Ok();
 }
 
+Maybe<void> UserOp::EnumerateNdSbpSignatures(
+    const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
+    const ParallelDesc& parallel_desc, std::vector<NdSbpSignature>* nd_sbp_sig_list) const {
+  if (val_->enumerate_nd_sbp_signatures_fn) {
+    UserOpGetNdSbpSignatureListContext user_op_get_nd_sbp_list_context(
+        this, LogicalBlobDesc4Ibn, parallel_desc, nd_sbp_sig_list);
+    return val_->enumerate_nd_sbp_signatures_fn(&user_op_get_nd_sbp_list_context);
+  }
+  JUST(Operator::EnumerateNdSbpSignatures(LogicalBlobDesc4Ibn, parallel_desc, nd_sbp_sig_list));
+  return Maybe<void>::Ok();
+}
+
 Maybe<void> UserOp::GetNdSbpSignatureList(
     const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
     const ParallelDesc& parallel_desc, std::vector<NdSbpSignature>* nd_sbp_sig_list) const {

--- a/oneflow/core/operator/user_op.h
+++ b/oneflow/core/operator/user_op.h
@@ -69,6 +69,10 @@ class UserOp final : public Operator {
       const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
       const ParallelDesc& parallel_desc,
       std::vector<NdSbpSignature>* nd_sbp_sig_list) const override;
+  Maybe<void> EnumerateNdSbpSignatures(
+      const std::function<Maybe<const BlobDesc&>(const std::string&)>& LogicalBlobDesc4Ibn,
+      const ParallelDesc& parallel_desc,
+      std::vector<NdSbpSignature>* nd_sbp_sig_list) const override;
   Maybe<void> InferOpTimeShape(
       const std::function<Maybe<const Shape>(const std::string&)>& GetTimeShape4BnInOp,
       std::shared_ptr<const Shape>* time_shape) const override;

--- a/oneflow/ir/include/OneFlow/OneFlowBase.td
+++ b/oneflow/ir/include/OneFlow/OneFlowBase.td
@@ -89,6 +89,7 @@ class OneFlow_BaseOp<string mnemonic, list<Trait> traits = []> :
   bit has_nd_sbp_infer_fn = 0;
   bit has_compute_complexity_fn = 0;
   bit has_get_nd_sbp_fn = 0;
+  bit has_enumerate_nd_sbp_signatures_fn = 0;
   bit has_dump_nd_sbp_signature_for_op_conf_fn = 0;
 }
 

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -8195,6 +8195,7 @@ def OneFlow_ReshapeOp : OneFlow_BaseOp<"reshape", [NoSideEffect, DeclareOpInterf
   let has_logical_tensor_desc_infer_fn = 1;
   let has_physical_tensor_desc_infer_fn = 1;
   let has_get_sbp_fn = 1;
+  let has_enumerate_nd_sbp_signatures_fn = 1;
   let has_data_type_infer_fn = 1;
   let hasFolder = 1;
 }

--- a/oneflow/user/ops/reshape_op.cpp
+++ b/oneflow/user/ops/reshape_op.cpp
@@ -30,6 +30,11 @@ namespace oneflow {
       in_shape, *outshape, {{"in", 0}}, {{"out", 0}}, ctx->hierarchy_value(), &builder);
 }
 
+/*static*/ Maybe<void> ReshapeOp::EnumerateNdSbpSignatures(
+    user_op::GetNdSbpSignatureListContext* ctx) {
+  return Maybe<void>::Ok();
+}
+
 /*static*/ Maybe<void> ReshapeOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
   Shape shape = ctx->Attr<Shape>("shape");
   const user_op::TensorDesc& in_tensor_desc = ctx->InputTensorDesc("in", 0);

--- a/oneflow/user/ops/reshape_op.cpp
+++ b/oneflow/user/ops/reshape_op.cpp
@@ -32,6 +32,13 @@ namespace oneflow {
 
 /*static*/ Maybe<void> ReshapeOp::EnumerateNdSbpSignatures(
     user_op::GetNdSbpSignatureListContext* ctx) {
+  const Shape& in_shape = ctx->BlobShape4InputArgNameAndIndex("in", 0);
+  const Shape& shape = ctx->Attr<Shape>("shape");
+  const Shape& out_shape = *JUST(ReshapeUserOpUtil::GetLogicalOutBlobShape(in_shape, shape));
+  std::vector<NdSbpSignature> nd_sbp_sig_list;
+  JUST(ReshapeUserOpUtil::EnumerateNdSbpSignatures({{"in", 0}}, in_shape, {{"out", 0}}, out_shape,
+                                                   ctx->parallel_hierarchy(), &nd_sbp_sig_list));
+  for (auto& nd_sbp_sig : nd_sbp_sig_list) { ctx->AddNdSbpSignature(nd_sbp_sig); }
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/user/ops/reshape_user_op_util.h
+++ b/oneflow/user/ops/reshape_user_op_util.h
@@ -33,6 +33,14 @@ struct ReshapeUserOpUtil {
                                                    const std::vector<user_op::OpArg>& out_args,
                                                    const int64_t hierarchy_value,
                                                    user_op::UserOpSbpSignatureBuilder* builder);
+  static Maybe<void> EnumerateNdSplitInAxis2OutAxis(
+      const Shape& in_shape, const Shape& out_shape, const Shape& rank_mesh,
+      std::vector<std::vector<std::pair<int, int>>>* in2out_axis);
+  static Maybe<void> EnumerateNdSbpSignatures(const std::vector<user_op::OpArg>& in_args,
+                                              const Shape& in_shape,
+                                              const std::vector<user_op::OpArg>& out_args,
+                                              const Shape& out_shape, const Shape& rank_mesh,
+                                              std::vector<NdSbpSignature>* nd_sbp_sig_list);
 };
 }  // namespace oneflow
 

--- a/oneflow/user/ops/reshape_user_op_util_test.cpp
+++ b/oneflow/user/ops/reshape_user_op_util_test.cpp
@@ -1,0 +1,79 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/user/ops/reshape_user_op_util.h"
+
+#include <gtest/gtest.h>
+
+namespace oneflow {
+namespace test {
+
+namespace {
+
+void TestEnumerateNdSplitInAxis2OutAxis(
+    const Shape& in_shape, const Shape& out_shape, const Shape& rank_mesh,
+    const std::vector<std::vector<std::pair<int, int>>>& expected_in2out_axis) {
+  std::vector<std::vector<std::pair<int, int>>> actual_in2out_axis;
+  CHECK_JUST(ReshapeUserOpUtil::EnumerateNdSplitInAxis2OutAxis(in_shape, out_shape, rank_mesh,
+                                                               &actual_in2out_axis));
+  ASSERT_EQ(expected_in2out_axis.size(), actual_in2out_axis.size());
+  for (size_t i = 0; i < expected_in2out_axis.size(); ++i) {
+    const auto& exp_nd_split_axis = expected_in2out_axis[i];
+    const auto& act_nd_split_axis = actual_in2out_axis[i];
+    ASSERT_EQ(exp_nd_split_axis.size(), act_nd_split_axis.size());
+    for (size_t j = 0; j < exp_nd_split_axis.size(); ++j) {
+      ASSERT_EQ(exp_nd_split_axis[j].first, act_nd_split_axis[j].first);
+      ASSERT_EQ(exp_nd_split_axis[j].second, act_nd_split_axis[j].second);
+    }
+  }
+}
+
+}  // namespace
+
+TEST(ReshapeUserOpUtil, EnumerateNdSplitInAxis2OutAxis) {
+  // 2D-split
+  TestEnumerateNdSplitInAxis2OutAxis({4}, {2, 2}, {2, 2}, {{{0, 0}, {0, 1}}});
+  TestEnumerateNdSplitInAxis2OutAxis({12}, {2, 2, 3}, {2, 2}, {{{0, 0}, {0, 1}}});
+  TestEnumerateNdSplitInAxis2OutAxis({2, 4}, {8}, {2, 2}, {{{0, 0}, {1, 0}}});
+  TestEnumerateNdSplitInAxis2OutAxis({2, 1, 4}, {8}, {2, 2}, {{{0, 0}, {2, 0}}});
+  TestEnumerateNdSplitInAxis2OutAxis({8, 2}, {2, 4, 2}, {2, 2}, {{{0, 0}, {0, 1}}});
+  TestEnumerateNdSplitInAxis2OutAxis({8, 1, 2}, {2, 1, 4, 2}, {2, 2}, {{{0, 0}, {0, 2}}});
+  TestEnumerateNdSplitInAxis2OutAxis({3, 2, 3, 5}, {3, 30}, {2, 3}, {{{1, 1}, {2, 1}}});
+  TestEnumerateNdSplitInAxis2OutAxis({2, 4}, {4, 2}, {2, 2}, {{{0, 0}, {1, 0}}});
+  TestEnumerateNdSplitInAxis2OutAxis({4, 2}, {2, 4}, {2, 2}, {{{0, 0}, {0, 1}}});
+  TestEnumerateNdSplitInAxis2OutAxis({4, 3}, {3, 4}, {2, 3}, {});
+  TestEnumerateNdSplitInAxis2OutAxis({2, 6}, {4, 3}, {2, 3}, {});
+  TestEnumerateNdSplitInAxis2OutAxis({2, 2, 5, 4}, {4, 5, 2, 2}, {2, 2},
+                                     {{{0, 0}, {1, 0}}, {{3, 2}, {3, 3}}});
+  // 3D-split
+  TestEnumerateNdSplitInAxis2OutAxis({24}, {2, 4, 3}, {2, 2, 2}, {{{0, 0}, {0, 1}, {0, 1}}});
+  TestEnumerateNdSplitInAxis2OutAxis({3, 24}, {3, 2, 2, 6}, {2, 2, 2}, {{{1, 1}, {1, 2}, {1, 3}}});
+  TestEnumerateNdSplitInAxis2OutAxis({2, 3, 2, 5}, {12, 5}, {2, 3, 2}, {{{0, 0}, {1, 0}, {2, 0}}});
+  TestEnumerateNdSplitInAxis2OutAxis({2, 1, 3, 2, 5}, {12, 1, 5}, {2, 3, 2},
+                                     {{{0, 0}, {2, 0}, {3, 0}}});
+  TestEnumerateNdSplitInAxis2OutAxis({8, 4}, {2, 2, 8}, {2, 2, 2}, {{{0, 0}, {0, 1}, {0, 2}}});
+  TestEnumerateNdSplitInAxis2OutAxis({8, 2, 2}, {2, 2, 4, 2}, {2, 2, 2},
+                                     {{{0, 0}, {0, 1}, {0, 2}}});
+  TestEnumerateNdSplitInAxis2OutAxis({8, 2, 1, 2}, {2, 2, 1, 4, 2}, {2, 2, 2},
+                                     {{{0, 0}, {0, 1}, {0, 3}}});
+  TestEnumerateNdSplitInAxis2OutAxis({6, 4}, {2, 3, 2, 2}, {2, 3, 2}, {{{0, 0}, {0, 1}, {1, 2}}});
+  TestEnumerateNdSplitInAxis2OutAxis({6, 4, 1}, {2, 1, 3, 2, 2}, {2, 3, 2},
+                                     {{{0, 0}, {0, 2}, {1, 3}}});
+  TestEnumerateNdSplitInAxis2OutAxis({6, 5, 4}, {2, 3, 5, 2, 2}, {2, 3, 2},
+                                     {{{0, 0}, {0, 1}, {2, 3}}});
+}
+
+}  // namespace test
+}  // namespace oneflow

--- a/tools/oneflow-tblgen/op_schema_emitter.cpp
+++ b/tools/oneflow-tblgen/op_schema_emitter.cpp
@@ -142,6 +142,7 @@ void OpSchemaEmitter<Target>::run(raw_ostream& os) {
     emitBit(def, "has_output_blob_time_shape_infer_fn", &op);
     emitBit(def, "has_sbp_signature_infer_fn", &op);
     emitBit(def, "has_get_nd_sbp_fn", &op);
+    emitBit(def, "has_enumerate_nd_sbp_signatures_fn", &op);
     emitBit(def, "has_dump_nd_sbp_signature_for_op_conf_fn", &op);
     emitBit(def, "has_compute_complexity_fn", &op);
     emitBit(def, "has_check_fn", &op);

--- a/tools/oneflow-tblgen/op_schema_header.inc
+++ b/tools/oneflow-tblgen/op_schema_header.inc
@@ -51,6 +51,9 @@ class {{opname}} : public OpDefinition<{{opname}}> {
   {% if op.has_get_nd_sbp_fn -%}
   static Maybe<void> GetNdSbpSignatureList(user_op::GetNdSbpSignatureListContext* ctx);
   {% endif -%}
+  {% if op.has_enumerate_nd_sbp_signatures_fn -%}
+  static Maybe<void> EnumerateNdSbpSignatures(user_op::GetNdSbpSignatureListContext* ctx);
+  {% endif -%}
   {% if op.has_dump_nd_sbp_signature_for_op_conf_fn -%}
   static Maybe<void> DumpNdSbpSignatureForOpConfFn(const NdSbpSignature& nd_sbp_sig, OperatorConf* op_conf);
   {% endif -%}

--- a/tools/oneflow-tblgen/op_schema_source.inc
+++ b/tools/oneflow-tblgen/op_schema_source.inc
@@ -79,6 +79,9 @@ REGISTER_USER_OP("{{op.name}}")
 {%- if op.has_get_nd_sbp_fn -%}
     .SetGetNdSbpSignatureListFn(&{{opname}}::GetNdSbpSignatureList)
 {%- endif -%}
+{%- if op.has_enumerate_nd_sbp_signatures_fn -%}
+    .SetEnumerateNdSbpSignaturesFn(&{{opname}}::EnumerateNdSbpSignatures)
+{%- endif -%}
 {%- if op.has_dump_nd_sbp_signature_for_op_conf_fn -%}
     .SetDumpNdSbpSignatureForOpConfFn(&{{opname}}::DumpNdSbpSignatureForOpConfFn)
 {%- endif -%}


### PR DESCRIPTION
对于绝大多数 op 来说，我们只需要列举其可能支持的 1-D SBP signatures，在 2-D (可推及到 ND) 时，对其 1-D SBP signature list 做叉积即可得到 2-D SBP signature list。

但 reshape op 某些情况就属于例外，见如下的例子：

```
(8, 4) reshape to (2, 4, 4)
with 2x2 ranks, has the 1-D sbp signatrue list as below:
  S(0) -> S(0)
  S(1) -> S(2)
by cross product, get the 2-D sbp signatrue list as below:
  [S(0), S(1)] -> [S(0), S(2)]
  [S(1), S(0)] -> [S(2), S(0)]  (will bring huge comm cost, ignore it in later discuss)
but below 2-D sbp signatrue is supported too:
  [S(0), S(0)] -> [S(0), S(1)]
```

从上面的例子中可以发现一个规律：**高维的 SBP signatures 不能完全由低维组合而来**。

基于以上理由，为 op 提供一个新的重载函数 **EnumerateNdSbpSignatures**：其会在 1-D SBP signatures 被列举完后，并由 1-D 叉积产生了 2-D SBP signature list 后被调用。作为当 1-D 叉积不能产生全部的 2-D SBP signatures 的情况，来额外补充 2-D SBP signatures 的一种手段。

为 reshape 实现了 EnumerateNdSbpSignatures，规则简单来说就是，找到那些被 reshape 的 dimension，从高到低连续按 rank num 切分，直到失败，或者能均匀切到每个 rank 上（从高到底是为了保证切分连续性）。

EnumerateNdSbpSignatures 与已有的 **GetNdSbpSignatureList** 重载区别是：EnumerateNdSbpSignatures 是在 1-D SBP signatures 叉积之后的额外补充。而 GetNdSbpSignatureList 是完全重载 2-D SBP signatures 的列举逻辑，不会包含 1-D SBP 的叉积生成，其主要作用是为了 source op，用户可以直接通过 attr 来设置输出的 sbp，而无需推导。
