### PR TITLE
Support GetDataType for cuComplex and cuDoubleComplex, and modify some docstring

### DIFF
--- a/oneflow/core/common/data_type.h
+++ b/oneflow/core/common/data_type.h
@@ -21,6 +21,7 @@ limitations under the License.
 #if defined(WITH_CUDA)
 #include <cuda_fp16.h>
 #include <cuda.h>
+#include <cuComplex.h>
 #if CUDA_VERSION >= 11000
 #include <cuda_bf16.h>
 #endif  // CUDA_VERSION >= 11000
@@ -154,6 +155,13 @@ OF_PP_FOR_EACH_TUPLE(SPECIALIZE_GET_DATA_TYPE,
 template<typename T>
 struct GetDataType<T, typename std::enable_if<IsFloat16<T>::value>::type>
     : std::integral_constant<DataType, DataType::kFloat16> {};
+
+#ifdef WITH_CUDA
+template<>
+struct GetDataType<cuComplex> : std::integral_constant<DataType, DataType::kComplex64> {};
+template<>
+struct GetDataType<cuDoubleComplex> : std::integral_constant<DataType, DataType::kComplex128> {};
+#endif  // WITH_CUDA
 
 #if CUDA_VERSION >= 11000
 template<>

--- a/python/oneflow/framework/docstr/math_ops.py
+++ b/python/oneflow/framework/docstr/math_ops.py
@@ -805,7 +805,7 @@ add_docstr(
         >>> input = flow.tensor(arr, dtype=flow.float32)
         >>> output = flow.cosh(input).numpy()
         >>> output
-        array([1.0133467, 1.7859949, 1.2535788, 1.2804903], dtype=float32)
+        array([1.0133467, 1.7859949, 1.2535787, 1.2804903], dtype=float32)
 
     """,
 )
@@ -881,12 +881,12 @@ add_docstr(
         >>> x = flow.tensor(np.array([0, -1., 10.]), dtype=flow.float32)
         >>> out = flow.erfc(x)
         >>> out
-        tensor([1.0000e+00, 1.8427e+00, 1.4013e-45], dtype=oneflow.float32)
+        tensor([1.0000e+00, 1.8427e+00, 2.8026e-45], dtype=oneflow.float32)
 
         >>> x = flow.tensor(np.array([[0, -1., 10.], [5, 7, 0.8]]), dtype=flow.float32)
         >>> out = flow.erfc(x)
         >>> out
-        tensor([[1.0000e+00, 1.8427e+00, 1.4013e-45],
+        tensor([[1.0000e+00, 1.8427e+00, 2.8026e-45],
                 [1.5375e-12, 4.1838e-23, 2.5790e-01]], dtype=oneflow.float32)
 
     """,
@@ -927,11 +927,11 @@ add_docstr(
         >>> print(y.shape)
         oneflow.Size([2, 2, 3])
         >>> print(y.numpy())
-        [[[6.3890562e+00 5.3598148e+01 4.0242880e+02]
+        [[[6.3890562e+00 5.3598152e+01 4.0242880e+02]
           [1.0956332e+03 2.9799580e+03 8.1020840e+03]]
         <BLANKLINE>
          [[2.2025465e+04 5.9873141e+04 1.6275380e+05]
-          [4.4241241e+05 1.2026032e+06 3.2690162e+06]]]
+          [4.4241238e+05 1.2026032e+06 3.2690165e+06]]]
 
 
     """,


### PR DESCRIPTION
主要工作：

为支持在GPU上进行复数数据类型运算的相关op，扩展`GetDataType`接口支持`cuComplex`和`cuDoubleComplex`两种数据类型。

问题讨论：

发现扩展`GetDataType`接口后使已有接口如`cosh`, `expm1`运算结果产生微小变化，但是变化范围在float32数据类型精度允许范围之内（6位有效数字），猜测原因是编译器行为改变导致。
