### PR TITLE
add master broadcast perf tool

### DIFF
--- a/cmake/oneflow.cmake
+++ b/cmake/oneflow.cmake
@@ -440,6 +440,10 @@ function(oneflow_add_test target_name)
                                 "HTTP_PROXY='';HTTPS_PROXY='';http_proxy='';https_proxy='';")
 endfunction()
 
+# broadcast perf program
+oneflow_add_executable(broadcast_perf "${PROJECT_SOURCE_DIR}/oneflow/perf/master_broadcast_perf.cpp")
+target_link_libraries(broadcast_perf ${of_libs} ${oneflow_third_party_libs} glog::glog)
+
 # build test
 if(BUILD_TESTING)
   if(of_all_test_cc)

--- a/oneflow/perf/master_broadcast_perf.cpp
+++ b/oneflow/perf/master_broadcast_perf.cpp
@@ -1,0 +1,177 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <glog/logging.h>
+#include <cstddef>
+#include <cmath>
+#include <cstdlib>
+#include <mutex>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <string>
+#include <vector>
+#include <chrono>
+#include "oneflow/core/common/env_var/env_var.h"
+#include "oneflow/core/common/env_var/lazy.h"
+#include "oneflow/core/common/singleton.h"
+#include "oneflow/core/framework/nn_graph.h"
+#include "oneflow/core/framework/shut_down_util.h"
+#include "oneflow/core/rpc/include/base.h"
+#include "oneflow/core/rpc/include/global_process_ctx.h"
+#include "oneflow/core/thread/thread_manager.h"
+#include "oneflow/core/control/ctrl_client.h"
+#include "oneflow/core/control/global_process_ctx.h"
+#include "oneflow/api/cpp/api.h"
+
+using namespace oneflow;
+
+#define WORLD_SIZE 3
+
+bool HasEnvVar(const std::string& key) {
+  const char* value = getenv(key.c_str());
+  return value != nullptr;
+}
+
+std::string GetEnvVar(const std::string& key, const std::string& default_value) {
+  const char* value = getenv(key.c_str());
+  if (value == nullptr) { return default_value; }
+  return std::string(value);
+}
+
+int64_t GetEnvVar(const std::string& key, int64_t default_value) {
+  const char* value = getenv(key.c_str());
+  if (value == nullptr) { return default_value; }
+  return std::atoll(value);
+}
+
+class DistributeOneFlowEnv {
+ public:
+  explicit DistributeOneFlowEnv(size_t rank, size_t world_size) {
+    EnvProto env_proto;
+    CompleteEnvProto(env_proto, rank, world_size);
+    env_ctx_ = std::make_shared<EnvGlobalObjectsScope>(env_proto);
+  }
+  ~DistributeOneFlowEnv() { env_ctx_.reset(); }
+
+  void CompleteEnvProto(EnvProto& env_proto, size_t rank, size_t world_size) {
+    auto bootstrap_conf = env_proto.mutable_ctrl_bootstrap_conf();
+    auto master_addr = bootstrap_conf->mutable_master_addr();
+    // TODO: addr和port作为参数传入
+    const std::string addr = "127.0.0.1";
+    size_t master_port = 49155;
+    size_t port = master_port + rank;
+
+    master_addr->set_host(addr);
+    master_addr->set_port(master_port);
+
+    bootstrap_conf->set_world_size(world_size);
+    bootstrap_conf->set_rank(rank);
+    bootstrap_conf->set_ctrl_port(port);
+    bootstrap_conf->set_host("127.0.0.1");
+
+    auto cpp_logging_conf = env_proto.mutable_cpp_logging_conf();
+    if (HasEnvVar("GLOG_log_dir")) {
+      cpp_logging_conf->set_log_dir(GetEnvVar("GLOG_log_dir", ""));
+      LOG(INFO) << "LOG DIR: " << cpp_logging_conf->log_dir();
+    }
+    if (HasEnvVar("GLOG_logtostderr")) {
+      cpp_logging_conf->set_logtostderr(GetEnvVar("GLOG_logtostderr", -1));
+    }
+    if (HasEnvVar("GLOG_logbuflevel")) {
+      cpp_logging_conf->set_logbuflevel(GetEnvVar("GLOG_logbuflevel", -1));
+    }
+    if (HasEnvVar("GLOG_minloglevel")) {
+      cpp_logging_conf->set_minloglevel(GetEnvVar("GLOG_minloglevel", -1));
+    }
+  }
+
+ private:
+  std::shared_ptr<EnvGlobalObjectsScope> env_ctx_;
+};
+
+class TestEnvScope {
+ public:
+  explicit TestEnvScope(size_t rank, size_t world_size) {
+    if (Singleton<DistributeOneFlowEnv>::Get() == nullptr) {
+      Singleton<DistributeOneFlowEnv>::New(rank, world_size);
+    }
+  }
+
+  ~TestEnvScope() {
+    if (Singleton<DistributeOneFlowEnv>::Get() != nullptr) {
+      Singleton<DistributeOneFlowEnv>::Delete();
+    }
+  }
+};
+
+template<typename X, typename Y>
+std::set<std::string> MultiThreadBroadcastFromMasterToWorkers(size_t world_size,
+                                                              const std::string& prefix,
+                                                              const X& master_data,
+                                                              Y* worker_data) {
+  const size_t thread_num = ThreadLocalEnvInteger<ONEFLOW_LAZY_COMPILE_RPC_THREAD_NUM>();
+  const size_t split_num = std::sqrt(world_size);
+  BalancedSplitter bs(world_size, split_num);
+  std::set<std::string> keys;
+  if (GlobalProcessCtx::IsThisProcessMaster()) {
+    std::mutex mtx4keys;
+    const std::string& data = master_data;
+    MultiThreadLoop(
+        split_num,
+        [&](int i) {
+          std::string key = prefix + std::to_string(i);
+          Singleton<CtrlClient>::Get()->PushKV(key, data);
+          std::lock_guard<std::mutex> lock(mtx4keys);
+          CHECK(keys.insert(key).second);
+        },
+        thread_num);
+  } else {
+    const int64_t bs_index = bs.GetRangIndex(GlobalProcessCtx::Rank());
+    std::string key = prefix + std::to_string(bs_index);
+    Singleton<CtrlClient>::Get()->PullKV(key, worker_data);
+  }
+  return keys;
+}
+
+int main(int argc, char* argv[]) {
+  if (argc == 1) { LOG(FATAL) << "Error: must set world_size and rank"; }
+  size_t world_size = std::stoi(argv[1]);
+  size_t rank = std::stoi(argv[2]);
+
+  std::string master_data, worker_data;
+  if (rank == 0) {
+    master_data.resize(10 * 1024 * 1024);  // 10MB
+  }
+  std::string prefix("test");
+
+  TestEnvScope scope(rank, world_size);
+
+  LOG(INFO) << "world size: " << Singleton<GlobalProcessCtx>::Get()->WorldSize();
+  auto start_time = std::chrono::high_resolution_clock::now();
+  std::set<std::string> keys =
+      MultiThreadBroadcastFromMasterToWorkers(world_size, prefix, master_data, &worker_data);
+
+  // synchronize all process
+  Singleton<CtrlClient>::Get()->Barrier("sync all process");
+  auto end_time = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+
+  if (rank == 0) {
+    LOG(INFO) << "broadcast to all workers"
+              << " spends time: " << duration.count() << " ms";
+  }
+
+  return 0;
+}


### PR DESCRIPTION
构造一个 CtrlClient 同步数据的模拟工具，用于评估master向worker广播的性能。
开启3个进程测试功能：
发现仍存在问题待解决：
```
W20230327 06:15:53.597208 2091708 rank_info_bootstrap_server.cpp:103] BootstrapServer not ready, rpc server on some rank have not been created successfully. Failed at 2 times, total ranks(world_size): 3, ready ranks: 2
```
尝试解决：
1. 多次执行发现个别尝试能够3个进程都 ready，但大多数时候不行，考虑重试次数太少
```cpp
DEFINE_ENV_INTEGER(ONEFLOW_RPC_BOOTSTRAP_SERVER_MAX_RETRY_TIMES, 3);
DEFINE_ENV_INTEGER(ONEFLOW_RPC_CLIENT_MAX_RETRY_TIMES, 6);
```
将上两个重试次数更改为1000次，依旧失败.

2. 在链路加上大量log，排查原因
上述问题出现在 Boostrap 阶段 
```cpp
  CHECK_JUST(Singleton<RpcManager>::Get()->CreateServer());
  LOG(WARNING) << "rank " << rank << " create server success";
  CHECK_JUST(Singleton<RpcManager>::Get()->Bootstrap());
  LOG(WARNING) << "rank " << rank << " bootstrap success";
  CHECK_JUST(Singleton<RpcManager>::Get()->CreateClient());
  LOG(WARNING) << "rank " << rank << " create client success";
```
进一步查找是在 LoadServer 阶段:
于是在 RPC server中加上log：
```cpp
Add([this](CtrlCall<CtrlMethod::kLoadServer>* call) {
    LOG(WARNING) << "RPC Server receive KLoadServer call"; // 增加log
    OnLoadServer(call);
  });
```
在 OnLoadServer中加入log：
```cpp
void RankInfoBootstrapServer::OnLoadServer(CtrlCall<CtrlMethod::kLoadServer>* call) {
  int64_t rank = call->request().rank();
  CHECK_GE(rank, 0);
  CHECK_LT(rank, world_size_);
  if (!rank2host_) { rank2host_ = std::make_shared<std::vector<std::string>>(world_size_); }
  std::lock_guard<std::mutex> lock(lock_);
  rank2host_->at(rank) = GetHostFromUri(call->server_ctx().peer());
  LOG(WARNING) << "rank " << rank << " 's url: " << call->server_ctx().peer(); // 增加log，表示rank load ready
  call->SendResponse();
  EnqueueRequest<CtrlMethod::kLoadServer>();
}
```
再在RPC client中加入log：
```cpp
void RpcClient::LoadServer(const LoadServerRequest& request, CtrlService::Stub* stub) {
  int32_t retry_idx = 0;
  int32_t skip_warning_times = 3;
  for (; retry_idx < rpc_client_max_retry_times(); ++retry_idx) {
    grpc::ClientContext client_ctx;
    LoadServerResponse response;
    LOG(WARNING) << "rank " << request.rank() << " call LoadServer to " << request.addr()
                 << " at retry " << retry_idx;  // 加入log
    grpc::Status st = stub->CallMethod<CtrlMethod::kLoadServer>(&client_ctx, request, &response);
    if (st.error_code() == grpc::StatusCode::OK) {
      VLOG(3) << "LoadServer " << request.addr() << " Successful at " << retry_idx + 1 << " times";
      break;
    } else if (st.error_code() == grpc::StatusCode::UNAVAILABLE) {
      if (retry_idx >= skip_warning_times) {
        LOG(WARNING) << "LoadServer " << request.addr() << " Failed at " << retry_idx + 1
                     << " times"
                     << " error_code: " << st.error_code()
                     << " error_message: " << st.error_message();
      }
      std::this_thread::sleep_for(std::chrono::seconds(rpc_client_sleep_seconds()));
      continue;
    } else {
      LOG(FATAL) << st.error_message();
    }
  }
  LOG(WARNING) << "rank " << request.rank() << " ends LoadServer loop";  // 加入log，表示退出重试循环
  CHECK_LT(retry_idx, rpc_client_max_retry_times());
}
```

运行程序得到log
在master中：
```
W20230327 06:15:13.594259 2091639 env_global_objects_scope.cpp:176] rank 0 create server success
W20230327 06:15:13.595381 2091639 rpc_client.cpp:196] rank 0 call LoadServer to 127.0.0.1 at retry 0
W20230327 06:15:13.596731 2091707 rpc_server.cpp:67] RPC Server receive KLoadServer call
W20230327 06:15:13.596812 2091707 rank_info_bootstrap_server.cpp:130] rank 0 's url: ipv4:127.0.0.1:34044
W20230327 06:15:13.597214 2091639 rpc_client.cpp:216] rank 0 ends LoadServer loop
W20230327 06:15:14.802946 2091707 rpc_server.cpp:67] RPC Server receive KLoadServer call
W20230327 06:15:14.803052 2091707 rank_info_bootstrap_server.cpp:130] rank 2 's url: ipv4:127.0.0.1:57382
W20230327 06:15:15.993507 2091706 rpc_server.cpp:67] RPC Server receive KLoadServer call
W20230327 06:15:53.597208 2091708 rank_info_bootstrap_server.cpp:103] BootstrapServer not ready, rpc server on some rank have not been created successfully. Failed at 2 times, total ranks(world_size): 3, ready ranks: 2
W20230327 06:16:13.597550 2091708 rank_info_bootstrap_server.cpp:103] BootstrapServer not ready, rpc server on some rank have not been created successfully. Failed at 3 times, total ranks(world_size): 3, ready ranks: 2
```
在worker1中：
```
W20230327 06:15:15.991744 2091981 env_global_objects_scope.cpp:176] rank 1 create server success
W20230327 06:15:15.992609 2091981 rpc_client.cpp:196] rank 1 call LoadServer to 127.0.0.1 at retry 0
W20230327 06:15:15.993794 2091981 rpc_client.cpp:216] rank 1 ends LoadServer loop
```
在worker2中：
```
W20230327 06:15:14.799631 2091909 env_global_objects_scope.cpp:176] rank 2 create server success
W20230327 06:15:14.801512 2091909 rpc_client.cpp:196] rank 2 call LoadServer to 127.0.0.1 at retry 0
W20230327 06:15:14.803706 2091909 rpc_client.cpp:216] rank 2 ends LoadServer loop
```
分析log内容：
首选在master中，可以看到master收到了3次`RPC Server receive KLoadServer call`，但只执行了2次，即只load了rank0和rank2，rank1并没有被load，
再看worker中，rank1和rank2都结束了`LoadServer loop` ，也就是grpc返回了`OK` 
这样看的话，应该不是客户端中出现的问题，而是server收到了请求，但并没有处理