### PR TITLE
Fix bug of the sum priority ratio

### DIFF
--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -766,7 +766,7 @@ Maybe<void> Operator::GreedilyFindMinCopyCostNdSbp(
     for (int32_t i = 0; i < nd_sbp_sig_list.size(); ++i) {
       double total_copy_cost = 0.0;
       double sum_priority_ratio = 0.0;
-      // The initial ratio do not need to be a large one. 
+      // The initial ratio do not need to be a large one.
       // Since any copy cost less than infinity would reset the min_sum_priority_ratio.
       double min_sum_priority_ratio = 0.0;
       bool same_sbp_before_reduce = true;

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include <utility>
+#include "oneflow/core/auto_parallel/algorithm_util.h"
 #include "oneflow/core/common/balanced_splitter.h"
 #include "oneflow/core/common/container_util.h"
 #include "oneflow/core/common/decorator.h"
@@ -810,11 +811,12 @@ Maybe<void> Operator::GreedilyFindMinCopyCostNdSbp(
         break;
       }
       // Otherwise, select the case with the lowest cost
-      if (total_copy_cost < min_copy_cost
-          || (total_copy_cost == min_copy_cost && sum_priority_ratio < min_sum_priority_ratio)) {
+      if (total_copy_cost < min_copy_cost * kFloatDeviationMinus      // Strict less than
+          || (total_copy_cost <= min_copy_cost * kFloatDeviationPlus  // Loose equal
+              && sum_priority_ratio < min_sum_priority_ratio)) {
         select_sbp_idx = i;
         min_copy_cost = total_copy_cost;
-        min_sum_priority_ratio = sum_priority_ratio;
+        min_sum_priority_ratio = sum_priority_ratio;  // NOLINT(clang-analyzer-deadcode.DeadStores)
       }
     }
     // Can't find any available sbp

--- a/oneflow/core/operator/operator.cpp
+++ b/oneflow/core/operator/operator.cpp
@@ -766,6 +766,9 @@ Maybe<void> Operator::GreedilyFindMinCopyCostNdSbp(
     for (int32_t i = 0; i < nd_sbp_sig_list.size(); ++i) {
       double total_copy_cost = 0.0;
       double sum_priority_ratio = 0.0;
+      // The initial ratio do not need to be a large one. 
+      // Since any copy cost less than infinity would reset the min_sum_priority_ratio.
+      double min_sum_priority_ratio = 0.0;
       bool same_sbp_before_reduce = true;
       for (int32_t ibn_id = 0; ibn_id < input_bns().size(); ibn_id++) {
         const auto& ibn = input_bns().at(ibn_id);
@@ -807,9 +810,11 @@ Maybe<void> Operator::GreedilyFindMinCopyCostNdSbp(
         break;
       }
       // Otherwise, select the case with the lowest cost
-      if (total_copy_cost <= min_copy_cost) {
+      if (total_copy_cost < min_copy_cost
+          || (total_copy_cost == min_copy_cost && sum_priority_ratio < min_sum_priority_ratio)) {
         select_sbp_idx = i;
         min_copy_cost = total_copy_cost;
+        min_sum_priority_ratio = sum_priority_ratio;
       }
     }
     // Can't find any available sbp


### PR DESCRIPTION
@leaves-zwx 在测试时发现 SBP_INFER_RULE_TAG = 2时有时候挑不到all match 的sbp。
这里打了一个补丁，会在启用 match as much as possible时挑选最match的情形