### PR TITLE
NewCclCommMgr on runtime

### DIFF
--- a/oneflow/core/job/runtime.cpp
+++ b/oneflow/core/job/runtime.cpp
@@ -70,9 +70,13 @@ Runtime::Runtime(
     Singleton<RuntimeJobDescs>::Get()->AddPlan(plan);
     collective_boxing_scheduler_plan_token_ =
         Singleton<boxing::collective::Scheduler>::Get()->AddPlan(plan);
-#ifdef WITH_CUDA
+    const auto& vaild_ccl_comm_mgr_device_types =
+        EagerCclCommMgrBuilder::Get().vaild_ccl_comm_mgr_device_types();
+    if (!vaild_ccl_comm_mgr_device_types.empty() && !Singleton<EagerCclCommMgr>::Get()) {
+      Singleton<EagerCclCommMgr>::SetAllocated(
+          EagerCclCommMgrBuilder::Get().NewCclCommMgr(vaild_ccl_comm_mgr_device_types.front()));
+    }
     Singleton<EagerCclCommMgr>::Get()->CreateCommFromPlan(plan);
-#endif  // WITH_CUDA
   }
   std::vector<const TaskProto*> source_tasks;
   source_tasks.reserve(plan.task().size());


### PR DESCRIPTION
问题描述：
import oneflow时会创建一些全局对象，其中下面段落创建了`NewCclCommMgr`对象。
https://github.com/Oneflow-Inc/oneflow/blob/master/oneflow/core/job/env_global_objects_scope.cpp#L200-L208

不过当使用非CUDA设备时，无法创建`NewCclCommMgr`对象，在runtime阶段带来一些问题。

这里的改动，就是在runtime阶段也尝试创建`NewCclCommMgr`对象。

注：`NewCclCommMgr`对象的创建，依赖`RegisterEagerCclCommMgrType`

没有解决的问题：在runtime之前，`NewCclCommMgr`对象仅仅用于`InsertNcclLogicalOpPass`，我觉得，并不是必须的，或许就可以把NewCclCommMgr对象的创建放到后面，不过涉及的范围比较大，怕有其他副作用。