### PR TITLE
add set_grad_mode in __init__

### DIFF
--- a/oneflow/api/python/autograd/autograd_mode.cpp
+++ b/oneflow/api/python/autograd/autograd_mode.cpp
@@ -32,6 +32,7 @@ ONEFLOW_API_PYBIND11_MODULE("autograd", m) {
       .def("__exit__", [](const AutoGradMode& no_grad_obj, const py::object& type,
                           const py::object& value, const py::object& traceback) {});
   m.def("is_grad_enabled", &GradMode::is_enabled);
+  m.def("set_grad_enabled", &GradMode::set_enabled);
 }
 
 }  // namespace autograd

--- a/python/oneflow/autograd/autograd_mode.py
+++ b/python/oneflow/autograd/autograd_mode.py
@@ -196,20 +196,21 @@ class set_grad_enabled:
 
     def __init__(self, is_train=True):
         self.is_train = is_train
+        self.prev_mode = oneflow._oneflow_internal.autograd.is_grad_enabled()
+        oneflow._oneflow_internal.autograd.set_grad_enabled(is_train)
 
     def __call__(self, func):
         def wrapper(*args, **kwargs):
             with AutoGradMode(self.is_train):
                 return func(*args, **kwargs)
-
+        oneflow._oneflow_internal.autograd.set_grad_enabled(self.prev_mode)
         return wrapper
 
     def __enter__(self):
-        self.grad_mode = AutoGradMode(self.is_train)
-        return self
+        pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+        oneflow._oneflow_internal.autograd.set_grad_enabled(self.prev_mode)
 
 
 if __name__ == "__main__":

--- a/python/oneflow/test/modules/test_autograd_mode.py
+++ b/python/oneflow/test/modules/test_autograd_mode.py
@@ -94,6 +94,24 @@ class TestAutogradMode(oneflow.unittest.TestCase):
         func()
         test_case.assertTrue(flow.is_grad_enabled())
 
+        flow.set_grad_enabled(False)
+        test_case.assertFalse(flow.is_grad_enabled())
+
+        with flow.set_grad_enabled(True):
+            test_case.assertTrue(flow.is_grad_enabled())
+            flow.set_grad_enabled(False)
+            test_case.assertFalse(flow.is_grad_enabled())
+        test_case.assertFalse(flow.is_grad_enabled())
+
+        flow.set_grad_enabled(True)
+        test_case.assertTrue(flow.is_grad_enabled())
+
+        with flow.set_grad_enabled(False):
+            test_case.assertFalse(flow.is_grad_enabled())
+            flow.set_grad_enabled(True)
+            test_case.assertTrue(flow.is_grad_enabled())
+        test_case.assertTrue(flow.is_grad_enabled())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#close https://github.com/Oneflow-Inc/OneCloud/issues/203#issuecomment-1473171630

原先这里和 torch 的实现不同，我们是用 AutoGradMode 这个 C++ 对象的 RAII 来实现更改 grad mode 的，而 torch 是显式地调用 set_grad_mode 来更改的。这就导致了 OneFlow 里面没法全局修改线程里面的 grad mode，只能在装饰器或者上下文语句里面修改。