### PR TITLE
[feature]add tensor folder map to graph

### DIFF
--- a/oneflow/api/common/folder_rule_table.h
+++ b/oneflow/api/common/folder_rule_table.h
@@ -1,0 +1,26 @@
+#ifndef ONEFLOW_API_COMMON_FOLDER_RULE_TABLE_H_
+#define ONEFLOW_API_COMMON_FOLDER_RULE_TABLE_H_
+
+#include "oneflow/core/common/singleton.h"
+#include "oneflow/core/framework/folder_rule_table.h"
+
+namespace oneflow {
+
+inline std::vector<std::string>& GetFolderRuleTable() {
+  auto folder_rule_table= Singleton<FolderRuleTable>::Get();
+  return folder_rule_table->GetRules();
+}
+
+inline void AppendRuleToFolderRuleTable(std::string new_rule) {
+  auto folder_rule_table= Singleton<FolderRuleTable>::Get();
+  folder_rule_table->Append(new_rule);
+}
+
+inline void ResetFolderRuleTable() {
+  auto folder_rule_table= Singleton<FolderRuleTable>::Get();
+  folder_rule_table->Reset();
+}
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_API_COMMON_FOLDER_RULE_TABLE_H_

--- a/oneflow/api/python/framework/folder_rule_table.cpp
+++ b/oneflow/api/python/framework/folder_rule_table.cpp
@@ -1,0 +1,15 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <tuple>
+#include "oneflow/api/common/folder_rule_table.h"
+#include "oneflow/api/python/of_api_registry.h"
+
+namespace py = pybind11;
+
+namespace oneflow {
+
+ONEFLOW_API_PYBIND11_MODULE("", m) {
+  m.def("GetFolderRuleTable", &GetFolderRuleTable, py::return_value_policy::reference_internal);
+}
+
+}  // namespace oneflow

--- a/oneflow/core/framework/folder_rule_table.h
+++ b/oneflow/core/framework/folder_rule_table.h
@@ -1,0 +1,40 @@
+#ifndef ONEFLOW_CORE_FRAMEWORK_FOLDER_RULE_TABLE_H_
+#define ONEFLOW_CORE_FRAMEWORK_FOLDER_RULE_TABLE_H_
+
+#include <vector>
+#include <string>
+#include "oneflow/core/common/util.h"
+
+namespace oneflow {
+
+template<typename T, typename Kind>
+class Singleton;
+
+class FolderRuleTable final {
+  public:
+    OF_DISALLOW_COPY_AND_MOVE(FolderRuleTable);
+    ~FolderRuleTable() = default;
+    void Append(std::string new_rule) {
+      if(!infix_rules_.empty()){
+        for(auto& rule : infix_rules_) {
+            if(new_rule!=rule && new_rule.find(rule)!=std::string::npos) {
+                rule = new_rule;
+                return;
+            }
+        }
+      }
+      infix_rules_.push_back(new_rule);
+    }
+    void Reset() {
+        infix_rules_.clear();
+    }
+    std::vector<std::string>& GetRules() {return infix_rules_;}
+  private:
+    friend class Singleton<FolderRuleTable>;
+    FolderRuleTable() = default;
+    std::vector<std::string> infix_rules_;
+};
+
+}  // namespace oneflow
+
+#endif  // ONEFLOW_CORE_FRAMEWORK_FOLDER_RULE_TABLE_H_

--- a/oneflow/core/framework/multi_client_session_context.cpp
+++ b/oneflow/core/framework/multi_client_session_context.cpp
@@ -39,6 +39,7 @@ limitations under the License.
 #include "oneflow/core/job/collective_boxing/scheduler.h"
 #include "oneflow/core/graph/task_stream_index_manager.h"
 #include "oneflow/core/framework/variable_tensor_mgr.h"
+#include "oneflow/core/framework/folder_rule_table.h"
 #ifdef WITH_CUDA
 #include <cuda.h>
 #endif  // WITH_CUDA
@@ -113,6 +114,7 @@ Maybe<void> MultiClientSessionContext::TryInit(const ConfigProto& config_proto) 
       Singleton<summary::EventsWriter>::New();
       Singleton<boxing::collective::Scheduler>::New();
       Singleton<VariableTensorMgr>::New();
+      Singleton<FolderRuleTable>::New();
     }
 
     is_inited_ = true;

--- a/python/oneflow/nn/graph/graph.py
+++ b/python/oneflow/nn/graph/graph.py
@@ -61,6 +61,8 @@ from oneflow.nn.modules.module import Module
 from oneflow.nn.optimizer.lr_scheduler import LRScheduler
 from oneflow.optim.optimizer import Optimizer
 
+from oneflow.nn.graph.tensor_folder_map import TensorFolderMap
+
 
 class Graph(object):
     r"""Base class for training or evaluating a neural network in static graph mode.
@@ -282,6 +284,9 @@ class Graph(object):
 
         if not self._is_compiled:
             self._compile(*args, **kwargs)
+            
+            # generater tensor folder map
+            self.tensor_folder_map = TensorFolderMap(oneflow._oneflow_internal.GetFolderRuleTable())
 
         return self.__run(*args, **kwargs)
 

--- a/python/oneflow/nn/graph/tensor_folder_map.py
+++ b/python/oneflow/nn/graph/tensor_folder_map.py
@@ -1,0 +1,141 @@
+import oneflow as flow
+from oneflow.framework.tensor import Tensor
+# import torch as flow
+# from torch import Tensor
+from typing import List, Callable, Tuple
+
+_unary_ops = set(['Transpose', 'Reshape', 'ScalarAdd', 'Sqrt',])
+_binary_ops = set(['BroadcastMul', 'BroadcastDiv', 'BroadcastSub'])
+
+def _is_unary_op(token):
+    global _unary_ops
+    return any(token.find(op)!=-1 for op in _unary_ops)
+
+def _is_binary_op(token):
+    global _binary_ops
+    return token in _binary_ops
+
+def _cal_transpose(token, var):
+    arg_start_index = token.find('[')
+    arg_end_index = token.find(']')
+    arg = [int(x) for x in token[arg_start_index+1:arg_end_index].split(",")[:-1]]
+    # TODO: 不确定 transpose的参数是什么样的，因为 resnet18 没用到 transpose
+    return flow.transpose(var, *arg)
+
+def _cal_reshape(token, var):
+    arg_start_index = token.find('[')
+    arg_end_index = token.find(']')
+    arg = [int(x) for x in token[arg_start_index+1:arg_end_index].split(",")[:-1]]
+    return flow.reshape(var, arg)
+
+def _cal_scalar_add(token, var):
+    arg_start_index = token.find('(')
+    arg_end_index = token.find(')')
+    arg = int(token[arg_start_index+1:arg_end_index])
+    return var + arg
+
+def _get_eval_func(postfix_rule: List[str]):
+    
+    def eval(*inputs: List[Tensor]) -> Tensor:
+        global _unary_ops
+        global _binary_ops
+        cnt = 0
+        stack: List[Tensor] = []
+        for token in postfix_rule:
+            if _is_unary_op(token):
+                var = stack.pop()
+                if token.find('Transpose') != -1 :
+                    stack.append(_cal_transpose(token, var))
+                elif token.find('Reshape') != -1 :
+                    stack.append(_cal_reshape(token, var))
+                elif token.find('ScalarAdd') != -1 :
+                    stack.append(_cal_scalar_add(token, var))
+                elif token == 'Sqrt' :
+                    stack.append(flow.sqrt(var))
+                else :
+                    raise ValueError("Bad Unary Operator " + token)
+            elif _is_binary_op(token):
+                rhs = stack.pop()
+                lhs = stack.pop()
+                if token == 'BroadcastMul':
+                    stack.append(lhs * rhs)
+                elif token == 'BroadcastDiv':
+                    stack.append(lhs / rhs)
+                elif token == 'BroadcastSub':
+                    stack.append(lhs - rhs)
+                else:
+                    raise ValueError("Bad Binaary Operator " + token)
+            else:
+                stack.append(inputs[cnt])
+                cnt+=1
+        
+        assert len(stack) == 1, "Bad postfix rule: " + " ".join(postfix_rule)
+        return stack[0]
+
+    return eval
+
+
+def _transform_infix_to_postfix(infix_rule: str) -> Tuple[List[str], List[str]]:
+    global _unary_ops
+    global _binary_ops
+    #  infix to postfix
+    input_tensor_names = []
+    op_stack = []
+    postfix_rule = []
+    for token in infix_rule.split():
+        if token == "(" :
+            op_stack.append(token)
+        elif token == ")" :
+            while len(op_stack)!=0 and op_stack[-1]!="(" :
+                postfix_rule.append(op_stack.pop())
+            assert len(op_stack)!=0 and op_stack[-1]=="(", "input rules with unmatch brackets: " + infix_rule
+            op_stack.pop()
+        elif _is_unary_op(token) or _is_binary_op(token):
+            # Because all ops are wrapped in parentheses
+            # we don’t need to compare the priority of the top of the stack and the new op
+            op_stack.append(token)
+        else: # tensor
+            postfix_rule.append(token)
+            input_tensor_names.append(token)
+    while len(op_stack)!=0 :
+        postfix_rule.append(op_stack.pop())
+    
+    return postfix_rule, input_tensor_names
+
+# help func
+def _transform(infix_rule: str) -> Tuple[List[str], str, Callable[[List[Tensor]], Tensor]]:
+    '''
+    transform a infix eval rule to a TensorFolderMap element
+    for example, input rule is ( model.conv1.weight ) Broadcast ( Reshape ( ( model.bn1.weight ) BroadcastDiv ( Sqrt ( ScalarAdd ( model.bn1.running_var ) ) ) ) )
+    the output are [
+        input_names = [model.conv1.weight, model.bn1.weight, model.bn1.running_var]
+        ouput_name = infix_rule
+        a function to eval rule, its input are tensors which names are input_names, its output is the eval result, which tensor is match ouput_name
+    ]
+    '''
+    postfix_rule, input_tensor_names = _transform_infix_to_postfix(infix_rule)
+
+    return input_tensor_names, infix_rule, _get_eval_func(postfix_rule)
+
+
+class TensorFolderMap:
+    def __init__(self, rules:List[str]):
+        super().__init__()
+        # include input tensor name list, output tensor name, a function of (List[Tensor]) -> Tensor
+        self._map: List[Tuple[List[str], str, Callable[[List[Tensor]], Tensor]]] = []
+        for rule in rules:
+            self._map.append(_transform(rule))
+    
+    @property
+    def map(self):
+        return self._map
+
+    
+    
+if __name__ == "__main__" :
+    infix_rule = "( model.conv1.weight ) BroadcastMul ( Reshape ( ( model.bn1.weight ) BroadcastDiv ( Sqrt ( ScalarAdd ( model.bn1.running_var ) ) ) ) )"
+    postfix_rule, input_tensor_names = _transform_infix_to_postfix(infix_rule)
+    print(" ".join(postfix_rule))
+    print(input_tensor_names)
+    
+    

--- a/python/oneflow/test/graph/test_tensor_folder_map.py
+++ b/python/oneflow/test/graph/test_tensor_folder_map.py
@@ -1,0 +1,50 @@
+import oneflow as flow
+from flowvision.models.resnet import resnet18
+import oneflow.nn as nn
+import numpy as np
+import copy
+import os
+os.environ["ONEFLOW_MLIR_ENABLE_ROUND_TRIP"] = "1"
+os.environ["ONEFLOW_MLIR_ENABLE_INFERENCE_OPTIMIZATION"] = "1"
+os.environ["ONEFLOW_DEBUG_MODE"] = "1"
+os.environ["ONEFLOW_MLIR_DUMPMLIR"] = "1"
+
+def test_tensor_folder_map():
+    data = flow.randn(1, 3, 224, 224)
+
+    model = resnet18(pretrained=False, progress=True)
+    model.eval()
+    eager_res = model(data)
+    copymodel = copy.deepcopy(model)
+    param_table = dict(copymodel.named_parameters(prefix='model'))
+    buffer_table = dict(copymodel.named_buffers(prefix='model'))
+    param_table.update(buffer_table)
+
+    class Resnet18Graph(nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.model = model
+
+        def build(self, *input):
+            return self.model(*input)
+
+    graph = Resnet18Graph()
+    _ = graph(data)
+
+    output_tensor_name_list, output_tensor_list = flow._oneflow_internal.DumpVariableTensorMgr()
+    for input_tensor_names, output_tensor_name, eval_func in graph.tensor_folder_map.map:
+        input_tensor_list = [param_table[name].data for name in input_tensor_names]
+        manual_output_tensor = eval_func(*input_tensor_list)
+
+        index = output_tensor_name_list.index(output_tensor_name)
+        automatic_output_tensor = output_tensor_list[index]
+
+        assert np.allclose(manual_output_tensor.numpy(), automatic_output_tensor.numpy(), rtol=1e-2, atol=1e-2)
+
+        flow._oneflow_internal.FillVariableTensorMgr([output_tensor_name], [manual_output_tensor])
+    
+    lazy_res = graph(data)
+    assert np.allclose(eager_res.numpy(), lazy_res.numpy(), rtol=1e-2, atol=1e-2)
+
+if __name__ == "__main__":
+    test_tensor_folder_map()


### PR DESCRIPTION
给 graph 增加了 folder tensor map 这个结构，包含了所有经由 folder op 做的优化 pass 的输入输出 tensor 的名字，以及可以用来做等价计算的函数。

这个特征的应用场景是，在 sd 模型中，存在两个权重不同，但结构完全一样的 unet ，在第一次编译完以后，第二次加载不同的权重，可以手动计算图优化以后的权重，而不是再做一次图编译，节省时间。