### PR TITLE
support NoneType in Graph proxy

### DIFF
--- a/python/oneflow/nn/graph/proxy.py
+++ b/python/oneflow/nn/graph/proxy.py
@@ -104,17 +104,20 @@ class ProxyModule(Proxy):
             return
         assert isinstance(origin, Module)
         for (n, m) in origin._modules.items():
-            self.__setattr__(
-                n,
-                get_proxy_cls(m)(
-                    m,
-                    self.to(GraphModule)._name_prefix
-                    + self.to(GraphModule)._name
-                    + ".",
+            if m is None:
+                self.__setattr__(n, None)
+            else:
+                self.__setattr__(
                     n,
-                    self.to(GraphModule)._belonged_graph,
-                ),
-            )
+                    get_proxy_cls(m)(
+                        m,
+                        self.to(GraphModule)._name_prefix
+                        + self.to(GraphModule)._name
+                        + ".",
+                        n,
+                        self.to(GraphModule)._belonged_graph,
+                    ),
+                )
         for (n, p) in list(origin.named_parameters("", False)):
             self.__setattr__(
                 n,


### PR DESCRIPTION
修正跑 https://huggingface.co/latent-consistency/lcm-lora-sdxl 会报错的问题。

因为遇到一些 Module 是 m = None 的情况，现在是没有处理的。