### PR TITLE
Merge JUST-series macros between oneflow/core/common and oneflow/maybe

### DIFF
--- a/oneflow/core/common/optional_test.cpp
+++ b/oneflow/core/common/optional_test.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include "oneflow/core/common/optional.h"
 #include "oneflow/core/common/util.h"
 #include "oneflow/core/common/exception.h"
+#include "oneflow/maybe/just.h"
 
 namespace oneflow {
 namespace test {
@@ -51,7 +52,7 @@ TEST(Optional, JUST) {
   ASSERT_EQ(CHECK_JUST(f(a)), 233);
   ASSERT_EQ(f(b).error()->msg(), "");
 
-  auto g = [](const Optional<int>& v) -> Optional<int> { return JUST_OPT(v); };
+  auto g = [](const Optional<int>& v) -> Optional<int> { return OPT_JUST(v); };
 
   ASSERT_EQ(CHECK_JUST(g(a)), 233);
 


### PR DESCRIPTION
Since JUST macros in oneflow/maybe can be more customizable and modular, we can replace JUST macros in oneflow/core/common with these in oneflow/maybe, so that all infra in oneflow/maybe can be introduced to the codebase without naming conflict. And it is also the first step to replace all old maybe infra (TODO: maybe a tracking issue is needed).