### PR TITLE
[Feature, Graph] Add config ONEFLOW_DISABLE_HD_COPY_STREAM

### DIFF
--- a/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
@@ -764,9 +764,9 @@ Maybe<void> LazyInterpreter::ApplyImpl(const UserOpExpr& op_expr, const TensorTu
     return LazyInterpreterApplyImplForSourceUserOpExpr(op_expr, outputs, ctx);
   }
   if (op_expr.op_type_name() == "copy"
-      && !ParseBooleanFromEnv("ONEFLOW_DISABLE_COPY_HD_STREAM", false)) {
+      && !ParseBooleanFromEnv("ONEFLOW_DISABLE_HD_COPY_STREAM", false)) {
     // NOTE(chengcheng): handle for copy UserOp which will NOT add op to job.
-    // Unless ONEFLOW_DISABLE_COPY_HD_STREAM is True
+    // Unless ONEFLOW_DISABLE_HD_COPY_STREAM is True
     return LazyInterpreterApplyImplForCopyUserOpExpr(op_expr, inputs, outputs, ctx);
   }
 
@@ -858,7 +858,7 @@ Maybe<void> LazyInterpreter::ApplyImpl(const UserOpExpr& op_expr, const TensorTu
           << op_attr.DebugString() << std::endl;
 
   if (op_expr.op_type_name() == "copy") {
-    CHECK_OR_RETURN(ParseBooleanFromEnv("ONEFLOW_DISABLE_COPY_HD_STREAM", false));
+    CHECK_OR_RETURN(ParseBooleanFromEnv("ONEFLOW_DISABLE_HD_COPY_STREAM", false));
     CHECK_EQ_OR_RETURN(inputs.size(), 1);          // NOLINT(maybe-need-error-msg)
     CHECK_EQ_OR_RETURN(op_expr.input_size(), 1);   // NOLINT(maybe-need-error-msg)
     CHECK_EQ_OR_RETURN(outputs->size(), 1);        // NOLINT(maybe-need-error-msg)

--- a/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/lazy_op_interpreter.cpp
@@ -763,8 +763,10 @@ Maybe<void> LazyInterpreter::ApplyImpl(const UserOpExpr& op_expr, const TensorTu
     // NOTE(chengcheng): handle for source UserOp like OFRecordReader, CoinFlip
     return LazyInterpreterApplyImplForSourceUserOpExpr(op_expr, outputs, ctx);
   }
-  if (op_expr.op_type_name() == "copy") {
+  if (op_expr.op_type_name() == "copy"
+      && !ParseBooleanFromEnv("ONEFLOW_DISABLE_COPY_HD_STREAM", false)) {
     // NOTE(chengcheng): handle for copy UserOp which will NOT add op to job.
+    // Unless ONEFLOW_DISABLE_COPY_HD_STREAM is True
     return LazyInterpreterApplyImplForCopyUserOpExpr(op_expr, inputs, outputs, ctx);
   }
 
@@ -855,21 +857,52 @@ Maybe<void> LazyInterpreter::ApplyImpl(const UserOpExpr& op_expr, const TensorTu
   VLOG(3) << "Lazy nn.Graph name " << graph_name << " infer and and op attr : \n"
           << op_attr.DebugString() << std::endl;
 
-  int64_t parallel_desc_sym_id = JUST(scope->GetParallelDescSymbolId(*op_conf));
-  auto blob_parallel_desc = JUST(GetSymbol<ParallelDesc>(parallel_desc_sym_id));
-  for (int i = 0; i < op_expr.output_size(); ++i) {
-    const std::string& obn = op_expr.indexed_obns().at(i);
-    if (!(*outputs)[i]) {
-      (*outputs)[i] =
-          JUST(BuildTensor(op_attr, obn, blob_parallel_desc, /* is_lazy= */ true, is_local));
+  if (op_expr.op_type_name() == "copy") {
+    CHECK_OR_RETURN(ParseBooleanFromEnv("ONEFLOW_DISABLE_COPY_HD_STREAM", false));
+    CHECK_EQ_OR_RETURN(inputs.size(), 1);          // NOLINT(maybe-need-error-msg)
+    CHECK_EQ_OR_RETURN(op_expr.input_size(), 1);   // NOLINT(maybe-need-error-msg)
+    CHECK_EQ_OR_RETURN(outputs->size(), 1);        // NOLINT(maybe-need-error-msg)
+    CHECK_EQ_OR_RETURN(op_expr.output_size(), 1);  // NOLINT(maybe-need-error-msg)
+    const std::shared_ptr<Tensor>& input_tensor = inputs.at(0);
+    const std::string& obn = op_expr.indexed_obns().at(0);
+    auto device = JUST(ctx.attrs.GetAttr<Symbol<Device>>("device"));
+
+    if (input_tensor->is_local()) {
+      (*outputs)[0] =
+          JUST(LocalTensor::MakeTensor(input_tensor->shape(), JUST(input_tensor->stride()),
+                                       input_tensor->dtype()->data_type(), device,
+                                       /* is_lazy= */ true,
+                                       /*requires_grad=*/false, /*is_leaf=*/true));
     } else {
-      VLOG(2) << "Lazy nn.Graph name " << graph_name << " op name " << new_op_name
-              << " run with inplace.";
-      const std::shared_ptr<Tensor>& inplace_out = (*outputs)[i];
-      JUST(CheckTensorMatchAttr(inplace_out, op_attr, obn, blob_parallel_desc, is_local));
+      ParallelConf parallel_conf = JUST(input_tensor->parallel_desc())->parallel_conf();
+      parallel_conf.set_device_tag(device->type());
+      ParallelDesc parallel_desc(parallel_conf);
+      (*outputs)[0] =
+          JUST(GlobalTensor::MakeTensor(input_tensor->shape(), input_tensor->dtype()->data_type(),
+                                        JUST(input_tensor->nd_sbp()), SymbolOf(parallel_desc),
+                                        /* is_lazy= */ true,
+                                        /*requires_grad=*/false, /*is_leaf=*/true));
     }
-    TensorNameScope::Global()->Record((*outputs)[i], GenLogicalBlobName(new_op_name, obn));
+
+    TensorNameScope::Global()->Record((*outputs)[0], GenLogicalBlobName(new_op_name, obn));
+  } else {
+    int64_t parallel_desc_sym_id = JUST(scope->GetParallelDescSymbolId(*op_conf));
+    auto blob_parallel_desc = JUST(GetSymbol<ParallelDesc>(parallel_desc_sym_id));
+    for (int i = 0; i < op_expr.output_size(); ++i) {
+      const std::string& obn = op_expr.indexed_obns().at(i);
+      if (!(*outputs)[i]) {
+        (*outputs)[i] =
+            JUST(BuildTensor(op_attr, obn, blob_parallel_desc, /* is_lazy= */ true, is_local));
+      } else {
+        VLOG(2) << "Lazy nn.Graph name " << graph_name << " op name " << new_op_name
+                << " run with inplace.";
+        const std::shared_ptr<Tensor>& inplace_out = (*outputs)[i];
+        JUST(CheckTensorMatchAttr(inplace_out, op_attr, obn, blob_parallel_desc, is_local));
+      }
+      TensorNameScope::Global()->Record((*outputs)[i], GenLogicalBlobName(new_op_name, obn));
+    }
   }
+
   return Maybe<void>::Ok();
 }
 

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -503,6 +503,11 @@ TaskNode* TaskGraph::GetProxyNode(TaskNode* src_node, const LogicalBlobId& lbi,
       return src_node;
     } else if (dst_mem_zone_id.device_type() == DeviceType::kCPU) {
       if (src_mem_zone_id.rank() == dst_mem_zone_id.rank()) {
+        if (ParseBooleanFromEnv("ONEFLOW_DISABLE_COPY_HD_STREAM", false)) {
+          // D2H Copy nodes have been added at running lazy_op_interpreter
+          proxy2node[key] = src_node;
+          return src_node;
+        }
         // on the same node, not on the same device
         // src must be not on the cpu mem zone, copy d2h first
         CHECK(IsMemcpyDtoHSupported(src_mem_zone_id.device_type()));
@@ -523,6 +528,11 @@ TaskNode* TaskGraph::GetProxyNode(TaskNode* src_node, const LogicalBlobId& lbi,
         return copy_comm_net_task;
       }
     } else {
+      if (ParseBooleanFromEnv("ONEFLOW_DISABLE_COPY_HD_STREAM", false)) {
+        // H2D Copy nodes have been added at running lazy_op_interpreter
+        proxy2node[key] = src_node;
+        return src_node;
+      }
       TaskNode* proxy_on_dst_host =
           GetProxyNode(src_node, lbi, GetNodeCPUMemZoneId(dst_mem_zone_id.rank()));
       CHECK(IsMemcpyHtoDSupported(dst_mem_zone_id.device_type()));

--- a/oneflow/core/graph/task_graph.cpp
+++ b/oneflow/core/graph/task_graph.cpp
@@ -503,7 +503,7 @@ TaskNode* TaskGraph::GetProxyNode(TaskNode* src_node, const LogicalBlobId& lbi,
       return src_node;
     } else if (dst_mem_zone_id.device_type() == DeviceType::kCPU) {
       if (src_mem_zone_id.rank() == dst_mem_zone_id.rank()) {
-        if (ParseBooleanFromEnv("ONEFLOW_DISABLE_COPY_HD_STREAM", false)) {
+        if (ParseBooleanFromEnv("ONEFLOW_DISABLE_HD_COPY_STREAM", false)) {
           // D2H Copy nodes have been added at running lazy_op_interpreter
           proxy2node[key] = src_node;
           return src_node;
@@ -528,7 +528,7 @@ TaskNode* TaskGraph::GetProxyNode(TaskNode* src_node, const LogicalBlobId& lbi,
         return copy_comm_net_task;
       }
     } else {
-      if (ParseBooleanFromEnv("ONEFLOW_DISABLE_COPY_HD_STREAM", false)) {
+      if (ParseBooleanFromEnv("ONEFLOW_DISABLE_HD_COPY_STREAM", false)) {
         // H2D Copy nodes have been added at running lazy_op_interpreter
         proxy2node[key] = src_node;
         return src_node;

--- a/python/oneflow/test/graph/test_graph_disable_hd_copy_steam.py
+++ b/python/oneflow/test/graph/test_graph_disable_hd_copy_steam.py
@@ -1,0 +1,194 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+# Enable feature to test
+os.environ["ONEFLOW_DISABLE_HD_COPY_STREAM"] = "true"
+import unittest
+import numpy as np
+
+import oneflow as flow
+import oneflow.nn as nn
+import oneflow.unittest
+
+
+@unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+@flow.unittest.skip_unless_1n1d()
+class TestDisableHDCopyStreamGraph(oneflow.unittest.TestCase):
+    def test_graph(test_case):
+        input_arr = np.array(
+            [
+                [-0.00570775, 1.56608823, -1.03485088, 0.78815096],
+                [-0.71527717, -1.23406712, -0.52557294, -0.460845],
+                [-0.63852083, 0.86328106, 0.80663667, -0.37680572],
+                [-0.08430816, -0.20784022, 0.67156639, 0.90230402],
+            ],
+            dtype=np.float32,
+        )
+        np_weight = np.ones((4, 4)).astype(np.float32)
+        np_weight.fill(2.3)
+        x = flow.tensor(input_arr)
+        np_out = np.matmul(input_arr, np_weight)
+
+        class MatmulModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = flow.tensor(np_weight)
+
+            def forward(self, x):
+                # test H2D, D2H both
+                x = x.to(flow.device("cuda"))
+                w = self.weight.to(flow.device("cuda"))
+                return flow.matmul(x, w).to(flow.device("cpu"))
+
+        model = MatmulModel()
+        eager_out = model(x)
+
+        class MatmulGraph(flow.nn.Graph):
+            def __init__(self):
+                super().__init__()
+                self.model = model
+
+            def build(self, x):
+                return self.model(x)
+
+        linear_g = MatmulGraph()
+        of_lazy_out = linear_g(x)
+
+        test_case.assertTrue(
+            np.allclose(of_lazy_out.numpy(), eager_out.numpy(), 1e-05, 1e-05)
+        )
+        test_case.assertTrue(np.allclose(of_lazy_out.numpy(), np_out, 1e-05, 1e-05))
+
+
+@unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+@flow.unittest.skip_unless_1n2d()
+class TestDisableHDCopyStreamGraphWithParallel(oneflow.unittest.TestCase):
+    def test_graph_with_DP(test_case):
+        PLACEMENT = flow.placement("cpu", [0, 1])
+        S0 = flow.sbp.split(0)
+        B = flow.sbp.broadcast
+
+        input_arr = np.array(
+            [
+                [
+                    [1.96443248, -0.35818048, 0.8386318, -0.12787708],
+                    [-0.30933945, 0.01075953, -0.85546622, 0.4462768],
+                    [-0.38192172, -1.15709959, -1.33283149, -0.69705033],
+                    [-0.08594144, -1.91884209, -0.56027761, 0.13399851],
+                ],
+                [
+                    [-0.00570775, 1.56608823, -1.03485088, 0.78815096],
+                    [-0.71527717, -1.23406712, -0.52557294, -0.460845],
+                    [-0.63852083, 0.86328106, 0.80663667, -0.37680572],
+                    [-0.08430816, -0.20784022, 0.67156639, 0.90230402],
+                ],
+            ],
+            dtype=np.float32,
+        )
+        np_weight = np.ones((4, 4)).astype(np.float32)
+        x = flow.tensor(input_arr, placement=PLACEMENT, sbp=S0)
+        np_out = np.matmul(input_arr, np_weight)
+
+        class MatmulModel_DP(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = flow.tensor(np_weight, placement=PLACEMENT, sbp=B)
+
+            def forward(self, x):
+                # test H2D, D2H both
+                x = x.to("cuda")
+                w = self.weight.to("cuda")
+                return flow.matmul(x, w).to("cpu")
+
+        model = MatmulModel_DP()
+
+        eager_out = model(x)
+        test_case.assertTrue(np.allclose(eager_out.numpy(), np_out, 1e-05, 1e-05))
+
+        class MatmulGraph_DP(flow.nn.Graph):
+            def __init__(self):
+                super().__init__()
+                self.model = model
+
+            def build(self, x):
+                return self.model(x)
+
+        graph = MatmulGraph_DP()
+        of_lazy_out = graph(x)
+
+        test_case.assertTrue(np.allclose(of_lazy_out.numpy(), np_out, 1e-05, 1e-05))
+
+    def test_graph_with_MP(test_case):
+        PLACEMENT = flow.placement("cpu", [0, 1])
+        S1 = flow.sbp.split(1)
+        B = flow.sbp.broadcast
+
+        input_arr = np.array(
+            [
+                [
+                    [1.96443248, -0.35818048, 0.8386318, -0.12787708],
+                    [-0.30933945, 0.01075953, -0.85546622, 0.4462768],
+                    [-0.38192172, -1.15709959, -1.33283149, -0.69705033],
+                    [-0.08594144, -1.91884209, -0.56027761, 0.13399851],
+                ],
+                [
+                    [-0.00570775, 1.56608823, -1.03485088, 0.78815096],
+                    [-0.71527717, -1.23406712, -0.52557294, -0.460845],
+                    [-0.63852083, 0.86328106, 0.80663667, -0.37680572],
+                    [-0.08430816, -0.20784022, 0.67156639, 0.90230402],
+                ],
+            ],
+            dtype=np.float32,
+        )
+        np_weight = np.ones((4, 4)).astype(np.float32)
+        x = flow.tensor(input_arr, placement=PLACEMENT, sbp=B)
+        np_out = np.matmul(input_arr, np_weight)
+
+        class MatmulModel_MP(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = flow.tensor(np_weight, placement=PLACEMENT, sbp=S1)
+
+            def forward(self, x):
+                # test H2D, D2H both
+                x = x.to("cuda")
+                w = self.weight.to("cuda")
+                print(x.shape)
+                print(w.shape)
+
+                return flow.matmul(x, w).to("cpu")
+
+        model = MatmulModel_MP()
+
+        eager_out = model(x)
+        test_case.assertTrue(np.allclose(eager_out.numpy(), np_out, 1e-05, 1e-05))
+
+        class MatmulGraph_MP(flow.nn.Graph):
+            def __init__(self):
+                super().__init__()
+                self.model = model
+
+            def build(self, x):
+                return self.model(x)
+
+        graph = MatmulGraph_MP()
+        of_lazy_out = graph(x)
+
+        test_case.assertTrue(np.allclose(of_lazy_out.numpy(), np_out, 1e-05, 1e-05))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
增加一个环境变量，用于配置是否关闭Host-to-Device、Device-to-Host的并行
当使用该配置时，H2D、 D2H操作将在Compte Stream中进行
用途:
（1）H2D、D2H操作不占用固定显存，达到显存复用的目的（解决 https://github.com/Oneflow-Inc/oneflow/issues/9716 提到的问题）；
（2）曲线实现静态图下的权重load 和 offload

待改进方面（可指点思路，继续补充实现）：
（1）目前仅用于推理
（2）H2D、 D2H 操作合并到Compte Stream后效率将受到影响，最好能实现类似Double Buffer的方法

**测试**
已用以下脚本测试，使用选项后显存与动态图相当，即实现了显存复用
https://github.com/PYNing/ttt/blob/main/bug_report_230108.py
另外补充了单元测试，在单卡、多卡下均能正常工作