### PR TITLE
Fix rand ops that have the same seed in graph and have different seed in checkpointing

### DIFF
--- a/oneflow/core/functional/impl/activation_functor.cpp
+++ b/oneflow/core/functional/impl/activation_functor.cpp
@@ -435,9 +435,6 @@ class GumbelSoftmaxFunctor {
     const int64_t num_axes = in_shape->NumAxes();
 
     const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
-    auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("tau", "seed", "hard");
-    attrs.SetAllAttrs(tau, static_cast<int64_t>(gen->current_seed()), hard);
-
     auto random_tensor =
         JUST(functional::Rand(*in_shape.get(), dtype, device, gen, /*requires_grad=*/false));
     auto gumbel_noise_tensor = JUST(functional::ScalarSub(

--- a/oneflow/core/functional/impl/random_functor.cpp
+++ b/oneflow/core/functional/impl/random_functor.cpp
@@ -37,23 +37,43 @@ class BernoulliFunctor {
   }
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const Symbol<DType>& dtype,
                            const Optional<one::Generator>& generator, const bool& inplace) const {
-    const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
-    auto& bernoulli_attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("dtype", "seed", "p");
+    Optional<Symbol<Device>> device;
+    Optional<Symbol<ParallelDesc>> placement;
+    Optional<Symbol<NdSbp>> nd_sbp;
 
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed = 0;
+    if (x->is_global()) {
+      JUST(CheckDeviceIdsIsValid(JUST(x->parallel_desc())));
+      placement = JUST(x->parallel_desc());
+      nd_sbp = JUST(x->nd_sbp());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
+    } else {
+      device = JUST(x->device());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+    }
+
+    auto& bernoulli_attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("dtype", "seed", "p");
     // p == -1 means bernoulli op doesn't use p to generate random number
-    bernoulli_attrs.SetAllAttrs(dtype->data_type(), static_cast<int64_t>(gen->current_seed()),
+    bernoulli_attrs.SetAllAttrs(dtype->data_type(), static_cast<int64_t>(random_seed),
                                 static_cast<double>(-1));
+
     const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
+    OpExprInterpContext ctx(bernoulli_attrs, distribution_state);
+    ctx.device = device;
+    ctx.parallel_desc = placement;
+    ctx.nd_sbp = nd_sbp;
+
     if (inplace) {
       auto outputs = std::make_shared<TensorTuple>(1);
       JUST(CheckInplaceValid(x));
       (*outputs)[0] = x;
-      JUST(OpInterpUtil::Dispatch(*bernoulli_op_, {x}, outputs.get(),
-                                  OpExprInterpContext(bernoulli_attrs, distribution_state)));
+      JUST(OpInterpUtil::Dispatch(*bernoulli_op_, {x}, outputs.get(), ctx));
       return outputs->at(0);
     } else {
-      return OpInterpUtil::Dispatch<Tensor>(
-          *bernoulli_op_, {x}, OpExprInterpContext(bernoulli_attrs, distribution_state));
+      return OpInterpUtil::Dispatch<Tensor>(*bernoulli_op_, {x}, ctx);
     }
   }
 
@@ -77,22 +97,43 @@ class BernoulliProbFunctor {
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const double& p,
                            const Symbol<DType>& dtype, const Optional<one::Generator>& generator,
                            const bool& inplace) const {
-    const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
-    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
     CHECK_OR_THROW(p >= 0.0 && p <= 1.0) << "bernoulli expects p to be in [0, 1], but got p=" << p;
 
+    Optional<Symbol<Device>> device;
+    Optional<Symbol<ParallelDesc>> placement;
+    Optional<Symbol<NdSbp>> nd_sbp;
+
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed = 0;
+    if (x->is_global()) {
+      JUST(CheckDeviceIdsIsValid(JUST(x->parallel_desc())));
+      placement = JUST(x->parallel_desc());
+      nd_sbp = JUST(x->nd_sbp());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
+    } else {
+      device = JUST(x->device());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+    }
+
     auto& bernoulli_attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("dtype", "seed", "p");
-    bernoulli_attrs.SetAllAttrs(dtype->data_type(), static_cast<int64_t>(gen->current_seed()), p);
+    bernoulli_attrs.SetAllAttrs(dtype->data_type(), static_cast<int64_t>(random_seed), p);
+
+    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
+    OpExprInterpContext ctx(bernoulli_attrs, distribution_state);
+    ctx.device = device;
+    ctx.parallel_desc = placement;
+    ctx.nd_sbp = nd_sbp;
+
     if (inplace) {
       auto outputs = std::make_shared<TensorTuple>(1);
       JUST(CheckInplaceValid(x));
       (*outputs)[0] = x;
-      JUST(OpInterpUtil::Dispatch(*bernoulli_op_, {x}, outputs.get(),
-                                  OpExprInterpContext(bernoulli_attrs, distribution_state)));
+      JUST(OpInterpUtil::Dispatch(*bernoulli_op_, {x}, outputs.get(), ctx));
       return outputs->at(0);
     } else {
-      return OpInterpUtil::Dispatch<Tensor>(
-          *bernoulli_op_, {x}, OpExprInterpContext(bernoulli_attrs, distribution_state));
+      return OpInterpUtil::Dispatch<Tensor>(*bernoulli_op_, {x}, ctx);
     }
   }
 
@@ -133,59 +174,44 @@ class InplaceUniformFunctor {
     }
     DataType dtype_val = dtype->data_type();
 
+    Optional<Symbol<Device>> device;
+    Optional<Symbol<ParallelDesc>> placement;
+    Optional<Symbol<NdSbp>> nd_sbp;
+
     auto gen = JUST(one::DefaultAutoGenerator());
+    uint64_t random_seed = 0;
+    if (x->is_global()) {
+      JUST(CheckDeviceIdsIsValid(JUST(x->parallel_desc())));
+      placement = JUST(x->parallel_desc());
+      nd_sbp = JUST(x->nd_sbp());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
+    } else {
+      device = JUST(x->device());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+    }
+
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("from", "to", "shape", "dtype", "seed", "nb_sbp");
+    Optional<std::vector<std::string>> attr_nd_sbp{NullOpt};
+    if (nd_sbp) { attr_nd_sbp = *JUST(GetNdSbpStrList(JUST(nd_sbp))); }
+    if (IsInteger) {
+      attrs.SetAllAttrs(from.Value<int64_t>(), to.Value<int64_t>(), shape, dtype_val,
+                        static_cast<int64_t>(random_seed), attr_nd_sbp);
+    } else {
+      attrs.SetAllAttrs(from.Value<double>(), to.Value<double>(), shape, dtype_val,
+                        static_cast<int64_t>(random_seed), attr_nd_sbp);
+    }
+
+    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
+    OpExprInterpContext ctx(attrs, distribution_state);
+    ctx.parallel_desc = placement;
+    ctx.nd_sbp = nd_sbp;
+    ctx.device = device;
+
     auto outputs = std::make_shared<TensorTuple>(1);
     (*outputs)[0] = x;
-    if (x->is_global())  // global
-    {
-      const auto& nb_sbp = JUST(x->nd_sbp());
-      const auto& placement = JUST(x->parallel_desc());
-      JUST(CheckDeviceIdsIsValid(placement));
-      uint64_t init_seed = JUST(gen->Get<CPUGeneratorImpl>(0))->engine()();
-      if (LazyMode::is_enabled())  // lazy
-      {
-        if (IsInteger) {
-          attrs.SetAllAttrs(from.Value<int64_t>(), to.Value<int64_t>(), shape, dtype_val,
-                            static_cast<int64_t>(init_seed), *JUST(GetNdSbpStrList(nb_sbp)));
-        } else {
-          attrs.SetAllAttrs(from.Value<double>(), to.Value<double>(), shape, dtype_val,
-                            static_cast<int64_t>(init_seed), *JUST(GetNdSbpStrList(nb_sbp)));
-        }
-      } else  // eager
-      {
-        uint64_t rank_seed = 0;
-        {
-          JUST(BroadcastSeedToAllRanks(&init_seed, /*root=*/0));
-          rank_seed =
-              JUST(GetRandomSeedForRank(*placement, *nb_sbp, init_seed, GlobalProcessCtx::Rank()));
-        }
-        if (IsInteger) {
-          attrs.SetAllAttrs(from.Value<int64_t>(), to.Value<int64_t>(), shape, dtype_val,
-                            static_cast<int64_t>(rank_seed), NullOpt);
-        } else {
-          attrs.SetAllAttrs(from.Value<double>(), to.Value<double>(), shape, dtype_val,
-                            static_cast<int64_t>(rank_seed), NullOpt);
-        }
-        gen = JUST(MakeGenerator(placement->device_type()));
-        gen->set_current_seed(rank_seed);
-      }
-      const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
-      OpExprInterpContext ctx(attrs, placement, nb_sbp, distribution_state);
-      JUST(OpInterpUtil::Dispatch(*exec_op, {}, outputs.get(), ctx));
-    } else {  // local
-      if (IsInteger) {
-        attrs.SetAllAttrs(from.Value<int64_t>(), to.Value<int64_t>(), shape, dtype_val,
-                          static_cast<int64_t>(gen->current_seed()), NullOpt);
-      } else {
-        attrs.SetAllAttrs(from.Value<double>(), to.Value<double>(), shape, dtype_val,
-                          static_cast<int64_t>(gen->current_seed()), NullOpt);
-      }
-      const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
-      OpExprInterpContext ctx(attrs, distribution_state);
-      ctx.device = JUST(x->device());
-      JUST(OpInterpUtil::Dispatch(*exec_op, {}, outputs.get(), ctx));
-    }
+    JUST(OpInterpUtil::Dispatch(*exec_op, {}, outputs.get(), ctx));
     return outputs->at(0);
   }
 
@@ -214,15 +240,17 @@ class RandFunctor {
       }
     }
 
-    const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed =
+        JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("from", "to", "shape", "dtype", "seed");
     attrs.SetAllAttrs(static_cast<double>(0), static_cast<double>(1), shape, dtype_val,
-                      static_cast<int64_t>(gen->current_seed()));
+                      static_cast<int64_t>(random_seed));
 
     const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
+    OpExprInterpContext ctx(attrs, JUST(device), distribution_state);
 
-    OpExprInterpContext ctx(attrs, distribution_state);
-    ctx.device = device;
     auto result = JUST(OpInterpUtil::Dispatch<Tensor>(*op_, {}, ctx));
     JUST(result->set_requires_grad(requires_grad));
     return result;
@@ -240,7 +268,6 @@ class GlobalRandFunctor {
                            const Optional<Symbol<DType>>& dtype,
                            const Optional<one::Generator>& generator,
                            const bool& requires_grad) const {
-    JUST(CheckDeviceIdsIsValid(placement));
     DataType dtype_val = GetDefaultDType()->data_type();
     if (dtype.has_value()) {
       dtype_val = JUST(dtype)->data_type();
@@ -249,27 +276,18 @@ class GlobalRandFunctor {
       }
     }
 
-    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
-    uint64_t init_seed = JUST(gen->Get<CPUGeneratorImpl>(0))->engine()();
-
+    JUST(CheckDeviceIdsIsValid(placement));
     const auto& nd_sbp = JUST(GetNdSbp(sbp_tuple));
+    auto attr_nd_sbp = *JUST(GetNdSbpStrList(nd_sbp));
+
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed =
+        JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
 
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("from", "to", "shape", "dtype", "seed", "nd_sbp");
-    if (LazyMode::is_enabled()) {
-      attrs.SetAllAttrs(static_cast<double>(0), static_cast<double>(1), shape, dtype_val,
-                        static_cast<int64_t>(init_seed), *JUST(GetNdSbpStrList(nd_sbp)));
-    } else {
-      uint64_t rank_seed = 0;
-      {
-        JUST(BroadcastSeedToAllRanks(&init_seed, /*root=*/0));
-        rank_seed =
-            JUST(GetRandomSeedForRank(*placement, *nd_sbp, init_seed, GlobalProcessCtx::Rank()));
-      }
-      attrs.SetAllAttrs(static_cast<double>(0), static_cast<double>(1), shape, dtype_val,
-                        static_cast<int64_t>(rank_seed), NullOpt);
-      gen = JUST(MakeGenerator(placement->device_type()));
-      gen->set_current_seed(rank_seed);
-    }
+    attrs.SetAllAttrs(static_cast<double>(0), static_cast<double>(1), shape, dtype_val,
+                      static_cast<int64_t>(random_seed), attr_nd_sbp);
+
     const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
 
     auto result = JUST(OpInterpUtil::Dispatch<Tensor>(
@@ -281,6 +299,7 @@ class GlobalRandFunctor {
  private:
   std::shared_ptr<OpExpr> op_;
 };
+
 class RandNFunctor {
  public:
   Maybe<Tensor> operator()(const Shape& shape, const Optional<Symbol<DType>>& dtype,
@@ -353,14 +372,18 @@ class NormalFunctor {
       }
       device = out_tensor_device;
     }
-    const auto gen = optional_generator.value_or(JUST(one::DefaultAutoGenerator()));
+
+    auto gen = optional_generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed =
+        JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("mean", "std", "shape", "dtype", "seed");
     attrs.SetAllAttrs(static_cast<double>(mean), static_cast<double>(std), shape,
-                      dtype->data_type(), static_cast<int64_t>(gen->current_seed()));
+                      dtype->data_type(), static_cast<int64_t>(random_seed));
 
     const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
-    OpExprInterpContext ctx(attrs, distribution_state);
-    ctx.device = device;
+    OpExprInterpContext ctx(attrs, device, distribution_state);
+
     if (out.has_value()) {
       std::shared_ptr<TensorTuple> outputs = std::make_shared<TensorTuple>(1);
       (*outputs)[0] = JUST(out);
@@ -400,8 +423,6 @@ class GlobalNormalFunctor {
                            const Optional<Symbol<DType>>& optional_dtype,
                            const Optional<one::Generator>& optional_generator,
                            const bool& requires_grad) const {
-    JUST(CheckDeviceIdsIsValid(placement));
-
     Symbol<DType> dtype = DType::Float();
     if (optional_dtype.has_value()) {
       if (!JUST(optional_dtype)->is_floating_point()) {
@@ -421,42 +442,29 @@ class GlobalNormalFunctor {
       dtype = output_tensor_dtype;
     }
 
-    auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("mean", "std", "shape", "dtype", "seed", "nd_sbp");
-
+    JUST(CheckDeviceIdsIsValid(placement));
     const auto& nd_sbp = JUST(GetNdSbp(sbp_tuple));
+    auto attr_nd_sbp = *JUST(GetNdSbpStrList(nd_sbp));
 
     std::shared_ptr<Generator> gen = optional_generator.value_or(JUST(one::DefaultAutoGenerator()));
-    uint64_t init_seed = JUST(gen->Get<CPUGeneratorImpl>(0))->engine()();
+    uint64_t random_seed =
+        JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
 
-    if (LazyMode::is_enabled()) {
-      attrs.SetAllAttrs(static_cast<double>(mean), static_cast<double>(std), shape,
-                        dtype->data_type(), static_cast<int64_t>(init_seed),
-                        *JUST(GetNdSbpStrList(nd_sbp)));
-    } else {
-      uint64_t rank_seed = 0;
-      {
-        JUST(BroadcastSeedToAllRanks(&init_seed, /*root=*/0));
-        rank_seed =
-            JUST(GetRandomSeedForRank(*placement, *nd_sbp, init_seed, GlobalProcessCtx::Rank()));
-      }
-      attrs.SetAllAttrs(static_cast<double>(mean), static_cast<double>(std), shape,
-                        dtype->data_type(), static_cast<int64_t>(rank_seed), NullOpt);
-      gen = JUST(MakeGenerator(placement->device_type()));
-      gen->set_current_seed(rank_seed);
-    }
+    auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("mean", "std", "shape", "dtype", "seed", "nd_sbp");
+    attrs.SetAllAttrs(static_cast<double>(mean), static_cast<double>(std), shape,
+                      dtype->data_type(), static_cast<int64_t>(random_seed), attr_nd_sbp);
+
     const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
+    OpExprInterpContext ctx(attrs, placement, nd_sbp, distribution_state);
 
     if (out.has_value()) {
       std::shared_ptr<TensorTuple> outputs = std::make_shared<TensorTuple>(1);
       (*outputs)[0] = JUST(out);
-      JUST(OpInterpUtil::Dispatch(
-          *op_, {}, outputs.get(),
-          OpExprInterpContext(attrs, placement, nd_sbp, distribution_state)));
+      JUST(OpInterpUtil::Dispatch(*op_, {}, outputs.get(), ctx));
       return (*outputs)[0];
     }
 
-    auto result = JUST(OpInterpUtil::Dispatch<Tensor>(
-        *op_, {}, OpExprInterpContext(attrs, placement, nd_sbp, distribution_state)));
+    auto result = JUST(OpInterpUtil::Dispatch<Tensor>(*op_, {}, ctx));
     JUST(result->set_requires_grad(requires_grad));
     return result;
   }
@@ -518,17 +526,19 @@ class RandIntFunctor {
           low, high, shape, GetGlobalParallelDescFromDevice(device),
           *JUST(GetSbpList(GlobalMode::nd_sbp())), dtype, generator, requires_grad));
     }
+
     DataType dtype_val = DataType::kInt64;
     if (dtype) { dtype_val = JUST(dtype)->data_type(); }
 
-    const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed =
+        JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("shape", "from", "to", "dtype", "seed");
-    attrs.SetAllAttrs(shape, low, high, dtype_val, static_cast<int64_t>(gen->current_seed()));
+    attrs.SetAllAttrs(shape, low, high, dtype_val, static_cast<int64_t>(random_seed));
 
     const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
-
-    OpExprInterpContext ctx(attrs, distribution_state);
-    ctx.device = device;
+    OpExprInterpContext ctx(attrs, JUST(device), distribution_state);
 
     auto result = JUST(OpInterpUtil::Dispatch<Tensor>(*op_, {}, ctx));
     JUST(result->set_requires_grad(requires_grad));
@@ -588,30 +598,19 @@ class GlobalRandIntFunctor {
     DataType dtype_val = DataType::kInt64;
     if (dtype) { dtype_val = JUST(dtype)->data_type(); }
 
-    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
     const auto& nd_sbp = JUST(GetNdSbp(sbp));
-    uint64_t init_seed = JUST(gen->Get<CPUGeneratorImpl>(0))->engine()();
+    auto attr_nd_sbp = *JUST(GetNdSbpStrList(nd_sbp));
+
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed =
+        JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
 
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("shape", "from", "to", "dtype", "seed", "nd_sbp");
-    if (LazyMode::is_enabled()) {
-      attrs.SetAllAttrs(shape, low, high, dtype_val, static_cast<int64_t>(init_seed),
-                        *JUST(GetNdSbpStrList(nd_sbp)));
-    } else {
-      uint64_t rank_seed = 0;
-      {
-        JUST(BroadcastSeedToAllRanks(&init_seed, /*root=*/0));
-        rank_seed =
-            JUST(GetRandomSeedForRank(*placement, *nd_sbp, init_seed, GlobalProcessCtx::Rank()));
-      }
-      attrs.SetAllAttrs(shape, low, high, dtype_val, static_cast<int64_t>(rank_seed), NullOpt);
-      gen = JUST(MakeGenerator(placement->device_type()));
-      gen->set_current_seed(rank_seed);
-    }
-    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
+    attrs.SetAllAttrs(shape, low, high, dtype_val, static_cast<int64_t>(random_seed), attr_nd_sbp);
 
+    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
     auto result = JUST(OpInterpUtil::Dispatch<Tensor>(
         *op_, {}, OpExprInterpContext(attrs, placement, nd_sbp, distribution_state)));
-
     JUST(result->set_requires_grad(requires_grad));
     return result;
   }
@@ -670,14 +669,16 @@ class RandPermFunctor {
                                              *JUST(GetSbpList(GlobalMode::nd_sbp())), generator,
                                              dtype, requires_grad));
     }
-    const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed =
+        JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("n", "seed");
-    attrs.SetAllAttrs(n, static_cast<int64_t>(gen->current_seed()));
+    attrs.SetAllAttrs(n, static_cast<int64_t>(random_seed));
 
     const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
-
-    OpExprInterpContext ctx(attrs, distribution_state);
-    ctx.device = device;
+    OpExprInterpContext ctx(attrs, JUST(device), distribution_state);
 
     auto result = JUST(OpInterpUtil::Dispatch<Tensor>(*randperm_op_, {}, ctx));
     JUST(result->set_requires_grad(requires_grad));
@@ -698,21 +699,19 @@ class GlobalRandPermFunctor {
                            const Optional<one::Generator>& generator, const Symbol<DType>& dtype,
                            const bool& requires_grad) const {
     JUST(CheckDeviceIdsIsValid(placement));
-    const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
-    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
     const auto& nd_sbp = JUST(GetNdSbp(sbp_tuple));
+    auto attr_nd_sbp = *JUST(GetNdSbpStrList(nd_sbp));
+
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed =
+        JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
 
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("n", "seed", "nd_sbp");
-    if (LazyMode::is_enabled()) {
-      attrs.SetAllAttrs(n, static_cast<int64_t>(gen->current_seed()),
-                        *JUST(GetNdSbpStrList(nd_sbp)));
-    } else {
-      attrs.SetAllAttrs(n, static_cast<int64_t>(gen->current_seed()), NullOpt);
-    }
+    attrs.SetAllAttrs(n, static_cast<int64_t>(random_seed), attr_nd_sbp);
+    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
 
     auto result = JUST(OpInterpUtil::Dispatch<Tensor>(
         *randperm_op_, {}, OpExprInterpContext(attrs, placement, nd_sbp, distribution_state)));
-
     JUST(result->set_requires_grad(requires_grad));
     return functional::Cast(result, dtype, /*pin_memory=*/false);
   }
@@ -727,33 +726,40 @@ class ExponentialFunctor {
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x, const float& lambd,
                            const Optional<one::Generator>& generator) const {
     DataType dtype_val = x->dtype()->data_type();
+
+    Optional<Symbol<Device>> device;
+    Optional<Symbol<ParallelDesc>> placement;
+    Optional<Symbol<NdSbp>> nd_sbp;
+
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed = 0;
+    if (x->is_global()) {
+      JUST(CheckDeviceIdsIsValid(JUST(x->parallel_desc())));
+      placement = JUST(x->parallel_desc());
+      nd_sbp = JUST(x->nd_sbp());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
+    } else {
+      device = JUST(x->device());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+    }
+
+    auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("seed", "lambd", "dtype", "out_shape", "nd_sbp");
     const Shape& out_shape = *(x->shape());
-    const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    Optional<std::vector<std::string>> attr_nd_sbp{NullOpt};
+    if (nd_sbp) { attr_nd_sbp = *JUST(GetNdSbpStrList(JUST(nd_sbp))); }
+    attrs.SetAllAttrs(static_cast<int64_t>(random_seed), lambd, dtype_val, out_shape, attr_nd_sbp);
+
     const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
+    OpExprInterpContext ctx(attrs, distribution_state);
+    ctx.device = device;
+    ctx.parallel_desc = placement;
+    ctx.nd_sbp = nd_sbp;
 
     std::shared_ptr<TensorTuple> outputs = std::make_shared<TensorTuple>(1);
     outputs->at(0) = x;
-    if (x->is_global()) {
-      const auto& placement = JUST(x->parallel_desc());
-      const auto& nd_sbp = JUST(x->nd_sbp());
-      auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("seed", "lambd", "dtype", "out_shape", "nd_sbp");
-      if (LazyMode::is_enabled()) {
-        attrs.SetAllAttrs(static_cast<int64_t>(gen->current_seed()), lambd, dtype_val, out_shape,
-                          *JUST(GetNdSbpStrList(nd_sbp)));
-      } else {
-        attrs.SetAllAttrs(static_cast<int64_t>(gen->current_seed()), lambd, dtype_val, out_shape,
-                          NullOpt);
-      }
-      JUST(OpInterpUtil::Dispatch(
-          *op_, {}, outputs.get(),
-          OpExprInterpContext(attrs, placement, nd_sbp, distribution_state)));
-    } else {
-      auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("seed", "lambd", "dtype", "out_shape");
-      attrs.SetAllAttrs(static_cast<int64_t>(gen->current_seed()), lambd, dtype_val, out_shape);
-      OpExprInterpContext ctx(attrs, distribution_state);
-      ctx.device = JUST(x->device());
-      JUST(OpInterpUtil::Dispatch(*op_, {}, outputs.get(), ctx));
-    }
+    JUST(OpInterpUtil::Dispatch(*op_, {}, outputs.get(), ctx));
     return outputs->at(0);
   }
 
@@ -793,6 +799,7 @@ class MultinomialFunctor {
     // Since the index tensor is float, numCategories cannot exceed max float integer precision
     CHECK_OR_RETURN(num_categories <= FLOAT32_MAX_CONSECUTIVE_INT)
         << "number of categories cannot exceed 2^24";
+
     // Fast-path for no replacement.
     // Reference:
     // https://github.com/pytorch/pytorch/issues/11931#issuecomment-625882503
@@ -825,12 +832,33 @@ class MultinomialFunctor {
       return result;
     }
 
-    const auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
-    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
+    Optional<Symbol<Device>> device;
+    Optional<Symbol<ParallelDesc>> placement;
+    Optional<Symbol<NdSbp>> nd_sbp;
+
+    auto gen = generator.value_or(JUST(one::DefaultAutoGenerator()));
+    uint64_t random_seed = 0;
+    if (x->is_global()) {
+      JUST(CheckDeviceIdsIsValid(JUST(x->parallel_desc())));
+      placement = JUST(x->parallel_desc());
+      nd_sbp = JUST(x->nd_sbp());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), placement, nd_sbp));
+    } else {
+      device = JUST(x->device());
+      random_seed =
+          JUST(GetRandomSeedForLazyOrGlobal(gen, LazyMode::is_enabled(), NullOpt, NullOpt));
+    }
+
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("seed", "num_samples");
-    attrs.SetAllAttrs(static_cast<int64_t>(gen->current_seed()), num_samples);
+    attrs.SetAllAttrs(static_cast<int64_t>(random_seed), num_samples);
+
+    const auto& distribution_state = std::make_shared<DistributionKernelState>(gen);
     OpExprInterpContext ctx(attrs, distribution_state);
     ctx.device = JUST(x->device());
+    ctx.parallel_desc = placement;
+    ctx.nd_sbp = nd_sbp;
+
     DeviceType input_device = JUST(x->device())->enum_type();
     if (input_device == DeviceType::kCPU) {
       return OpInterpUtil::Dispatch<Tensor>(*op_cpu_, {x}, ctx);

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -5258,6 +5258,7 @@ def OneFlow_FusedMatmulBiasAddReluDropoutOp : OneFlow_BaseOp<"fused_matmul_bias_
   );
   let attrs = (ins
     DefaultValuedAttr<BoolAttr, "false">:$skip_final_activation,
+    DefaultValuedAttr<SI64Attr, "0">:$seed,
     F32ArrayAttr:$dropout_rate_list
   );
   let has_logical_tensor_desc_infer_fn = 1;

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -5506,7 +5506,8 @@ def OneFlow_DropoutOp : OneFlow_BaseOp<"dropout", [NoSideEffect, DeclareOpInterf
     OneFlow_Tensor:$mask
   );
   let attrs = (ins
-    DefaultValuedAttr<F32Attr, "0.">:$rate
+    DefaultValuedAttr<F32Attr, "0.">:$rate,
+    DefaultValuedAttr<SI64Attr, "0">:$seed
   );
   let has_check_fn = 1;
   let has_logical_tensor_desc_infer_fn = 1;

--- a/oneflow/user/kernels/bernoulli_kernel.cpp
+++ b/oneflow/user/kernels/bernoulli_kernel.cpp
@@ -29,8 +29,9 @@ class BernoulliKerenl final : public user_op::OpKernel {
 
   std::shared_ptr<user_op::OpKernelState> CreateOpKernelState(
       user_op::KernelInitContext* ctx) const override {
-    const auto& generator = CHECK_JUST(one::MakeGenerator(kCPU));
-    generator->set_current_seed(ctx->Attr<int64_t>("seed"));
+    const auto& generator = CHECK_JUST(one::MakeGenerator(DeviceType::kCPU));
+    generator->set_current_seed(
+        CHECK_JUST(GetOpKernelRandomSeedInCurrentRank(ctx, ctx->Attr<int64_t>("seed"))));
     return std::make_shared<DistributionKernelState>(generator);
   }
 

--- a/oneflow/user/kernels/dropout_kernel.cpp
+++ b/oneflow/user/kernels/dropout_kernel.cpp
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "oneflow/core/framework/framework.h"
-#include "oneflow/user/kernels/op_kernel_wrapper.h"
 #include "oneflow/core/kernel/kernel_util.h"
+#include "oneflow/user/kernels/op_kernel_wrapper.h"
 #include "oneflow/user/kernels/dropout_kernel.h"
+#include "oneflow/user/kernels/random_seed_util.h"
 #include "oneflow/core/ep/include/primitive/add.h"
 
 namespace oneflow {
@@ -53,7 +54,9 @@ class DropoutKernelCPU final : public user_op::OpKernel {
 
   std::shared_ptr<user_op::OpKernelState> CreateOpKernelState(
       user_op::KernelInitContext* ctx) const override {
-    const auto& generator = CHECK_JUST(one::MakeGenerator(DeviceType::kCPU));
+    const auto& generator = CHECK_JUST(one::MakeGenerator(kCPU));
+    generator->set_current_seed(
+        CHECK_JUST(GetOpKernelRandomSeedInCurrentRank(ctx, ctx->Attr<int64_t>("seed"))));
     return std::make_shared<FusedDropoutKernelState>(generator);
   }
 

--- a/oneflow/user/kernels/fused_matmul_bias_add_relu_dropout.cu
+++ b/oneflow/user/kernels/fused_matmul_bias_add_relu_dropout.cu
@@ -309,6 +309,8 @@ class FusedMatmulBiasAddReluDropoutKernel final : public user_op::OpKernel {
   std::shared_ptr<user_op::OpKernelState> CreateOpKernelState(
       user_op::KernelInitContext* ctx) const override {
     const auto& generator = CHECK_JUST(one::MakeGenerator(DeviceType::kCUDA));
+    generator->set_current_seed(
+        CHECK_JUST(GetOpKernelRandomSeedInCurrentRank(ctx, ctx->Attr<int64_t>("seed"))));
     return std::make_shared<FusedDropoutKernelState>(generator);
   }
 

--- a/oneflow/user/kernels/random_mask_like_kernel.h
+++ b/oneflow/user/kernels/random_mask_like_kernel.h
@@ -16,9 +16,10 @@ limitations under the License.
 #ifndef ONEFLOW_USER_KERNELS_RANDOM_MASK_LIKE_KERNEL_H_
 #define ONEFLOW_USER_KERNELS_RANDOM_MASK_LIKE_KERNEL_H_
 
-#include "oneflow/user/kernels/random_mask_generator.h"
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/core/kernel/cuda_graph_support.h"
+#include "oneflow/user/kernels/random_mask_generator.h"
+#include "oneflow/user/kernels/random_seed_util.h"
 #include "oneflow/core/ep/include/device.h"
 
 namespace oneflow {
@@ -45,7 +46,8 @@ class RandomMaskLikeKernel final : public user_op::OpKernel, public user_op::Cud
   std::shared_ptr<user_op::OpKernelState> CreateOpKernelState(
       user_op::KernelInitContext* ctx) const override {
     const auto& generator = CHECK_JUST(one::MakeGenerator(device_type));
-    generator->set_current_seed(ctx->Attr<int64_t>("seed"));
+    generator->set_current_seed(
+        CHECK_JUST(GetOpKernelRandomSeedInCurrentRank(ctx, ctx->Attr<int64_t>("seed"))));
     return std::make_shared<RandomMaskLikeKernelState>(generator);
   }
 

--- a/oneflow/user/kernels/random_seed_util.h
+++ b/oneflow/user/kernels/random_seed_util.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define ONEFLOW_USER_KERNELS_RANDOM_SEED_UTIL_H_
 
 #include "oneflow/core/framework/op_kernel.h"
+#include "oneflow/core/framework/random_generator.h"
 
 namespace oneflow {
 
@@ -26,6 +27,11 @@ Maybe<uint64_t> GetRandomSeedForRank(const ParallelDesc& placement, const NdSbp&
 Maybe<uint64_t> GetOpKernelRandomSeed(const user_op::KernelInitContext* ctx);
 Maybe<uint64_t> GetOpKernelRandomSeedInCurrentRank(const user_op::KernelInitContext* ctx,
                                                    uint64_t init_seed);
+
+Maybe<uint64_t> GetRandomSeedForLazyOrGlobal(std::shared_ptr<one::Generator>& generator,
+                                             bool is_lazy,
+                                             const Optional<Symbol<ParallelDesc>>& placement,
+                                             const Optional<Symbol<NdSbp>>& nd_sbp);
 
 }  // namespace oneflow
 

--- a/oneflow/user/kernels/randperm_kernel.cpp
+++ b/oneflow/user/kernels/randperm_kernel.cpp
@@ -14,15 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "oneflow/core/framework/framework.h"
-#include "oneflow/user/kernels/op_kernel_wrapper.h"
-#include "oneflow/core/common/data_type.h"
-#include "oneflow/core/ep/include/stream.h"
 #include "oneflow/core/framework/random_generator.h"
+#include "oneflow/core/common/data_type.h"
+#include "oneflow/core/common/container_util.h"
+#include "oneflow/user/kernels/op_kernel_wrapper.h"
 #include "oneflow/user/kernels/arange_kernel_util.h"
 #include "oneflow/user/kernels/distributions/common.h"
+#include "oneflow/user/kernels/random_seed_util.h"
 #include "oneflow/core/job/nd_sbp_util.h"
-#include "oneflow/core/common/container_util.h"
 #include "oneflow/core/register/tensor_slice_view.h"
+#include "oneflow/core/ep/include/stream.h"
 
 namespace oneflow {
 class CpuRandPermKernelCache final : public user_op::OpKernelCache {
@@ -63,7 +64,8 @@ class CpuRandPermKernel final : public user_op::OpKernel {
   std::shared_ptr<user_op::OpKernelState> CreateOpKernelState(
       user_op::KernelInitContext* ctx) const override {
     const auto& generator = CHECK_JUST(one::MakeGenerator(kCPU));
-    generator->set_current_seed(ctx->Attr<int64_t>("seed"));
+    generator->set_current_seed(
+        CHECK_JUST(GetOpKernelRandomSeedInCurrentRank(ctx, ctx->Attr<int64_t>("seed"))));
     return std::make_shared<DistributionKernelState>(generator);
   }
 

--- a/oneflow/user/kernels/randperm_kernel.cu
+++ b/oneflow/user/kernels/randperm_kernel.cu
@@ -16,21 +16,22 @@ limitations under the License.
 #include <curand.h>
 #include <curand_kernel.h>
 
-#include "oneflow/core/common/data_type.h"
-#include "oneflow/core/ep/include/stream.h"
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/core/framework/random_generator.h"
+#include "oneflow/core/common/data_type.h"
+#include "oneflow/core/common/container_util.h"
+#include "oneflow/core/device/cuda_util.h"
 #include "oneflow/user/kernels/op_kernel_wrapper.h"
 #include "oneflow/user/kernels/arange_kernel_util.h"
 #include "oneflow/user/kernels/radix_sort.cuh"
+#include "oneflow/user/kernels/random_seed_util.h"
 #include "oneflow/user/kernels/distributions/common.h"
+#include "oneflow/user/kernels/distributions/distribution_template_util.cuh"
 #include "oneflow/core/ep/include/device.h"
+#include "oneflow/core/ep/include/stream.h"
 #include "oneflow/core/ep/cuda/cuda_stream.h"
 #include "oneflow/core/job/nd_sbp_util.h"
-#include "oneflow/core/common/container_util.h"
 #include "oneflow/core/register/tensor_slice_view.h"
-#include "oneflow/core/device/cuda_util.h"
-#include "oneflow/user/kernels/distributions/distribution_template_util.cuh"
 
 namespace oneflow {
 __global__ void GeneKeysAndValues(const int32_t n, uint64_t seed, uint64_t offset, int32_t* values,
@@ -102,7 +103,8 @@ class GpuRandPermKernel final : public user_op::OpKernel {
   std::shared_ptr<user_op::OpKernelState> CreateOpKernelState(
       user_op::KernelInitContext* ctx) const override {
     const auto& generator = CHECK_JUST(one::MakeGenerator(kCUDA));
-    generator->set_current_seed(ctx->Attr<int64_t>("seed"));
+    generator->set_current_seed(
+        CHECK_JUST(GetOpKernelRandomSeedInCurrentRank(ctx, ctx->Attr<int64_t>("seed"))));
     return std::make_shared<DistributionKernelState>(generator);
   }
 
@@ -206,4 +208,5 @@ REGISTER_USER_KERNEL("randperm")
       return sorted_in_aligned_bytes + indices_aligned_bytes + temp_storage_bytes
              + temp_aligned_bytes;
     });
+
 }  // namespace oneflow

--- a/oneflow/user/kernels/rrelu_kernel.cpp
+++ b/oneflow/user/kernels/rrelu_kernel.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/core/kernel/kernel_util.h"
 #include "oneflow/user/kernels/distributions/common.h"
+#include "oneflow/user/kernels/random_seed_util.h"
 
 namespace oneflow {
 
@@ -46,6 +47,8 @@ class CpuRReluKernel final : public user_op::OpKernel {
   std::shared_ptr<user_op::OpKernelState> CreateOpKernelState(
       user_op::KernelInitContext* ctx) const override {
     const auto& generator = CHECK_JUST(one::MakeGenerator(DeviceType::kCPU));
+    generator->set_current_seed(
+        CHECK_JUST(GetOpKernelRandomSeedInCurrentRank(ctx, ctx->Attr<int64_t>("seed"))));
     return std::make_shared<DistributionKernelState>(generator);
   }
 

--- a/oneflow/user/kernels/rrelu_kernel.cu
+++ b/oneflow/user/kernels/rrelu_kernel.cu
@@ -18,6 +18,7 @@ limitations under the License.
 #include "oneflow/user/kernels/distributions/normal_distribution.h"
 #include "oneflow/user/kernels/distributions/distribution_template_util.cuh"
 #include "oneflow/user/kernels/distributions/common.h"
+#include "oneflow/user/kernels/random_seed_util.h"
 
 namespace oneflow {
 
@@ -76,6 +77,8 @@ class CudaRReluKernel final : public user_op::OpKernel {
   std::shared_ptr<user_op::OpKernelState> CreateOpKernelState(
       user_op::KernelInitContext* ctx) const override {
     const auto& generator = CHECK_JUST(one::MakeGenerator(DeviceType::kCUDA));
+    generator->set_current_seed(
+        CHECK_JUST(GetOpKernelRandomSeedInCurrentRank(ctx, ctx->Attr<int64_t>("seed"))));
     return std::make_shared<DistributionKernelState>(generator);
   }
 


### PR DESCRIPTION
修复关于 random op 系列的 bug:

- 一些 random op kernel 在 CreateOpKernelState 时，直接 MakeGenerator，使用的是 default_rng_seed_val，所有的 random op 的 generator 使用的相同的 seed，那么会产生相同的结果。例如：transformer 所有的 layer 的 dropout 都产生一样的随机结果，很可能影响最终精度。
- 一些 random op kernel 在 CreateOpKernelState 时，没考虑 split 时，不同 rank 上应该有不同的结果（broadcast 需要相同的结果），应该通过 GetOpKernelRandomSeedInCurrentRank 为不同 rank 的 generator 设置相同的 seed。
- 在 checkpoint activation 开启后，要求前后向对应的 random op（例如 dropout）具有相同的 random state，这样才能使前后向中相同的 dropout 产生一致的结果。所以这里要求前后向对应的 dropout 拥有相同的 seed，可以通过为 dropout 添加 attr seed 来完成。

eager 所有 random op 使用相同的 generator（有些 op 容许传入自定义的 generator）。但 lazy 不同，所有的 random op kernel 都会创建自己的 generator，只能通过 seed 来控制随机结果。同一张图内的不同 random op 需要不同 seed，split 的不同 rank 需要不同 seed，checkpoint activation 的前后向 random op 需要相同 seed，broadcast 的不同 rank 需要相同 seed。

