### PR TITLE
fix fuse-bn-add-relu bug.

### DIFF
--- a/oneflow/core/job_rewriter/cudnn_fused_normalization_add_relu_pass.cpp
+++ b/oneflow/core/job_rewriter/cudnn_fused_normalization_add_relu_pass.cpp
@@ -84,7 +84,11 @@ Maybe<void> CudnnFusedNormalizationAddReluPass::Apply(Job* job, JobPassCtx* ctx)
     OperatorConf new_op_conf = op_conf;
     auto mute_attrs = new_op_conf.mutable_user_conf()->mutable_attr();
     auto training_it = mute_attrs->find("training");
-    if (training_it != mute_attrs->end()) { mute_attrs->erase(training_it); }
+    if (training_it != mute_attrs->end()) {
+      const bool training = user_op_conf.attr<bool>("training");
+      if (!training) { return; }
+      mute_attrs->erase(training_it);
+    }
     new_op_conf.mutable_user_conf()->set_op_type_name("cudnn_fused_" + op_type_name);
     job_builder.MutOpsOnlyOnce({new_op_conf});
   });


### PR DESCRIPTION
在`--Graph --use-fp16 --fuse-bn-relu --fuse-bn-add-relu ...`参数训练时，eval阶段会在FusedNormalizationAddRelu算子处报错，原因是cudnn_fused_normalization_add_relu算子中使用的cudnn接口只在训练阶段才支持`CUDNN_BATCHNORM_OPS_BN_ACTIVATION / CUDNN_BATCHNORM_OPS_BN_ADD_ACTIVATION`操作，相关代码逻辑也是根据训练阶段写的，不适配推理阶段，所以在这个Pass处需要根据是否为推理阶段来做算子替换。