### PR TITLE
refactor and remove order_in_graph

### DIFF
--- a/oneflow/core/graph/plan_task_graph.cpp
+++ b/oneflow/core/graph/plan_task_graph.cpp
@@ -19,11 +19,6 @@ limitations under the License.
 
 namespace oneflow {
 
-int64_t PlanTaskNode::chain_id() const {
-  int64_t chain_id = task_proto_->task_set_info().chain_id();
-  return chain_id;
-}
-
 PlanTaskGraph::PlanTaskGraph(const Plan& plan) : plan_(&plan) {
   InitNodes();
   InitEdges();

--- a/oneflow/core/graph/plan_task_graph.h
+++ b/oneflow/core/graph/plan_task_graph.h
@@ -38,8 +38,8 @@ class PlanTaskNode final : public Node<PlanTaskNode, PlanTaskEdge> {
 
   const TaskProto* task_proto() const { return task_proto_; }
   int64_t task_id() const { return task_proto_->task_id(); }
-  int64_t chain_id() const;
-  int64_t order_in_graph() const { return task_proto_->task_set_info().order_in_graph(); }
+  int64_t chain_id() const { return task_proto_->chain_id(); }
+  int64_t order_in_chain() const { return task_proto_->order_in_chain(); }
 
  private:
   const TaskProto* task_proto_;

--- a/oneflow/core/graph/straighten_nodes.cpp
+++ b/oneflow/core/graph/straighten_nodes.cpp
@@ -413,7 +413,6 @@ void UpdateSat(const HashMap<TaskNode*, TopoStruct>& task_node2topo_struct) {
 
 void StraightenNodes(TaskGraph* task_graph, std::vector<TaskNode*>* ordered_task_nodes) {
   // The function for settle the order in the graph
-  int64_t order_in_graph = 0;
 
   // Generate topological data structure for each task node
   HashMap<TaskNode*, TopoStruct> task_node2topo_struct;
@@ -522,11 +521,7 @@ void StraightenNodes(TaskGraph* task_graph, std::vector<TaskNode*>* ordered_task
 
   std::vector<int32_t> remain_task_nums(num_classifier, 0);
 
-  auto SetOrderInGraph = [&](TaskNode* task_node) {
-    task_node->set_order_in_graph(order_in_graph);
-    ordered_task_nodes->emplace_back(task_node);
-    ++order_in_graph;
-  };
+  auto SetOrderInGraph = [&](TaskNode* task_node) { ordered_task_nodes->emplace_back(task_node); };
 
   // wait in the list
   auto wait = [&](TaskNode* node) {

--- a/oneflow/core/graph/task_graph.h
+++ b/oneflow/core/graph/task_graph.h
@@ -91,7 +91,7 @@ class TaskGraph : public Graph<TaskNode, TaskEdge> {
 
   void ConnectCtrlEdge(CompTaskNode* src_task_node, CompTaskNode* dst_task_node);
 
-  void SetOrderInGraphForEachNode();
+  void InitOrderedTaskNodes();
   void MergeChainByPhysicalTaskGraph();
   void MergeChainByLogicalChainId();
   void BuildCtrlRegstDescInSameChain();

--- a/oneflow/core/graph/task_node.cpp
+++ b/oneflow/core/graph/task_node.cpp
@@ -41,7 +41,7 @@ void ForEachDataEdge(const std::unordered_set<TaskEdge*>& edges,
 }  // namespace
 
 TaskNode::TaskNode()
-    : machine_id_(-1), thrd_id_(-1), task_id_(-1), chain_id_(-1), order_in_graph_(-1) {}
+    : machine_id_(-1), thrd_id_(-1), task_id_(-1), chain_id_(-1), order_in_chain_(-1) {}
 
 std::shared_ptr<RegstDesc> TaskNode::GetProducedRegst(const std::string& name) {
   auto produced_regsts_it = produced_regsts_.find(name);
@@ -89,9 +89,9 @@ void TaskNode::set_chain_id(int64_t val) {
   chain_id_ = val;
 }
 
-void TaskNode::set_order_in_graph(int64_t val) {
-  CHECK_EQ(order_in_graph_, -1);
-  order_in_graph_ = val;
+void TaskNode::set_order_in_chain(int64_t val) {
+  CHECK_EQ(order_in_chain_, -1);
+  order_in_chain_ = val;
 }
 
 void TaskNode::PinConsumedRegst() {
@@ -211,8 +211,8 @@ void TaskNode::InitFromProtoExceptConsumedRegsts(const TaskProto& task_proto) {
   task_id_ = task_proto.task_id();
   new_task_id_.reset(new TaskId(DecodeTaskIdFromInt64(task_id_)));
   CHECK(task_proto.job_id() == GlobalJobDesc().job_id());
-  chain_id_ = task_proto.task_set_info().chain_id();
-  order_in_graph_ = task_proto.task_set_info().order_in_graph();
+  chain_id_ = task_proto.chain_id();
+  order_in_chain_ = task_proto.order_in_chain();
   // Step2: check exec_gph empty.
   CHECK(task_proto.exec_sequence().exec_node().empty());
   // Step3: init produced_regst.
@@ -243,8 +243,8 @@ void TaskNode::ToProto(TaskProto* task_proto, bool check) const {
   task_proto->set_thrd_id(thrd_id_);
   task_proto->set_task_id(task_id_);
   task_proto->set_job_id(GlobalJobDesc().job_id());
-  task_proto->mutable_task_set_info()->set_chain_id(chain_id_);
-  task_proto->mutable_task_set_info()->set_order_in_graph(order_in_graph_);
+  task_proto->set_chain_id(chain_id_);
+  task_proto->set_order_in_chain(order_in_chain_);
 
   // Step2: process exec_gph.
   exec_gph_.ToExecSequence(parallel_ctx(), task_proto->mutable_exec_sequence());

--- a/oneflow/core/graph/task_node.h
+++ b/oneflow/core/graph/task_node.h
@@ -58,7 +58,7 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
   int64_t task_id() const { return task_id_; }
   const StreamId& stream_id() const;
   int64_t chain_id() const { return chain_id_; }
-  int64_t order_in_graph() const { return order_in_graph_; }
+  int64_t order_in_chain() const { return order_in_chain_; }
   const ExecGraph& exec_gph() const { return exec_gph_; }
   std::shared_ptr<RegstDesc> GetProducedRegst(const std::string& name);
   const std::list<std::shared_ptr<RegstDesc>>& GetConsumedRegst(const std::string& name);
@@ -78,7 +78,7 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
   void set_machine_id(int64_t val);
   void set_thrd_id(int64_t val);
   void set_chain_id(int64_t val);
-  void set_order_in_graph(int64_t val);
+  void set_order_in_chain(int64_t val);
 
   // Build
   virtual void ProduceAllRegstsAndBindEdges() = 0;
@@ -162,7 +162,7 @@ class TaskNode : public Node<TaskNode, TaskEdge> {
   int64_t thrd_id_;
   int64_t task_id_;
   int64_t chain_id_;
-  int64_t order_in_graph_;
+  int64_t order_in_chain_;
   std::unique_ptr<TaskId> new_task_id_;
 
   ExecGraph exec_gph_;

--- a/oneflow/core/job/intra_job_mem_sharing_util.cpp
+++ b/oneflow/core/job/intra_job_mem_sharing_util.cpp
@@ -90,11 +90,10 @@ void InitMemoryChains(Plan* plan,
     DeviceType device_type = stream_id.device_id().device_type();
     // TODO(zwx): eliminate this special 'is cpu' determine
     if (device_type == DeviceType::kCPU) { continue; }
-    if (!IsValidChainId(task->task_set_info().chain_id())) { continue; }
+    if (!IsValidChainId(task->chain_id())) { continue; }
     int64_t device_id = stream_id.device_id().device_index();
     int64_t device_unique_id = GenDeviceUniqueId(machine_id, device_id);
-    MemoryChain* mem_chain =
-        &((*device2chain2mem_chain)[device_unique_id][task->task_set_info().chain_id()]);
+    MemoryChain* mem_chain = &((*device2chain2mem_chain)[device_unique_id][task->chain_id()]);
     mem_chain->sorted_tasks.emplace_back(task);
     for (auto& pair : *(task->mutable_produced_regst_desc())) {
       RegstDescProto* regst_desc = &pair.second;
@@ -130,36 +129,13 @@ void InitMemoryChains(Plan* plan,
       MemoryChain* mem_chain = &pair.second;
       std::sort(mem_chain->sorted_tasks.begin(), mem_chain->sorted_tasks.end(),
                 [&](const TaskProto* lhs, const TaskProto* rhs) {
-                  int64_t lhs_order_in_graph = lhs->task_set_info().order_in_graph();
-                  int64_t rhs_order_in_graph = rhs->task_set_info().order_in_graph();
-                  CHECK_NE(lhs_order_in_graph, rhs_order_in_graph);
-                  return lhs_order_in_graph < rhs_order_in_graph;
+                  int64_t lhs_order_in_chain = lhs->order_in_chain();
+                  int64_t rhs_order_in_chain = rhs->order_in_chain();
+                  CHECK_NE(lhs_order_in_chain, rhs_order_in_chain);
+                  return lhs_order_in_chain < rhs_order_in_chain;
                 });
     }
   }
-}
-
-bool TryMergeMemChain2MergedChains(
-    std::vector<MemoryChain*>* merged_chains, MemoryChain* mem_chain,
-    const std::function<bool(const MemoryChain*, const MemoryChain*)>& IsStrictOrderL2R) {
-  Shape meta_shape({1, 1});
-  std::sort(merged_chains->begin(), merged_chains->end(), [&](MemoryChain* lhs, MemoryChain* rhs) {
-    return lhs->total_mem_reused_size > rhs->total_mem_reused_size;
-  });
-  for (MemoryChain* merged_chain : *merged_chains) {
-    if (merged_chain->time_shape == meta_shape && mem_chain->time_shape == meta_shape) {
-      if (IsStrictOrderL2R(merged_chain, mem_chain)) {
-        merged_chain->sorted_tasks.insert(merged_chain->sorted_tasks.end(),
-                                          mem_chain->sorted_tasks.begin(),
-                                          mem_chain->sorted_tasks.end());
-        merged_chain->mem_reused_regsts.insert(mem_chain->mem_reused_regsts.begin(),
-                                               mem_chain->mem_reused_regsts.end());
-        merged_chain->total_mem_reused_size += mem_chain->total_mem_reused_size;
-        return true;
-      }
-    }
-  }
-  return false;
 }
 
 bool IsReachableToAnyOtherTask(const TaskProto* src_task, const HashSet<int64_t>& task_ids) {
@@ -192,73 +168,29 @@ void GenMemChainTasksAndRegsts(
   HashMap<int64_t, HashMap<int64_t, MemoryChain>> device2chain2mem_chain;
   InitMemoryChains(plan, &device2chain2mem_chain, mem_reused_regst2size);
 
-  auto TryGetTaskNodeLogicalOpName = [&](const TaskProto* task_proto,
-                                         std::string* op_name) -> bool {
-    if (task_proto->task_type() == TaskType::kNormalForward
-        && task_proto->exec_sequence().exec_node_size() == 1) {
-      *op_name = PlanUtil::GetOpAttribute(plan, task_proto->job_id(),
-                                          task_proto->exec_sequence().exec_node(0).kernel_conf())
-                     .op_conf()
-                     .name();
-      return true;
-    }
-    return false;
-  };
-
-  auto IsStrictOrderL2R = [&](const MemoryChain* lhs, const MemoryChain* rhs) -> bool {
-    const TaskProto* l_chain_sink_task_node = lhs->sorted_tasks.back();
-    const TaskProto* r_chain_source_task_node = rhs->sorted_tasks.front();
-    std::string l_op_name;
-    std::string r_op_name;
-    if (TryGetTaskNodeLogicalOpName(l_chain_sink_task_node, &l_op_name)
-        && TryGetTaskNodeLogicalOpName(r_chain_source_task_node, &r_op_name)) {
-      return IsOpNameDataOrCtrlReachable(l_op_name, r_op_name);
-    }
-    return false;
-  };
-
   int64_t mem_chain_id = 0;
-
-  bool enable_mem_chain_merge =
-      Singleton<ResourceDesc, ForSession>::Get()->resource().enable_mem_chain_merge();
 
   for (auto& device_chain_pair : device2chain2mem_chain) {
     if (device_chain_pair.second.empty()) { continue; }
-    // sort
     std::vector<MemoryChain*> mem_chains;
     mem_chains.reserve(device_chain_pair.second.size());
-    std::vector<MemoryChain*> merged_chains;
     for (auto& pair : device_chain_pair.second) { mem_chains.emplace_back(&pair.second); }
-    std::sort(mem_chains.begin(), mem_chains.end(), [&](MemoryChain* lhs, MemoryChain* rhs) {
-      int64_t lhs_order_in_graph = lhs->sorted_tasks.front()->task_set_info().order_in_graph();
-      int64_t rhs_order_in_graph = rhs->sorted_tasks.front()->task_set_info().order_in_graph();
-      CHECK_NE(lhs_order_in_graph, rhs_order_in_graph);
-      return lhs_order_in_graph < rhs_order_in_graph;
-    });
-    if (enable_mem_chain_merge) {
-      for (MemoryChain* mem_chain : mem_chains) {
-        if (!TryMergeMemChain2MergedChains(&merged_chains, mem_chain, IsStrictOrderL2R)) {
-          merged_chains.emplace_back(mem_chain);
-        }
-      }
-    } else {
-      merged_chains.swap(mem_chains);
-    }
-    for (MemoryChain* merged_chain : merged_chains) {
+
+    for (MemoryChain* mem_chain : mem_chains) {
       std::vector<TaskProto*>* sorted_tasks = &((*mem_chain2sorted_tasks)[mem_chain_id]);
       CHECK(sorted_tasks->empty());
-      sorted_tasks->insert(sorted_tasks->end(), merged_chain->sorted_tasks.begin(),
-                           merged_chain->sorted_tasks.end());
+      sorted_tasks->insert(sorted_tasks->end(), mem_chain->sorted_tasks.begin(),
+                           mem_chain->sorted_tasks.end());
       std::vector<RegstDescProto*>* mem_reused_regsts =
           &((*mem_chain2mem_reused_regsts)[mem_chain_id]);
       CHECK(mem_reused_regsts->empty());
-      mem_reused_regsts->insert(mem_reused_regsts->end(), merged_chain->mem_reused_regsts.begin(),
-                                merged_chain->mem_reused_regsts.end());
+      mem_reused_regsts->insert(mem_reused_regsts->end(), mem_chain->mem_reused_regsts.begin(),
+                                mem_chain->mem_reused_regsts.end());
       // Merge HashSet mem_chain2mem_reused_regsts and HashMap regst_desc_id2reuse_regst_desc
       auto& regst_desc_id2reuse_regst_desc =
           (*mem_chain2regst_desc_id2reuse_regst_desc)[mem_chain_id];
       CHECK(regst_desc_id2reuse_regst_desc.empty());
-      for (auto& mem_reused_regst : merged_chain->mem_reused_regsts) {
+      for (auto& mem_reused_regst : mem_chain->mem_reused_regsts) {
         regst_desc_id2reuse_regst_desc[mem_reused_regst->regst_desc_id()] = mem_reused_regst;
       }
       ++mem_chain_id;

--- a/oneflow/core/job/plan_util.cpp
+++ b/oneflow/core/job/plan_util.cpp
@@ -250,8 +250,8 @@ void PlanUtil::MergeMemBlockIdByLogicalChainId(Plan* plan, const Job& job, int64
     DeviceType device_type = stream_id.device_id().device_type();
     // TODO(zwx): eliminate this special 'is cpu' determine
     if (device_type == DeviceType::kCPU) { continue; }
-    if (!IsValidChainId(task->task_set_info().chain_id())) { continue; }
-    int64_t logical_chain_id = task->task_set_info().chain_id();
+    if (!IsValidChainId(task->chain_id())) { continue; }
+    int64_t logical_chain_id = task->chain_id();
 
     for (auto& pair : *(task->mutable_produced_regst_desc())) {
       RegstDescProto* regst_desc = &pair.second;
@@ -315,7 +315,7 @@ void PlanUtil::MergeMemBlockIdByLogicalChainId(Plan* plan, const Job& job, int64
     DeviceType device_type = stream_id.device_id().device_type();
     // TODO(zwx): eliminate this special 'is cpu' determine
     if (device_type == DeviceType::kCPU) { continue; }
-    if (!IsValidChainId(task->task_set_info().chain_id())) { continue; }
+    if (!IsValidChainId(task->chain_id())) { continue; }
 
     for (auto& pair : *(task->mutable_produced_regst_desc())) {
       RegstDescProto* regst_desc = &pair.second;
@@ -1116,13 +1116,6 @@ struct RankDeviceMemoryInfo {
 }  // namespace
 
 void PlanUtil::PlanMemoryLog(Plan* plan, const std::string& plan_name) {
-  std::vector<const TaskProto*> ordered_tasks;
-  for (const TaskProto& task : plan->task()) { ordered_tasks.push_back(&task); }
-  auto CompTask = [](const TaskProto* a, const TaskProto* b) {
-    return a->task_set_info().order_in_graph() < b->task_set_info().order_in_graph();
-  };
-  std::sort(ordered_tasks.begin(), ordered_tasks.end(), CompTask);
-
   std::vector<RankDeviceMemoryInfo> rank_device_memory_infos(GlobalProcessCtx::WorldSize(),
                                                              RankDeviceMemoryInfo());
   HashMap<int64_t, MemBlockMemoryInfo> mem_block_id2info;
@@ -1161,8 +1154,8 @@ void PlanUtil::PlanMemoryLog(Plan* plan, const std::string& plan_name) {
     }
   }
 
-  for (const auto* task : ordered_tasks) {
-    for (const auto& pair : task->produced_regst_desc()) {
+  for (const auto& task : plan->task()) {
+    for (const auto& pair : task.produced_regst_desc()) {
       const auto& regst = pair.second;
       if (regst.regst_desc_type().has_data_regst_desc()
           && mem_block_id2info.find(regst.mem_block_id()) != mem_block_id2info.end()) {
@@ -1264,10 +1257,11 @@ void PlanUtil::PlanMemoryLog(Plan* plan, const std::string& plan_name) {
 }
 
 void PlanUtil::GenLightPlan(Plan* plan, const std::string& plan_name, int64_t filter_rank) {
+  // NOTE(chengcheng): ordered_tasks is NOT exec order, just task id order.
   std::vector<const TaskProto*> ordered_tasks;
   for (const TaskProto& task : plan->task()) { ordered_tasks.push_back(&task); }
   auto CompTask = [](const TaskProto* a, const TaskProto* b) {
-    return a->task_set_info().order_in_graph() < b->task_set_info().order_in_graph();
+    return a->task_id() < b->task_id();
   };
   std::sort(ordered_tasks.begin(), ordered_tasks.end(), CompTask);
 
@@ -1352,7 +1346,7 @@ void PlanUtil::GenLightPlan(Plan* plan, const std::string& plan_name, int64_t fi
           << " task_id2name cannot find" << task_id;
       int64_t thrd_id = task->thrd_id();
       StreamId stream_id = DecodeStreamIdFromInt64(thrd_id);
-      file_stream << "order : " << std::to_string(i) << " , actor id : " << std::to_string(task_id)
+      file_stream << " actor id : " << std::to_string(task_id)
                   << " name : " << task_id2name.at(task_id) << " thrd : " << std::to_string(thrd_id)
                   << " device_type : " << DeviceType_Name(stream_id.device_type())
                   << " stream_index : " << std::to_string(stream_id.stream_index()) << " {\n";

--- a/oneflow/core/job/task.proto
+++ b/oneflow/core/job/task.proto
@@ -44,11 +44,6 @@ message RegstDescIdSet {
   repeated int64 regst_desc_id = 1;
 }
 
-message TaskSetInfo {
-  required int64 chain_id = 4;
-  required int64 order_in_graph = 5;
-}
-
 message TaskProto {
   // common
   required TaskType task_type = 1;
@@ -56,11 +51,12 @@ message TaskProto {
   required int64 thrd_id = 3;
   required int64 task_id = 4;
   required int64 job_id = 5;
-  required TaskSetInfo task_set_info = 6;
-  required ExecSequence exec_sequence = 7;
-  map<string, RegstDescProto> produced_regst_desc = 8;
-  map<string, RegstDescIdSet> consumed_regst_desc_id = 9;
-  optional bool all_register_num_eq_one_hint = 10 [default = false];
+  required int64 chain_id = 10;
+  required int64 order_in_chain = 11;
+  required ExecSequence exec_sequence = 20;
+  map<string, RegstDescProto> produced_regst_desc = 30;
+  map<string, RegstDescIdSet> consumed_regst_desc_id = 31;
+  optional bool all_register_num_eq_one_hint = 42 [default = false];
   // compute task
   optional ParallelContext parallel_ctx = 1000; // CompTask
 };

--- a/oneflow/core/job_rewriter/logical_chain_pass.cpp
+++ b/oneflow/core/job_rewriter/logical_chain_pass.cpp
@@ -560,9 +560,11 @@ Maybe<void> LogicalChainPass::Apply(const OpGraph& op_graph, JobBuilder* job_bui
 
   auto InsertLogicalChainId = [&](const std::vector<const OpNode*>& ordered_op_nodes,
                                   const int64_t logical_chain_id) {
+    int64_t order = 0;
     for (const OpNode* op_node : ordered_op_nodes) {
-      CHECK_JUST(MapAt(mut_op_name2conf, op_node->op().op_name()))
-          .set_logical_chain_id(logical_chain_id);
+      auto& conf = CHECK_JUST(MapAt(mut_op_name2conf, op_node->op().op_name()));
+      conf.set_logical_chain_id(logical_chain_id);
+      conf.set_order_in_logical_chain(order++);
     }
   };
 

--- a/oneflow/core/operator/op_conf.proto
+++ b/oneflow/core/operator/op_conf.proto
@@ -398,6 +398,7 @@ message OperatorConf {
   optional string pass_tag = 10;
   optional string loc = 11 [default = ""];
   optional int64 logical_chain_id = 12 [default = -1];
+  optional int64 order_in_logical_chain = 13 [default = -1];
   oneof op_type {
     // system op
     CopyCommNetOpConf copy_comm_net_conf = 106;


### PR DESCRIPTION
修复 order_in_graph 在分离编译下，由于 TaskGraph 不是完整的图（缺少其他 rank 的信息）导致拓扑序失效造成 死锁、内存分配写错的 BUG。

（后续再拆成两个 PR 合并到 master）

移除 order_in_graph，使用 order_in_chain，在分离编译下，logical chain 将 order_in_logical_chain 写入各个 op，从逻辑图上读取 order，跳过物理图的拓扑信息。