### PR TITLE
supprt fine-grained disable

### DIFF
--- a/oneflow/core/ep/include/primitive/primitive.h
+++ b/oneflow/core/ep/include/primitive/primitive.h
@@ -47,6 +47,7 @@ class Factory {
 template<typename FactoryType, typename... Args>
 static std::unique_ptr<typename FactoryType::PrimitiveType> NewPrimitive(DeviceType device_type,
                                                                          Args&&... args) {
+  if (!IsClassRegistered<DeviceType, FactoryType>(device_type)) { return nullptr; }
   std::unique_ptr<FactoryType> factory = NewObjUniquePtr<DeviceType, FactoryType>(device_type);
   if (!factory) { return nullptr; }
   return factory->New(std::forward<Args>(args)...);

--- a/python/oneflow/mock_torch/__init__.py
+++ b/python/oneflow/mock_torch/__init__.py
@@ -32,7 +32,13 @@ error_msg = """ is not implemented, please submit an issue at
 'https://github.com/Oneflow-Inc/oneflow/issues' including the log information of the error, the 
 minimum reproduction code, and the system information."""
 
-hazard_list = ["_distutils_hack", "importlib", "regex", "tokenizers", "safetensors._safetensors_rust"]
+hazard_list = [
+    "_distutils_hack",
+    "importlib",
+    "regex",
+    "tokenizers",
+    "safetensors._safetensors_rust",
+]
 
 # module wrapper with checks for existence of methods
 class ModuleWrapper(ModuleType):
@@ -179,7 +185,11 @@ class OneflowImporter(MetaPathFinder, Loader):
                 for alias in aliases:
                     del globals[alias]
             name = k if "." not in k else k[: k.find(".")]
-            if not name in hazard_list and not k in hazard_list and k in self.delete_list:
+            if (
+                not name in hazard_list
+                and not k in hazard_list
+                and k in self.delete_list
+            ):
                 aliases = list(filter(lambda alias: globals[alias] is v, globals))
                 self.enable_mod_cache.update({k: (v, aliases)})
                 del sys.modules[k]

--- a/python/oneflow/mock_torch/__init__.py
+++ b/python/oneflow/mock_torch/__init__.py
@@ -32,8 +32,7 @@ error_msg = """ is not implemented, please submit an issue at
 'https://github.com/Oneflow-Inc/oneflow/issues' including the log information of the error, the 
 minimum reproduction code, and the system information."""
 
-# TODO(peiyuan): support fine-grained package name like "safetensor.safetensor_rust"
-HAZARD_LIST = ["_distutils_hack", "importlib", "regex", "tokenizers", "safetensors"]
+hazard_list = ["_distutils_hack", "importlib", "regex", "tokenizers", "safetensors._safetensors_rust"]
 
 # module wrapper with checks for existence of methods
 class ModuleWrapper(ModuleType):
@@ -180,7 +179,7 @@ class OneflowImporter(MetaPathFinder, Loader):
                 for alias in aliases:
                     del globals[alias]
             name = k if "." not in k else k[: k.find(".")]
-            if not name in HAZARD_LIST and k in self.delete_list:
+            if not name in hazard_list and not k in hazard_list and k in self.delete_list:
                 aliases = list(filter(lambda alias: globals[alias] is v, globals))
                 self.enable_mod_cache.update({k: (v, aliases)})
                 del sys.modules[k]

--- a/python/oneflow/test/misc/test_mock_scope.py
+++ b/python/oneflow/test/misc/test_mock_scope.py
@@ -170,7 +170,12 @@ class TestMock(flow.unittest.TestCase):
             test_case.assertFalse(
                 hasattr(torch.nn.functional, "scaled_dot_product_attention")
             )
-
+            
+    def test_hazard_list(test_case):
+        with mock.enable():
+            import sys
+            import safetensors
+        test_case.assertTrue('safetensors._safetensors_rust' in sys.modules)
 
 # MUST use pytest to run this test
 def test_verbose(capsys):

--- a/python/oneflow/test/misc/test_mock_scope.py
+++ b/python/oneflow/test/misc/test_mock_scope.py
@@ -176,6 +176,7 @@ class TestMock(flow.unittest.TestCase):
             import sys
             import safetensors
         test_case.assertTrue('safetensors._safetensors_rust' in sys.modules)
+        import safetensors
 
 # MUST use pytest to run this test
 def test_verbose(capsys):

--- a/python/oneflow/test/misc/test_mock_scope.py
+++ b/python/oneflow/test/misc/test_mock_scope.py
@@ -170,13 +170,14 @@ class TestMock(flow.unittest.TestCase):
             test_case.assertFalse(
                 hasattr(torch.nn.functional, "scaled_dot_product_attention")
             )
-            
+
     def test_hazard_list(test_case):
         with mock.enable():
             import sys
             import safetensors
-        test_case.assertTrue('safetensors._safetensors_rust' in sys.modules)
+        test_case.assertTrue("safetensors._safetensors_rust" in sys.modules)
         import safetensors
+
 
 # MUST use pytest to run this test
 def test_verbose(capsys):


### PR DESCRIPTION
* 支持更加精细化的disable（例如`safetensors._safetensors_rust`），并在在test_mock_scope.py中增加了单测
* 将HAZARD_LIST由大写改成小写，用户可以自行添加维护此list