### PR TITLE
add_npu_support for goup_norm

### DIFF
--- a/python/oneflow/nn/modules/normalization.py
+++ b/python/oneflow/nn/modules/normalization.py
@@ -44,7 +44,7 @@ def group_norm(
     ), "The channels of input tensor must equal num_channels"
 
     affine = weight is not None and bias is not None
-    if input.is_cuda:
+    if not input.is_cpu:
         return flow._C.group_norm(input, weight, bias, affine, num_groups, eps)
     else:
         origin_shape = input.shape


### PR DESCRIPTION
原来的实现中只考虑了cuda作为底层实现，而没考虑npu，mlu等其他硬件