### PR TITLE
fix layernorm grad sbp

### DIFF
--- a/oneflow/user/ops/layer_norm_op.cpp
+++ b/oneflow/user/ops/layer_norm_op.cpp
@@ -183,10 +183,16 @@ oneflow::DataType InferBnParamDataType(const DataType x_data_type) {
     broadcast_args.emplace_back(user_op::OpArg("gamma", 0));
   }
   int64_t begin_norm_axis = ctx->Attr<int64_t>("begin_norm_axis");
+  int64_t begin_params_axis = ctx->Attr<int64_t>("begin_params_axis");
+  CHECK_EQ(begin_norm_axis, begin_params_axis) 
+      << "begin_norm_axis and begin_params_axis must be equal, but got "
+      << begin_norm_axis << " and " << begin_params_axis;
   for (int i = 0; i < begin_norm_axis; ++i) {
     ctx->NewBuilder()
         .Split(ctx->inputs(), i)
-        .Split(ctx->outputs(), i)
+        .Split(user_op::OpArg("dx", 0), i)
+        .PartialSum(user_op::OpArg("gamma_diff", 0))
+        .PartialSum(user_op::OpArg("beta_diff", 0))
         .Broadcast(broadcast_args)
         .Build();
   }


### PR DESCRIPTION
Fix SBP settings for LayerNormGradOp to ensure correct gradient aggregation for gamma_diff and beta_diff

Changes

- Updated SBP strategy in LayerNormGradOp: Set gamma_diff and beta_diff to use PartialSum instead of Split to avoid dimension mismatches during distributed training.
- Added consistency check for begin_norm_axis and begin_params_axis: Enforce equality to ensure proper alignment of normalization and parameter dimensions.