### PR TITLE
Remove CUDA-only restriction for multi-tensor model updates in optimizer

### DIFF
--- a/oneflow/core/job_rewriter/multi_tensor_model_update.cpp
+++ b/oneflow/core/job_rewriter/multi_tensor_model_update.cpp
@@ -232,9 +232,9 @@ Maybe<void> MultiTensorModelUpdatePass::Apply(const OpGraph& op_graph,
       const user_op::UserOpConfWrapper model_update_user_conf(
           find_model_update_update_node->op().op_conf());
       // Multi tensor update pass only support for CUDA currently.
-      if (find_model_update_update_node->parallel_desc().device_type() != DeviceType::kCUDA) {
-        continue;
-      }
+      // if (find_model_update_update_node->parallel_desc().device_type() != DeviceType::kCUDA) {
+      //   continue;
+      // }
 
       // Multi tensor update pass only support Data Parallel.
       bool if_data_parallel = true;

--- a/python/oneflow/nn/optimizer/adamw.py
+++ b/python/oneflow/nn/optimizer/adamw.py
@@ -163,9 +163,9 @@ class AdamW(Optimizer):
                     warnings.warn("Fused Adamw is not supported when amsgrad=True.")
                     param_group["fused"] = False
 
-                if param_group["fused"] and not param.is_cuda:
-                    warnings.warn("Fused Adamw only support cuda parameters.")
-                    param_group["fused"] = False
+                # if param_group["fused"] and not param.is_cuda:
+                #     warnings.warn("Fused Adamw only support cuda parameters.")
+                #     param_group["fused"] = False
 
         self._op_with_amsgrad = (
             flow.stateful_op("adam_update")


### PR DESCRIPTION
This PR removes the CUDA-only restriction in the multi-tensor model update pass within both multi_tensor_model_update.cpp and adamw.py. 

By commenting out the device type checks, we allow multi-tensor and fused updates to run on non-CUDA devices as well.