### PR TITLE
graph runtime state dict save/load without eager

### DIFF
--- a/python/oneflow/nn/graph/cache.py
+++ b/python/oneflow/nn/graph/cache.py
@@ -115,7 +115,7 @@ class GraphCache(object):
             return graph(*args, **kwargs)
 
     def runtime_state_dict(
-        self, destination=None
+        self, destination=None, with_eager=True,
     ) -> Dict[str, Dict[str, Union[Dict[str, Tensor], str]]]:
         if destination is None:
             destination = OrderedDict()
@@ -123,7 +123,7 @@ class GraphCache(object):
 
         for (key, graph) in self._cache.items():
             with AvoidRecursiveCacheCall(graph):
-                state_dict = graph.runtime_state_dict()
+                state_dict = graph.runtime_state_dict(with_eager=with_eager)
             state_dict["cache_order"] = graph._oneflow_graph_cache_order
             state_dict["cache_key"] = key
             destination[state_dict["graph_name"]] = state_dict

--- a/python/oneflow/nn/graph/cache.py
+++ b/python/oneflow/nn/graph/cache.py
@@ -115,7 +115,7 @@ class GraphCache(object):
             return graph(*args, **kwargs)
 
     def runtime_state_dict(
-        self, destination=None, with_eager=True,
+        self, destination=None, with_eager=False,
     ) -> Dict[str, Dict[str, Union[Dict[str, Tensor], str]]]:
         if destination is None:
             destination = OrderedDict()

--- a/python/oneflow/nn/graph/graph.py
+++ b/python/oneflow/nn/graph/graph.py
@@ -1085,7 +1085,6 @@ class Graph(object):
                                 self._state_tensor_tuple[state_idx].device
                             )
                         )
-                        print("fake save ", self._state_op_names[state_idx])
                     else:
                         _state_tensor_tuple4save.append(
                             self._state_tensor_tuple[state_idx]
@@ -1197,8 +1196,6 @@ class Graph(object):
                             assert oneflow.allclose(
                                 state_tensor_from_eager, self._state_tensor_tuple[s_idx]
                             )
-                        else:
-                            print("skip compare with eager of ", s_name)
                         self._state_tensor_tuple[s_idx] = state_tensor_from_eager
 
         self.__build_outputs_buffer()

--- a/python/oneflow/nn/graph/graph.py
+++ b/python/oneflow/nn/graph/graph.py
@@ -1012,7 +1012,7 @@ class Graph(object):
             self._enable_save_runtime_state_dict = False
 
     def runtime_state_dict(
-        self, destination=None, with_eager=True
+        self, destination=None, with_eager=False
     ) -> Union[
         Dict[str, Union[Dict[str, Tensor], str]],
         Dict[str, Dict[str, Union[Dict[str, Tensor], str]]],

--- a/python/oneflow/nn/graph/graph.py
+++ b/python/oneflow/nn/graph/graph.py
@@ -730,6 +730,7 @@ class Graph(object):
                 self._variables_conf[state_tensor] = VariableConfig(op_name)
 
         self._state_tensor_tuple = convert_to_tensor_tuple(state_tensors)
+        self._eager_state_op_names = deepcopy(state_op_names)
         return state_op_names
 
     def _generate_config_proto(self):
@@ -1011,13 +1012,15 @@ class Graph(object):
             self._enable_save_runtime_state_dict = False
 
     def runtime_state_dict(
-        self, destination=None
+        self, destination=None, with_eager=True
     ) -> Union[
         Dict[str, Union[Dict[str, Tensor], str]],
         Dict[str, Dict[str, Union[Dict[str, Tensor], str]]],
     ]:
         if self._run_with_cache == True:
-            return self._dynamic_input_graph_cache.runtime_state_dict()
+            return self._dynamic_input_graph_cache.runtime_state_dict(
+                with_eager=with_eager
+            )
 
         assert (
             self._enable_save_runtime_state_dict
@@ -1067,10 +1070,29 @@ class Graph(object):
         )
         destination["outputs"] = outputs_sub_destination
 
+        destination["oneflow_with_eager_tensor"] = with_eager
         if not self._build_with_shared_graph:
+            _state_tensor_tuple4save = []
+            if with_eager:
+                _state_tensor_tuple4save = self._state_tensor_tuple
+            else:
+                assert len(self._state_tensor_tuple) == len(self._state_op_names)
+                for state_idx in range(len(self._state_tensor_tuple)):
+                    if self._state_op_names[state_idx] in self._eager_state_op_names:
+                        # This state tensor is from eager module. Just save a dummy tensor here.
+                        _state_tensor_tuple4save.append(
+                            oneflow.Tensor().to(
+                                self._state_tensor_tuple[state_idx].device
+                            )
+                        )
+                        print("fake save ", self._state_op_names[state_idx])
+                    else:
+                        _state_tensor_tuple4save.append(
+                            self._state_tensor_tuple[state_idx]
+                        )
             states_sub_destination = OrderedDict()
             _fill_sub_destination(
-                states_sub_destination, self._state_op_names, self._state_tensor_tuple
+                states_sub_destination, self._state_op_names, _state_tensor_tuple4save
             )
             destination["states"] = states_sub_destination
 
@@ -1140,6 +1162,13 @@ class Graph(object):
             get_tensor_in_tuple, *_eager_outputs_index
         )
         self._eager_outputs = _eager_outputs
+
+        # Load state tensor of modules
+        if "oneflow_with_eager_tensor" in state_dict:
+            with_eager = state_dict["oneflow_with_eager_tensor"]
+        else:
+            with_eager = True
+
         if self._build_with_shared_graph:
             self._state_op_names = self._shared_graph._state_op_names
             self._state_tensor_tuple = self._shared_graph._state_tensor_tuple
@@ -1160,10 +1189,16 @@ class Graph(object):
                 for s_idx, s_name in enumerate(self._state_op_names):
                     if s_name in states_from_eager:
                         state_tensor_from_eager = states_from_eager[s_name]
-                        # Note: compare value has extra cost.
-                        assert oneflow.allclose(
-                            state_tensor_from_eager, self._state_tensor_tuple[s_idx]
+                        assert (
+                            state_tensor_from_eager.device
+                            == self._state_tensor_tuple[s_idx].device
                         )
+                        if with_eager:
+                            assert oneflow.allclose(
+                                state_tensor_from_eager, self._state_tensor_tuple[s_idx]
+                            )
+                        else:
+                            print("skip compare with eager of ", s_name)
                         self._state_tensor_tuple[s_idx] = state_tensor_from_eager
 
         self.__build_outputs_buffer()

--- a/python/oneflow/test/expensive/test_graph_multi_graph_v2.py
+++ b/python/oneflow/test/expensive/test_graph_multi_graph_v2.py
@@ -131,7 +131,7 @@ def _test_linear_multi_graph_share(test_case, device, with_reshape):
 
 
 @_with_new_session
-def _test_linear_multi_graph_save(return_dict, device, with_reshape):
+def _test_linear_multi_graph_save(return_dict, device, with_reshape, with_eager):
     linear = flow.nn.Linear(3, 8, False)
     linear = linear.to(device)
     np_weight = np.ones((3, 8)).astype(np.float32)
@@ -222,7 +222,7 @@ def _test_linear_multi_graph_save(return_dict, device, with_reshape):
     test_case1 = np.array_equal(of_lazy_out1.numpy(), of_eager_out1.numpy())
     return_dict["save4"] = test_case1
 
-    state_dict = linear_g.runtime_state_dict()
+    state_dict = linear_g.runtime_state_dict(with_eager=with_eager)
     print("====> saved graphs", state_dict.keys())
     return state_dict
 
@@ -301,8 +301,10 @@ def _test_linear_multi_graph_load(return_dict, device, with_reshape, state_dict)
     # TODO(strint): shared from a load graph.
 
 
-def _graph_save(return_dict, filename):
-    state_dict = _test_linear_multi_graph_save(return_dict, flow.device("cuda"), True)
+def _graph_save(return_dict, filename, with_eager):
+    state_dict = _test_linear_multi_graph_save(
+        return_dict, flow.device("cuda"), True, with_eager
+    )
     flow.save(state_dict, filename)
 
 
@@ -314,14 +316,14 @@ def _graph_load(return_dict, filename):
     )
 
 
-def _test_linear_multi_graph_save_load_gpu(test_case):
+def _test_linear_multi_graph_save_load_gpu(test_case, with_eager):
     # A graph runtime state dict
     with tempfile.NamedTemporaryFile() as f:
         # Save a graph
         manager = multiprocessing.Manager()
         return_dict = manager.dict()
         save_p = multiprocessing.get_context("spawn").Process(
-            target=_graph_save, args=(return_dict, f.name)
+            target=_graph_save, args=(return_dict, f.name, with_eager)
         )
         save_p.start()
         save_p.join()
@@ -349,7 +351,10 @@ class TestLinearMultiGraph(oneflow.unittest.TestCase):
         _test_linear_multi_graph_share(test_case, flow.device("cuda"), True)
 
     def test_linear_multi_graph_save_load_gpu_with_share(test_case):
-        _test_linear_multi_graph_save_load_gpu(test_case)
+        _test_linear_multi_graph_save_load_gpu(test_case, True)
+
+    def test_linear_multi_graph_save_load_gpu_with_share_without_eager(test_case):
+        _test_linear_multi_graph_save_load_gpu(test_case, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
sd unet graph save/load test: https://github.com/Oneflow-Inc/diffusers/blob/main/examples/unet_torch_interplay.py

## with_eager True
```
saving graphs...
get state dict time:  0.33900022506713867
state_dict(with_eager=True) tensors size  2768.363235473633  MB.
save state dict time:  13.160083293914795
```

```
loading graphs...
load state dict time:  2.118417739868164
state_dict tensors size  2768.363235473633  MB.
load into graph time:  3.463979482650757
```

## with_eager False
Set with_eager to False
```
runtime_state_dict(with_eager=False)
```

```
saving graphs...
get state dict time:  0.3210592269897461
state_dict(with_eager=False) tensors size  1128.9570999145508  MB.
save state dict time:  5.13447380065918
```

```
loading graphs...
load state dict time:  0.9304521083831787
state_dict tensors size  1128.9570999145508  MB.
load into graph time:  3.212466239929199
```

**with_eager False can make state_dict size and time cost reduced 56%**