### PR TITLE
update freedesktop urls

### DIFF
--- a/cmake/third_party/hwloc.cmake
+++ b/cmake/third_party/hwloc.cmake
@@ -32,7 +32,8 @@ if(BUILD_HWLOC)
 
     set(XORG_MACROS_INSTALL ${THIRD_PARTY_DIR}/xorg-macros)
     set(XORG_MACROS_TAR_URL
-        https://gitlab.freedesktop.org/xorg/util/macros/-/archive/util-macros-1.19.1/macros-util-macros-1.19.1.tar.gz)
+        https://gitlab.freedesktop.org/xorg/util/macros/-/archive/util-macros-1.19.1/macros-util-macros-1.19.1.tar.gz
+    )
     use_mirror(VARIABLE XORG_MACROS_TAR_URL URL ${XORG_MACROS_TAR_URL})
     set(XORG_MACROS_URL_HASH 37afda9e9b44ecb9b2c16293bacd0e21)
     set(XORG_MACROS_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/xorg-macros)
@@ -50,7 +51,8 @@ if(BUILD_HWLOC)
       INSTALL_COMMAND make install)
 
     set(PCIACCESS_TAR_URL
-        https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.gz)
+        https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.gz
+    )
     use_mirror(VARIABLE PCIACCESS_TAR_URL URL ${PCIACCESS_TAR_URL})
     set(PCIACCESS_URL_HASH 92e2b604e294a9160bc977c000507340)
     set(PCIACCESS_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/pciaccess)

--- a/cmake/third_party/hwloc.cmake
+++ b/cmake/third_party/hwloc.cmake
@@ -35,7 +35,7 @@ if(BUILD_HWLOC)
         https://gitlab.freedesktop.org/xorg/util/macros/-/archive/util-macros-1.19.1/macros-util-macros-1.19.1.tar.gz
     )
     use_mirror(VARIABLE XORG_MACROS_TAR_URL URL ${XORG_MACROS_TAR_URL})
-    set(XORG_MACROS_URL_HASH 37afda9e9b44ecb9b2c16293bacd0e21)
+    set(XORG_MACROS_URL_HASH 764fb1647d7ebd1c8c5d707db525832f)
     set(XORG_MACROS_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/xorg-macros)
     set(XORG_MACROS_PKG_CONFIG_DIR ${XORG_MACROS_INSTALL}/share/pkgconfig)
 
@@ -54,7 +54,7 @@ if(BUILD_HWLOC)
         https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.gz
     )
     use_mirror(VARIABLE PCIACCESS_TAR_URL URL ${PCIACCESS_TAR_URL})
-    set(PCIACCESS_URL_HASH 92e2b604e294a9160bc977c000507340)
+    set(PCIACCESS_URL_HASH 93554c189796c27dfc72af17a367a0b4)
     set(PCIACCESS_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/pciaccess)
 
     set(PCIACCESS_CFLAGS "-O3 -fPIC")

--- a/cmake/third_party/hwloc.cmake
+++ b/cmake/third_party/hwloc.cmake
@@ -32,7 +32,7 @@ if(BUILD_HWLOC)
 
     set(XORG_MACROS_INSTALL ${THIRD_PARTY_DIR}/xorg-macros)
     set(XORG_MACROS_TAR_URL
-        https://github.com/freedesktop/xorg-macros/archive/refs/tags/util-macros-1.19.1.tar.gz)
+        https://gitlab.freedesktop.org/xorg/util/macros/-/archive/util-macros-1.19.1/macros-util-macros-1.19.1.tar.gz)
     use_mirror(VARIABLE XORG_MACROS_TAR_URL URL ${XORG_MACROS_TAR_URL})
     set(XORG_MACROS_URL_HASH 37afda9e9b44ecb9b2c16293bacd0e21)
     set(XORG_MACROS_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/xorg-macros)
@@ -50,7 +50,7 @@ if(BUILD_HWLOC)
       INSTALL_COMMAND make install)
 
     set(PCIACCESS_TAR_URL
-        https://github.com/freedesktop/xorg-libpciaccess/archive/refs/tags/libpciaccess-0.16.tar.gz)
+        https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.gz)
     use_mirror(VARIABLE PCIACCESS_TAR_URL URL ${PCIACCESS_TAR_URL})
     set(PCIACCESS_URL_HASH 92e2b604e294a9160bc977c000507340)
     set(PCIACCESS_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/pciaccess)


### PR DESCRIPTION
freedesktop.org 的项目从 github 迁移到自建的 gitlab 了，github 链接挂了，导致 ci 全挂，这个 PR 修复