### PR TITLE
Optimize broadcast strategy

### DIFF
--- a/oneflow/core/control/ctrl_client.cpp
+++ b/oneflow/core/control/ctrl_client.cpp
@@ -86,6 +86,15 @@ void GrpcCtrlClient::PushMasterKV(const std::string& k, const PbMessage& msg) {
   rpc_client_.PushMasterKV(k, msg);
 }
 
+void GrpcCtrlClient::PushRankKV(const size_t rank, const std::string& k,
+                                std::function<void(std::string*)> VSetter) {
+  rpc_client_.PushRankKV(rank, k, VSetter);
+}
+
+void GrpcCtrlClient::PushRankKV(const size_t rank, const std::string& k, const std::string& v) {
+  rpc_client_.PushRankKV(rank, k, v);
+}
+
 void GrpcCtrlClient::ClearKV(const std::string& k) { rpc_client_.ClearKV(k); }
 
 void GrpcCtrlClient::ClearMasterKV(const std::string& k) { rpc_client_.ClearMasterKV(k); }
@@ -100,6 +109,15 @@ void GrpcCtrlClient::PullKV(const std::string& k, std::function<void(const std::
 
 void GrpcCtrlClient::PullMasterKV(const std::string& k, PbMessage* msg) {
   rpc_client_.PullMasterKV(k, msg);
+}
+
+void GrpcCtrlClient::PullRankKV(const size_t rank, const std::string& k,
+                                std::function<void(const std::string&)> VGetter) {
+  rpc_client_.PullRankKV(rank, k, VGetter);
+}
+
+void GrpcCtrlClient::PullRankKV(const size_t rank, const std::string& k, std::string* v) {
+  rpc_client_.PullRankKV(rank, k, v);
 }
 
 void GrpcCtrlClient::Clear() { rpc_client_.Clear(); }

--- a/oneflow/core/control/ctrl_client.cpp
+++ b/oneflow/core/control/ctrl_client.cpp
@@ -120,6 +120,10 @@ void GrpcCtrlClient::PullRankKV(const size_t rank, const std::string& k, std::st
   rpc_client_.PullRankKV(rank, k, v);
 }
 
+void GrpcCtrlClient::PullRankKV(const size_t rank, const std::string& k, PbMessage* msg) {
+  rpc_client_.PullRankKV(rank, k, msg);
+}
+
 void GrpcCtrlClient::Clear() { rpc_client_.Clear(); }
 
 int32_t GrpcCtrlClient::IncreaseCount(const std::string& k, int32_t v) {

--- a/oneflow/core/control/rpc_client.cpp
+++ b/oneflow/core/control/rpc_client.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "oneflow/core/control/rpc_client.h"
+#include "oneflow/core/common/protobuf.h"
 #include "oneflow/core/control/global_process_ctx.h"
 #include "oneflow/core/job/env_desc.h"
 #include "oneflow/core/common/env_var/bootstrap.h"
@@ -179,6 +180,10 @@ void RpcClient::PullRankKV(const size_t rank, const std::string& k,
 
 void RpcClient::PullRankKV(const size_t rank, const std::string& k, std::string* v) {
   PullRankKV(rank, k, [&](const std::string& i) { *v = i; });
+}
+
+void RpcClient::PullRankKV(const size_t rank, const std::string& k, PbMessage* msg) {
+  PullRankKV(rank, k, [&](const std::string& i) { msg->ParseFromString(i); });
 }
 
 void RpcClient::Clear() {

--- a/oneflow/core/control/rpc_client.h
+++ b/oneflow/core/control/rpc_client.h
@@ -44,6 +44,9 @@ class RpcClient {
   typename std::enable_if<std::is_arithmetic<T>::value>::type PushKVT(const std::string& k, T v) {
     PushKV(k, std::to_string(v));
   }
+  void PushRankKV(const size_t rank, const std::string& k,
+                  std::function<void(std::string*)> VSetter);
+  void PushRankKV(const size_t rank, const std::string& k, const std::string& v);
 
   void ClearKV(const std::string& k);
   void ClearMasterKV(const std::string& k);
@@ -58,6 +61,10 @@ class RpcClient {
     PullKV(k, &v_str);
     *v = oneflow_cast<T>(v_str);
   }
+
+  void PullRankKV(const size_t rank, const std::string& k,
+                  std::function<void(const std::string&)> VGetter);
+  void PullRankKV(const size_t rank, const std::string& k, std::string* v);
 
   void Clear();
 

--- a/oneflow/core/control/rpc_client.h
+++ b/oneflow/core/control/rpc_client.h
@@ -65,6 +65,7 @@ class RpcClient {
   void PullRankKV(const size_t rank, const std::string& k,
                   std::function<void(const std::string&)> VGetter);
   void PullRankKV(const size_t rank, const std::string& k, std::string* v);
+  void PullRankKV(const size_t, const std::string& k, PbMessage* msg);
 
   void Clear();
 

--- a/oneflow/core/framework/nn_graph.cpp
+++ b/oneflow/core/framework/nn_graph.cpp
@@ -471,28 +471,61 @@ std::set<std::string> MultiThreadBroadcastFromMasterToWorkers(size_t world_size,
                                                               const std::string& prefix,
                                                               const X& master_data,
                                                               Y* worker_data) {
-  const size_t thread_num = ThreadLocalEnvInteger<ONEFLOW_LAZY_COMPILE_RPC_THREAD_NUM>();
-  const size_t split_num = std::sqrt(world_size);
-  BalancedSplitter bs(world_size, split_num);
   std::set<std::string> keys;
-  if (GlobalProcessCtx::IsThisProcessMaster()) {
-    std::mutex mtx4keys;
-    std::string data;
-    master_data.SerializeToString(&data);
-    MultiThreadLoop(
-        split_num,
-        [&](int i) {
-          std::string key = prefix + std::to_string(i);
-          Singleton<CtrlClient>::Get()->PushKV(key, data);
-          std::lock_guard<std::mutex> lock(mtx4keys);
-          CHECK(keys.insert(key).second);
-        },
-        thread_num);
+  char* broadcast_strategy = std::getenv("BROADCAST_STRATEGY");
+  const size_t thread_num = ThreadLocalEnvInteger<ONEFLOW_LAZY_COMPILE_RPC_THREAD_NUM>();
+  // optimize n <= k case
+  if (broadcast_strategy && std::string(broadcast_strategy) == "LOCAL_RANK_PROXY") {
+    if (GlobalProcessCtx::IsThisProcessMaster()) {
+      std::mutex mtx4keys;
+      std::string data;
+      master_data.SerializeToString(&data);
+      const size_t node_size = Singleton<GlobalProcessCtx>::Get()->NodeSize();
+      MultiThreadLoop(
+          node_size,
+          [&](int i) {
+            const size_t single_node_process_num =
+                Singleton<GlobalProcessCtx>::Get()->NumOfProcessPerNode();
+            const size_t target_rank = single_node_process_num * i;
+            std::string key = prefix + std::to_string(i);
+            Singleton<CtrlClient>::Get()->PushRankKV(target_rank, key, data);
+            std::lock_guard<std::mutex> lock(mtx4keys);
+            CHECK(keys.insert(key).second);
+          },
+          thread_num);
+    } else {
+      const size_t rank = Singleton<GlobalProcessCtx>::Get()->Rank();
+      const size_t local_rank = Singleton<GlobalProcessCtx>::Get()->LocalRank();
+      const size_t node_id = Singleton<GlobalProcessCtx>::Get()->NodeId(rank);
+      std::string key = prefix + std::to_string(node_id);
+      const size_t target_rank = rank - local_rank;
+      Singleton<CtrlClient>::Get()->PullRankKV(target_rank, key, worker_data);
+    }
+
+    // other broadcast case
   } else {
-    const int64_t bs_index = bs.GetRangeIndexForVal(GlobalProcessCtx::Rank());
-    std::string key = prefix + std::to_string(bs_index);
-    Singleton<CtrlClient>::Get()->PullKV(key, worker_data);
+    const size_t split_num = std::sqrt(world_size);
+    BalancedSplitter bs(world_size, split_num);
+    if (GlobalProcessCtx::IsThisProcessMaster()) {
+      std::mutex mtx4keys;
+      std::string data;
+      master_data.SerializeToString(&data);
+      MultiThreadLoop(
+          split_num,
+          [&](int i) {
+            std::string key = prefix + std::to_string(i);
+            Singleton<CtrlClient>::Get()->PushKV(key, data);
+            std::lock_guard<std::mutex> lock(mtx4keys);
+            CHECK(keys.insert(key).second);
+          },
+          thread_num);
+    } else {
+      const int64_t bs_index = bs.GetRangeIndexForVal(GlobalProcessCtx::Rank());
+      std::string key = prefix + std::to_string(bs_index);
+      Singleton<CtrlClient>::Get()->PullKV(key, worker_data);
+    }
   }
+
   return keys;
 }
 

--- a/oneflow/core/rpc/include/base.h
+++ b/oneflow/core/rpc/include/base.h
@@ -85,6 +85,8 @@ class CtrlClient {
   typename std::enable_if<std::is_arithmetic<T>::value>::type PushKVT(const std::string& k, T v) {
     PushKV(k, std::to_string(v));
   }
+  virtual void PushRankKV(const size_t rank, const std::string& k, std::function<void(std::string*)> VSetter) = 0;
+  virtual void PushRankKV(const size_t rank, const std::string& k, const std::string& v) = 0;
 
   virtual void ClearKV(const std::string& k) = 0;
   virtual void ClearMasterKV(const std::string& k) = 0;
@@ -99,6 +101,8 @@ class CtrlClient {
     PullKV(k, &v_str);
     *v = oneflow_cast<T>(v_str);
   }
+  virtual void PullRankKV(const size_t rank, const std::string& k, std::function<void(const std::string&)> VGetter) = 0;
+  virtual void PullRankKV(const size_t rank, const std::string& k, std::string* v) = 0;
 
   virtual void Clear() = 0;
   virtual int32_t IncreaseCount(const std::string& k, int32_t v) = 0;

--- a/oneflow/core/rpc/include/base.h
+++ b/oneflow/core/rpc/include/base.h
@@ -103,6 +103,7 @@ class CtrlClient {
   }
   virtual void PullRankKV(const size_t rank, const std::string& k, std::function<void(const std::string&)> VGetter) = 0;
   virtual void PullRankKV(const size_t rank, const std::string& k, std::string* v) = 0;
+  virtual void PullRankKV(const size_t rank, const std::string& k, PbMessage* msg) = 0;
 
   virtual void Clear() = 0;
   virtual int32_t IncreaseCount(const std::string& k, int32_t v) = 0;

--- a/oneflow/core/rpc/include/grpc.h
+++ b/oneflow/core/rpc/include/grpc.h
@@ -53,6 +53,7 @@ class GrpcCtrlClient final : public CtrlClient {
   void PullRankKV(const size_t rank, const std::string& k,
                   std::function<void(const std::string&)> VGetter) override;
   void PullRankKV(const size_t rank, const std::string& k, std::string* v) override;
+  void PullRankKV(const size_t rank, const std::string& k, PbMessage* msg) override;
   void Clear() override;
   int32_t IncreaseCount(const std::string& k, int32_t v) override;
   void EraseCount(const std::string& k) override;

--- a/oneflow/core/rpc/include/grpc.h
+++ b/oneflow/core/rpc/include/grpc.h
@@ -39,6 +39,9 @@ class GrpcCtrlClient final : public CtrlClient {
   void PushKV(const std::string& k, const std::string& v) override;
   void PushKV(const std::string& k, const PbMessage& msg) override;
   void PushMasterKV(const std::string& k, const PbMessage& msg) override;
+  void PushRankKV(const size_t rank, const std::string& k,
+                  std::function<void(std::string*)> VSetter) override;
+  void PushRankKV(const size_t rank, const std::string& k, const std::string& v) override;
 
   void ClearKV(const std::string& k) override;
   void ClearMasterKV(const std::string& k) override;
@@ -47,6 +50,9 @@ class GrpcCtrlClient final : public CtrlClient {
   void PullKV(const std::string& k, std::string* v) override;
   void PullKV(const std::string& k, PbMessage* msg) override;
   void PullMasterKV(const std::string& k, PbMessage* msg) override;
+  void PullRankKV(const size_t rank, const std::string& k,
+                  std::function<void(const std::string&)> VGetter) override;
+  void PullRankKV(const size_t rank, const std::string& k, std::string* v) override;
   void Clear() override;
   int32_t IncreaseCount(const std::string& k, int32_t v) override;
   void EraseCount(const std::string& k) override;

--- a/oneflow/core/rpc/include/local.h
+++ b/oneflow/core/rpc/include/local.h
@@ -42,6 +42,9 @@ class LocalCtrlClient : public CtrlClient {
   void PushKV(const std::string& k, const std::string& v) override;
   void PushKV(const std::string& k, const PbMessage& msg) override;
   void PushMasterKV(const std::string& k, const PbMessage& msg) override;
+  void PushRankKV(const size_t rank, const std::string& k,
+                  std::function<void(std::string*)> VSetter) override;
+  void PushRankKV(const size_t rank, const std::string& k, const std::string& v) override;
 
   void ClearKV(const std::string& k) override;
   void ClearMasterKV(const std::string& k) override;
@@ -50,6 +53,9 @@ class LocalCtrlClient : public CtrlClient {
   void PullKV(const std::string& k, std::string* v) override;
   void PullKV(const std::string& k, PbMessage* msg) override;
   void PullMasterKV(const std::string& k, PbMessage* msg) override;
+  void PullRankKV(const size_t rank, const std::string& k,
+                  std::function<void(const std::string&)> VGetter) override;
+  void PullRankKV(const size_t rank, const std::string& k, std::string* v) override;
   void Clear() override;
   int32_t IncreaseCount(const std::string& k, int32_t v) override;
   void EraseCount(const std::string& k) override;

--- a/oneflow/core/rpc/include/local.h
+++ b/oneflow/core/rpc/include/local.h
@@ -56,6 +56,7 @@ class LocalCtrlClient : public CtrlClient {
   void PullRankKV(const size_t rank, const std::string& k,
                   std::function<void(const std::string&)> VGetter) override;
   void PullRankKV(const size_t rank, const std::string& k, std::string* v) override;
+  void PullRankKV(const size_t rank, const std::string& k, PbMessage* msg) override;
   void Clear() override;
   int32_t IncreaseCount(const std::string& k, int32_t v) override;
   void EraseCount(const std::string& k) override;

--- a/oneflow/core/rpc/lib/local.cpp
+++ b/oneflow/core/rpc/lib/local.cpp
@@ -148,6 +148,10 @@ void LocalCtrlClient::PullRankKV(const size_t rank, const std::string& k, std::s
   PullKV(k, v);
 }
 
+void LocalCtrlClient::PullRankKV(const size_t rank, const std::string& k, PbMessage* msg) {
+  PullKV(k, msg);
+}
+
 void LocalCtrlClient::Clear() {
   {
     std::unique_lock<std::mutex> lck(done_names_mtx_);
@@ -242,6 +246,10 @@ class DryRunCtrlClient : public CtrlClient {
   void PullRankKV(const size_t rank, const std::string& k, std::string* v) override {
     local_ctrl_client_->PullRankKV(rank, k, v);
   }
+  void PullRankKV(const size_t rank, const std::string& k, PbMessage* msg) override {
+    local_ctrl_client_->PullRankKV(rank, k, msg);
+  }
+
   void Clear() override { local_ctrl_client_->Clear(); }
   int32_t IncreaseCount(const std::string& k, int32_t v) override {
     return local_ctrl_client_->IncreaseCount(k, v);

--- a/oneflow/core/rpc/lib/local.cpp
+++ b/oneflow/core/rpc/lib/local.cpp
@@ -98,6 +98,14 @@ void LocalCtrlClient::PushMasterKV(const std::string& k, const PbMessage& msg) {
   PushKV(k, [&](std::string* o) { msg.SerializeToString(o); });
 }
 
+void LocalCtrlClient::PushRankKV(const size_t rank, const std::string& k,
+                                 std::function<void(std::string*)> VSetter) {
+  PushKV(k, VSetter);
+}
+void LocalCtrlClient::PushRankKV(const size_t rank, const std::string& k, const std::string& v) {
+  PushKV(k, v);
+}
+
 void LocalCtrlClient::ClearKV(const std::string& k) {
   std::unique_lock<std::mutex> lck(kv_mtx_);
   kv_.erase(k);
@@ -130,6 +138,14 @@ void LocalCtrlClient::PullKV(const std::string& k, PbMessage* msg) {
 
 void LocalCtrlClient::PullMasterKV(const std::string& k, PbMessage* msg) {
   PullKV(k, [&](const std::string& i) { msg->ParseFromString(i); });
+}
+
+void LocalCtrlClient::PullRankKV(const size_t rank, const std::string& k,
+                                 std::function<void(const std::string&)> VGetter) {
+  PullKV(k, VGetter);
+}
+void LocalCtrlClient::PullRankKV(const size_t rank, const std::string& k, std::string* v) {
+  PullKV(k, v);
 }
 
 void LocalCtrlClient::Clear() {
@@ -199,6 +215,13 @@ class DryRunCtrlClient : public CtrlClient {
   void PushMasterKV(const std::string& k, const PbMessage& msg) override {
     local_ctrl_client_->PushMasterKV(k, msg);
   }
+  void PushRankKV(const size_t rank, const std::string& k,
+                  std::function<void(std::string*)> VSetter) override {
+    local_ctrl_client_->PushRankKV(rank, k, VSetter);
+  }
+  void PushRankKV(const size_t rank, const std::string& k, const std::string& v) override {
+    local_ctrl_client_->PushRankKV(rank, k, v);
+  }
 
   void ClearKV(const std::string& k) override { local_ctrl_client_->ClearKV(k); }
   void ClearMasterKV(const std::string& k) override { local_ctrl_client_->ClearMasterKV(k); }
@@ -210,6 +233,14 @@ class DryRunCtrlClient : public CtrlClient {
   void PullKV(const std::string& k, PbMessage* msg) override { local_ctrl_client_->PullKV(k, msg); }
   void PullMasterKV(const std::string& k, PbMessage* msg) override {
     local_ctrl_client_->PullMasterKV(k, msg);
+  }
+
+  void PullRankKV(const size_t rank, const std::string& k,
+                  std::function<void(const std::string&)> VGetter) override {
+    local_ctrl_client_->PullRankKV(rank, k, VGetter);
+  }
+  void PullRankKV(const size_t rank, const std::string& k, std::string* v) override {
+    local_ctrl_client_->PullRankKV(rank, k, v);
   }
   void Clear() override { local_ctrl_client_->Clear(); }
   int32_t IncreaseCount(const std::string& k, int32_t v) override {


### PR DESCRIPTION
relate:   https://github.com/Oneflow-Inc/OneTeam/issues/1952

n 机 k 卡，只要 n <= k ，经过测试使用 local_rank_0 代理会更优
如果是 8 机 8 卡，我们可以做成 7次 master -> local_rank_0 + local_rank_0 到 local_rank_n，这个是优于 master -> local_rank_k + othre_rank_k 到 local_rank_n 的。

利用 issue 里的模拟同步工具，测试 2 机 8 rank
结果：
- https://github.com/Oneflow-Inc/OneTeam/issues/1952#issuecomment-1495248180
- https://github.com/Oneflow-Inc/OneTeam/issues/1952#issuecomment-1495264311

总耗时减少大概 50 %。

缺点：
这种方案只适用于机器数少的情况，机器数多了，master负载会太高