### PR TITLE
fix rtol and atol in test_complex

### DIFF
--- a/python/oneflow/test/tensor/test_complex.py
+++ b/python/oneflow/test/tensor/test_complex.py
@@ -106,7 +106,7 @@ def _np_zero_pad2d_grad(src, dest, padding):
     return numpy_dest
 
 
-def _test_ZeroPad2d(test_case, shape, padding, value, device):
+def _test_ZeroPad2d(test_case, shape, padding, value, device, rtol, atol):
     np_input = np.random.random(shape)
     of_input = flow.tensor(
         np_input, dtype=test_case.dtype, device=flow.device(device), requires_grad=True
@@ -125,14 +125,12 @@ def _test_ZeroPad2d(test_case, shape, padding, value, device):
     layer = flow.nn.ZeroPad2d(padding=padding)
     of_out = layer(of_input)
     np_out = np.pad(np_input, np_boundary, mode="constant", constant_values=value)
-    test_case.assertTrue(
-        np.allclose(of_out.cpu().detach().numpy(), np_out, 1e-05, 1e-05)
-    )
+    test_case.assertTrue(np.allclose(of_out.cpu().detach().numpy(), np_out, rtol, atol))
     of_out = of_out.sum()
     of_out.backward()
     np_out_grad = _np_zero_pad2d_grad(np_out, np_input, layer.padding)
     test_case.assertTrue(
-        np.allclose(of_input.grad.cpu().detach().numpy(), np_out_grad, 1e-05, 1e-05)
+        np.allclose(of_input.grad.cpu().detach().numpy(), np_out_grad, rtol, atol)
     )
 
 
@@ -144,6 +142,8 @@ class TestTensorComplex64(unittest.TestCase):
         self.type_str = "ComplexFloatTensor"
         self.real_dtype = flow.float
         self.np_real_dtype = np.float32
+        self.rtol = 1e-5
+        self.atol = 1e-5
         self.a = [1.0 + 1j, 2.0]
         self.np_a = np.array(self.a, dtype=self.np_dtype)
         self.b = [[1.0 + 1j, 2.0], [1.0, 2.0 - 1j], [-1.0, 1j]]
@@ -393,12 +393,16 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.add(flow_x, flow_y)
             np_ret = np_x + np_y
-            compare_result(flow_ret, np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret, np_ret, self.rtol, self.atol)
 
             # backward
             flow_ret.sum().backward()
-            compare_result(flow_x.grad.numpy(), np.ones(input_shape), 1e-5, 1e-2)
-            compare_result(flow_y.grad.numpy(), np.ones(input_shape), 1e-5, 1e-2)
+            compare_result(
+                flow_x.grad.numpy(), np.ones(input_shape), self.rtol, self.atol
+            )
+            compare_result(
+                flow_y.grad.numpy(), np.ones(input_shape), self.rtol, self.atol
+            )
 
     @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
     def test_add_cuda(self):
@@ -418,15 +422,21 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.add(flow_x, flow_y)
             np_ret = np_x + np_y
-            compare_result(flow_ret.cpu().detach(), np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret.cpu().detach(), np_ret, self.rtol, self.atol)
 
             # backward
             flow_ret.sum().backward()
             compare_result(
-                flow_x.grad.cpu().detach().numpy(), np.ones(input_shape), 1e-5, 1e-2
+                flow_x.grad.cpu().detach().numpy(),
+                np.ones(input_shape),
+                self.rtol,
+                self.atol,
             )
             compare_result(
-                flow_y.grad.cpu().detach().numpy(), np.ones(input_shape), 1e-5, 1e-2
+                flow_y.grad.cpu().detach().numpy(),
+                np.ones(input_shape),
+                self.rtol,
+                self.atol,
             )
 
     def test_sub_cpu(self):
@@ -446,12 +456,16 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.sub(flow_x, flow_y)
             np_ret = np_x - np_y
-            compare_result(flow_ret, np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret, np_ret, self.rtol, self.atol)
 
             # backward
             flow_ret.sum().backward()
-            compare_result(flow_x.grad.numpy(), np.ones(input_shape), 1e-5, 1e-2)
-            compare_result(flow_y.grad.numpy(), -np.ones(input_shape), 1e-5, 1e-2)
+            compare_result(
+                flow_x.grad.numpy(), np.ones(input_shape), self.rtol, self.atol
+            )
+            compare_result(
+                flow_y.grad.numpy(), -np.ones(input_shape), self.rtol, self.atol
+            )
 
     @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
     def test_sub_cuda(self):
@@ -471,15 +485,21 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.sub(flow_x, flow_y)
             np_ret = np_x - np_y
-            compare_result(flow_ret.cpu().detach(), np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret.cpu().detach(), np_ret, self.rtol, self.atol)
 
             # backward
             flow_ret.sum().backward()
             compare_result(
-                flow_x.grad.cpu().detach().numpy(), np.ones(input_shape), 1e-5, 1e-2
+                flow_x.grad.cpu().detach().numpy(),
+                np.ones(input_shape),
+                self.rtol,
+                self.atol,
             )
             compare_result(
-                flow_y.grad.cpu().detach().numpy(), -np.ones(input_shape), 1e-5, 1e-2
+                flow_y.grad.cpu().detach().numpy(),
+                -np.ones(input_shape),
+                self.rtol,
+                self.atol,
             )
 
     def test_mul_cpu(self):
@@ -499,12 +519,12 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.mul(flow_x, flow_y)
             np_ret = np_x * np_y
-            compare_result(flow_ret, np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret, np_ret, self.rtol, self.atol)
 
             # backward
             flow_ret.sum().backward()
-            compare_result(flow_x.grad.numpy(), flow_y.numpy(), 1e-5, 1e-2)
-            compare_result(flow_y.grad.numpy(), flow_x.numpy(), 1e-5, 1e-2)
+            compare_result(flow_x.grad.numpy(), flow_y.numpy(), self.rtol, self.atol)
+            compare_result(flow_y.grad.numpy(), flow_x.numpy(), self.rtol, self.atol)
 
     @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
     def test_mul_cuda(self):
@@ -524,15 +544,15 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.mul(flow_x, flow_y)
             np_ret = np_x * np_y
-            compare_result(flow_ret.cpu().detach(), np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret.cpu().detach(), np_ret, self.rtol, self.atol)
 
             # backward
             flow_ret.sum().backward()
             compare_result(
-                flow_x.grad.cpu().detach().numpy(), flow_y.numpy(), 1e-5, 1e-2
+                flow_x.grad.cpu().detach().numpy(), flow_y.numpy(), self.rtol, self.atol
             )
             compare_result(
-                flow_y.grad.cpu().detach().numpy(), flow_x.numpy(), 1e-5, 1e-2
+                flow_y.grad.cpu().detach().numpy(), flow_x.numpy(), self.rtol, self.atol
             )
 
     def test_sum_cpu(self):
@@ -553,11 +573,13 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.sum(flow_x, dim=dims, keepdim=keepdim)
             np_ret = np.sum(np_x, axis=tuple(dims), keepdims=keepdim)
-            compare_result(flow_ret, np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret, np_ret, self.rtol, self.atol * 1000)
 
             # backward
             flow_ret.sum().backward()
-            compare_result(flow_x.grad.numpy(), np.ones(input_shape), 1e-5, 1e-2)
+            compare_result(
+                flow_x.grad.numpy(), np.ones(input_shape), self.rtol, self.atol
+            )
 
     @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
     def test_sum_cuda(self):
@@ -578,12 +600,15 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.sum(flow_x, dim=dims, keepdim=keepdim)
             np_ret = np.sum(np_x, axis=tuple(dims), keepdims=keepdim)
-            compare_result(flow_ret.cpu().detach(), np_ret, 1e-5, 1e-3)
+            compare_result(flow_ret.cpu().detach(), np_ret, self.rtol, self.atol * 1000)
 
             # backward
             flow_ret.sum().backward()
             compare_result(
-                flow_x.grad.cpu().detach().numpy(), np.ones(input_shape), 1e-5, 1e-3
+                flow_x.grad.cpu().detach().numpy(),
+                np.ones(input_shape),
+                self.rtol,
+                self.atol,
             )
 
     def test_equal_cpu(self):
@@ -608,13 +633,17 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.equal(flow_x, flow_y)
             np_ret = np.equal(np_x, np_y)
-            compare_result(flow_ret, np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret, np_ret, self.rtol, self.atol)
 
             flow_ret = flow.equal(flow_x, flow_z)
-            compare_result(flow_ret, np.ones(flow_x.shape).astype(bool), 1e-5, 1e-2)
+            compare_result(
+                flow_ret, np.ones(flow_x.shape).astype(bool), self.rtol, self.atol
+            )
 
             flow_ret = flow.not_equal(flow_x, flow_z)
-            compare_result(flow_ret, np.zeros(flow_x.shape).astype(bool), 1e-5, 1e-2)
+            compare_result(
+                flow_ret, np.zeros(flow_x.shape).astype(bool), self.rtol, self.atol
+            )
 
     @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
     def test_equal_cuda(self):
@@ -639,14 +668,19 @@ class TestTensorComplex64(unittest.TestCase):
             # forward
             flow_ret = flow.equal(flow_x, flow_y)
             np_ret = np.equal(np_x, np_y)
-            compare_result(flow_ret, np_ret, 1e-5, 1e-2)
+            compare_result(flow_ret, np_ret, self.rtol, self.atol)
 
             flow_ret = flow.equal(flow_x, flow_z)
-            compare_result(flow_ret, np.ones(flow_x.shape).astype(bool), 1e-5, 1e-2)
+            compare_result(
+                flow_ret, np.ones(flow_x.shape).astype(bool), self.rtol, self.atol
+            )
 
             flow_ret = flow.not_equal(flow_x, flow_z)
             compare_result(
-                flow_ret.cpu().detach(), np.zeros(flow_x.shape).astype(bool), 1e-5, 1e-2
+                flow_ret.cpu().detach(),
+                np.zeros(flow_x.shape).astype(bool),
+                self.rtol,
+                self.atol,
             )
 
     def test_constant_pad(self):
@@ -657,6 +691,8 @@ class TestTensorComplex64(unittest.TestCase):
         arg_dict["device"] = (
             ["cpu", "cuda"] if os.getenv("ONEFLOW_TEST_CPU_ONLY") is None else ["cpu"]
         )
+        arg_dict["rtol"] = [self.rtol]
+        arg_dict["atol"] = [self.atol]
         for arg in GenArgList(arg_dict):
             _test_ZeroPad2d(self, *arg)
 
@@ -736,6 +772,8 @@ class TestTensorComplex128(TestTensorComplex64):
         self.type_str = "ComplexDoubleTensor"
         self.real_dtype = flow.double
         self.np_real_dtype = np.float64
+        self.rtol = 1e-7
+        self.atol = 1e-7
         self.a = [1.0 + 1j, 2.0]
         self.np_a = np.array(self.a, dtype=self.np_dtype)
         self.b = [[1.0 + 1j, 2.0], [1.0, 2.0 - 1j], [-1.0, 1j]]


### PR DESCRIPTION
对于complex64数据类型，设置rtol=atol=1e-5。
对于complex128数据类型，设置rtol=atol=1e-7。
对于sum算子，放宽atol阈值，为原先atol阈值*1000。