### PR TITLE
Refactor sub task graph build

### DIFF
--- a/oneflow/core/graph/task_graph.h
+++ b/oneflow/core/graph/task_graph.h
@@ -31,9 +31,10 @@ namespace oneflow {
 class SubTskGphBuilderCtx;
 class HierarchicalSubTskGphBuilder;
 
-#define BLD_SUB_TSK_GPH_MTHD_ARGS()                                                \
-  (const OpEdge* op_edge, const std::vector<CompTaskNode*>& sorted_src_comp_tasks, \
-   const std::vector<CompTaskNode*>& sorted_dst_comp_tasks)
+#define BLD_SUB_TSK_GPH_MTHD_ARGS()                                       \
+  (const OpEdge* op_edge, const LogicalBlobId& lbi,                       \
+   const std::function<const std::vector<CompTaskNode*>&(const OpNode*)>& \
+       GetSortedCompTaskNodesFn)
 
 class TaskGraph;
 using BldSubTskGphMthd = void(TaskGraph::*) BLD_SUB_TSK_GPH_MTHD_ARGS();


### PR DESCRIPTION
重构根据边 build sub task graph 的逻辑，原本一条边中可能包含多个 lbi，同时要求这些 lbi 必须全部有相同的 sbp 或全部都是不相同的 sbp (IsConnectedLbisAllSameNdSbp)。而在 xrt 中暴露出问题，对于合并了多个 op 的 xrt op node，它连向下一个 xrt op node 的 edge 中可能包含多个 lbi，且这些 lbi 的生成端和消费端有不同的 sbp。这是一种正常情况，原来要求 edge 中所有 sbp 一致属于过严的限制，是为了之前实现方便的做法。

本 PR 重构了 build sub task graph 的逻辑，每次产生新的 task edge 时，是根据 op edge 上某个具体的 lbi 来生成的，不再假设 op edge 上的 lbi 的 sbp 一致性。重构过后对构图的影响在于: 原有的 boxing task edge 中可能包含若干 lbi，而现在每次都是按单个 lbi 来 build 的，所以 boxing task edge 中只会包含一个 lbi。