### PR TITLE
fix autocast to support global tensor

### DIFF
--- a/oneflow/core/framework/autocast.cpp
+++ b/oneflow/core/framework/autocast.cpp
@@ -94,7 +94,7 @@ Maybe<one::Tensor> cached_cast(const std::shared_ptr<one::Tensor>& tensor, Symbo
                     && cast_type == get_lower_precision_fp_from_device_type(device_type)
                     && tensor->dtype()->data_type() == DataType::kFloat && tensor->is_leaf()
                     && !tensor->is_view());
-  if (use_cache) {
+  if (use_cache && tensor->is_local()) {
     auto it = cached_casts()->find(
         std::make_pair(JUST(tensor->mut_eager_local_tensor_impl()), cast_type->data_type()));
     if (it == cached_casts()->end() || it->second.first.lock() == nullptr) {

--- a/oneflow/core/functional/tensor_processor.cpp
+++ b/oneflow/core/functional/tensor_processor.cpp
@@ -225,8 +225,10 @@ Maybe<void> TensorAutoCastProcessor::Apply() {
     for (int i = 0; i < inputs_.size(); ++i) {
       if (args_eligible[i] && JUST(IsDeviceType(inputs_[i], autocast_device_type))
           && inputs_[i]->dtype()->is_floating_point() && inputs_[i]->dtype() != autocast_dtype) {
-        autocast_inputs_[i] = JUST(autocast::cached_cast(inputs_[i], autocast_dtype,
-                                                         JUST(inputs_[i]->device())->enum_type()));
+        auto device_type = inputs_[i]->is_local()
+                               ? JUST(inputs_[i]->device())->enum_type()
+                               : JUST(inputs_[i]->parallel_desc())->device_type();
+        autocast_inputs_[i] = JUST(autocast::cached_cast(inputs_[i], autocast_dtype, device_type));
       } else {
         autocast_inputs_[i] = inputs_[i];
       }


### PR DESCRIPTION
oneflow autocast 不支持 global tensor。下面代码直接报错
```python
import oneflow as flow

placement = flow.placement("cuda", ranks=[0])
sbp = flow.sbp.broadcast
a = flow.randn(2, 3).to_global(placement=placement, sbp=sbp)
b = flow.randn(3, 4).to_global(placement=placement, sbp=sbp)
with flow.autocast(device_type="cuda"):
    c = flow.matmul(a, b)
```