### PR TITLE
this fixes the bug of jit.ScriptModule not found

### DIFF
--- a/python/oneflow/jit/__ScriptModule.py
+++ b/python/oneflow/jit/__ScriptModule.py
@@ -1,0 +1,27 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import warnings
+from typing import Any, Dict, List, Set, Tuple, Union, Callable
+
+
+def ScriptModule(
+    obj,
+    optimize=None,
+    _frames_up=0,
+    _rcb=None,
+    example_inputs: Union[List[Tuple], Dict[Callable, List[Tuple]], None] = None,
+):
+    warnings.warn(
+        "The oneflow.jit.ScriptModule interface is just to align the torch.jit.script interface and has no practical significance."
+    )
+    return obj

--- a/python/oneflow/jit/__init__.py
+++ b/python/oneflow/jit/__init__.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 import warnings
 from typing import Any, Dict, List, Set, Tuple, Union, Callable
-
+from oneflow.jit.__ScriptModule import ScriptModule
 
 def script(
     obj,


### PR DESCRIPTION
注册了一个空的jit.ScriptModule，在进行调用时不会再报出Attribute not implemented的问题