### PR TITLE
add FusedApplyRotaryEmbGradKernel

### DIFF
--- a/oneflow/core/autograd/gradient_funcs/fused_apply_rotary_emb.cpp
+++ b/oneflow/core/autograd/gradient_funcs/fused_apply_rotary_emb.cpp
@@ -21,7 +21,7 @@ namespace oneflow {
 namespace one {
 
 struct FusedApplyRotaryEmbCaptureState : public AutoGradCaptureState {
-  bool requires_grad; // 输入x是否需要梯度   只有一个输入x;
+  bool requires_grad;
   std::string x_layout{};
   std::string output_layout{};
   std::string mode{};
@@ -43,35 +43,37 @@ class FusedApplyRotaryEmb : public OpExprGradFunction<FusedApplyRotaryEmbCapture
   AttrMap base_attrs_;
 };
 
-Maybe<void> FusedApplyRotaryEmb::Init(const OpExpr& op) {    // 是否需要实现存疑;
+Maybe<void> FusedApplyRotaryEmb::Init(const OpExpr& op) {
   const UserOpExpr* fw_op_expr = dynamic_cast<const UserOpExpr*>(&op);
-  CHECK_NOTNULL_OR_RETURN(fw_op_expr);
+  CHECK_NOTNULL_OR_RETURN(fw_op_expr);  // NOLINT(maybe-need-error-msg)
   base_attrs_ = MakeAttrMapFromUserOpConf(fw_op_expr->proto());
   return Maybe<void>::Ok();
 }
 
 Maybe<void> FusedApplyRotaryEmb::Capture(FusedApplyRotaryEmbCaptureState* ctx,
                                          const TensorTuple& inputs, const TensorTuple& outputs,
-                                         const AttrMap& attrs) const {   
-  // 这里需要检查sin和cos同时出现，或同时不出现;
-  CHECK_OR_RETURN((inputs.size() >= 1) && (inputs.size() <= 4));   // 这里的输入应该是 1 - 4;
-  ctx->requires_grad = inputs.at(0)->requires_grad();        
-  if (!ctx->requires_grad) { return Maybe<void>::Ok(); }     // 如果不需要梯度，也就不需要求导了，直接返回 Maybe<void>::Ok()
+                                         const AttrMap& attrs) const {
+  CHECK_OR_RETURN((inputs.size() >= 1) && (inputs.size() <= 4))
+      << Error::RuntimeError() << "the inputs size of fusedapplyrotaryembgrad\
+    should between 1 and 4";
+  ctx->requires_grad = inputs.at(0)->requires_grad();
+  if (!ctx->requires_grad) { return Maybe<void>::Ok(); }
 
-  ComposedAttrMap composed_attrs(attrs, base_attrs_);   // 写法确认;
-  ctx->SaveTensorForBackward(inputs.at(0));   
-  if (inputs.size() == 2)   // position_ids
+  ComposedAttrMap composed_attrs(attrs, base_attrs_);
+  ctx->SaveTensorForBackward(inputs.at(0));
+  if (inputs.size() == 2)  // position_ids
     ctx->SaveTensorForBackward(inputs.at(1));
-  if (inputs.size() == 3) {   // cos, sin
+
+  if (inputs.size() == 3) {  // cos, sin
     ctx->SaveTensorForBackward(inputs.at(1));
     ctx->SaveTensorForBackward(inputs.at(2));
   }
-    
-  if (inputs.size() == 4) {   // cos, sin, position_ids;
+
+  if (inputs.size() == 4) {  // cos, sin, position_ids;
     ctx->SaveTensorForBackward(inputs.at(1));
     ctx->SaveTensorForBackward(inputs.at(2));
     ctx->SaveTensorForBackward(inputs.at(3));
-  }    
+  }
 
   ctx->x_layout = JUST(composed_attrs.GetAttr<std::string>("x_layout"));
   ctx->output_layout = JUST(composed_attrs.GetAttr<std::string>("output_layout"));
@@ -86,48 +88,54 @@ Maybe<void> FusedApplyRotaryEmb::Capture(FusedApplyRotaryEmbCaptureState* ctx,
 
 Maybe<void> FusedApplyRotaryEmb::Apply(const FusedApplyRotaryEmbCaptureState* ctx,
                                        const TensorTuple& out_grads, TensorTuple* in_grads) const {
-    CHECK_EQ_OR_RETURN(out_grads.size(), 1);  // 检查梯度 Tensor 个数是否为 1 TODO: 不确定是否输入为1 -- (dy)
-    // in_grads->resize(1);    // 这里不能resize, 需要和input_meta_data_.size() 一致;
-    const auto& saved_tensors = ctx->SavedTensors();
+  CHECK_EQ_OR_RETURN(out_grads.size(), 1)
+      << Error::RuntimeError() << "fusedapplyrotaryembgrad outgrad size should be 1";
+  const auto& saved_tensors = ctx->SavedTensors();
 
-    CHECK_OR_RETURN((saved_tensors.size() >= 1) && (saved_tensors.size() <= 4));
-    // 输出backward拿到的参数
-    if (ctx->requires_grad) {
-      if (saved_tensors.size() == 1) {
-        const auto& x = ctx->SavedTensors().at(0);
-        in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(x, out_grads.at(0), NullOpt/*cos*/, 
-        NullOpt/*sin*/, NullOpt/*position_ids*/,
-        ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
-      }
+  CHECK_OR_RETURN((saved_tensors.size() >= 1) && (saved_tensors.size() <= 4))
+      << Error::RuntimeError() << "the saved_tensors of fusedapplyrotaryembgrad\
+    should between 1 and 4";
 
-      if (saved_tensors.size() == 2) {
-        const auto& x = ctx->SavedTensors().at(0);
-        const auto& position_ids = ctx->SavedTensors().at(1);
-        in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(x, out_grads.at(0), NullOpt/*cos*/, 
-        NullOpt/*sin*/, position_ids,
-        ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
-      }
-
-      if (saved_tensors.size() == 3) {
-        const auto& x = ctx->SavedTensors().at(0);
-        const auto& cos = ctx->SavedTensors().at(1);
-        const auto& sin = ctx->SavedTensors().at(2);
-
-        in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(x, out_grads.at(0), cos, sin, NullOpt/*position_ids*/,
-        ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
-      }
-
-      if (saved_tensors.size() == 4) {
-        const auto& x = ctx->SavedTensors().at(0); // 调用 SavedTensors 接口，拿到先前通过 SaveTensorForBackward 接口保存的 Tensor
-        const auto& cos = ctx->SavedTensors().at(1);
-        const auto& sin = ctx->SavedTensors().at(2);
-        const auto& position_ids = ctx->SavedTensors().at(3);
-        in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(x, out_grads.at(0), cos, sin, position_ids,
-        ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
-      }
+  if (ctx->requires_grad) {
+    if (saved_tensors.size() == 1) {  // x
+      const auto& x = ctx->SavedTensors().at(0);
+      in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(
+          x, out_grads.at(0), NullOpt /*cos*/, NullOpt /*sin*/, NullOpt /*position_ids*/,
+          ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base,
+          ctx->rotary_size));
     }
 
-    return Maybe<void>::Ok();
+    if (saved_tensors.size() == 2) {  // x, position_ids
+      const auto& x = ctx->SavedTensors().at(0);
+      const auto& position_ids = ctx->SavedTensors().at(1);
+      in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(
+          x, out_grads.at(0), NullOpt /*cos*/, NullOpt /*sin*/, position_ids, ctx->x_layout,
+          ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base,
+          ctx->rotary_size));
+    }
+
+    if (saved_tensors.size() == 3) {  // x, cos, sin, position_ids
+      const auto& x = ctx->SavedTensors().at(0);
+      const auto& cos = ctx->SavedTensors().at(1);
+      const auto& sin = ctx->SavedTensors().at(2);
+
+      in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(
+          x, out_grads.at(0), cos, sin, NullOpt /*position_ids*/, ctx->x_layout, ctx->output_layout,
+          ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
+    }
+
+    if (saved_tensors.size() == 4) {
+      const auto& x = ctx->SavedTensors().at(0);
+      const auto& cos = ctx->SavedTensors().at(1);
+      const auto& sin = ctx->SavedTensors().at(2);
+      const auto& position_ids = ctx->SavedTensors().at(3);
+      in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(
+          x, out_grads.at(0), cos, sin, position_ids, ctx->x_layout, ctx->output_layout, ctx->mode,
+          ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
+    }
+  }
+
+  return Maybe<void>::Ok();
 }
 
 REGISTER_OP_EXPR_GRAD_FUNCTION("fused_apply_rotary_emb", FusedApplyRotaryEmb);

--- a/oneflow/core/autograd/gradient_funcs/fused_apply_rotary_emb.cpp
+++ b/oneflow/core/autograd/gradient_funcs/fused_apply_rotary_emb.cpp
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "oneflow/core/framework/op_expr_grad_function.h"
+#include "oneflow/core/framework/op_interpreter/op_interpreter_util.h"
+#include "oneflow/core/functional/functional.h"
+
+namespace oneflow {
+namespace one {
+
+struct FusedApplyRotaryEmbCaptureState : public AutoGradCaptureState {
+  bool requires_grad; // 输入x是否需要梯度   只有一个输入x;
+  std::string x_layout{};
+  std::string output_layout{};
+  std::string mode{};
+  int64_t tensor_index{};
+  int64_t k_size{};
+  float base;
+  int64_t rotary_size{};
+};
+
+class FusedApplyRotaryEmb : public OpExprGradFunction<FusedApplyRotaryEmbCaptureState> {
+ public:
+  Maybe<void> Init(const OpExpr& op) override;
+  Maybe<void> Capture(FusedApplyRotaryEmbCaptureState* ctx, const TensorTuple& inputs,
+                      const TensorTuple& outputs, const AttrMap& attrs) const override;
+  Maybe<void> Apply(const FusedApplyRotaryEmbCaptureState* ctx, const TensorTuple& out_grads,
+                    TensorTuple* in_grads) const override;
+
+ private:
+  AttrMap base_attrs_;
+};
+
+Maybe<void> FusedApplyRotaryEmb::Init(const OpExpr& op) {    // 是否需要实现存疑;
+  const UserOpExpr* fw_op_expr = dynamic_cast<const UserOpExpr*>(&op);
+  CHECK_NOTNULL_OR_RETURN(fw_op_expr);
+  base_attrs_ = MakeAttrMapFromUserOpConf(fw_op_expr->proto());
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> FusedApplyRotaryEmb::Capture(FusedApplyRotaryEmbCaptureState* ctx,
+                                         const TensorTuple& inputs, const TensorTuple& outputs,
+                                         const AttrMap& attrs) const {   
+  // 这里需要检查sin和cos同时出现，或同时不出现;
+  CHECK_OR_RETURN((inputs.size() >= 1) && (inputs.size() <= 4));   // 这里的输入应该是 1 - 4;
+  ctx->requires_grad = inputs.at(0)->requires_grad();        
+  if (!ctx->requires_grad) { return Maybe<void>::Ok(); }     // 如果不需要梯度，也就不需要求导了，直接返回 Maybe<void>::Ok()
+
+  ComposedAttrMap composed_attrs(attrs, base_attrs_);   // 写法确认;
+  ctx->SaveTensorForBackward(inputs.at(0));   
+  if (inputs.size() == 2)   // position_ids
+    ctx->SaveTensorForBackward(inputs.at(1));
+  if (inputs.size() == 3) {   // cos, sin
+    ctx->SaveTensorForBackward(inputs.at(1));
+    ctx->SaveTensorForBackward(inputs.at(2));
+  }
+    
+  if (inputs.size() == 4) {   // cos, sin, position_ids;
+    ctx->SaveTensorForBackward(inputs.at(1));
+    ctx->SaveTensorForBackward(inputs.at(2));
+    ctx->SaveTensorForBackward(inputs.at(3));
+  }    
+
+  ctx->x_layout = JUST(composed_attrs.GetAttr<std::string>("x_layout"));
+  ctx->output_layout = JUST(composed_attrs.GetAttr<std::string>("output_layout"));
+  ctx->mode = JUST(composed_attrs.GetAttr<std::string>("mode"));
+  ctx->tensor_index = JUST(composed_attrs.GetAttr<int64_t>("tensor_index"));
+  ctx->k_size = JUST(composed_attrs.GetAttr<int64_t>("k_size"));
+  ctx->base = JUST(composed_attrs.GetAttr<float>("base"));
+  ctx->rotary_size = JUST(composed_attrs.GetAttr<int64_t>("rotary_size"));
+
+  return Maybe<void>::Ok();
+}
+
+Maybe<void> FusedApplyRotaryEmb::Apply(const FusedApplyRotaryEmbCaptureState* ctx,
+                                       const TensorTuple& out_grads, TensorTuple* in_grads) const {
+    CHECK_EQ_OR_RETURN(out_grads.size(), 1);  // 检查梯度 Tensor 个数是否为 1 TODO: 不确定是否输入为1 -- (dy)
+    // in_grads->resize(1);    // 这里不能resize, 需要和input_meta_data_.size() 一致;
+    const auto& saved_tensors = ctx->SavedTensors();
+
+    CHECK_OR_RETURN((saved_tensors.size() >= 1) && (saved_tensors.size() <= 4));
+    // 输出backward拿到的参数
+    if (ctx->requires_grad) {
+      if (saved_tensors.size() == 1) {
+        const auto& x = ctx->SavedTensors().at(0);
+        in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(x, out_grads.at(0), NullOpt/*cos*/, 
+        NullOpt/*sin*/, NullOpt/*position_ids*/,
+        ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
+      }
+
+      if (saved_tensors.size() == 2) {
+        const auto& x = ctx->SavedTensors().at(0);
+        const auto& position_ids = ctx->SavedTensors().at(1);
+        in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(x, out_grads.at(0), NullOpt/*cos*/, 
+        NullOpt/*sin*/, position_ids,
+        ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
+      }
+
+      if (saved_tensors.size() == 3) {
+        const auto& x = ctx->SavedTensors().at(0);
+        const auto& cos = ctx->SavedTensors().at(1);
+        const auto& sin = ctx->SavedTensors().at(2);
+
+        in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(x, out_grads.at(0), cos, sin, NullOpt/*position_ids*/,
+        ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
+      }
+
+      if (saved_tensors.size() == 4) {
+        const auto& x = ctx->SavedTensors().at(0); // 调用 SavedTensors 接口，拿到先前通过 SaveTensorForBackward 接口保存的 Tensor
+        const auto& cos = ctx->SavedTensors().at(1);
+        const auto& sin = ctx->SavedTensors().at(2);
+        const auto& position_ids = ctx->SavedTensors().at(3);
+        in_grads->at(0) = JUST(functional::FusedApplyRotaryEmbGrad(x, out_grads.at(0), cos, sin, position_ids,
+        ctx->x_layout, ctx->output_layout, ctx->mode, ctx->tensor_index, ctx->k_size, ctx->base, ctx->rotary_size));
+      }
+    }
+
+    return Maybe<void>::Ok();
+}
+
+REGISTER_OP_EXPR_GRAD_FUNCTION("fused_apply_rotary_emb", FusedApplyRotaryEmb);
+
+}  // namespace one
+}  // namespace oneflow

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -2408,7 +2408,7 @@
   bind_python: False
 
 - name: "to_global"
-  signature: "Tensor (Tensor x, Placement placement, SbpList sbp, SbpList grad_sbp, Bool check_meta, Bool sync_data, Bool copy=False) => ToGlobal"
+  signature: "Tensor (Tensor x, Placement placement, SbpList sbp, SbpList grad_sbp, Bool check_meta, Bool copy=False) => ToGlobal"
   bind_python: True
 
 - name: "to_local"
@@ -2686,6 +2686,10 @@
 
 - name: "fused_bias_add_scale_mask_softmax_dropout"
   signature: "TensorTuple (Tensor x, Tensor bias, Tensor mask, *, Float fill_value=0.0, Float scale=1.0, Float p=0.5, Bool training=True, Generator generator=None) => FusedBiasAddScaleMaskSoftmaxDropout"
+  bind_python: True
+
+- name: "scaled_dot_product_attention"
+  signature: "Tensor (Tensor query, Tensor key, Tensor value, Tensor attn_mask=None, Float dropout_p=0.0, Bool is_causal=False, Float scale=None, Int64 seed=0) => ScaledDotProductFlashAttention"
   bind_python: True
 
 - name: "fused_multi_head_attention_inference"

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -1279,6 +1279,10 @@
   signature: 'Tensor (Tensor x, *, Tensor cos=None, Tensor sin=None, Tensor position_ids=None, String x_layout="BHMK", String output_layout=None, String mode="plane", Int64 tensor_index=None, Int64 k_size=None, Float base=1e4, Int64 rotary_size=None) => FusedApplyRotaryEmb'
   bind_python: True
 
+- name: "fused_apply_rotary_emb_grad"
+  signature: 'Tensor (Tensor x, Tensor dy, Tensor cos=None, Tensor sin=None, Tensor position_ids=None, String x_layout="BHMK", String output_layout=None, String mode="plane", Int64 tensor_index=None, Int64 k_size=None, Float base=1e4, Int64 rotary_size=None) => FusedApplyRotaryEmbGrad'
+  bind_python: False
+  
 - name: "fused_relu_dropout_grad"
   signature: "Tensor (Tensor dy, Tensor mask, Float scale) => FusedReluDropoutGrad"
   bind_python: False
@@ -2404,7 +2408,7 @@
   bind_python: False
 
 - name: "to_global"
-  signature: "Tensor (Tensor x, Placement placement, SbpList sbp, SbpList grad_sbp, Bool check_meta, Bool copy=False) => ToGlobal"
+  signature: "Tensor (Tensor x, Placement placement, SbpList sbp, SbpList grad_sbp, Bool check_meta, Bool sync_data, Bool copy=False) => ToGlobal"
   bind_python: True
 
 - name: "to_local"
@@ -2682,10 +2686,6 @@
 
 - name: "fused_bias_add_scale_mask_softmax_dropout"
   signature: "TensorTuple (Tensor x, Tensor bias, Tensor mask, *, Float fill_value=0.0, Float scale=1.0, Float p=0.5, Bool training=True, Generator generator=None) => FusedBiasAddScaleMaskSoftmaxDropout"
-  bind_python: True
-
-- name: "scaled_dot_product_attention"
-  signature: "Tensor (Tensor query, Tensor key, Tensor value, Tensor attn_mask=None, Float dropout_p=0.0, Bool is_causal=False, Float scale=None, Int64 seed=0) => ScaledDotProductFlashAttention"
   bind_python: True
 
 - name: "fused_multi_head_attention_inference"

--- a/oneflow/core/functional/impl/fused_attention_functor.cpp
+++ b/oneflow/core/functional/impl/fused_attention_functor.cpp
@@ -852,8 +852,6 @@ class FusedApplyRotaryEmbGradFunctor {
         return OpInterpUtil::Dispatch<Tensor>(*op_without_position_sinuous_, {x, dy}, attrs);
       }
     }
-
-    return dy;
   }
 
  private:

--- a/oneflow/core/functional/impl/fused_attention_functor.cpp
+++ b/oneflow/core/functional/impl/fused_attention_functor.cpp
@@ -644,7 +644,6 @@ class FusedApplyRotaryEmbFunctor {
                            const Optional<int64_t>& tensor_index, const Optional<int64_t>& k_size,
                            const float base, const Optional<int64_t>& rotary_size) const {
     int64_t b = 0, m = 0, h = 0, k = 0;
-    // std::cout << "go here!" << std::endl;
 
     if (tensor_index) {
       CHECK_OR_RETURN((JUST(tensor_index) >= 0) && (JUST(tensor_index) <= 2))
@@ -654,8 +653,7 @@ class FusedApplyRotaryEmbFunctor {
         << "mode should be \"intervel\" or \"plane\"";
 
     ParseDims("x", *x->shape(), x_layout, Optional<int64_t>(), k_size, &b, &m, &h, &k);
-    // std::cout << "cpp head_size: " << h << std::endl;
-    // printf("k_size: %ld\n", k_size);
+
     if (k_size) {
       CHECK_EQ_OR_RETURN(JUST(k_size), k)
           << "k_size if given should be equal to K of cos, sin and x.";
@@ -711,7 +709,6 @@ class FusedApplyRotaryEmbFunctor {
     attrs.SetAllAttrs(x_layout, output_layout.value_or(x_layout), mode, tensor_index.value_or(0),
                       k_size.value_or(k), base, rotary_size.value_or(k));
 
-    // std::cout << "dispatch!" << std::endl;
     if (position_ids) {
       if (cos && sin) {
         return OpInterpUtil::Dispatch<Tensor>(*op_with_position_sinuous_,
@@ -745,25 +742,25 @@ class FusedApplyRotaryEmbGradFunctor {
                                                .Input("cos")
                                                .Input("sin")
                                                .Input("position_ids")
-                                               .Output("out")
+                                               .Output("dx")
                                                .Build());
     op_with_position_ = CHECK_JUST(one::OpBuilder("fused_apply_rotary_emb_grad")
                                        .Input("x")
                                        .Input("dy")
                                        .Input("position_ids")
-                                       .Output("out")
+                                       .Output("dx")
                                        .Build());
     op_without_position_ = CHECK_JUST(one::OpBuilder("fused_apply_rotary_emb_grad")
                                           .Input("x")
                                           .Input("dy")
                                           .Input("cos")
                                           .Input("sin")
-                                          .Output("out")
+                                          .Output("dx")
                                           .Build());
     op_without_position_sinuous_ =
         CHECK_JUST(one::OpBuilder("fused_apply_rotary_emb_grad").Input("x")
                                                                 .Input("dy")
-                                                                .Output("out")
+                                                                .Output("dx")
                                                                 .Build());
   }
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
@@ -774,8 +771,89 @@ class FusedApplyRotaryEmbGradFunctor {
                            const Optional<std::string>& output_layout, const std::string& mode,
                            const Optional<int64_t>& tensor_index, const Optional<int64_t>& k_size,
                            const float base, const Optional<int64_t>& rotary_size) const {
-      std::cout << "FusedApplyRotaryEmbGradFunctor" << std::endl;
-      return dy;
+    int64_t b = 0, m = 0, h = 0, k = 0;
+    
+    if (tensor_index) {
+      CHECK_OR_RETURN((JUST(tensor_index) >= 0) && (JUST(tensor_index) <= 2))
+          << "tensor_index should be set between [0, 2]";
+    }
+    CHECK_OR_RETURN((mode == "interval") || (mode == "plane"))
+        << "mode should be \"intervel\" or \"plane\"";
+
+    ParseDims("x", *x->shape(), x_layout, Optional<int64_t>(), k_size, &b, &m, &h, &k);
+
+    if (k_size) {
+      CHECK_EQ_OR_RETURN(JUST(k_size), k)
+          << "k_size if given should be equal to K of cos, sin and x.";
+    }
+    if (rotary_size) {
+      CHECK_LE_OR_RETURN(JUST(rotary_size), k) << "rotary_size should be no more than k.";
+    }
+
+    int64_t rotary_emd_dim = 1;
+
+    if (position_ids) {
+      CHECK_EQ_OR_RETURN(JUST(position_ids)->shape()->NumAxes(), 3)
+          << "ndims of position_ids should be equal to 3, either in form of B1M or B2M.";
+      CHECK_EQ_OR_RETURN(JUST(position_ids)->shape()->At(0), b)
+          << "1st dim of position_ids should be equal to B.";
+      CHECK_EQ_OR_RETURN(JUST(position_ids)->shape()->At(2), m)
+          << "3rd dim of position_ids should be equal to M.";
+      rotary_emd_dim = JUST(position_ids)->shape()->At(1);
+      CHECK_OR_RETURN(rotary_emd_dim == 1 || rotary_emd_dim == 2)
+          << "2nd dim of position_ids should be 1 or 2.";
+    }
+
+    const int64_t actual_rotary_size = rotary_size.value_or(k) / rotary_emd_dim;
+    CHECK_EQ_OR_RETURN(actual_rotary_size % 2, 0)
+        << "k ,or rotary_size if given, should be a multiple of 2 * rotary_encoding_dim.";
+
+    if (cos && sin) {
+      CHECK_EQ_OR_RETURN(JUST(cos)->shape()->NumAxes(), 2)
+          << "The number of dimensions of cos should be equal to 2.";
+      CHECK_OR_RETURN(JUST(cos)->shape() == JUST(sin)->shape())
+          << "Each dimension of cos & sin should be the same.";
+      CHECK_EQ_OR_RETURN(JUST(cos)->shape()->At(1), actual_rotary_size)
+          << "The 1st dimension of cos & sin should equal to rotary_size // "
+             "rotary_embedding_dimension.";
+    } else if (!cos && !sin) {
+      // do nothing
+    } else {
+      UNIMPLEMENTED_THEN_RETURN() << "cos & sin should both be given or not given.";
+    }
+
+    if (!position_ids) {
+      if (cos && sin) {
+        CHECK_GE_OR_RETURN(JUST(cos)->shape()->At(0), m)
+            << "M of cos & sin should be to no less than "
+               "M of x when position_ids is not "
+               "given.";  // K of cos & sin is checked
+                          // inside ParseDims
+      }
+    }
+
+    auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("x_layout", "output_layout", "mode",
+                                                 "tensor_index", "k_size", "base", "rotary_size");
+    attrs.SetAllAttrs(x_layout, output_layout.value_or(x_layout), mode, tensor_index.value_or(0),
+                      k_size.value_or(k), base, rotary_size.value_or(k));
+
+    if (position_ids) {
+      if (cos && sin) {
+        return OpInterpUtil::Dispatch<Tensor>(*op_with_position_sinuous_,
+                                              {x, dy, JUST(cos), JUST(sin), JUST(position_ids)}, attrs);
+      } else {
+        return OpInterpUtil::Dispatch<Tensor>(*op_with_position_, {x, dy, JUST(position_ids)}, attrs);
+      }
+    } else {
+      if (cos && sin) {
+        return OpInterpUtil::Dispatch<Tensor>(*op_without_position_, {x, dy, JUST(cos), JUST(sin)},
+                                              attrs);
+      } else {
+        return OpInterpUtil::Dispatch<Tensor>(*op_without_position_sinuous_, {x, dy}, attrs);
+      }
+    }
+
+    return dy;
   }
 
  private:

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -2877,6 +2877,32 @@ def OneFlow_FusedCrossFeatureInteractionV2GradOp : OneFlow_BaseOp<"fused_cross_f
   let has_data_type_infer_fn = 1;
 }
 
+def OneFlow_ScaledDotProductFlashAttentionOp : OneFlow_BaseOp<"scaled_dot_product_flash_attention", [NoMemoryEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+  let input = (ins
+    OneFlow_Tensor:$query,
+    OneFlow_Tensor:$key,
+    OneFlow_Tensor:$value,
+    Optional<OneFlow_Tensor>:$alibi_slopes_
+  );
+  let output = (outs
+    OneFlow_Tensor:$out,
+    OneFlow_Tensor:$softmax_lse,
+    OneFlow_Tensor:$rng_state
+  );
+  let attrs = (ins
+    DefaultValuedAttr<F32Attr, "0.">:$p_dropout,
+    DefaultValuedAttr<F32Attr, "0.">:$softmax_scale,
+    DefaultValuedAttr<BoolAttr, "false">:$is_causal,
+    SI32Attr:$window_size_left,
+    SI32Attr:$window_size_right,
+    DefaultValuedAttr<SI64Attr, "0">:$seed
+  );
+  let has_logical_tensor_desc_infer_fn = 1;
+  let has_physical_tensor_desc_infer_fn = 1;
+  let has_get_sbp_fn = 1;
+  let has_data_type_infer_fn = 1;
+}
+
 def OneFlow_FusedMultiHeadAttentionInferenceOp : OneFlow_BaseOp<"fused_multi_head_attention_inference", [NoMemoryEffect, AttrSizedOperandSegments, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
     OneFlow_Tensor:$query,

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -2877,32 +2877,6 @@ def OneFlow_FusedCrossFeatureInteractionV2GradOp : OneFlow_BaseOp<"fused_cross_f
   let has_data_type_infer_fn = 1;
 }
 
-def OneFlow_ScaledDotProductFlashAttentionOp : OneFlow_BaseOp<"scaled_dot_product_flash_attention", [NoMemoryEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
-  let input = (ins
-    OneFlow_Tensor:$query,
-    OneFlow_Tensor:$key,
-    OneFlow_Tensor:$value,
-    Optional<OneFlow_Tensor>:$alibi_slopes_
-  );
-  let output = (outs
-    OneFlow_Tensor:$out,
-    OneFlow_Tensor:$softmax_lse,
-    OneFlow_Tensor:$rng_state
-  );
-  let attrs = (ins
-    DefaultValuedAttr<F32Attr, "0.">:$p_dropout,
-    DefaultValuedAttr<F32Attr, "0.">:$softmax_scale,
-    DefaultValuedAttr<BoolAttr, "false">:$is_causal,
-    SI32Attr:$window_size_left,
-    SI32Attr:$window_size_right,
-    DefaultValuedAttr<SI64Attr, "0">:$seed
-  );
-  let has_logical_tensor_desc_infer_fn = 1;
-  let has_physical_tensor_desc_infer_fn = 1;
-  let has_get_sbp_fn = 1;
-  let has_data_type_infer_fn = 1;
-}
-
 def OneFlow_FusedMultiHeadAttentionInferenceOp : OneFlow_BaseOp<"fused_multi_head_attention_inference", [NoMemoryEffect, AttrSizedOperandSegments, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
     OneFlow_Tensor:$query,
@@ -3934,6 +3908,32 @@ def OneFlow_FusedApplyRotaryEmbOp : OneFlow_BaseOp<"fused_apply_rotary_emb", [No
   );
   let output = (outs
     OneFlow_Tensor:$out
+  );
+  let attrs = (ins
+    DefaultValuedAttr<StrAttr, "\"BHMK\"">:$x_layout,
+    DefaultValuedAttr<StrAttr, "\"BHMK\"">:$output_layout,
+    DefaultValuedAttr<StrAttr, "\"plane\"">:$mode,
+    DefaultValuedAttr<SI64Attr, "0">:$tensor_index,
+    DefaultValuedAttr<F32Attr, "1e4">:$base,
+    DefaultValuedAttr<SI64Attr, "0">:$k_size,
+    DefaultValuedAttr<SI64Attr, "0">:$rotary_size
+  );
+  let has_logical_tensor_desc_infer_fn = 1;
+  let has_physical_tensor_desc_infer_fn = 1;
+  let has_get_sbp_fn = 1;
+  let has_data_type_infer_fn = 1;
+}
+
+def OneFlow_FusedApplyRotaryEmbGradOp : OneFlow_BaseOp<"fused_apply_rotary_emb_grad", [NoMemoryEffect, AttrSizedOperandSegments, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
+  let input = (ins
+    OneFlow_Tensor:$x,
+    OneFlow_Tensor:$dy,
+    Optional<OneFlow_Tensor>:$cos,
+    Optional<OneFlow_Tensor>:$sin,
+    Optional<OneFlow_Tensor>:$position_ids
+  );
+  let output = (outs
+    OneFlow_Tensor:$dx
   );
   let attrs = (ins
     DefaultValuedAttr<StrAttr, "\"BHMK\"">:$x_layout,

--- a/oneflow/user/kernels/fused_attention_kernels.cu
+++ b/oneflow/user/kernels/fused_attention_kernels.cu
@@ -1133,7 +1133,6 @@ template<typename T, typename PositionType, typename IndexType, size_t PackSize,
 __global__ void IntervalGradKernel(
     FusedApplyRotaryEmbParam<T, PositionType, IndexType, num_dims, rotary_emb_dim> param) {
     printf("IntervalGradKernel TODO!\n");
-  }
 }
 
 
@@ -1356,7 +1355,6 @@ void LaunchKernel(ep::CudaStream* stream, const T* x, const T* cos, const T* sin
             param);
     }
   }
-  
 }
 
 template<typename T, typename PositionType, typename IndexType, size_t num_dims,

--- a/oneflow/user/ops/fused_attention_ops.cpp
+++ b/oneflow/user/ops/fused_attention_ops.cpp
@@ -806,4 +806,189 @@ Maybe<void> ParseSplitAxis(const std::string& layout, bool can_hk_split, int64_t
   return Maybe<void>::Ok();
 }
 
+/* static */ Maybe<void> FusedApplyRotaryEmbGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {
+  const user_op::TensorDesc& x_desc = ctx->InputTensorDesc("x", 0);
+  const std::string& x_layout = ctx->Attr<std::string>("x_layout");
+  const std::string& output_layout = ctx->Attr<std::string>("output_layout");
+  const std::string& mode = ctx->Attr<std::string>("mode");
+  const int64_t rotary_size = ctx->Attr<int64_t>("rotary_size");
+  const int64_t k_size = ctx->Attr<int64_t>("k_size");
+  const int64_t tensor_index = ctx->Attr<int64_t>("tensor_index");
+
+  CHECK_OR_RETURN((tensor_index >= 0) && (tensor_index <= 2))
+      << "tensor_index should be in range [0, 2].";
+  CHECK_OR_RETURN((mode == "interval") || (mode == "plane"))
+      << "mode should be either \"interval\" or \"plane\".";
+
+  CHECK_OR_RETURN(output_layout != "BM(H2K)" && output_layout != "BM(H3K)"
+                  && output_layout != "MB(H2K)" && output_layout != "MB(H3K)")
+      << "output_layout should not be \"BM(H2k)\", \"BM(H3K)\", \"MB(H2K)\", \"MB(H3K)\".";
+
+  int64_t b = 0, m = 0, h = 0, k = 0;
+
+  JUST(ParseDims(x_desc.shape(), x_layout, Optional<int64_t>(), Optional<int64_t>(k_size), &b, &m,
+                 &h, &k));    // 这里需要检查是否正确;
+
+  CHECK_LE_OR_RETURN(rotary_size, k) << "rotary_size should be no more than K of input x.";
+
+  int64_t rotary_emb_dim = 1;
+
+  if (ctx->has_input("position_ids", 0)) {
+    const user_op::TensorDesc& position_ids_desc = ctx->InputTensorDesc("position_ids", 0);
+    CHECK_EQ_OR_RETURN(position_ids_desc.shape().NumAxes(), 3)
+        << "ndims of position_ids should be equal to 3, either in form of B1M or B2M.";
+    CHECK_EQ_OR_RETURN(position_ids_desc.shape().At(0), b)
+        << "1st dim of position_ids should be equal to B.";
+    CHECK_EQ_OR_RETURN(position_ids_desc.shape().At(2), m)
+        << "3rd dim of position_ids should be equal to M.";
+    rotary_emb_dim = position_ids_desc.shape().At(1);
+    CHECK_OR_RETURN(rotary_emb_dim == 1 || rotary_emb_dim == 2)
+        << "2nd dim of position_ids should be 1 or 2.";
+  }
+
+  const int64_t actual_rotary_size = rotary_size / rotary_emb_dim;
+  CHECK_EQ_OR_RETURN(actual_rotary_size % 2, 0)
+      << "rotary_size should be a multiple of 2 * rotary_encoding_dim.";
+
+  bool has_cos = ctx->has_input("cos", 0);
+  bool has_sin = ctx->has_input("sin", 0);
+  // TODO: fused_apply_rotary_emb have same logic no matter name
+  if (has_cos && has_sin) {
+    const user_op::TensorDesc& cos_desc = ctx->InputTensorDesc("cos", 0);
+    const user_op::TensorDesc& sin_desc = ctx->InputTensorDesc("sin", 0);
+    CHECK_EQ_OR_RETURN(cos_desc.shape().NumAxes(), 2)
+        << "The number of dimensions of cos should be equal to 2.";
+    CHECK_OR_RETURN(cos_desc.shape() == sin_desc.shape())
+        << "The dimensions of cos & sin should be the same.";
+    CHECK_EQ_OR_RETURN(cos_desc.shape().At(1), actual_rotary_size)
+        << "The 1st dimension of cos & sin should equal to rotary_size // "
+           "rotary_embedding_dimension.";
+  } else if (!has_cos && !has_sin) {
+    // Do nothing
+  } else {
+    UNIMPLEMENTED_THEN_RETURN();
+  }
+
+  if (!ctx->has_input("position_ids", 0)) {
+    if (has_cos && has_sin) {
+      const user_op::TensorDesc& cos_desc = ctx->InputTensorDesc("cos", 0);
+      CHECK_GE_OR_RETURN(cos_desc.shape().At(0), m)
+          << "M of cos should be no less than M of x if position_ids is not given.";
+      // K of cos & sin is checked inside ParseDims
+    }
+  }
+
+  Shape out_shape = *JUST(LayoutToShape(b, m, h, k, x_layout));
+  ctx->SetOutputShape("dx", 0, out_shape);
+  return Maybe<void>::Ok();
+}
+
+/* static */ Maybe<void> FusedApplyRotaryEmbGradOp::InferPhysicalTensorDesc(user_op::InferContext* ctx) {
+  return InferLogicalTensorDesc(ctx);
+}
+
+
+/* static */ Maybe<void> FusedApplyRotaryEmbGradOp::GetSbp(user_op::SbpContext* ctx) {
+  /*
+    1. 获取layout;
+    2. check dy shape;
+    3. 获取split_axis;
+    4. 设置sbp;
+    反向算子中的split应该与前向一致;
+  */
+  const user_op::TensorDesc& x_desc = ctx->LogicalTensorDesc4InputArgNameAndIndex("x", 0);
+  int num_heads = -1;
+  const int64_t k_size = ctx->Attr<int64_t>("k_size");
+  const std::string& x_layout = ctx->Attr<std::string>("x_layout");
+  const std::string& output_layout = ctx->Attr<std::string>("output_layout");
+
+  if (x_desc.shape().NumAxes() == 2) {
+    if (x_layout == "(BM)(HK)") {
+      CHECK_EQ_OR_RETURN(x_desc.shape().At(1) % k_size, 0);
+      num_heads = x_desc.shape().At(1) / k_size;
+    } else if (x_layout == "(BM)(H3K)") {
+      CHECK_EQ_OR_RETURN(x_desc.shape().At(1) % (k_size * 3), 0);
+      num_heads = x_desc.shape().At(1) / (k_size * 3);
+    } else {
+      UNIMPLEMENTED_THEN_RETURN();
+    }
+  } else if (x_desc.shape().NumAxes() == 3) {
+    if (x_layout == "BM(HK)" || x_layout == "MB(HK)") {
+      CHECK_EQ_OR_RETURN(x_desc.shape().At(2) % k_size, 0);
+      num_heads = x_desc.shape().At(2) / k_size;
+    } else if (x_layout == "BM(H3K)" || x_layout == "MB(H3K)") {
+      CHECK_EQ_OR_RETURN(x_desc.shape().At(2) % (k_size * 3), 0);
+      num_heads = x_desc.shape().At(2) / (k_size * 3);
+    } else if (x_layout == "(BM)HK") {
+      num_heads = x_desc.shape().At(1);
+    } else {
+      UNIMPLEMENTED_THEN_RETURN();
+    }
+  } else if (x_desc.shape().NumAxes() == 4) {
+    if (x_layout == "BMHK") {
+      num_heads = x_desc.shape().At(2);
+    } else if (x_layout == "BHMK") {
+      num_heads = x_desc.shape().At(1);
+    } else {
+      UNIMPLEMENTED_THEN_RETURN();
+    }
+  } else {
+    UNIMPLEMENTED_THEN_RETURN();
+  }
+
+  const bool can_hk_split = num_heads % ctx->parallel_num() == 0;
+  int64_t x_b_split_axis = -1;
+  int64_t x_h_split_axis = -1;
+  JUST(ParseSplitAxis(x_layout, can_hk_split, &x_b_split_axis, &x_h_split_axis));
+  int64_t o_b_split_axis = -1;
+  int64_t o_h_split_axis = -1;
+  JUST(ParseSplitAxis(output_layout, can_hk_split, &o_b_split_axis, &o_h_split_axis));
+
+  if (x_b_split_axis >= 0 && o_b_split_axis >= 0) {
+    auto builder = ctx->NewBuilder()
+                       .Split(user_op::OpArg("dy", 0), o_b_split_axis)
+                       .Split(user_op::OpArg("dx", 0), x_b_split_axis);
+    if (ctx->user_op_conf().has_input("cos", 0))
+      builder = builder.Broadcast(user_op::OpArg("cos", 0)).Broadcast(user_op::OpArg("sin", 0));
+    if (ctx->user_op_conf().has_input("position_ids", 0))
+      builder = builder.Split(user_op::OpArg("position_ids", 0), 0);   // 这里怎么split?
+    builder.Build();
+  }
+  if (x_h_split_axis >= 0 && o_h_split_axis >= 0) {
+    auto builder = ctx->NewBuilder()
+                       .Split(user_op::OpArg("dy", 0), o_h_split_axis)
+                       .Split(user_op::OpArg("dx", 0), x_h_split_axis);
+    if (ctx->user_op_conf().has_input("cos", 0))
+      builder = builder.Broadcast(user_op::OpArg("cos", 0)).Broadcast(user_op::OpArg("sin", 0));
+    if (ctx->user_op_conf().has_input("position_ids", 0))
+      builder = builder.Broadcast(user_op::OpArg("position_ids", 0));
+    builder.Build();
+  }
+
+  return Maybe<void>::Ok();
+}
+
+/* static */ Maybe<void> FusedApplyRotaryEmbGradOp::InferDataType(user_op::InferContext* ctx) {
+  const user_op::TensorDesc& first_in_desc = ctx->InputTensorDesc("dy", 0);
+
+  bool has_sinuous = ctx->has_input("cos", 0);
+
+  if (has_sinuous) {
+    const user_op::TensorDesc& cos_desc = ctx->InputTensorDesc("cos", 0);
+    const user_op::TensorDesc& sin_desc = ctx->InputTensorDesc("sin", 0);
+
+    CHECK_EQ_OR_RETURN(cos_desc.data_type(), first_in_desc.data_type())
+        << "InferDataType Failed. Expected " << DataType_Name(first_in_desc.data_type())
+        << ", but got " << DataType_Name(cos_desc.data_type());
+    CHECK_EQ_OR_RETURN(sin_desc.data_type(), first_in_desc.data_type())
+        << "InferDataType Failed. Expected " << DataType_Name(first_in_desc.data_type())
+        << ", but got " << DataType_Name(sin_desc.data_type());
+  }
+
+  user_op::TensorDesc* out_desc = ctx->MutOutputTensorDesc("dx", 0);
+  out_desc->set_data_type(first_in_desc.data_type());
+
+  return Maybe<void>::Ok();
+}
+
 }  // namespace oneflow

--- a/python/oneflow/test/modules/test_fused_rotary_embedding.py
+++ b/python/oneflow/test/modules/test_fused_rotary_embedding.py
@@ -1387,7 +1387,7 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
         args_dict = OrderedDict()
         args_dict["test_fun"] = [_test_plane]
         # args_dict["x_layout"] = ["MB(H3K)"]
-        args_dict["x_layout"] = ["BMHK", "MB(HK)"]  # TODO: MB(H3K) paramdims bug;
+        args_dict["x_layout"] = ["BMHK", "MB(HK)"]  # TODO: MB(H3K) bug;
         args_dict["mode"] = ["plane"]
         args_dict["base"] = [1e1]
         args_dict["rotary_size"] = [4, 8]

--- a/python/oneflow/test/modules/test_fused_rotary_embedding.py
+++ b/python/oneflow/test/modules/test_fused_rotary_embedding.py
@@ -525,6 +525,7 @@ def _test_without_position(
         )
     )
 
+
 # this assume that rotary_ndims is by default 1
 def _test_without_position_sinuous(
     test_case, x_layout, mode, base, rotary_size, dims, rotary_ndims, dtype, device
@@ -1385,8 +1386,8 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
     def test_fused_rotary_embedding_op_plane(test_case):
         args_dict = OrderedDict()
         args_dict["test_fun"] = [_test_plane]
-        #args_dict["x_layout"] = ["MB(H3K)", "MB(HK)"]
-        args_dict["x_layout"] = ["BMHK", "MB(H3K)"]  # TODO: MB(H3K) paramdims bug;
+        # args_dict["x_layout"] = ["MB(H3K)"]
+        args_dict["x_layout"] = ["BMHK", "MB(HK)"]  # TODO: MB(H3K) paramdims bug;
         args_dict["mode"] = ["plane"]
         args_dict["base"] = [1e1]
         args_dict["rotary_size"] = [4, 8]

--- a/python/oneflow/test/modules/test_fused_rotary_embedding.py
+++ b/python/oneflow/test/modules/test_fused_rotary_embedding.py
@@ -24,20 +24,20 @@ import math
 
 # tensor version:
 def plane_shuffle_tensor(x):
-    x1, x2 = x[..., :x.shape[-1] // 2], x[..., x.shape[-1] // 2:]
+    x1, x2 = x[..., : x.shape[-1] // 2], x[..., x.shape[-1] // 2 :]
     return flow.cat((-x2, x1), dim=-1)
 
 
 def shuffle_adjacent_two_elem_tensor(x):
-    y = x.clone()  # 使用.clone()以确保我们不会在原始输入上进行操作
+    y = x.clone()
     for i in range(x.shape[-1] // 2):
-        y[..., 2*i] = -x[..., 2*i + 1]
-        y[..., 2*i + 1] = x[..., 2*i]
+        y[..., 2 * i] = -x[..., 2 * i + 1]
+        y[..., 2 * i + 1] = x[..., 2 * i]
     return y
 
 
 def parseDims_tensor(dims, x_layout):
-    B, M, H, K = 1, 1, 1, 1  # 初始化维度
+    B, M, H, K = 1, 1, 1, 1
     merged_dims = dims
     if x_layout == "BHMK":
         B, H, M, K = dims
@@ -61,7 +61,21 @@ def parseDims_tensor(dims, x_layout):
     return B, M, H, K, merged_dims
 
 
-def naive_embedding_tensor(x, cos, sin, x_layout, B, M, H, K, dims, merged_dims, rotary_size, rotary_ndims, mode):
+def naive_embedding_tensor(
+    x,
+    cos,
+    sin,
+    x_layout,
+    B,
+    M,
+    H,
+    K,
+    dims,
+    merged_dims,
+    rotary_size,
+    rotary_ndims,
+    mode,
+):
     naive_out = None
     if mode == "plane":
         if rotary_ndims == 2:
@@ -109,23 +123,15 @@ def naive_embedding_tensor(x, cos, sin, x_layout, B, M, H, K, dims, merged_dims,
 
         naive_out = flow.cat((out0, out1, out2), axis=-1)
     elif x_layout == "MB(H3K)":
-        #test = cos.transpose([2, 0, 1, 3]).reshape( [M, B, 1, K] )
-        #test = cos.permute([2, 0, 1, 3])
         out0 = x[..., 0, :].reshape(dims) * cos.permute([2, 0, 1, 3]).reshape(
             [M, B, 1, K]
-        ) + y[..., 0, :].reshape(dims) * sin.permute([2, 0, 1, 3]).reshape(
-            [M, B, 1, K]
-        )
+        ) + y[..., 0, :].reshape(dims) * sin.permute([2, 0, 1, 3]).reshape([M, B, 1, K])
         out1 = x[..., 1, :].reshape(dims) * cos.permute([2, 0, 1, 3]).reshape(
             [M, B, 1, K]
-        ) + y[..., 1, :].reshape(dims) * sin.permute([2, 0, 1, 3]).reshape(
-            [M, B, 1, K]
-        )
+        ) + y[..., 1, :].reshape(dims) * sin.permute([2, 0, 1, 3]).reshape([M, B, 1, K])
         out2 = x[..., 2, :].reshape(dims) * cos.permute([2, 0, 1, 3]).reshape(
             [M, B, 1, K]
-        ) + y[..., 2, :].reshape(dims) * sin.permute([2, 0, 1, 3]).reshape(
-            [M, B, 1, K]
-        )
+        ) + y[..., 2, :].reshape(dims) * sin.permute([2, 0, 1, 3]).reshape([M, B, 1, K])
 
         naive_out = flow.cat((out0, out1, out2), dim=-1)
 
@@ -361,7 +367,9 @@ def _test_without_position(
         mode,
     )
 
-    naive_x_tensor = flow.tensor(naive_x, dtype=dtype, device=device, requires_grad=True)
+    naive_x_tensor = flow.tensor(
+        naive_x, dtype=dtype, device=device, requires_grad=True
+    )
     naive_cos_tensor = flow.tensor(naive_cos, dtype=dtype, device=device)  # 不用grad
     naive_sin_tensor = flow.tensor(naive_sin, dtype=dtype, device=device)
     naive_out_tensor = naive_embedding_tensor(
@@ -380,7 +388,7 @@ def _test_without_position(
         mode,
     )
 
-    # 验证这里的naive_out_tensor与naive_out是否有精度误差;
+    # check naive_out_tensor and naive_out;
     test_case.assertTrue(
         np.allclose(
             naive_out.reshape(merged_dims),
@@ -390,6 +398,7 @@ def _test_without_position(
         )
     )
 
+    # get naive_out_grad
     naive_out_backward = naive_out_tensor.sum()
     naive_out_backward.backward()
     naive_out_grad = naive_x_tensor.grad
@@ -477,10 +486,8 @@ def _test_without_position(
             tensor_index=2,
         )
 
-        # fused_out = np.concatenate((out0, out1, out2), axis=-1)
-        fused_out = flow.cat((out0, out1, out2), dim = -1)
+        fused_out = flow.cat((out0, out1, out2), dim=-1)
     else:
-        print("apply!")
         fused_out = flow._C.fused_apply_rotary_emb(
             fused_x,
             cos=fused_cos,
@@ -492,13 +499,12 @@ def _test_without_position(
             rotary_size=rotary_size,
             mode=mode,
         )
-        print("end!")
-    
+
+    # get fused_out_grad
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
     fused_out_grad = fused_x.grad
-    print("get grad!")
-    #print(fused_out_grad)
+
     # test forward
     test_case.assertTrue(
         np.allclose(
@@ -518,7 +524,6 @@ def _test_without_position(
             rtol=5e-3,
         )
     )
-
 
 # this assume that rotary_ndims is by default 1
 def _test_without_position_sinuous(
@@ -596,8 +601,10 @@ def _test_without_position_sinuous(
         rotary_ndims,
         mode,
     )
-    naive_x_tensor = flow.tensor(naive_x, dtype=dtype, device=device, requires_grad=True)
-    naive_cos_tensor = flow.tensor(naive_cos, dtype=dtype, device=device)  # 不用grad
+    naive_x_tensor = flow.tensor(
+        naive_x, dtype=dtype, device=device, requires_grad=True
+    )
+    naive_cos_tensor = flow.tensor(naive_cos, dtype=dtype, device=device)
     naive_sin_tensor = flow.tensor(naive_sin, dtype=dtype, device=device)
     naive_out_tensor = naive_embedding_tensor(
         naive_x_tensor,
@@ -615,7 +622,7 @@ def _test_without_position_sinuous(
         mode,
     )
 
-    # 验证这里的naive_out_tensor与naive_out是否有精度误差;
+    # check naive_out_tensor and naive_out;
     test_case.assertTrue(
         np.allclose(
             naive_out.reshape(merged_dims),
@@ -625,12 +632,13 @@ def _test_without_position_sinuous(
         )
     )
 
+    # get naive_out_grad
     naive_out_backward = naive_out_tensor.sum()
     naive_out_backward.backward()
     naive_out_grad = naive_x_tensor.grad
 
     fused_x = flow.tensor(x, dtype=dtype, device=device, requires_grad=True)
-    
+
     if x_layout == "BM(H3K)":
         out0 = flow._C.fused_apply_rotary_emb(
             fused_x,
@@ -672,8 +680,7 @@ def _test_without_position_sinuous(
             tensor_index=2,
         )
 
-        #fused_out = np.concatenate((out0, out1, out2), axis=-1)
-        fused_out = flow.cat((out0, out1, out2), dim = -1)
+        fused_out = flow.cat((out0, out1, out2), dim=-1)
     else:
         fused_out = flow._C.fused_apply_rotary_emb(
             fused_x,
@@ -686,11 +693,11 @@ def _test_without_position_sinuous(
             rotary_size=rotary_size,
             mode=mode,
         )
-    
+    # get fused_out_grad
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
     fused_out_grad = fused_x.grad
-    #print(fused_out_grad)
+
     # test forward
     test_case.assertTrue(
         np.allclose(
@@ -781,7 +788,7 @@ def _test_with_position_sinuous(
         naive_x = x.reshape([B, M, H, -1, K])
     elif x_layout == "MB(HK)" or x_layout == "MB(H2K)" or x_layout == "MB(H3K)":
         naive_x = x.reshape([M, B, H, -1, K])
-    
+
     naive_out = naive_embedding(
         naive_x,
         naive_cos,
@@ -798,8 +805,10 @@ def _test_with_position_sinuous(
         mode,
     )
 
-    naive_x_tensor = flow.tensor(naive_x, dtype=dtype, device=device, requires_grad=True)
-    naive_cos_tensor = flow.tensor(naive_cos, dtype=dtype, device=device)  # 不用grad
+    naive_x_tensor = flow.tensor(
+        naive_x, dtype=dtype, device=device, requires_grad=True
+    )
+    naive_cos_tensor = flow.tensor(naive_cos, dtype=dtype, device=device)
     naive_sin_tensor = flow.tensor(naive_sin, dtype=dtype, device=device)
     naive_out_tensor = naive_embedding_tensor(
         naive_x_tensor,
@@ -817,7 +826,7 @@ def _test_with_position_sinuous(
         mode,
     )
 
-    # 验证这里的naive_out_tensor与naive_out是否有精度误差;
+    # check naive_out_tensor and naive_out;
     test_case.assertTrue(
         np.allclose(
             naive_out.reshape(merged_dims),
@@ -827,10 +836,10 @@ def _test_with_position_sinuous(
         )
     )
 
+    # get naive_out_grad;
     naive_out_backward = naive_out_tensor.sum()
     naive_out_backward.backward()
     naive_out_grad = naive_x_tensor.grad
-    #print(naive_out_grad)
 
     fused_cos = np.array(
         [
@@ -917,8 +926,7 @@ def _test_with_position_sinuous(
             tensor_index=2,
         )
 
-        #fused_out = np.concatenate((out0, out1, out2), axis=-1)
-        fused_out = flow.cat((out0, out1, out2), dim = -1)
+        fused_out = flow.cat((out0, out1, out2), dim=-1)
     else:
         fused_out = flow._C.fused_apply_rotary_emb(
             fused_x,
@@ -931,11 +939,11 @@ def _test_with_position_sinuous(
             rotary_size=rotary_size,
             mode=mode,
         )
-
+    # get fused_out_grad;
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
     fused_out_grad = fused_x.grad
-    #print(fused_out_grad)
+
     # test forward
     test_case.assertTrue(
         np.allclose(
@@ -1038,7 +1046,9 @@ def _test_with_position(
         mode,
     )
 
-    naive_x_tensor = flow.tensor(naive_x, dtype=dtype, device=device, requires_grad=True)
+    naive_x_tensor = flow.tensor(
+        naive_x, dtype=dtype, device=device, requires_grad=True
+    )
     naive_cos_tensor = flow.tensor(naive_cos, dtype=dtype, device=device)  # 不用grad
     naive_sin_tensor = flow.tensor(naive_sin, dtype=dtype, device=device)
     naive_out_tensor = naive_embedding_tensor(
@@ -1057,7 +1067,7 @@ def _test_with_position(
         mode,
     )
 
-    # 验证这里的naive_out_tensor与naive_out是否有精度误差;
+    # check naive_out_tensor and naive_out;
     test_case.assertTrue(
         np.allclose(
             naive_out.reshape(merged_dims),
@@ -1066,7 +1076,7 @@ def _test_with_position(
             rtol=5e-3,
         )
     )
-
+    # get naive_out_grad
     naive_out_backward = naive_out_tensor.sum()
     naive_out_backward.backward()
     naive_out_grad = naive_x_tensor.grad
@@ -1115,7 +1125,6 @@ def _test_with_position(
             tensor_index=2,
         )
 
-        #fused_out = np.concatenate((out0, out1, out2), axis=-1)
         fused_out = flow.cat((out0, out1, out2), dim=-1)
     else:
         fused_out = flow._C.fused_apply_rotary_emb(
@@ -1129,11 +1138,10 @@ def _test_with_position(
             rotary_size=rotary_size,
             mode=mode,
         )
-
+    # get fused_out_grad
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
     fused_out_grad = fused_x.grad
-    #print(fused_out_grad)
     # test forward
     test_case.assertTrue(
         np.allclose(
@@ -1244,7 +1252,9 @@ def _test_plane(
         mode,
     )
 
-    naive_x_tensor = flow.tensor(naive_x, dtype=dtype, device=device, requires_grad=True)
+    naive_x_tensor = flow.tensor(
+        naive_x, dtype=dtype, device=device, requires_grad=True
+    )
     naive_cos_tensor = flow.tensor(naive_cos, dtype=dtype, device=device)  # 不用grad
     naive_sin_tensor = flow.tensor(naive_sin, dtype=dtype, device=device)
     naive_out_tensor = naive_embedding_tensor(
@@ -1263,7 +1273,7 @@ def _test_plane(
         mode,
     )
 
-    # 验证这里的naive_out_tensor与naive_out是否有精度误差;
+    # check naive_out_tensor and naive_out;
     test_case.assertTrue(
         np.allclose(
             naive_out.reshape(merged_dims),
@@ -1276,10 +1286,9 @@ def _test_plane(
     naive_out_backward = naive_out_tensor.sum()
     naive_out_backward.backward()
     naive_out_grad = naive_x_tensor.grad
-    
+
     fused_x = flow.tensor(x, dtype=dtype, device=device, requires_grad=True)
     fused_position_ids = flow.tensor(position_ids, dtype=flow.int32, device=device)
-
 
     if x_layout == "MB(H3K)":
         out0 = flow._C.fused_apply_rotary_emb(
@@ -1339,7 +1348,6 @@ def _test_plane(
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
     fused_out_grad = fused_x.grad
-    #print(fused_out_grad)
     # test forward
     test_case.assertTrue(
         np.allclose(
@@ -1362,7 +1370,6 @@ def _test_plane(
     print("tset plane done")
 
 
-
 """
 1. if cos&sin is given, then base will not be used
 2. if cos&sin is not given, then any form of x_layout which cannot infer the dimension of k is not allowed, e.g. BM(HK)
@@ -1374,11 +1381,11 @@ def _test_plane(
 @flow.unittest.skip_unless_1n1d()
 class TestFusedRotaryEmbedding(flow.unittest.TestCase):
     # because rule no.2, kernels without cos&sin cannot work under specific x_layout
-    
+
     def test_fused_rotary_embedding_op_plane(test_case):
         args_dict = OrderedDict()
         args_dict["test_fun"] = [_test_plane]
-        #args_dict["x_layout"] = ["MB(H3K)", "MB(HK)"]
+        # args_dict["x_layout"] = ["MB(H3K)", "MB(HK)"]
         args_dict["x_layout"] = ["BMHK"]
         args_dict["mode"] = ["plane"]
         args_dict["base"] = [1e1]
@@ -1392,9 +1399,8 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
 
         for arg in GenArgList(args_dict):
             arg[0](test_case, *arg[1:])
-    
 
-    '''
+    """ TODO: interval mode grad kernel 
     def test_fused_rotary_embedding_op_interval_2d(test_case):
         args_dict = OrderedDict()
         args_dict["test_fun"] = [_test_with_position, 
@@ -1413,9 +1419,9 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
 
         for arg in GenArgList(args_dict):
             arg[0](test_case, *arg[1:])
-    '''
+    """
 
-    '''
+    """ TODO: interval mode grad kernel
     def test_fused_rotary_embedding_op_interval_1d(test_case):
         args_dict = OrderedDict()
         args_dict["test_fun"] = [
@@ -1437,7 +1443,8 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
 
         for arg in GenArgList(args_dict):
             arg[0](test_case, *arg[1:])
-    '''
+    """
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/oneflow/test/modules/test_fused_rotary_embedding.py
+++ b/python/oneflow/test/modules/test_fused_rotary_embedding.py
@@ -1163,6 +1163,7 @@ def _test_with_position(
     )
 
 
+# TODO: with cos & sin test
 def _test_plane(
     test_case, x_layout, mode, base, rotary_size, dims, rotary_ndims, dtype, device
 ):
@@ -1367,7 +1368,6 @@ def _test_plane(
             rtol=5e-3,
         )
     )
-    print("tset plane done")
 
 
 """
@@ -1385,8 +1385,8 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
     def test_fused_rotary_embedding_op_plane(test_case):
         args_dict = OrderedDict()
         args_dict["test_fun"] = [_test_plane]
-        # args_dict["x_layout"] = ["MB(H3K)", "MB(HK)"]
-        args_dict["x_layout"] = ["BMHK"]
+        #args_dict["x_layout"] = ["MB(H3K)", "MB(HK)"]
+        args_dict["x_layout"] = ["BMHK", "MB(H3K)"]  # TODO: MB(H3K) paramdims bug;
         args_dict["mode"] = ["plane"]
         args_dict["base"] = [1e1]
         args_dict["rotary_size"] = [4, 8]

--- a/python/oneflow/test/modules/test_fused_rotary_embedding.py
+++ b/python/oneflow/test/modules/test_fused_rotary_embedding.py
@@ -289,7 +289,7 @@ def _test_without_position(
             for m in range(M)
         ]
     ).reshape(M, rotary_size // rotary_ndims)
-    fused_x = flow.tensor(x, dtype=dtype, device=device)
+    fused_x = flow.tensor(x, dtype=dtype, device=device, requires_grad=True)
     fused_cos = flow.tensor(fused_cos, dtype=dtype, device=device)
     fused_sin = flow.tensor(fused_sin, dtype=dtype, device=device)
 
@@ -435,7 +435,7 @@ def _test_without_position_sinuous(
         mode,
     )
 
-    fused_x = flow.tensor(x, dtype=dtype, device=device)
+    fused_x = flow.tensor(x, dtype=dtype, device=device, requires_grad=True)
 
     if x_layout == "BM(H3K)":
         out0 = flow._C.fused_apply_rotary_emb(
@@ -627,7 +627,7 @@ def _test_with_position_sinuous(
         ]
     )
 
-    fused_x = flow.tensor(x, dtype=dtype, device=device)
+    fused_x = flow.tensor(x, dtype=dtype, device=device, requires_grad=True)
     fused_cos = flow.tensor(fused_cos, dtype=dtype, device=device)
     fused_sin = flow.tensor(fused_sin, dtype=dtype, device=device)
     fused_position_ids = flow.tensor(position_ids, dtype=flow.int32, device=device)
@@ -778,7 +778,7 @@ def _test_with_position(
         mode,
     )
 
-    fused_x = flow.tensor(x, dtype=dtype, device=device)
+    fused_x = flow.tensor(x, dtype=dtype, device=device, requires_grad=True)
     fused_position_ids = flow.tensor(position_ids, dtype=flow.int32, device=device)
 
     if x_layout == "BM(H3K)":
@@ -935,7 +935,7 @@ def _test_plane(
         mode,
     )
 
-    fused_x = flow.tensor(x, dtype=dtype, device=device)
+    fused_x = flow.tensor(x, dtype=dtype, device=device, requires_grad=True)
     fused_position_ids = flow.tensor(position_ids, dtype=flow.int32, device=device)
 
     if x_layout == "MB(H3K)":

--- a/python/oneflow/test/modules/test_fused_rotary_embedding.py
+++ b/python/oneflow/test/modules/test_fused_rotary_embedding.py
@@ -22,7 +22,115 @@ import oneflow as flow
 import numpy as np
 import math
 
+# tensor version:
+def plane_shuffle_tensor(x):
+    x1, x2 = x[..., :x.shape[-1] // 2], x[..., x.shape[-1] // 2:]
+    return flow.cat((-x2, x1), dim=-1)
 
+
+def shuffle_adjacent_two_elem_tensor(x):
+    y = x.clone()  # 使用.clone()以确保我们不会在原始输入上进行操作
+    for i in range(x.shape[-1] // 2):
+        y[..., 2*i] = -x[..., 2*i + 1]
+        y[..., 2*i + 1] = x[..., 2*i]
+    return y
+
+
+def parseDims_tensor(dims, x_layout):
+    B, M, H, K = 1, 1, 1, 1  # 初始化维度
+    merged_dims = dims
+    if x_layout == "BHMK":
+        B, H, M, K = dims
+    elif x_layout == "BMHK":
+        B, M, H, K = dims
+    elif x_layout == "MBHK":
+        M, B, H, K = dims
+    elif x_layout == "BM(HK)":
+        B, M, H, K = dims
+        merged_dims = [dims[0], dims[1], dims[2] * dims[3]]  # merge H and K
+    elif x_layout == "MB(HK)":
+        M, B, H, K = dims
+        merged_dims = [dims[0], dims[1], dims[2] * dims[3]]
+    elif x_layout == "BM(H3K)":
+        B, M, H, K = dims
+        merged_dims = [dims[0], dims[1], 3 * dims[2] * dims[3]]  # merge and scale
+    elif x_layout == "MB(H3K)":
+        M, B, H, K = dims
+        merged_dims = [dims[0], dims[1], 3 * dims[2] * dims[3]]
+
+    return B, M, H, K, merged_dims
+
+
+def naive_embedding_tensor(x, cos, sin, x_layout, B, M, H, K, dims, merged_dims, rotary_size, rotary_ndims, mode):
+    naive_out = None
+    if mode == "plane":
+        if rotary_ndims == 2:
+            y1 = plane_shuffle_tensor(x[..., : rotary_size // 2])
+            y2 = plane_shuffle_tensor(x[..., rotary_size // 2 : rotary_size])
+            y3 = x[..., rotary_size:]
+            y = flow.cat((y1, y2, y3), dim=-1)
+        else:
+            y1 = plane_shuffle_tensor(x[..., :rotary_size])
+            y2 = x[..., rotary_size:]
+            y = flow.cat((y1, y2), dim=-1)
+    else:
+        y = shuffle_adjacent_two_elem_tensor(x)
+
+    if x_layout == "BHMK":
+        naive_out = x * cos + y * sin
+    elif x_layout == "BMHK":
+        naive_out = x.reshape(dims) * cos.reshape([B, M, 1, K]) + y.reshape(
+            dims
+        ) * sin.reshape(
+            [B, M, 1, K]
+        )  # un-merge
+    elif x_layout == "MBHK" or x_layout == "MB(HK)":
+        naive_out = x.reshape(dims) * cos.transpose([2, 0, 1, 3]).reshape(
+            [M, B, 1, K]
+        ) + y.reshape(dims) * sin.transpose([2, 0, 1, 3]).reshape(
+            [M, B, 1, K]
+        )  # un-merge
+    elif x_layout == "BM(HK)":
+        naive_out = x.reshape(dims) * cos.reshape([B, M, 1, K]) + y.reshape(
+            dims
+        ) * sin.reshape(
+            [B, M, 1, K]
+        )  # un-merge
+    elif x_layout == "BM(H3K)":
+        out0 = x[..., 0, :].reshape(dims) * cos.reshape([B, M, 1, K]) + y[
+            ..., 0, :
+        ].reshape(dims) * sin.reshape([B, M, 1, K])
+        out1 = x[..., 1, :].reshape(dims) * cos.reshape([B, M, 1, K]) + y[
+            ..., 1, :
+        ].reshape(dims) * sin.reshape([B, M, 1, K])
+        out2 = x[..., 2, :].reshape(dims) * cos.reshape([B, M, 1, K]) + y[
+            ..., 2, :
+        ].reshape(dims) * sin.reshape([B, M, 1, K])
+
+        naive_out = flow.cat((out0, out1, out2), axis=-1)
+    elif x_layout == "MB(H3K)":
+        out0 = x[..., 0, :].reshape(dims) * cos.transpose([2, 0, 1, 3]).reshape(
+            [M, B, 1, K]
+        ) + y[..., 0, :].reshape(dims) * sin.transpose([2, 0, 1, 3]).reshape(
+            [M, B, 1, K]
+        )
+        out1 = x[..., 1, :].reshape(dims) * cos.transpose([2, 0, 1, 3]).reshape(
+            [M, B, 1, K]
+        ) + y[..., 1, :].reshape(dims) * sin.transpose([2, 0, 1, 3]).reshape(
+            [M, B, 1, K]
+        )
+        out2 = x[..., 2, :].reshape(dims) * cos.transpose([2, 0, 1, 3]).reshape(
+            [M, B, 1, K]
+        ) + y[..., 2, :].reshape(dims) * sin.transpose([2, 0, 1, 3]).reshape(
+            [M, B, 1, K]
+        )
+
+        naive_out = flow.cat((out0, out1, out2), axis=-1)
+
+    return naive_out
+
+
+# numpy version:
 def plane_shuffle(x):
     x1, x2 = x[..., : x.shape[-1] // 2], x[..., x.shape[-1] // 2 :]
     return np.concatenate((-x2, x1), axis=-1)
@@ -571,7 +679,7 @@ def _test_with_position_sinuous(
         naive_x = x.reshape([B, M, H, -1, K])
     elif x_layout == "MB(HK)" or x_layout == "MB(H2K)" or x_layout == "MB(H3K)":
         naive_x = x.reshape([M, B, H, -1, K])
-
+    
     naive_out = naive_embedding(
         naive_x,
         naive_cos,
@@ -587,6 +695,41 @@ def _test_with_position_sinuous(
         rotary_ndims,
         mode,
     )
+
+    naive_x_tensor = flow.tensor(naive_x, dtype=dtype, device=device, requires_grad=True)
+    naive_cos_tensor = flow.tensor(naive_cos, dtype=dtype, device=device)  # 不用grad
+    naive_sin_tensor = flow.tensor(naive_sin, dtype=dtype, device=device)
+    naive_out_tensor = naive_embedding_tensor(
+        naive_x_tensor,
+        naive_cos_tensor,
+        naive_sin_tensor,
+        x_layout,
+        B,
+        M,
+        H,
+        K,
+        dims,
+        merged_dims,
+        rotary_size,
+        rotary_ndims,
+        mode,
+    )
+    #print('naive_out_tensor')
+   #print(naive_out_tensor)   # 验证这里的naive_out_tensor与naive_out是否有精度误差;
+    # get grad
+    test_case.assertTrue(
+        np.allclose(
+            naive_out.reshape(merged_dims),
+            naive_out_tensor.numpy().reshape(merged_dims),
+            atol=5e-2,
+            rtol=5e-3,
+        )
+    )
+
+    naive_out_backward = naive_out_tensor.sum()
+    naive_out_backward.backward()
+    naive_out_grad = naive_x_tensor.grad
+    #print(naive_out_grad)
 
     fused_cos = np.array(
         [
@@ -673,7 +816,8 @@ def _test_with_position_sinuous(
             tensor_index=2,
         )
 
-        fused_out = np.concatenate((out0, out1, out2), axis=-1)
+        #fused_out = np.concatenate((out0, out1, out2), axis=-1)
+        fused_out = flow.cat((out0, out1, out2), dim = -1)
     else:
         fused_out = flow._C.fused_apply_rotary_emb(
             fused_x,
@@ -685,12 +829,27 @@ def _test_with_position_sinuous(
             base=base,
             rotary_size=rotary_size,
             mode=mode,
-        ).numpy()
+        )
 
+    fused_out_backward = fused_out.sum()
+    fused_out_backward.backward()
+    fused_out_grad = fused_out_backward.grad
+    #print(fused_out_grad)
+    # test forward
     test_case.assertTrue(
         np.allclose(
             naive_out.reshape(merged_dims),
-            fused_out.reshape(merged_dims),
+            fused_out.numpy().reshape(merged_dims),
+            atol=5e-2,
+            rtol=5e-3,
+        )
+    )
+
+    # test backward
+    test_case.assertTrue(
+        np.allclose(
+            naive_out_grad.numpy().reshape(merged_dims),
+            fused_out_grad.numpy().reshape(merged_dims),
             atol=5e-2,
             rtol=5e-3,
         )

--- a/python/oneflow/test/modules/test_fused_rotary_embedding.py
+++ b/python/oneflow/test/modules/test_fused_rotary_embedding.py
@@ -480,6 +480,7 @@ def _test_without_position(
         # fused_out = np.concatenate((out0, out1, out2), axis=-1)
         fused_out = flow.cat((out0, out1, out2), dim = -1)
     else:
+        print("apply!")
         fused_out = flow._C.fused_apply_rotary_emb(
             fused_x,
             cos=fused_cos,
@@ -491,10 +492,12 @@ def _test_without_position(
             rotary_size=rotary_size,
             mode=mode,
         )
+        print("end!")
     
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
-    fused_out_grad = fused_out_backward.grad
+    fused_out_grad = fused_x.grad
+    print("get grad!")
     #print(fused_out_grad)
     # test forward
     test_case.assertTrue(
@@ -686,7 +689,7 @@ def _test_without_position_sinuous(
     
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
-    fused_out_grad = fused_out_backward.grad
+    fused_out_grad = fused_x.grad
     #print(fused_out_grad)
     # test forward
     test_case.assertTrue(
@@ -931,7 +934,7 @@ def _test_with_position_sinuous(
 
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
-    fused_out_grad = fused_out_backward.grad
+    fused_out_grad = fused_x.grad
     #print(fused_out_grad)
     # test forward
     test_case.assertTrue(
@@ -1129,7 +1132,7 @@ def _test_with_position(
 
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
-    fused_out_grad = fused_out_backward.grad
+    fused_out_grad = fused_x.grad
     #print(fused_out_grad)
     # test forward
     test_case.assertTrue(
@@ -1335,7 +1338,7 @@ def _test_plane(
 
     fused_out_backward = fused_out.sum()
     fused_out_backward.backward()
-    fused_out_grad = fused_out_backward.grad
+    fused_out_grad = fused_x.grad
     #print(fused_out_grad)
     # test forward
     test_case.assertTrue(
@@ -1356,6 +1359,7 @@ def _test_plane(
             rtol=5e-3,
         )
     )
+    print("tset plane done")
 
 
 
@@ -1390,7 +1394,7 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
             arg[0](test_case, *arg[1:])
     
 
-    
+    '''
     def test_fused_rotary_embedding_op_interval_2d(test_case):
         args_dict = OrderedDict()
         args_dict["test_fun"] = [_test_with_position, 
@@ -1409,8 +1413,9 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
 
         for arg in GenArgList(args_dict):
             arg[0](test_case, *arg[1:])
-    
+    '''
 
+    '''
     def test_fused_rotary_embedding_op_interval_1d(test_case):
         args_dict = OrderedDict()
         args_dict["test_fun"] = [
@@ -1420,7 +1425,7 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
             #_test_with_position_sinuous,
         ]
         args_dict["x_layout"] = ["BMHK"]
-        args_dict["mode"] = ["plane"]
+        args_dict["mode"] = ["interval"]
         args_dict["base"] = [1e1]
         args_dict["rotary_size"] = [4]
         args_dict["dims"] = [(3, 2, 5, 8)]
@@ -1432,7 +1437,7 @@ class TestFusedRotaryEmbedding(flow.unittest.TestCase):
 
         for arg in GenArgList(args_dict):
             arg[0](test_case, *arg[1:])
-    
+    '''
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### 内容:
- 完成fusedapplyrotaryembgradkernel算子相关的反向流程添加(planegrad);
- 完成相应的测试文件添加
- 具体的算子实现解析在后文给出;

**TODO:**
- intervel mode grad kernel的添加;
- test_plane中 MB(H3K) shape 反向精度未对齐;
- 在反向计算过程中，实际可以不传入正向的输入x(当前为了方便实现选择传入x);
- 更完整的测试样例: 针对test_plane, 添加cos & sin 的测试;