### PR TITLE
update mock disable behaviour

### DIFF
--- a/python/oneflow/mock_torch/__init__.py
+++ b/python/oneflow/mock_torch/__init__.py
@@ -118,8 +118,8 @@ class OneflowImporter(MetaPathFinder, Loader):
                             )
                         return DummyModule(oneflow_mod_fullname)
                     else:
-                        raise ModuleNotFoundError(oneflow_mod_fullname + error_msg)
-                    
+                        raise ModuleNotFoundError(oneflow_mod_fullname + error_msg)     
+                         
                 real_mod = module_from_spec(real_spec)
                 real_spec.loader.exec_module(real_mod)
             else:

--- a/python/oneflow/mock_torch/__init__.py
+++ b/python/oneflow/mock_torch/__init__.py
@@ -178,7 +178,7 @@ class OneflowImporter(MetaPathFinder, Loader):
                 del sys.modules[k]
                 for alias in aliases:
                     del globals[alias]
-            name = k if k.find('.') == -1 else k[:k.find('.')]
+            name = k if '.' not in k else k[:k.find('.')]
             if not name in HAZARD_LIST and k in self.delete_list:
                 aliases = list(filter(lambda alias: globals[alias] is v, globals))
                 self.enable_mod_cache.update({k: (v, aliases)})

--- a/python/oneflow/mock_torch/__init__.py
+++ b/python/oneflow/mock_torch/__init__.py
@@ -178,7 +178,7 @@ class OneflowImporter(MetaPathFinder, Loader):
                 del sys.modules[k]
                 for alias in aliases:
                     del globals[alias]
-            name = k if '.' not in k else k[:k.find('.')]
+            name = k if "." not in k else k[: k.find(".")]
             if not name in HAZARD_LIST and k in self.delete_list:
                 aliases = list(filter(lambda alias: globals[alias] is v, globals))
                 self.enable_mod_cache.update({k: (v, aliases)})

--- a/python/oneflow/mock_torch/__init__.py
+++ b/python/oneflow/mock_torch/__init__.py
@@ -119,6 +119,7 @@ class OneflowImporter(MetaPathFinder, Loader):
                         return DummyModule(oneflow_mod_fullname)
                     else:
                         raise ModuleNotFoundError(oneflow_mod_fullname + error_msg)
+                    
                 real_mod = module_from_spec(real_spec)
                 real_spec.loader.exec_module(real_mod)
             else:

--- a/python/oneflow/mock_torch/__init__.py
+++ b/python/oneflow/mock_torch/__init__.py
@@ -118,8 +118,8 @@ class OneflowImporter(MetaPathFinder, Loader):
                             )
                         return DummyModule(oneflow_mod_fullname)
                     else:
-                        raise ModuleNotFoundError(oneflow_mod_fullname + error_msg)     
-                         
+                        raise ModuleNotFoundError(oneflow_mod_fullname + error_msg)
+
                 real_mod = module_from_spec(real_spec)
                 real_spec.loader.exec_module(real_mod)
             else:

--- a/python/oneflow/test/misc/test_mock_diffusers.py
+++ b/python/oneflow/test/misc/test_mock_diffusers.py
@@ -28,11 +28,15 @@ class TestMock(flow.unittest.TestCase):
         
         flow.mock_torch.enable(lazy=True)
         from diffusers import UNet2DConditionModel
-        
+        torch_module = UNet2DConditionModel.__dict__['forward'].__globals__["torch"]
+        print("Enable:")
+        print(f"{type(torch_module) = }")
         flow.mock_torch.disable()
         from diffusers import UNet2DConditionModel
         
         torch_module = UNet2DConditionModel.__dict__['forward'].__globals__["torch"]
+        print("Disable:")
+        print(f"{type(torch_module) = }")
         # check whether the torch module is the original torch
         test_case.assertFalse(isinstance(torch_module, flow.mock_torch.ModuleWrapper))
 if __name__ == "__main__":

--- a/python/oneflow/test/misc/test_mock_diffusers.py
+++ b/python/oneflow/test/misc/test_mock_diffusers.py
@@ -25,19 +25,20 @@ flow.mock_torch.disable() should be able to restore the original torch within th
 
 class TestMock(flow.unittest.TestCase):
     def test_mock_diffusers(test_case):
-        
+
         flow.mock_torch.enable(lazy=True)
         from diffusers import UNet2DConditionModel
-        torch_module = UNet2DConditionModel.__dict__['forward'].__globals__["torch"]
+
+        torch_module = UNet2DConditionModel.__dict__["forward"].__globals__["torch"]
 
         flow.mock_torch.disable()
         from diffusers import UNet2DConditionModel
-        
-        torch_module = UNet2DConditionModel.__dict__['forward'].__globals__["torch"]
-        
+
+        torch_module = UNet2DConditionModel.__dict__["forward"].__globals__["torch"]
+
         # check whether the torch module is the original torch
         test_case.assertFalse(isinstance(torch_module, flow.mock_torch.ModuleWrapper))
-        
-        
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/oneflow/test/misc/test_mock_diffusers.py
+++ b/python/oneflow/test/misc/test_mock_diffusers.py
@@ -39,5 +39,7 @@ class TestMock(flow.unittest.TestCase):
         print(f"{type(torch_module) = }")
         # check whether the torch module is the original torch
         test_case.assertFalse(isinstance(torch_module, flow.mock_torch.ModuleWrapper))
+        
+        
 if __name__ == "__main__":
     unittest.main()

--- a/python/oneflow/test/misc/test_mock_diffusers.py
+++ b/python/oneflow/test/misc/test_mock_diffusers.py
@@ -1,0 +1,39 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+import oneflow as flow
+import oneflow.unittest
+
+"""
+If some modules import torch internally, 
+flow.mock_torch.disable() should be able to restore the original torch within these modules.
+"""
+
+
+class TestMock(flow.unittest.TestCase):
+    def test_mock_diffusers(test_case):
+        
+        flow.mock_torch.enable(lazy=True)
+        from diffusers import UNet2DConditionModel
+        
+        flow.mock_torch.disable()
+        from diffusers import UNet2DConditionModel
+        
+        torch_module = UNet2DConditionModel.__dict__['forward'].__globals__["torch"]
+        # check whether the torch module is the original torch
+        test_case.assertFalse(isinstance(torch_module, flow.mock_torch.ModuleWrapper))
+if __name__ == "__main__":
+    unittest.main()

--- a/python/oneflow/test/misc/test_mock_diffusers.py
+++ b/python/oneflow/test/misc/test_mock_diffusers.py
@@ -29,14 +29,12 @@ class TestMock(flow.unittest.TestCase):
         flow.mock_torch.enable(lazy=True)
         from diffusers import UNet2DConditionModel
         torch_module = UNet2DConditionModel.__dict__['forward'].__globals__["torch"]
-        print("Enable:")
-        print(f"{type(torch_module) = }")
+
         flow.mock_torch.disable()
         from diffusers import UNet2DConditionModel
         
         torch_module = UNet2DConditionModel.__dict__['forward'].__globals__["torch"]
-        print("Disable:")
-        print(f"{type(torch_module) = }")
+        
         # check whether the torch module is the original torch
         test_case.assertFalse(isinstance(torch_module, flow.mock_torch.ModuleWrapper))
         


### PR DESCRIPTION
1. 修复了`flow.mock.disable`时，有些torch变量依旧内置于其他引用的`globals`里而导致`disable`不彻底的问题。
2. 采用的是删除import的机制，因此需要维护一个`HAZARD_LIST`存放只能被`import`一次的库(后续有可能还需更新)。
