### PR TITLE
add ONEFLOW_SKIP_RANDOM_INIT_IN_MODEL_INFERENCE to skip model inference init parameter

### DIFF
--- a/python/oneflow/nn/init.py
+++ b/python/oneflow/nn/init.py
@@ -49,6 +49,8 @@ def uniform_(tensor, a=0.0, b=1.0):
     """
     assert a <= b, "b must be greater than or equal to a,but got {%d} vs {%d}" % (b, a)
     with flow.no_grad():
+        if os.getenv("ONEFLOW_SKIP_RANDOM_INIT_IN_MODEL_INFERENCE") == "1":
+            return tensor
         return flow._C.uniform_(tensor, a, b)
 
 
@@ -71,6 +73,8 @@ def normal_(tensor, mean=0.0, std=1.0):
         >>> nn.init.normal_(w)
     """
     with flow.no_grad():
+        if os.getenv("ONEFLOW_SKIP_RANDOM_INIT_IN_MODEL_INFERENCE") == "1":
+            return tensor
         if tensor.is_local:
             return flow.normal(mean=mean, std=std, size=tensor.shape, out=tensor)
         else:


### PR DESCRIPTION
在模型推理中，特别是LLM模型，以codegeex为例，虽然它的参数只有10B级别（130亿）但是初始化的时间也需要3分钟左右，原因是因为目前oneflow的某些cpu算子存在性能瓶颈，具体在这里可以看到。https://github.com/Oneflow-Inc/OneTeam/issues/1884#issuecomment-1409719165 由于模型推理时初始化的参数都会被load_state_dict进来的真实模型参数覆盖掉，所以这里暂时使用一个环境变量 ONEFLOW_SKIP_RANDOM_INIT_IN_MODEL_INFERENCE 来跳过模型推理时的参数初始化，节省初始化时间。