### PR TITLE
Add NPU support for NMS with scores input

### DIFF
--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -2789,7 +2789,7 @@
   bind_python: False
 
 - name: "nms"
-  signature: "Tensor (Tensor x, Float iou_threshold, Int32 keep_n=-1) => Nms"
+  signature: "Tensor (Tensor x, Tensor scores=None, Float iou_threshold, Int32 keep_n=-1) => Nms"
   bind_python: True
 
 - name: "roi_align"

--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -4020,16 +4020,14 @@ class NmsFunctor {
   }
 
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
-			   const Optional<one::Tensor>& scores,
-			   const float& iou_threshold,
+                           const Optional<one::Tensor>& scores, const float& iou_threshold,
                            const int32_t& keep_n) const {
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("iou_threshold", "keep_n");
     attrs.SetAllAttrs(iou_threshold, keep_n);
     DeviceType device_type = JUST(x->device())->enum_type();
     if (device_type == DeviceType::kNPU) {
       return OpInterpUtil::Dispatch<Tensor>(*fused_op_, {x, JUST(scores)}, attrs);
-    }
-    else {
+    } else {
       return OpInterpUtil::Dispatch<Tensor>(*op_, {x}, attrs);
     }
   }

--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -4026,7 +4026,11 @@ class NmsFunctor {
     attrs.SetAllAttrs(iou_threshold, keep_n);
     DeviceType device_type = JUST(x->device())->enum_type();
     if (device_type == DeviceType::kNPU) {
-      return OpInterpUtil::Dispatch<Tensor>(*fused_op_, {x, JUST(scores)}, attrs);
+      if (scores) {
+        return OpInterpUtil::Dispatch<Tensor>(*fused_op_, {x, JUST(scores)}, attrs);
+      } else {
+        return OpInterpUtil::Dispatch<Tensor>(*op_, {x}, attrs);
+      }
     } else {
       return OpInterpUtil::Dispatch<Tensor>(*op_, {x}, attrs);
     }

--- a/oneflow/ir/include/OneFlow/OneFlowUserOps.td
+++ b/oneflow/ir/include/OneFlow/OneFlowUserOps.td
@@ -1886,7 +1886,8 @@ def OneFlow_InTopKOp : OneFlow_BaseOp<"in_top_k", [NoMemoryEffect, NoGrad, Decla
 
 def OneFlow_NmsOp : OneFlow_BaseOp<"nms", [NoMemoryEffect, DeclareOpInterfaceMethods<UserOpCompatibleInterface>]> {
   let input = (ins
-    OneFlow_Tensor:$in
+    OneFlow_Tensor:$in,
+    Optional<OneFlow_Tensor>:$scores
   );
   let output = (outs
     OneFlow_Tensor:$out

--- a/python/oneflow/nn/modules/nms.py
+++ b/python/oneflow/nn/modules/nms.py
@@ -23,26 +23,34 @@ def nms_op(boxes, scores, iou_threshold: float):
         if boxes.ndim == 2 and boxes.shape[-1] == 4:
             boxes = boxes.unsqueeze(0)
         elif boxes.ndim != 3 or boxes.shape[-1] != 4:
-            raise ValueError(f"boxes must be of shape [B, N, 4] or [N, 4], but got {boxes.shape}")
+            raise ValueError(
+                f"boxes must be of shape [B, N, 4] or [N, 4], but got {boxes.shape}"
+            )
 
         if scores.ndim == 1:
             scores = scores.unsqueeze(0).unsqueeze(0)
         elif scores.ndim == 2:
             scores = scores.unsqueeze(0)
         elif scores.ndim != 3:
-            raise ValueError(f"scores must be of shape [B, C, N], [C, N] or [N], but got {scores.shape}")
+            raise ValueError(
+                f"scores must be of shape [B, C, N], [C, N] or [N], but got {scores.shape}"
+            )
 
         if boxes.shape[0] != scores.shape[0]:
-            raise ValueError(f"batch_size mismatch: boxes {boxes.shape[0]} vs scores {scores.shape[0]}")
+            raise ValueError(
+                f"batch_size mismatch: boxes {boxes.shape[0]} vs scores {scores.shape[0]}"
+            )
         if boxes.shape[1] != scores.shape[2]:
-            raise ValueError(f"spatial_dimension mismatch: boxes {boxes.shape[1]} vs scores {scores.shape[2]}")
+            raise ValueError(
+                f"spatial_dimension mismatch: boxes {boxes.shape[1]} vs scores {scores.shape[2]}"
+            )
 
         return flow._C.nms(boxes, scores, iou_threshold)
 
     score_inds = flow.argsort(scores, dim=0, descending=True)
     boxes = flow._C.gather(boxes, score_inds, axis=0)
     keep = flow._C.nms(boxes, iou_threshold=iou_threshold)
-    print(keep.shape) 
+    print(keep.shape)
     index = flow.squeeze(flow.argwhere(keep), dim=[1])
-    print(index.shape) 
+    print(index.shape)
     return flow._C.gather(score_inds, index, axis=0)

--- a/python/oneflow/nn/modules/nms.py
+++ b/python/oneflow/nn/modules/nms.py
@@ -20,9 +20,29 @@ from oneflow.nn.modules.module import Module
 
 def nms_op(boxes, scores, iou_threshold: float):
     if boxes.device == flow.device("npu"):
+        if boxes.ndim == 2 and boxes.shape[-1] == 4:
+            boxes = boxes.unsqueeze(0)
+        elif boxes.ndim != 3 or boxes.shape[-1] != 4:
+            raise ValueError(f"boxes must be of shape [B, N, 4] or [N, 4], but got {boxes.shape}")
+
+        if scores.ndim == 1:
+            scores = scores.unsqueeze(0).unsqueeze(0)
+        elif scores.ndim == 2:
+            scores = scores.unsqueeze(0)
+        elif scores.ndim != 3:
+            raise ValueError(f"scores must be of shape [B, C, N], [C, N] or [N], but got {scores.shape}")
+
+        if boxes.shape[0] != scores.shape[0]:
+            raise ValueError(f"batch_size mismatch: boxes {boxes.shape[0]} vs scores {scores.shape[0]}")
+        if boxes.shape[1] != scores.shape[2]:
+            raise ValueError(f"spatial_dimension mismatch: boxes {boxes.shape[1]} vs scores {scores.shape[2]}")
+
         return flow._C.nms(boxes, scores, iou_threshold)
+
     score_inds = flow.argsort(scores, dim=0, descending=True)
     boxes = flow._C.gather(boxes, score_inds, axis=0)
-    keep = flow._C.nms(boxes, iou_threshold)
+    keep = flow._C.nms(boxes, iou_threshold=iou_threshold)
+    print(keep.shape) 
     index = flow.squeeze(flow.argwhere(keep), dim=[1])
+    print(index.shape) 
     return flow._C.gather(score_inds, index, axis=0)

--- a/python/oneflow/nn/modules/nms.py
+++ b/python/oneflow/nn/modules/nms.py
@@ -19,6 +19,8 @@ from oneflow.nn.modules.module import Module
 
 
 def nms_op(boxes, scores, iou_threshold: float):
+    if boxes.device == flow.device("npu"):
+        return flow._C.nms(boxes, scores, iou_threshold)
     score_inds = flow.argsort(scores, dim=0, descending=True)
     boxes = flow._C.gather(boxes, score_inds, axis=0)
     keep = flow._C.nms(boxes, iou_threshold)


### PR DESCRIPTION
This PR extends the nms operator to support an additional scores input, enabling a fused path for NPU execution. The key changes include:
- Updated the functional API signature to include scores as an optional input.
- Added fused_op_ in NmsFunctor to handle the new input combination.
- Dispatched to the NPU-specific fused kernel when the input tensor is on NPU.
- Extended the op definition in OneFlowUserOps.td to support the optional scores input.
- Modified the Python frontend (nms_op) to route NPU inputs to the device-specific implementation.

This improves compatibility with hardware-accelerated NMS kernels (e.g., using aclnnNonMaxSuppression) on NPU devices while keeping existing behavior unchanged for CPU/GPU.