### PR TITLE
fix GroupNorm init

### DIFF
--- a/python/oneflow/nn/modules/normalization.py
+++ b/python/oneflow/nn/modules/normalization.py
@@ -137,8 +137,12 @@ class GroupNorm(Module):
         if dtype:
             factory_kwargs["dtype"] = dtype
         if self.affine:
-            self.weight = flow.nn.Parameter(flow.Tensor(num_channels).to(**factory_kwargs))
-            self.bias = flow.nn.Parameter(flow.Tensor(num_channels).to(**factory_kwargs))
+            self.weight = flow.nn.Parameter(
+                flow.Tensor(num_channels).to(**factory_kwargs)
+            )
+            self.bias = flow.nn.Parameter(
+                flow.Tensor(num_channels).to(**factory_kwargs)
+            )
         else:
             self.register_parameter("weight", None)
             self.register_parameter("bias", None)

--- a/python/oneflow/nn/modules/normalization.py
+++ b/python/oneflow/nn/modules/normalization.py
@@ -137,8 +137,8 @@ class GroupNorm(Module):
         if dtype:
             factory_kwargs["dtype"] = dtype
         if self.affine:
-            self.weight = flow.nn.Parameter(flow.Tensor(num_channels, **factory_kwargs))
-            self.bias = flow.nn.Parameter(flow.Tensor(num_channels, **factory_kwargs))
+            self.weight = flow.nn.Parameter(flow.Tensor(num_channels).to(**factory_kwargs))
+            self.bias = flow.nn.Parameter(flow.Tensor(num_channels).to(**factory_kwargs))
         else:
             self.register_parameter("weight", None)
             self.register_parameter("bias", None)


### PR DESCRIPTION
Creating GroupNorm with device and dtype throws Exceptions.

```python
import oneflow as flow
m = flow.nn.GroupNorm(2, 3, device=flow.device("cpu"), dtype=flow.float32)
```

Exception messages:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/zhengjianhua/oneflow/python/oneflow/nn/modules/normalization.py", line 140, in __init__
    self.weight = flow.nn.Parameter(flow.Tensor(num_channels, **factory_kwargs))
TypeError: Error: _legacy_tensor_ctor(): received an invalid combination of arguments. The valid signatures are:
        *0: Tensor (*, Device device=None)
        *1: Tensor (*, Placement placement, SbpList sbp)
        *2: Tensor (Tensor other)
        *3: Tensor (PyObject* data, *, Device device=None)
        *4: Tensor (PyObject* data, *, Placement placement, SbpList sbp)
        *5: Tensor (Shape size, *, Device device=None)
        *6: Tensor (Shape size, *, Placement placement, SbpList sbp)
```