### PR TITLE
Fix the problem of not checking if attr exists for cpg

### DIFF
--- a/python/oneflow/nn/modules/module.py
+++ b/python/oneflow/nn/modules/module.py
@@ -1268,12 +1268,13 @@ class Module(object):
         return handle
 
     def _apply(self, fn):
-        if self.cpg is not None:
-            self.cpg = None
-            warnings.warn(
-                "deleted ContiguousParamsGroup since creating it before "
-                "apply operations like to(), to_global() will cause error."
-            )
+        if hasattr(self, "cpg"):
+            if self.cpg is not None:
+                self.cpg = None
+                warnings.warn(
+                    "deleted ContiguousParamsGroup since creating it before "
+                    "apply operations like to(), to_global() will cause error."
+                )
 
         # A dict to store tensors that has already been applied.
         # There is no need to apply multiple times on a same tensor.


### PR DESCRIPTION
* When load network saved using previous version of oneflow, as the cpg attribute not exist, the `self.cpg` reference will fail.
* PR address this problem by adding an additional layer of check.