### PR TITLE
nngraph run_cnt

### DIFF
--- a/oneflow/core/framework/nn_graph.h
+++ b/oneflow/core/framework/nn_graph.h
@@ -41,7 +41,8 @@ class NNGraph final : public NNGraphIf {
         job_id_(job_id),
         session_ctx_(session_ctx),
         runtime_inited_(false),
-        is_closed_(false) {}
+        is_closed_(false),
+        run_cnt_(0) {}
   explicit NNGraph(const std::string& name, const Plan& plan, int64_t job_id,
                    const std::shared_ptr<MultiClientSessionContext>& session_ctx)
       : name_(name),
@@ -49,7 +50,8 @@ class NNGraph final : public NNGraphIf {
         session_ctx_(session_ctx),
         plan_(plan),
         runtime_inited_(false),
-        is_closed_(false) {}
+        is_closed_(false),
+        run_cnt_(0) {}
   OF_DISALLOW_COPY_AND_MOVE(NNGraph);
   ~NNGraph();
 
@@ -68,6 +70,8 @@ class NNGraph final : public NNGraphIf {
   const std::vector<std::string>& outputs_tensor_meta_str() const;
   int64_t variable_op_size() const;
   const std::shared_ptr<vm::EagerBlobObjectList>& var_blobs() const;
+  int64_t run_cnt() const override { return run_cnt_; }
+  void NextRunCnt() override { run_cnt_++; }
 
   Maybe<void> RegisterAdditionalVarOpNamesAndTensorsToBeLoaded(
       const std::vector<std::string>& additional_var_names,
@@ -137,6 +141,7 @@ class NNGraph final : public NNGraphIf {
   std::unique_ptr<Runtime> runtime_;
   bool runtime_inited_;
   bool is_closed_;
+  int64_t run_cnt_;
 };
 
 Maybe<void> RunLazyNNGraph(const one::TensorTuple& inputs, const one::TensorTuple& outputs,

--- a/oneflow/core/framework/nn_graph_if.h
+++ b/oneflow/core/framework/nn_graph_if.h
@@ -34,6 +34,8 @@ class NNGraphIf {
   virtual const std::vector<std::string>& outputs_op_names() const = 0;
   virtual const std::vector<bool>& inputs_valid() const = 0;
   virtual const std::vector<bool>& outputs_valid() const = 0;
+  virtual int64_t run_cnt() const = 0;
+  virtual void NextRunCnt() = 0;
 
  protected:
   NNGraphIf() = default;

--- a/oneflow/core/vm/lazy_job_instruction_policy.h
+++ b/oneflow/core/vm/lazy_job_instruction_policy.h
@@ -95,14 +95,14 @@ class LaunchLazyJobInstructionPolicy final : public InstructionPolicy {  // NOLI
   std::string DebugName(const Instruction&) const override { return "LaunchLazyJob"; }
   Maybe<void> Prepare(Instruction* instruction) override { return Maybe<void>::Ok(); }
   void Compute(Instruction* instruction) override {
-    static thread_local int64_t run_cnt = 0;
-    VLOG(3) << " VM try launch Graph: " << nn_graph_->job_name() << " in run_cnt: " << run_cnt
-            << " START.";
+    VLOG(3) << " VM try launch Graph: " << nn_graph_->job_name()
+            << " in run_cnt: " << nn_graph_->run_cnt() << " START.";
     auto* lazy_job_stream_policy = GetLazyJobStreamPolicy(instruction);
     {
       OF_PROFILER_RANGE_GUARD("WaitUntilQueueEmptyIfFrontNNGraphNotEquals");
       lazy_job_stream_policy->WaitUntilQueueEmptyIfFrontNNGraphNotEquals(nn_graph_);
-      VLOG(3) << " VM launch Graph: " << nn_graph_->job_name() << " in run_cnt: " << run_cnt
+      VLOG(3) << " VM launch Graph: " << nn_graph_->job_name()
+              << " in run_cnt: " << nn_graph_->run_cnt()
               << " WaitUntilQueueEmptyIfFrontNNGraphNotEquals.";
     }
     {
@@ -112,15 +112,16 @@ class LaunchLazyJobInstructionPolicy final : public InstructionPolicy {  // NOLI
       auto* buffer_mgr = Singleton<BufferMgr<std::shared_ptr<JobInstance>>>::Get();
       buffer_mgr->Get(GetCallbackNotifierBufferName(job_name))->Push(job_instance);
       VLOG(3) << " VM Push CallbackNotifier to Graph: " << nn_graph_->job_name()
-              << " in run_cnt: " << run_cnt;
+              << " in run_cnt: " << nn_graph_->run_cnt();
       buffer_mgr->Get(GetSourceTickBufferName(job_name))->Push(job_instance);
       VLOG(3) << " VM Push SourceTick to Graph: " << nn_graph_->job_name()
-              << " in run_cnt: " << run_cnt;
+              << " in run_cnt: " << nn_graph_->run_cnt();
     }
     OF_PROFILER_RANGE_GUARD("EnqueueNNGraph");
     lazy_job_stream_policy->EnqueueNNGraph(nn_graph_);
-    VLOG(3) << " VM Enqueue Graph: " << nn_graph_->job_name() << " run_cnt: " << run_cnt++
-            << " END.";
+    VLOG(3) << " VM Enqueue Graph: " << nn_graph_->job_name()
+            << " run_cnt: " << nn_graph_->run_cnt() << " END.";
+    nn_graph_->NextRunCnt();
   }
 
  private:


### PR DESCRIPTION
NNGraph 自己提供 run_cnt 和 NextRunCnt 接口，用于解决之前 Lazy Job 日志打印中，run cnt 在多 Graph 下无法区分的问题。