### PR TITLE
remove jit warning in __init__

### DIFF
--- a/python/oneflow/jit/__init__.py
+++ b/python/oneflow/jit/__init__.py
@@ -16,10 +16,6 @@ limitations under the License.
 import warnings
 from typing import Any, Dict, List, Set, Tuple, Union, Callable
 
-warnings.warn(
-    "The oneflow.jit interface is just to align the torch.jit interface and has no practical significance."
-)
-
 
 def script(
     obj,


### PR DESCRIPTION
https://github.com/Oneflow-Inc/oneflow/pull/10395 这个 PR 里多此一举给 jit/\_\_init__.py 加了一个 warning，导致 import oneflow 的时候就会显示这个 warning，这里去掉