### PR TITLE
add dummy interfaces for import timm

### DIFF
--- a/python/oneflow/ao/quantization.py
+++ b/python/oneflow/ao/quantization.py
@@ -13,6 +13,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Tuple, List
 
-BroadcastingList2 = Tuple
+
+class DeQuantStub:
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError(
+            "The oneflow.ao.DeQuantStub interface is just to align the torch.ao.DeQuantStub interface and has no practical significance."
+        )
+
+
+class QuantStub:
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError(
+            "The oneflow.ao.QuantStub interface is just to align the torch.ao.QuantStub interface and has no practical significance."
+        )

--- a/python/oneflow/jit/__init__.py
+++ b/python/oneflow/jit/__init__.py
@@ -20,6 +20,7 @@ warnings.warn(
     "The oneflow.jit interface is just to align the torch.jit interface and has no practical significance."
 )
 
+
 def script(
     obj,
     optimize=None,
@@ -75,17 +76,19 @@ def is_scripting():
 def is_tracing():
     return False
 
+
 class _Final:
     """Mixin to prohibit subclassing"""
 
-    __slots__ = ('__weakref__',)
+    __slots__ = ("__weakref__",)
 
     def __init_subclass__(self, *args, **kwds):
-        if '_root' not in kwds:
+        if "_root" not in kwds:
             raise TypeError("Cannot subclass special typing classes")
 
+
 class _SpecialForm(_Final, _root=True):
-    __slots__ = ('_name', '__doc__', '_getitem')
+    __slots__ = ("_name", "__doc__", "_getitem")
 
     def __init__(self, getitem):
         self._getitem = getitem
@@ -93,7 +96,7 @@ class _SpecialForm(_Final, _root=True):
         self.__doc__ = getitem.__doc__
 
     def __getattr__(self, item):
-        if item in {'__name__', '__qualname__'}:
+        if item in {"__name__", "__qualname__"}:
             return self._name
 
         raise AttributeError(item)
@@ -102,7 +105,7 @@ class _SpecialForm(_Final, _root=True):
         raise TypeError(f"Cannot subclass {self!r}")
 
     def __repr__(self):
-        return 'typing.' + self._name
+        return "typing." + self._name
 
     def __reduce__(self):
         return self._name
@@ -125,15 +128,16 @@ class _SpecialForm(_Final, _root=True):
     def __getitem__(self, parameters):
         return self._getitem(self, parameters)
 
+
 @_SpecialForm
 def Final(*args, **kwargs):
     warnings.warn(
         "The oneflow.jit.Final interface is just to align the torch.jit.Final interface and has no practical significance."
     )
 
+
 def interface(fn):
     warnings.warn(
         "The oneflow.jit.interface interface is just to align the torch.jit.interface interface and has no practical significance."
     )
     return fn
-

--- a/python/oneflow/jit/__init__.py
+++ b/python/oneflow/jit/__init__.py
@@ -16,6 +16,10 @@ limitations under the License.
 import warnings
 from typing import Any, Dict, List, Set, Tuple, Union, Callable
 
+warnings.warn(
+    "The oneflow.jit interface is just to align the torch.jit interface and has no practical significance."
+)
+
 
 def script(
     obj,
@@ -71,3 +75,69 @@ def is_scripting():
 
 def is_tracing():
     return False
+
+
+class _Final:
+    """Mixin to prohibit subclassing"""
+
+    __slots__ = ("__weakref__",)
+
+    def __init_subclass__(self, /, *args, **kwds):
+        if "_root" not in kwds:
+            raise TypeError("Cannot subclass special typing classes")
+
+
+class _SpecialForm(_Final, _root=True):
+    __slots__ = ("_name", "__doc__", "_getitem")
+
+    def __init__(self, getitem):
+        self._getitem = getitem
+        self._name = getitem.__name__
+        self.__doc__ = getitem.__doc__
+
+    def __getattr__(self, item):
+        if item in {"__name__", "__qualname__"}:
+            return self._name
+
+        raise AttributeError(item)
+
+    def __mro_entries__(self, bases):
+        raise TypeError(f"Cannot subclass {self!r}")
+
+    def __repr__(self):
+        return "typing." + self._name
+
+    def __reduce__(self):
+        return self._name
+
+    def __call__(self, *args, **kwds):
+        raise TypeError(f"Cannot instantiate {self!r}")
+
+    def __or__(self, other):
+        return Union[self, other]
+
+    def __ror__(self, other):
+        return Union[other, self]
+
+    def __instancecheck__(self, obj):
+        raise TypeError(f"{self} cannot be used with isinstance()")
+
+    def __subclasscheck__(self, cls):
+        raise TypeError(f"{self} cannot be used with issubclass()")
+
+    def __getitem__(self, parameters):
+        return self._getitem(self, parameters)
+
+
+@_SpecialForm
+def Final(*args, **kwargs):
+    warnings.warn(
+        "The oneflow.jit.Final interface is just to align the torch.jit.Final interface and has no practical significance."
+    )
+
+
+def interface(fn):
+    warnings.warn(
+        "The oneflow.jit.interface interface is just to align the torch.jit.interface interface and has no practical significance."
+    )
+    return fn

--- a/python/oneflow/jit/__init__.py
+++ b/python/oneflow/jit/__init__.py
@@ -20,7 +20,6 @@ warnings.warn(
     "The oneflow.jit interface is just to align the torch.jit interface and has no practical significance."
 )
 
-
 def script(
     obj,
     optimize=None,
@@ -76,19 +75,17 @@ def is_scripting():
 def is_tracing():
     return False
 
-
 class _Final:
     """Mixin to prohibit subclassing"""
 
-    __slots__ = ("__weakref__",)
+    __slots__ = ('__weakref__',)
 
-    def __init_subclass__(self, /, *args, **kwds):
-        if "_root" not in kwds:
+    def __init_subclass__(self, *args, **kwds):
+        if '_root' not in kwds:
             raise TypeError("Cannot subclass special typing classes")
 
-
 class _SpecialForm(_Final, _root=True):
-    __slots__ = ("_name", "__doc__", "_getitem")
+    __slots__ = ('_name', '__doc__', '_getitem')
 
     def __init__(self, getitem):
         self._getitem = getitem
@@ -96,7 +93,7 @@ class _SpecialForm(_Final, _root=True):
         self.__doc__ = getitem.__doc__
 
     def __getattr__(self, item):
-        if item in {"__name__", "__qualname__"}:
+        if item in {'__name__', '__qualname__'}:
             return self._name
 
         raise AttributeError(item)
@@ -105,7 +102,7 @@ class _SpecialForm(_Final, _root=True):
         raise TypeError(f"Cannot subclass {self!r}")
 
     def __repr__(self):
-        return "typing." + self._name
+        return 'typing.' + self._name
 
     def __reduce__(self):
         return self._name
@@ -128,16 +125,15 @@ class _SpecialForm(_Final, _root=True):
     def __getitem__(self, parameters):
         return self._getitem(self, parameters)
 
-
 @_SpecialForm
 def Final(*args, **kwargs):
     warnings.warn(
         "The oneflow.jit.Final interface is just to align the torch.jit.Final interface and has no practical significance."
     )
 
-
 def interface(fn):
     warnings.warn(
         "The oneflow.jit.interface interface is just to align the torch.jit.interface interface and has no practical significance."
     )
     return fn
+

--- a/python/oneflow/library.py
+++ b/python/oneflow/library.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Tuple, List
+import warnings
 
-BroadcastingList2 = Tuple
+warnings.warn(
+    "The oneflow.library interface is just to align the torch.library interface and has no practical significance."
+)

--- a/python/oneflow/onnx/__init__.py
+++ b/python/oneflow/onnx/__init__.py
@@ -13,6 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Tuple, List
+import warnings
 
-BroadcastingList2 = Tuple
+
+def symbolic_opset11():
+    warnings.warn(
+        "The oneflow.onnx.symbolic_opset11 interface is just to align the torch.onnx.symbolic_opset11 interface and has no practical significance."
+    )
+
+
+def register_custom_op_symbolic(*args, **kwargs):
+    warnings.warn(
+        "The oneflow.onnx.register_custom_op_symbolic interface is just to align the torch.onnx.register_custom_op_symbolic interface and has no practical significance."
+    )

--- a/python/oneflow/onnx/symbolic_helper.py
+++ b/python/oneflow/onnx/symbolic_helper.py
@@ -13,6 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Tuple, List
 
-BroadcastingList2 = Tuple
+import warnings
+
+
+def parse_args(*args, **kwargs):
+    warnings.warn(
+        "The oneflow.onnx.parse_args interface is just to align the torch.onnx.parse_args interface and has no practical significance."
+    )
+
+    def func(fn):
+        return fn
+
+    return func


### PR DESCRIPTION
python3 -c "import timm" 输出如下，然后成功返回
```
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:19: UserWarning: The oneflow.jit interface is just to align the torch.jit interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:134: UserWarning: The oneflow.jit.Final interface is just to align the torch.jit.Final interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:31: UserWarning: The oneflow.jit.script interface is just to align the torch.jit.script interface and has no practical significance.
  warnings.warn(
/home/wangyi/miniconda3/envs/py10/lib/python3.10/site-packages/torchvision/io/image.py:13: UserWarning: Failed to load image Python extension: 'load_library is not implemented'If you don't plan on using image functionality from `torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?
  warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:49: UserWarning: The oneflow.jit.unused interface is just to align the torch.jit.unused interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/onnx/symbolic_helper.py:21: UserWarning: The oneflow.onnx.parse_args interface is just to align the torch.onnx.parse_args interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:57: UserWarning: The oneflow.jit._script_if_tracing interface is just to align the torch.jit._script_if_tracing interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/onnx/__init__.py:26: UserWarning: The oneflow.onnx.register_custom_op_symbolic interface is just to align the torch.onnx.register_custom_op_symbolic interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:65: UserWarning: The oneflow.jit._overload_method interface is just to align the torch.jit._overload_method interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:134: UserWarning: The oneflow.jit.Final interface is just to align the torch.jit.Final interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:31: UserWarning: The oneflow.jit.script interface is just to align the torch.jit.script interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:38: UserWarning: The oneflow.jit.ignore interface is just to align the torch.jit.ignore interface and has no practical significance.
  warnings.warn(
/data/home/wangyi/workspace/oneflow-public/python/oneflow/jit/__init__.py:140: UserWarning: The oneflow.jit.interface interface is just to align the torch.jit.interface interface and has no practical significance.
  warnings.warn(
```