### PR TITLE
fix: limit numpy version to < 2.0 and fix missing dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,3 +16,4 @@ pytest-xdist
 pytest-repeat
 rich
 portalocker
+typing-extensions>=4.0.0, <5.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 black==19.10b0; python_version >= "3.6"
 click==8.0.0; python_version >= "3.6" # https://github.com/psf/black/issues/2964
-numpy>=1.21.6
+numpy>=1.21.6, <2.0
 protobuf>=3.9.2, <4.0
 wheel
 tqdm

--- a/python/oneflow/mock_torch/mock_utils.py
+++ b/python/oneflow/mock_torch/mock_utils.py
@@ -19,7 +19,7 @@ import pkgutil
 from collections import deque
 from importlib import import_module
 
-if sys.version_info < (3, 8):
+if sys.version_info <= (3, 8):
     try:
         from importlib_metadata import requires
     except ImportError:

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,7 +55,7 @@ def get_version():
 REQUIRED_PACKAGES = [
     f"numpy>={np.__version__}, <2.0",
     "protobuf>=3.9.2, <4.0",
-    "typing-extensions",
+    "typing-extensions>=4.0.0, <5.0",
     "tqdm",
     "requests",
     "pillow",

--- a/python/setup.py
+++ b/python/setup.py
@@ -53,8 +53,9 @@ def get_version():
 
 
 REQUIRED_PACKAGES = [
-    f"numpy>={np.__version__}",
+    f"numpy>={np.__version__}, <2.0",
     "protobuf>=3.9.2, <4.0",
+    "typing-extensions",
     "tqdm",
     "requests",
     "pillow",


### PR DESCRIPTION
Recently, numpy released [version 2.0](https://github.com/numpy/numpy/releases), which caused oneflow to crash:

```
$ python3 -m oneflow

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "~/miniconda3/envs/dev3/lib/python3.9/runpy.py", line 188, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "~/miniconda3/envs/dev3/lib/python3.9/runpy.py", line 147, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "~/miniconda3/envs/dev3/lib/python3.9/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "~/miniconda3/envs/dev3/lib/python3.9/site-packages/oneflow/__init__.py", line 34, in <module>
    oneflow._oneflow_internal.InitNumpyCAPI()
Traceback (most recent call last):
  File "~/miniconda3/envs/dev3/lib/python3.9/runpy.py", line 188, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "~/miniconda3/envs/dev3/lib/python3.9/runpy.py", line 147, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "~/miniconda3/envs/dev3/lib/python3.9/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "~/miniconda3/envs/dev3/lib/python3.9/site-packages/oneflow/__init__.py", line 34, in <module>
    oneflow._oneflow_internal.InitNumpyCAPI()
oneflow._oneflow_internal.exception.Exception: . Unable to import Numpy array, try to upgrade Numpy version!
  File "oneflow/extension/python/numpy.cpp", line 124, in InitNumpyCAPI
    CHECK_EQ_OR_RETURN(_import_array(), 0)
Error Type: oneflow.ErrorProto.check_failed_error
```

Also, we rely on the `typing-extensions` library:

https://github.com/Oneflow-Inc/oneflow/blob/9cf3ee59a0ce2f5419be264f909b2258977f194c/python/oneflow/framework/check_point_v2.py#L32

Since we depend on the `rich` library, and `rich` depends on `typing-extensions` when using Python < 3.9 (https://github.com/Textualize/rich/blob/master/pyproject.toml#L31C1-L31C18), `typing-extensions` is automatically installed when installing oneflow on Python < 3.9. However, starting from Python >= 3.9, `typing-extensions` is missing.

Another issue is that we will install `packaging` if Python < 3.8, but I encounter a `packaging` missing issue when using Python == 3.8:

```
$ python3 -m oneflow
Traceback (most recent call last):
  File "~/miniconda3/envs/dev3.8/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "~/miniconda3/envs/dev3.8/lib/python3.8/runpy.py", line 144, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "~/miniconda3/envs/dev3.8/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "~/miniconda3/envs/dev3.8/lib/python3.8/site-packages/oneflow/__init__.py", line 505, in <module>
    import oneflow.mock_torch
  File "~/miniconda3/envs/dev3.8/lib/python3.8/site-packages/oneflow/mock_torch/__init__.py", line 16, in <module>
    from .mock_importer import ModuleWrapper, enable, disable
  File "~/miniconda3/envs/dev3.8/lib/python3.8/site-packages/oneflow/mock_torch/mock_importer.py", line 31, in <module>
    from .mock_utils import MockEnableDisableMixin
  File "~/miniconda3/envs/dev3.8/lib/python3.8/site-packages/oneflow/mock_torch/mock_utils.py", line 33, in <module>
    from packaging.requirements import Requirement
ModuleNotFoundError: No module named 'packaging'
```

this PR:
- limit numpy version to < 2.0.
- explicitly add missing dependency `typing-extensions`.
- change condition to install `packaging` from Python < 3.8 to Python <= 3.8.