### PR TITLE
add macro EXPECT

### DIFF
--- a/oneflow/core/common/expect.h
+++ b/oneflow/core/common/expect.h
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef ONEFLOW_CORE_COMMON_EXPECT_H_
+#define ONEFLOW_CORE_COMMON_EXPECT_H_
+
+#include "oneflow/core/common/throw.h"
+
+#define EXPECT(expr) \
+  if (!(expr)) THROW(CheckFailedError)
+
+#define EXPECT_EQ(lhs, rhs) EXPECT((lhs) == (rhs))
+#define EXPECT_NE(lhs, rhs) EXPECT((lhs) != (rhs))
+#define EXPECT_LT(lhs, rhs) EXPECT((lhs) < (rhs))
+#define EXPECT_LE(lhs, rhs) EXPECT((lhs) <= (rhs))
+#define EXPECT_GT(lhs, rhs) EXPECT((lhs) > (rhs))
+#define EXPECT_GE(lhs, rhs) EXPECT((lhs) >= (rhs))
+#define EXPECT_ISNULL(expr) EXPECT((expr) == nullptr)
+#define EXPECT_NOTNULL(expr) EXPECT((expr) != nullptr)
+#define EXPECT_STREQ(lhs, rhs) EXPECT(std::string(lhs) == std::string(rhs))
+#define EXPECT_STRNE(lhs, rhs) EXPECT(std::string(lhs) != std::string(rhs))
+
+#endif  // ONEFLOW_CORE_COMMON_EXPECT_H_

--- a/oneflow/user/ops/matmul_op.cpp
+++ b/oneflow/user/ops/matmul_op.cpp
@@ -286,7 +286,7 @@ Maybe<double> GetComputationCost(user_op::ComputeComplexityFnContext* ctx) {
     // Then we emplace back m, n -> C(16, 8, 4, 6)
     const int64_t a_batch_dim = GetABatchDim(i);
     const int64_t b_batch_dim = GetBBatchDim(i);
-    CHECK(((a_batch_dim != 1 && b_batch_dim == 1) || (a_batch_dim == 1 && b_batch_dim != 1)
+    EXPECT(((a_batch_dim != 1 && b_batch_dim == 1) || (a_batch_dim == 1 && b_batch_dim != 1)
            || (a_batch_dim == b_batch_dim)))
         << "Batch Dims could not broadcast, please check. ";
     out_dim_vec[i] = std::max(a_batch_dim, b_batch_dim);

--- a/oneflow/user/ops/matmul_op.cpp
+++ b/oneflow/user/ops/matmul_op.cpp
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include "oneflow/core/common/expect.h"
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/core/framework/op_generated.h"
 


### PR DESCRIPTION
背景：https://github.com/Oneflow-Inc/OneTeam/issues/1384#issuecomment-1159933519

实现：把 THROW(CheckFailedError) 包了一层，定义为宏 EXPECT

使用 CHECK 条件不满足时，报错信息如下
```
(base) ➜  build-py39-cu114 git:(add_macro_expect) python3 /workspace/temp/test.py
F20230223 15:53:40.118029 1664625 matmul_op.cpp:290] Check failed: ((a_batch_dim != 1 && b_batch_dim == 1) || (a_batch_dim == 1 && b_batch_dim != 1) || (a_batch_dim == b_batch_dim)) Batch Dims could not broadcast, please check.
*** Check failure stack trace: ***
    @     0x7f60973fb03c  google::LogMessageFatal::~LogMessageFatal()
    @     0x7f60c60ca7c7  oneflow::BroadcastMatmulOp::InferLogicalTensorDesc()
    @     0x7f60c60cb849  oneflow::BroadcastMatmulOp::InferPhysicalTensorDesc()
    @     0x7f6177b5734c  std::_Function_handler<>::_M_invoke()
    @     0x7f60c2077868  oneflow::one::UserOpExpr::InferPhysicalTensorDesc()
    @     0x7f60c2010231  oneflow::one::LocalTensorInferCache::Infer()
    @     0x7f60c20138a2  oneflow::one::LocalTensorInferCache::GetOrInfer()
    @     0x7f60c20aa59d  oneflow::one::NaiveInterpret()
    @     0x7f60c20b6095  oneflow::one::EagerLocalInterpreter::ApplyImpl()
    @     0x7f60c212c469  oneflow::one::EagerInterpreter::Apply()
    @     0x7f60c212ce6f  oneflow::one::AutogradInterpreter::Apply()
    @     0x7f60c2131868  oneflow::one::OpInterpUtil::Dispatch()
    @     0x7f60c21309b7  oneflow::one::OpInterpUtil::Dispatch<>()
    @     0x7f60c213305c  oneflow::one::OpInterpUtil::Dispatch<>()
    @     0x7f617814a474  oneflow::one::OpInterpUtil::Dispatch<>()
    @     0x7f60c2867125  oneflow::one::functional::impl::MatMulFunctor::operator()()
    @     0x7f60c2864f29  _ZNSt17_Function_handlerIFN7oneflow5MaybeINS0_3one6TensorEvEERKSt10shared_ptrIS3_ES8_RKbSA_RKdEZNS2_10functional18PackedFunctorMakerISD_E4makeINSE_4impl13MatMulFunctorELi0EEENSE_13PackedFunctorISD_EERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKT_EUlS8_S8_SA_SA_SC_E_E9_M_invokeERKSt9_Any_dataS8_S8_SA_SA_SC_
    @     0x7f60c6326523  oneflow::one::functional::MatMul()
    @     0x7f6177d13e12  oneflow::one::functional::matmul()
    @     0x7f61780cc274  oneflow::one::PyTensorObject_nb_matrix_multiply()
    @     0x5557a4115509  binary_op
    @     0x5557a41b0051  _PyEval_EvalFrameDefault
    @     0x5557a416d663  _PyEval_EvalCode
    @     0x5557a421a45c  PyEval_EvalCodeEx
    @     0x5557a416e45b  PyEval_EvalCode
    @     0x5557a421a50b  run_eval_code_obj
    @     0x5557a424af75  run_mod
    @     0x5557a40eb987  pyrun_file.cold.3080
    @     0x5557a4250a2f  PyRun_SimpleFileExFlags
    @     0x5557a425110b  Py_RunMain
    @     0x5557a4251309  Py_BytesMain
    @     0x7f61788b7083  __libc_start_main
[1]    1664625 abort (core dumped)  python3 /workspace/temp/test.py
```

使用 EXPECT 条件不满足时，报错信息如下
```
(base) ➜  build-py39-cu114 git:(add_macro_expect) ✗ python3 /workspace/temp/test.py
Traceback (most recent call last):
  File "/workspace/temp/test.py", line 4, in <module>
    x @ y
RuntimeError: Batch Dims could not broadcast, please check.
  File "/workspace/oneflow_main/oneflow/oneflow/user/ops/matmul_op.cpp", line 290, in InferLogicalTensorDesc

Error Type: oneflow.ErrorProto.check_failed_error
```

源代码：
```
(base) ➜  build-py39-cu114 git:(add_macro_expect) ✗ cat /workspace/temp/test.py
import oneflow as flow
x = flow.randn(2, 3, 3)
y = flow.randn(3, 3, 3)
x @ y
```