### PR TITLE
Add knob ONEFLOW_LINEAR_EMBEDDING_SKIP_INIT

### DIFF
--- a/python/oneflow/nn/modules/linear.py
+++ b/python/oneflow/nn/modules/linear.py
@@ -118,7 +118,7 @@ class Linear(Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        if os.getenv("ONEFLOW_LINEAR_SKIP_INIT", "0") == "1":
+        if os.getenv("ONEFLOW_LINEAR_EMBEDDING_SKIP_INIT", "0") == "1":
             return
         flow.nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
         if self.bias is not None:

--- a/python/oneflow/nn/modules/linear.py
+++ b/python/oneflow/nn/modules/linear.py
@@ -118,6 +118,8 @@ class Linear(Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
+        if os.getenv("ONEFLOW_LINEAR_SKIP_INIT", "0") == "1":
+            return
         flow.nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
         if self.bias is not None:
             (fan_in, _) = _calculate_fan_in_and_fan_out(self.weight)

--- a/python/oneflow/nn/modules/sparse.py
+++ b/python/oneflow/nn/modules/sparse.py
@@ -146,6 +146,8 @@ class Embedding(Module):
         self.sparse = sparse
 
     def reset_parameters(self) -> None:
+        if os.getenv("ONEFLOW_LINEAR_EMBEDDING_SKIP_INIT", "0") == "1":
+            return
         flow.nn.init.normal_(self.weight)
         self._fill_padding_idx_with_zero()
 

--- a/python/oneflow/nn/modules/sparse.py
+++ b/python/oneflow/nn/modules/sparse.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 from typing import List, Optional, Tuple
 
 import oneflow as flow


### PR DESCRIPTION
添加环境变量支持跳过Linear的初始化，有效减少调试推理任务时的初始化时间