### PR TITLE
[bugfix] enable faster rcnn and sd model with oneflow backend

### DIFF
--- a/python/oneflow/framework/infer_compiler/import_tools/format_utils.py
+++ b/python/oneflow/framework/infer_compiler/import_tools/format_utils.py
@@ -40,7 +40,13 @@ class MockEntityNameFormatter:
 
         elif isinstance(obj, FunctionType):
             module = inspect.getmodule(obj)
-            obj = f"{module.__name__}.{obj.__qualname__}"
+            if (
+                module.__name__ == "torch.nn.functional"
+                and obj.__qualname__ == "boolean_dispatch.<locals>.fn"
+            ):
+                obj = f"{module.__name__}.{obj.__name__}"
+            else:
+                obj = f"{module.__name__}.{obj.__qualname__}"
 
         assert isinstance(obj, str), f"obj must be str, but got {type(obj)}"
 


### PR DESCRIPTION
oneflow backend 对接 torch compile ，在关闭和打开动态形状的时候，跑通了 faster rcnn 和 sd 模型。相关 issue: [oneflow backend 对接 torch compile ，运行 faster rcnn](https://github.com/Oneflow-Inc/oneflow/issues/10438)

主要改动包括：
1. 修复 oneflow 模型转 torch 模型时， 部分 torch.nn.functional.func 转换失败的 bug
2. 在 oneflow backend 中打开 nn.Graph 的动态形状支持，环境变量对其 oneflow compile
3. 在 oneflow backend 中对推理场景添加了 flow.no_grad ，避免了编译时错误：RuntimeError: The gradient function for op fused_multi_head_attention_inference is not found. Please check whether it has been implemented and registered correctly. 
4. 补全了对 nn.Graph 的不同返回数据类型的处理