### PR TITLE
add interpolate_like for cpu

### DIFF
--- a/oneflow/core/autograd/gradient_funcs/upsample.cpp
+++ b/oneflow/core/autograd/gradient_funcs/upsample.cpp
@@ -77,9 +77,10 @@ Maybe<void> Upsample::Apply(const UpsampleCaptureState* ctx, const TensorTuple& 
   return Maybe<void>::Ok();
 }
 
+REGISTER_OP_EXPR_GRAD_FUNCTION("upsample", Upsample);
+
 struct UpsampleNearest2DCaptureState : public AutoGradCaptureState {
   bool requires_grad = false;
-  bool has_like_input = false;
   double height_scale = 0.0;
   double width_scale = 0.0;
   std::vector<int64_t> output_size;
@@ -104,8 +105,6 @@ class UpsampleNearest2D : public OpExprGradFunction<UpsampleNearest2DCaptureStat
     }
     ctx->data_format = JUST(composed_attrs.GetAttr<std::string>("data_format"));
     ctx->SaveTensorForBackward(inputs.at(0));
-    ctx->has_like_input = inputs.size() == 2;
-    if (ctx->has_like_input) { ctx->SaveTensorForBackward(inputs.at(1)); }
     return Maybe<void>::Ok();
   }
 
@@ -115,15 +114,9 @@ class UpsampleNearest2D : public OpExprGradFunction<UpsampleNearest2DCaptureStat
     CHECK_EQ_OR_RETURN(out_grads.size(), 1);  // NOLINT(maybe-need-error-msg)
     const std::shared_ptr<oneflow::one::Tensor>& x = ctx->SavedTensors().at(0);
     in_grads->resize(1);
-    if (ctx->has_like_input) {
-      const std::shared_ptr<oneflow::one::Tensor>& like = ctx->SavedTensors().at(1);
-      JUST(oneflow::VectorAt(*in_grads, 0)) = JUST(functional::UpsampleNearest2DGrad(
-          JUST(oneflow::VectorAt(out_grads, 0)), x, like, ctx->data_format));
-    } else {
-      JUST(oneflow::VectorAt(*in_grads, 0)) = JUST(functional::UpsampleNearest2DGrad(
-          JUST(oneflow::VectorAt(out_grads, 0)), x, ctx->height_scale, ctx->width_scale,
-          ctx->output_size, ctx->data_format));
-    }
+    JUST(oneflow::VectorAt(*in_grads, 0)) = JUST(functional::UpsampleNearest2DGrad(
+        JUST(oneflow::VectorAt(out_grads, 0)), x, ctx->height_scale, ctx->width_scale,
+        ctx->output_size, ctx->data_format));
 
     return Maybe<void>::Ok();
   }
@@ -131,7 +124,6 @@ class UpsampleNearest2D : public OpExprGradFunction<UpsampleNearest2DCaptureStat
  private:
   AttrMap base_attrs_;
 };
-
 
 REGISTER_OP_EXPR_GRAD_FUNCTION("upsample_nearest_2d", UpsampleNearest2D);
 

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -1789,15 +1789,19 @@
   bind_python: False
 
 - name: "upsample_nearest_2d"
-  signature:
-    'Tensor (Tensor x, Double height_scale=0.0, Double width_scale=0.0, Int64List[2] output_size=None,
-    String data_format="channels_first") => UpsampleNearest2D'
+  signature: [
+      'Tensor (Tensor x, Double height_scale=0.0, Double width_scale=0.0, Int64List[2] output_size=None,
+       String data_format="channels_first") => UpsampleNearest2D',
+      'Tensor (Tensor x, Tensor like, String data_format="channels_first") => UpsampleNearest2D'
+    ]
   bind_python: True
 
 - name: "upsample_nearest_2d_grad"
-  signature:
-    'Tensor (Tensor dy, Tensor x, Double height_scale=0.0, Double width_scale=0.0, Int64List[2] output_size=None,
-    String data_format="channels_first") => UpsampleNearest2DGrad'
+  signature: [
+      'Tensor (Tensor dy, Tensor x, Double height_scale=0.0, Double width_scale=0.0, Int64List[2] output_size=None,
+       String data_format="channels_first") => UpsampleNearest2DGrad',
+      'Tensor (Tensor dy, Tensor x, Tensor like, String data_format="channels_first") =>UpsampleNearest2DGrad'
+    ]
   bind_python: False
 
 - name: "upsample_bilinear_2d"

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -1797,11 +1797,9 @@
   bind_python: True
 
 - name: "upsample_nearest_2d_grad"
-  signature: [
-      'Tensor (Tensor dy, Tensor x, Double height_scale=0.0, Double width_scale=0.0, Int64List[2] output_size=None,
-       String data_format="channels_first") => UpsampleNearest2DGrad',
-      'Tensor (Tensor dy, Tensor x, Tensor like, String data_format="channels_first") =>UpsampleNearest2DGrad'
-    ]
+  signature:
+    'Tensor (Tensor dy, Tensor x, Double height_scale=0.0, Double width_scale=0.0, Int64List[2] output_size=None,
+    String data_format="channels_first") => UpsampleNearest2DGrad'
   bind_python: False
 
 - name: "upsample_bilinear_2d"

--- a/oneflow/core/functional/impl/array_functor.cpp
+++ b/oneflow/core/functional/impl/array_functor.cpp
@@ -2034,29 +2034,6 @@ class UpsampleNearest2DGradFunctor {
   std::shared_ptr<OpExpr> op_;
 };
 
-class UpsampleNearestLike2DGradFunctor {
- public:
-  UpsampleNearestLike2DGradFunctor() {
-    op_ = CHECK_JUST(one::OpBuilder("upsample_nearest_2d_grad")
-                         .Input("dy")
-                         .Input("x")
-                         .Input("like")
-                         .Output("dx")
-                         .Build());
-  }
-  Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& dy,
-                           const std::shared_ptr<one::Tensor>& x,
-                           const std::shared_ptr<one::Tensor>& like,
-                           const std::string& data_format) const {
-    auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("data_format");
-    attrs.SetAllAttrs(data_format);
-    return OpInterpUtil::Dispatch<Tensor>(*op_, {dy, x, like}, attrs);
-  }
-
- private:
-  std::shared_ptr<OpExpr> op_;
-};
-
 class UpsampleBilinear2DFunctor {
  public:
   UpsampleBilinear2DFunctor() {
@@ -4161,8 +4138,7 @@ ONEFLOW_FUNCTION_LIBRARY(m) {
   m.add_functor<impl::UpsampleGradFunctor>("UpsampleGrad");
   m.add_functor<impl::UpsampleNearest2DFunctor, impl::UpsampleNearestLike2DFunctor>(
       "UpsampleNearest2D");
-  m.add_functor<impl::UpsampleNearest2DGradFunctor, impl::UpsampleNearestLike2DGradFunctor>(
-      "UpsampleNearest2DGrad");
+  m.add_functor<impl::UpsampleNearest2DGradFunctor>("UpsampleNearest2DGrad");
   m.add_functor<impl::UpsampleBilinear2DFunctor>("UpsampleBilinear2D");
   m.add_functor<impl::UpsampleBilinear2DGradFunctor>("UpsampleBilinear2DGrad");
   m.add_functor<impl::UpsampleLinear1DFunctor>("UpsampleLinear1D");

--- a/oneflow/user/kernels/upsample_nearest_kernel.cpp
+++ b/oneflow/user/kernels/upsample_nearest_kernel.cpp
@@ -56,17 +56,12 @@ static void UpsampleNearest2DForward(const int64_t elem_cnt, const T* in_dptr,
                                      NdIndexOffsetHelper<int64_t, 4> out_helper,
                                      const int64_t in_height, const int64_t in_width,
                                      const double scale_h, const double scale_w, T* out_dptr) {
-  std::cout << scale_h << " " << scale_w << std::endl;
   for (int64_t index = 0; index < elem_cnt; ++index) {
-    std::cout << "-------------------" << std::endl;
     int64_t n, c, h, w;
     out_helper.OffsetToNdIndex(index, n, c, h, w);
     const int64_t in_h = GetNearestInputIndex(h, scale_h, in_height);
     const int64_t in_w = GetNearestInputIndex(w, scale_w, in_width);
     out_dptr[index] = in_dptr[in_helper.NdIndexToOffset(n, c, in_h, in_w)];
-    std::cout << "out_index: " << index << " n: " << n << " c: " << c << " h: " << h << " w: " << w
-              << " in_h: " << in_h << " in_w: " << in_w
-              << "in_index: " << in_helper.NdIndexToOffset(n, c, in_h, in_w) << std::endl;
   }
 }
 
@@ -232,14 +227,9 @@ class UpsampleNearest2DCPUKernel final : public user_op::OpKernel {
     const int64_t out_height = y_tensor->shape_view().At(2);
     const int64_t out_width = y_tensor->shape_view().At(3);
     const int64_t elem_cnt = y_tensor->shape_view().elem_cnt();
-    std::cout << "here0: " << height_scale << " " << width_scale << std::endl;
-    std::cout << "here0: " << out_height << " " << out_width << std::endl;
-    std::cout << "here0: " << in_height << " " << in_width << std::endl;
-    std::cout << output_size.size() << std::endl;
     if (!output_size.empty() || ctx->Tensor4ArgNameAndIndex("like", 0)) {
       height_scale = static_cast<double>(out_height) / static_cast<double>(in_height);
       width_scale = static_cast<double>(out_width) / static_cast<double>(in_width);
-      std::cout << "here1: " << height_scale << " " << width_scale << std::endl;
     }
 
     if (in_height == out_height && in_width == out_width) {

--- a/oneflow/user/kernels/upsample_nearest_kernel.cpp
+++ b/oneflow/user/kernels/upsample_nearest_kernel.cpp
@@ -56,12 +56,17 @@ static void UpsampleNearest2DForward(const int64_t elem_cnt, const T* in_dptr,
                                      NdIndexOffsetHelper<int64_t, 4> out_helper,
                                      const int64_t in_height, const int64_t in_width,
                                      const double scale_h, const double scale_w, T* out_dptr) {
+  std::cout << scale_h << " " << scale_w << std::endl;
   for (int64_t index = 0; index < elem_cnt; ++index) {
+    std::cout << "-------------------" << std::endl;
     int64_t n, c, h, w;
     out_helper.OffsetToNdIndex(index, n, c, h, w);
     const int64_t in_h = GetNearestInputIndex(h, scale_h, in_height);
     const int64_t in_w = GetNearestInputIndex(w, scale_w, in_width);
     out_dptr[index] = in_dptr[in_helper.NdIndexToOffset(n, c, in_h, in_w)];
+    std::cout << "out_index: " << index << " n: " << n << " c: " << c << " h: " << h << " w: " << w
+              << " in_h: " << in_h << " in_w: " << in_w
+              << "in_index: " << in_helper.NdIndexToOffset(n, c, in_h, in_w) << std::endl;
   }
 }
 
@@ -227,9 +232,14 @@ class UpsampleNearest2DCPUKernel final : public user_op::OpKernel {
     const int64_t out_height = y_tensor->shape_view().At(2);
     const int64_t out_width = y_tensor->shape_view().At(3);
     const int64_t elem_cnt = y_tensor->shape_view().elem_cnt();
-    if (!output_size.empty()) {
+    std::cout << "here0: " << height_scale << " " << width_scale << std::endl;
+    std::cout << "here0: " << out_height << " " << out_width << std::endl;
+    std::cout << "here0: " << in_height << " " << in_width << std::endl;
+    std::cout << output_size.size() << std::endl;
+    if (!output_size.empty() || ctx->Tensor4ArgNameAndIndex("like", 0)) {
       height_scale = static_cast<double>(out_height) / static_cast<double>(in_height);
       width_scale = static_cast<double>(out_width) / static_cast<double>(in_width);
+      std::cout << "here1: " << height_scale << " " << width_scale << std::endl;
     }
 
     if (in_height == out_height && in_width == out_width) {

--- a/oneflow/user/ops/upsample_op.cpp
+++ b/oneflow/user/ops/upsample_op.cpp
@@ -23,6 +23,18 @@ typename std::enable_if<(N <= 3), Maybe<void>>::type UpsamplingInferLogicalDesc(
     user_op::InferContext* ctx, const std::string& func_name) {
   const user_op::TensorDesc& x_desc = ctx->InputTensorDesc("x", 0);
   user_op::TensorDesc* y_desc = ctx->MutOutputTensorDesc("y", 0);
+  if (ctx->has_input("like", 0)) {
+    const user_op::TensorDesc& like_desc = ctx->InputTensorDesc("like", 0);
+    int64_t like_num_axes = like_desc.shape().NumAxes();
+    CHECK_GT_OR_RETURN(like_num_axes, N)
+        << "like shape size should > " << N << ", but got " << like_desc.shape().ToString();
+    Shape output_shape = x_desc.shape();
+    for (int i = 0; i < N; ++i) {
+      output_shape[i + 2] = like_desc.shape().At(like_num_axes - N + i);
+    }
+    y_desc->set_shape(output_shape);
+    return Maybe<void>::Ok();
+  }
   if (N == 1) {
     CHECK_OR_RETURN(ctx->Attr<std::string>("data_format") == "channels_first"
                     && x_desc.shape().NumAxes() == (N + 2))
@@ -259,11 +271,7 @@ namespace oneflow {
 }
 
 /*static*/ Maybe<void> UpsampleNearest2DGradOp::GetSbp(user_op::SbpContext* ctx) {
-  ctx->NewBuilder()
-      .Split(user_op::OpArg("dy", 0), 0)
-      .Split(user_op::OpArg("x", 0), 0)
-      .Split(user_op::OpArg("dx", 0), 0)
-      .Build();
+  ctx->NewBuilder().Split(ctx->inputs(), 0).Split(user_op::OpArg("dx", 0), 0).Build();
   return Maybe<void>::Ok();
 }
 /*static*/ Maybe<void> UpsampleNearest2DGradOp::InferLogicalTensorDesc(user_op::InferContext* ctx) {

--- a/python/oneflow/nn/functional/__init__.py
+++ b/python/oneflow/nn/functional/__init__.py
@@ -13,7 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from oneflow.nn.modules.interpolate import interpolate
+from oneflow.nn.modules.interpolate_like import interpolate_like
 from oneflow.nn.modules.affine_grid import affine_grid
 from oneflow.nn.modules.grid_sample import grid_sample
 from oneflow.nn.modules.sparse_softmax_cross_entropy import sparse_softmax_cross_entropy

--- a/python/oneflow/nn/modules/interpolate_like.py
+++ b/python/oneflow/nn/modules/interpolate_like.py
@@ -1,0 +1,174 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
+import warnings
+from typing import Optional, Tuple, Union
+
+import oneflow as flow
+from oneflow.framework.tensor import register_tensor_op
+from oneflow.nn.modules.module import Module
+
+
+class InterpolateLike:
+    def __init__(
+        self,
+        mode: str = "nearest",
+        align_corners: Optional[bool] = None,
+    ):
+        if mode in ("nearest", "area") and align_corners is not None:
+            raise ValueError(
+                "align_corners option can only be set with the interpolating modes: linear | bilinear | bicubic | trilinear"
+            )
+        self.mode = mode
+        if align_corners == None:
+            align_corners = False
+        self.align_corners = align_corners
+        if self.mode not in (
+            "nearest",
+            "bilinear",
+            "linear",
+            "area",
+            "bicubic",
+            "trilinear",
+        ):
+            raise ValueError(
+                'interpolation must be "nearest" or "bilinear" or "linear" or "area" or "bicubic" or "trilinear".'
+            )
+        if self.mode == "nearest" and self.align_corners:
+            raise ValueError('interpolation "nearest" does not support align_corners.')
+
+    def forward(self, x, like):
+        if len(x.shape) == 3 and self.mode == "bilinear":
+            raise NotImplementedError("Got 3D input, but bilinear mode needs 4D input")
+        if len(x.shape) == 3 and self.mode == "trilinear":
+            raise NotImplementedError("Got 3D input, but trilinear mode needs 5D input")
+        if len(x.shape) == 4 and self.mode == "linear":
+            raise NotImplementedError("Got 4D input, but linear mode needs 3D input")
+        if len(x.shape) == 4 and self.mode == "trilinear":
+            raise NotImplementedError("Got 4D input, but trilinear mode needs 5D input")
+        if len(x.shape) == 5 and self.mode == "linear":
+            raise NotImplementedError("Got 5D input, but linear mode needs 3D input")
+        if len(x.shape) == 5 and self.mode == "bilinear":
+            raise NotImplementedError("Got 5D input, but bilinear mode needs 4D input")
+
+        dim = len(x.shape) - 2
+        if len(x.shape) == 3 and self.mode == "nearest":
+            return flow._C.upsample_nearest_1d(
+                x,
+                like,
+                data_format="channels_first",
+            )
+        if len(x.shape) == 4 and self.mode == "nearest":
+            return flow._C.upsample_nearest_2d(
+                x,
+                like,
+                data_format="channels_first",
+            )
+        if len(x.shape) == 5 and self.mode == "nearest":
+            return flow._C.upsample_nearest_3d(
+                x,
+                like,
+                data_format="channels_first",
+            )
+
+        raise NotImplementedError(
+            "Input Error: Only 3D, 4D and 5D input Tensors supported"
+            " (got {}D) for the modes: nearest"
+            " (got {})".format(len(x.shape), self.mode)
+        )
+
+
+def interpolate_like(
+    input,
+    like,
+    mode="nearest",
+    align_corners=None,
+):
+    """The interface is consistent with PyTorch.
+
+    The documentation is referenced from: https://pytorch.org/docs/1.10/_modules/torch/nn/functional.html#interpolate.
+
+
+    Down/up samples the input to :Tensor:`like` shape.
+
+    The algorithm used for interpolation is determined by :attr:`mode`.
+
+    Currently temporal, spatial and volumetric sampling are supported, i.e.
+    expected inputs are 3-D, 4-D or 5-D in shape.
+
+    The input dimensions are interpreted in the form:
+    `mini-batch x channels x [optional depth] x [optional height] x width`.
+
+    The modes available for resizing are: `nearest`, `linear` (3D-only),
+    `bilinear`, `bicubic` (4D-only), `trilinear` (5D-only), `area`
+
+    Args:
+        input (Tensor): the input tensor
+        like (Tensor): the like tensor
+        mode (str): algorithm used for upsampling:
+            ``'nearest'`` | ``'linear'`` | ``'bilinear'`` | ``'bicubic'`` |
+            ``'trilinear'`` | ``'area'``. Default: ``'nearest'``
+        align_corners (bool, optional): Geometrically, we consider the pixels of the
+            input and output as squares rather than points.
+            If set to ``True``, the input and output tensors are aligned by the
+            center points of their corner pixels, preserving the values at the corner pixels.
+            If set to ``False``, the input and output tensors are aligned by the corner
+            points of their corner pixels, and the interpolation uses edge value padding
+            for out-of-boundary values. This only has an effect when :attr:`mode`
+            is ``'linear'``, ``'bilinear'``, ``'bicubic'`` or ``'trilinear'``.
+            Default: ``False``
+
+    .. note::
+        With ``mode='bicubic'``, it's possible to cause overshoot, in other words it can produce
+        negative values or values greater than 255 for images.
+        Explicitly call ``result.clamp(min=0, max=255)`` if you want to reduce the overshoot
+        when displaying the image.
+
+    .. warning::
+        With ``align_corners = True``, the linearly interpolating modes
+        (`linear`, `bilinear`, and `trilinear`) don't proportionally align the
+        output and input pixels, and thus the output values can depend on the
+        input size. This was the default behavior for these modes up to version
+        0.3.1. Since then, the default behavior is ``align_corners = False``.
+        See :class:`~torch.nn.Upsample` for concrete examples on how this
+        affects the outputs.
+
+    For example:
+
+    .. code-block:: python
+
+        >>> import oneflow as flow
+        >>> import numpy as np
+
+        >>> input = flow.tensor(np.arange(1, 5).reshape((1, 1, 4)), dtype=flow.float32)
+        >>> like = flow.randn(1, 1, 8)
+        >>> output = flow.nn.functional.interpolate_like(input, like, mode="linear")
+        >>> output
+        tensor([[[1.0000, 1.2500, 1.7500, 2.2500, 2.7500, 3.2500, 3.7500, 4.0000]]],
+               dtype=oneflow.float32)
+
+    """
+    return InterpolateLike(
+        mode=mode,
+        align_corners=align_corners,
+    ).forward(input, like)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod(raise_on_error=True)


### PR DESCRIPTION
在npu上进行SD的推理时发现用到了`interpolate_like`算子，但在开源版本中还没提供该算子的cpu实现。

因此该pr将闭源版本的`interpolate_like`算子的正向计算过程补充到开源版本。