### PR TITLE
cache@v2->v4

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -114,13 +114,13 @@ jobs:
           sudo apt install -y libopenblas-dev nasm g++ gcc python3-pip ninja-build
       - name: Cache pip (Linux)
         if: startsWith(runner.os, 'Linux')
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ hashFiles('**/requirements.txt') }}
       - name: Cache pip (macOS)
         if: startsWith(runner.os, 'macOS')
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/Library/Caches/pip
           key: ${{ matrix.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1162,7 +1162,7 @@ jobs:
           wget https://raw.githubusercontent.com/oneflow-inc/llvm-project/maybe/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
           chmod +x oneflow-clang-tidy-16 clang-tidy-diff.py
       - name: Cache third party dir
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         if: ${{ !fromJSON(steps.save-cache.outputs.cache-hit) }}
         with:
           path: ~/.ccache


### PR DESCRIPTION
[actions/cache v1-v2 and actions/toolkit cache package closing down](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)